### PR TITLE
Fix bug stemming from swagger not sending Accept header

### DIFF
--- a/clients/web/src/stylesheets/apidocs/apidocs.styl
+++ b/clients/web/src/stylesheets/apidocs/apidocs.styl
@@ -1,5 +1,5 @@
 $boxShadow = 0 5px 12px 0px rgba(0, 0, 0, 0.2)
-$radius = 12px
+$radius = 8px
 $border = 1px solid #d7d7d7
 
 border-radius()
@@ -24,6 +24,9 @@ body
 .docs-body
   background-color white
   padding 15px 18px 5px
+
+  p
+    margin-bottom 13px
 
 .docs-swagger-container
   background-color #f0fafc

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "jquery-browser": "~1.10",
     "jshint": "1.0.0",
     "requirejs": "2.1.10",
-    "swagger-ui": "2.0.2",
+    "swagger-ui": "2.0.13",
     "underscore": "~1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
This was fixed in a more recent version of swagger; the problem
was only visible on firefox, whose default accept header is
slightly different from Chrome's.
