### PR TITLE
Forcing CherryPy to 3.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cffi
-CherryPy
+CherryPy==3.3.0
 Sphinx
 pymongo
 bcrypt


### PR DESCRIPTION
With the latest version of CherryPy I was getting this error:
`ImportError: No module named wsgiserver2`
