### PR TITLE
Give each server test its own assetstore

### DIFF
--- a/tests/JavascriptTests.cmake
+++ b/tests/JavascriptTests.cmake
@@ -39,6 +39,7 @@ function(add_web_client_test name specFile)
     "SPEC_FILE=${specFile}"
     "COVERAGE_FILE=${PROJECT_BINARY_DIR}/js_coverage/${name}.cvg"
     "GIRDER_TEST_DB=girder_test_webclient"
+    "GIRDER_TEST_ASSETSTORE=webclient"
   )
   set_property(TEST ${testname} APPEND PROPERTY DEPENDS js_coverage_reset)
   set_property(TEST js_coverage_combine_report APPEND PROPERTY DEPENDS ${testname})

--- a/tests/PythonTests.cmake
+++ b/tests/PythonTests.cmake
@@ -96,6 +96,7 @@ function(add_python_test case)
   set_property(TEST ${name} PROPERTY ENVIRONMENT
     "PYTHONPATH=${pythonpath}"
     "GIRDER_TEST_DB=girder_test_${name}"
+    "GIRDER_TEST_ASSETSTORE=${name}"
   )
   if(fn_RESOURCE_LOCKS)
     set_property(TEST ${name} PROPERTY RESOURCE_LOCK ${fn_RESOURCE_LOCKS})

--- a/tests/base.py
+++ b/tests/base.py
@@ -96,8 +96,12 @@ class TestCase(unittest.TestCase, model_importer.ModelImporter):
         can be used without 500 errors.
         """
         dropTestDatabase()
+        assetstorePath = os.path.join(
+            ROOT_DIR, 'tests', 'assetstore',
+            os.environ.get('GIRDER_TEST_ASSETSTORE', 'test'))
         self.model('assetstore').createFilesystemAssetstore(
-            name='Test', root=os.path.join(ROOT_DIR, 'tests', 'assetstore'))
+            name='Test', root=assetstorePath)
+
         addr = ':'.join(map(str, mockSmtp.address))
         self.model('setting').set(SettingKey.SMTP_HOST, addr)
 

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -216,14 +216,11 @@ class FileTestCase(base.TestCase):
         """
         Test usage of the Filesystem assetstore type.
         """
-        root = os.path.join(ROOT_DIR, 'tests', 'assetstore')
-        self.model('assetstore').remove(self.model('assetstore').getCurrent())
-        assetstore = self.model('assetstore').createFilesystemAssetstore(
-            name='Test', root=root)
-        self.assetstore = assetstore
+        self.assetstore = self.model('assetstore').getCurrent()
+        root = self.assetstore['root']
 
         # Clean out the test assetstore on disk
-        shutil.rmtree(assetstore['root'])
+        shutil.rmtree(root)
 
         # First clean out the temp directory
         tmpdir = os.path.join(root, 'temp')

--- a/tests/cases/item_test.py
+++ b/tests/cases/item_test.py
@@ -50,14 +50,11 @@ class ItemTestCase(base.TestCase):
             self.users[0], 'user', user=self.users[0])
         (self.publicFolder, self.privateFolder) = folders
 
-        root = os.path.join(ROOT_DIR, 'tests', 'assetstore')
-        self.model('assetstore').remove(self.model('assetstore').getCurrent())
-        assetstore = self.model('assetstore').createFilesystemAssetstore(
-            name='Test', root=root)
-        self.assetstore = assetstore
+        self.assetstore = self.model('assetstore').getCurrent()
+        root = self.assetstore['root']
 
         # Clean out the test assetstore on disk
-        shutil.rmtree(assetstore['root'])
+        shutil.rmtree(root)
 
         # First clean out the temp directory
         tmpdir = os.path.join(root, 'temp')


### PR DESCRIPTION
There were several race conditions that actually manifested as
errors on travis related to cleanup of the assetstore. So, we just
use a different subfolder for each test.
