### PR TITLE
Updating config_parse.py to work with both Python 2 and 3

### DIFF
--- a/config_parse.py
+++ b/config_parse.py
@@ -5,7 +5,10 @@ import json
 import os
 import sys
 
-from ConfigParser import ConfigParser
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
 
 if __name__ == '__main__':
     if len(sys.argv) <= 1:
@@ -20,4 +23,4 @@ if __name__ == '__main__':
     config = ConfigParser()
     config.read(f)
 
-    print json.dumps({k: dict(config.items(k)) for k in config.sections()})
+    print(json.dumps({k: dict(config.items(k)) for k in config.sections()}))


### PR DESCRIPTION
This makes the Grunt tasks work no matter if `python` refers to Python2 or Python3 on a given system.
- Py2's `ConfigParser` is called `configparser` in Py3 - a try/except block is used to import the correct module.
- Py3 doesn't allow Py2's "non-function" style of `print` statement, so it has been cast in the "function" style.
