### PR TITLE
SIGINT handler for server tests that prevents zombie asyncore loop

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -24,6 +24,7 @@ import io
 import json
 import mimetypes
 import os
+import signal
 import sys
 import unittest
 import urllib
@@ -383,3 +384,12 @@ class MultipartFormdataEncoder(object):
             body.write(chunk)
             size += chunkLen
         return self.contentType, body.getvalue(), size
+
+
+def _sigintHandler(*args):
+    print 'Received SIGINT, shutting down mock SMTP server...'
+    mockSmtp.stop()
+    sys.exit(1)
+
+
+signal.signal(signal.SIGINT, _sigintHandler)


### PR DESCRIPTION
fixes #237 

This doesn't really fix the issue, but it is one required step. This won't truly be fixed until CTest supports passing the signals through to running tests processes, which I've opened a feature request for: http://www.cmake.org/Bug/view.php?id=14987
