### PR TITLE
Make Travis badge report status of master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Girder [![Build Status](https://travis-ci.org/girder/girder.png?branch=travis)](https://travis-ci.org/girder/girder)
+Girder [![Build Status](https://travis-ci.org/girder/girder.png?branch=master)](https://travis-ci.org/girder/girder)
 ======
 
 Documentation of the Girder toolkit can be found at http://girder.readthedocs.org.


### PR DESCRIPTION
Is there still a special "travis" branch, or is correct to change this to master?
