### PR TITLE
Adding a vagrantfile and documentation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ girder.egg-info
 .DS_Store
 .*.swp
 .*.swo
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,9 @@
+Vagrant.configure("2") do |config|
+  config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+  config.vm.box = "trusty_64"
+  config.vm.network "forwarded_port", guest: 80, host: 9080
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "devops/ansible/playbook.yml"
+    ansible.verbose = "vvvv"
+  end
+end

--- a/devops/ansible/nginx.j2
+++ b/devops/ansible/nginx.j2
@@ -1,0 +1,18 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server ipv6only=on;
+
+    root /vagrant/clients/web;
+
+    # Make site accessible from http://localhost/
+    server_name localhost;
+
+    location / {
+         proxy_pass http://localhost:8080;
+         include /etc/nginx/proxy_params;
+    }
+
+    location /static {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/devops/ansible/playbook.yml
+++ b/devops/ansible/playbook.yml
@@ -1,0 +1,85 @@
+
+
+- hosts: all
+
+  handlers:
+  - name: restart nginx
+    action: service name=nginx pattern=/etc/init.d/nginx state=restarted enabled=yes
+
+  - name: restart mongodb
+    action: service name=mongodb pattern=/etc/init.d/mongodb state=restarted enabled=yes
+
+  tasks:
+
+  - name: add nodejs ppa
+    apt_repository: repo='ppa:chris-lea/node.js'
+    sudo: yes
+
+  - name: update apt cache
+    apt: update_cache=yes
+    sudo: yes
+
+  - name: install package dependencies
+    apt: name={{ item }} state=present
+    sudo: yes
+    with_items:
+      - python-pip
+      - python2.7-dev
+      - build-essential
+      - mongodb
+      - python-software-properties
+      - libffi-dev
+      - nodejs
+      - screen
+      - nginx
+
+  - name: Enable mongo full-text search
+    lineinfile: dest=/etc/mongodb.conf regexp=^setParameter= line=setParameter=textSearchEnabled=true
+    sudo: yes
+    notify:
+      - restart mongodb
+
+  - name: install girder requirements
+    pip: requirements=/vagrant/requirements.txt
+    sudo: yes
+
+  - name: install girder for development
+    command: python setup.py develop chdir=/vagrant
+    sudo: yes
+
+  - name: install grunt and globally
+    npm: name={{ item }} global=yes
+    with_items:
+      - grunt
+      - grunt-cli
+    sudo: yes
+
+  - name: run npm install
+    npm: path=/vagrant
+
+  - name: run grunt init
+    command: grunt init chdir=/vagrant
+
+  - name: run grunt
+    command: grunt chdir=/vagrant
+
+  - name: disable default nginx site
+    command: rm /etc/nginx/sites-enabled/default removes=/etc/nginx/sites-enabled/default
+    sudo: yes
+    notify:
+      - restart nginx
+
+  - name: add the girder nginx site
+    template: src=nginx.j2 dest=/etc/nginx/sites-available/girder
+    sudo: yes
+    notify:
+      - restart nginx
+
+  - name: enable girder nginx site
+    command: ln -s /etc/nginx/sites-available/girder /etc/nginx/sites-enabled/girder creates=/etc/nginx/sites-enabled/girder
+    sudo: yes
+    notify:
+      - restart nginx
+
+  - name: copy helper script
+    copy: src=start_girder_in_screen.sh dest=/home/vagrant mode=0744

--- a/devops/ansible/start_girder_in_screen.sh
+++ b/devops/ansible/start_girder_in_screen.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/usr/bin/screen -d -m /bin/bash -c '/usr/bin/python -m girder 2>&1 | tee /home/vagrant/girder_output.log'

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -7,6 +7,31 @@ loosely coupled. As such, development of girder can be divided into the server
 client. This section is intended to get prospective contributors to understand
 the tools used to develop Girder.
 
+Configuring Your Development Environment
+----------------------------------------
+
+In order to develop girder, you can refer to the :doc:`prerequisites` and
+:doc:`installation` sections to setup a local development environment. Once
+girder is started via ``python -m girder``, the server will reload itself
+whenever a python file is modified.
+
+To get the same auto-building behavior for javascript, we use ``grunt-watch``.
+Thus, running ``grunt watch`` in the root of the repository will watch for
+javascript, stylus, and jade changes in order to rebuild them on-the-fly.
+
+Vagrant
+^^^^^^^
+
+A shortcut to going through the installation steps for development is to use
+vagrant to setup the environment on a virtualbox virtual machine. To setup this
+environment run ``vagrant up`` in the root of the repository. This will spin
+up and provision a virtual machine, provided you have vagrant and virtualbox
+installed. Once this process is complete, you can run ``vagrant ssh`` in order to
+start girder. There is a helper script in the vagrant home directory that will
+start girder in a detached screen session. You may want to run a similar process
+to run ``grunt watch`` as detailed above.
+
+
 Utilities
 ---------
 


### PR DESCRIPTION
This sets up a 14.04 x86_64 vm and sets up girder under nginx. With this
setup, girder is used for the dynamic contents (the API) and nginx is used
for the static resources (javascript, one-page-app, etc). This should be
amenable to modifications for use in a general deployment.
