### PR TITLE
Fixed an issue where asking for the current user with a token would fail.

### DIFF
--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -44,11 +44,11 @@ def _cacheAuthUser(fun):
     is only performed once per request, and is cached on the request for
     subsequent calls to getCurrentUser().
     """
-    def inner(self, *args, **kwargs):
-        if hasattr(cherrypy.request, 'girderUser'):
+    def inner(self, returnToken=False, *args, **kwargs):
+        if not returnToken and hasattr(cherrypy.request, 'girderUser'):
             return cherrypy.request.girderUser
 
-        user = fun(self, *args, **kwargs)
+        user = fun(self, returnToken, *args, **kwargs)
         if type(user) is tuple:
             setattr(cherrypy.request, 'girderUser', user[0])
         else:


### PR DESCRIPTION
If the user is cached and a token was requested, getCurrentUser wouldn't respond appropriately.
