### PR TITLE
Fixes #72. Date stamps were broken on firefox and safari

### DIFF
--- a/clients/web/src/utilities.js
+++ b/clients/web/src/utilities.js
@@ -12,6 +12,7 @@ girder.DATE_SECOND = 3;
  * @param resolution The resolution, defaults to 'day'. Minimum is month.
  */
 girder.formatDate = function (datestr, resolution) {
+    datestr = datestr.replace(' ', 'T'); // Cross-browser accepted date format
     var date = new Date(datestr);
     var output = girder.MONTHS[date.getMonth()];
 


### PR DESCRIPTION
The stamps are passed down from python in human readable form.
We perform a trivial conversion to get them to ISO 8601, which is understood
across all major browsers' Date() object.
