### PR TITLE
Fixes #208. Return _accessLevel when fetching a collection

### DIFF
--- a/girder/api/v1/collection.py
+++ b/girder/api/v1/collection.py
@@ -88,7 +88,7 @@ class Collection(Resource):
 
     @loadmodel(map={'id': 'coll'}, model='collection', level=AccessType.READ)
     def getCollection(self, coll, params):
-        return self.model('collection').filter(coll)
+        return self.model('collection').filter(coll, self.getCurrentUser())
     getCollection.description = (
         Description('Get a collection by ID.')
         .responseClass('Collection')

--- a/tests/cases/collection_test.py
+++ b/tests/cases/collection_test.py
@@ -111,6 +111,12 @@ class CollectionTestCase(base.TestCase):
         self.assertEqual(resp.json[0]['_id'], newCollId)
         self.assertEqual(resp.json[0]['name'], 'New collection')
 
+        # Test collection get
+        resp = self.request(path='/collection/{}'.format(newCollId),
+                            user=self.admin)
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json['_accessLevel'], AccessType.ADMIN)
+
     def testDeleteCollection(self):
         # Requesting with no path should fail
         resp = self.request(path='/collection', method='DELETE',


### PR DESCRIPTION
This broke as a result of our filter() refactoring, and now we
verify the behavior with a test.
