### PR TITLE
Added a grunt package-remove task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -463,8 +463,20 @@ module.exports = function (grunt) {
         }
     });
 
+    // Remove all old packaging files
+    grunt.registerTask('remove-packaging', function () {
+        // match things that look like girder packages
+        grunt.file.expand('girder-*.tar.gz').forEach(function (f) {
+            // use regex's to further filter
+            if (f.match(/girder(-web-|-plugins-|-)[0-9]+\.[0-9]+.[0-9]+.*\.tar\.gz/)) {
+                grunt.file.delete(f);
+            }
+        });
+    });
+
     // Create tarballs for distribution through pip and github releases
     grunt.registerTask('package', 'Generate a python package for distribution.', [
+        'remove-packaging',
         'compress:package-web',
         'compress:package-plugins',
         'shell:package-server'


### PR DESCRIPTION
It will run on `grunt package`.  This is necessary to prevent the packaging
tests from picking up old versions because they don't use the version number
at the moment.  In any case, it is probably a good idea in general.
