### PR TITLE
Extend the @loadmodel to support its usage for plugins

### DIFF
--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -59,12 +59,12 @@ def _cacheAuthUser(fun):
     return inner
 
 
-def loadmodel(map, model, level=None):
+def loadmodel(map, model, plugin='_core', level=None):
     """
     This is a meta-decorator that can be used to convert parameters that are
     ObjectID's into the actual documents.
     """
-    _model = _importer.model(model)
+    _model = _importer.model(model, plugin)
 
     def meta(fun):
         def wrapper(self, *args, **kwargs):


### PR DESCRIPTION
Basic usage of the @loadmodel is to convert an ID to an actual
model object, but was only allowed on the core model objects.
This patch allow its usage in plugin as well.

Usage example:
 @loadmodel(map={'id': 'item'}, model='item', level=AccessType.READ
 @loadmodel(map={'id': 'task'}, model='task', plugin='ec2_cloud', level=AccessType.ADMIN)
