### PR TITLE
Increase the prominence of the current assetstore.

### DIFF
--- a/clients/web/src/stylesheets/body/assetstores.styl
+++ b/clients/web/src/stylesheets/body/assetstores.styl
@@ -19,3 +19,11 @@
     display none
   &:after
     display none
+
+.g-assetstore-current-text
+  font-weight bold
+  margin-left 10px
+
+.g-assetstore-current
+  background rgba(50, 118, 177, 0.25)
+  border-color: #444

--- a/clients/web/src/templates/body/assetstores.jade
+++ b/clients/web/src/templates/body/assetstores.jade
@@ -9,13 +9,14 @@
       Below is a list of all of the assetstores available to the server. The
       one set as "current" is the one that uploaded files will be written to.
   each assetstore in assetstores
-    .g-assetstore-container.panel.panel-default
+    .g-assetstore-container.panel.panel-default(class=assetstore.get('current')? 'g-assetstore-current' : undefined)
       .panel-body
         div
           b Name:
           span.g-assetstore-name  #{assetstore.get('name')}
           if assetstore.get('current')
-            |  (Current assetstore)
+            span.g-assetstore-current-text
+              |  (Current assetstore)
         if assetstore.get('type') == types.FILESYSTEM
           div
             b Type:

--- a/clients/web/src/views/body/AssetstoresView.js
+++ b/clients/web/src/views/body/AssetstoresView.js
@@ -69,11 +69,13 @@ girder.views.AssetstoresView = girder.View.extend({
             legend: {
                 show: true,
                 location: 'e',
+                background: 'transparent',
                 border: 'none'
             },
             grid: {
-                background: '#fff',
-                borderColor: '#fff',
+                background: 'transparent',
+                border: 'none',
+                borderWidth: 0,
                 shadow: false
             }
         });


### PR DESCRIPTION
This makes the current assetstore more obvious in the list on the web client, as per issue #263.  I have based the background color off of the color used for the set-as-current buttons, but made it mostly transparent so as to leave good contrast with the text.  Anyone who has an opinion on color is welcome to suggest change.
