### PR TITLE
swagger-ui latest version (2.0.3) does not download

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "jade": ">=0.34",
     "jquery-browser": "~1.10",
     "jshint": "1.0.0",
-    "swagger-ui": ">=1.1.15",
+    "swagger-ui": "2.0.2",
     "underscore": "~1.5"
   }
 }


### PR DESCRIPTION
To resolve this, at least for now, set the version
explicitly to 2.0.2. I assume npm will be repaired
sometime soon but for now this enables an error-free
installation.
