### PR TITLE
Sped up hierarchy widget paging on large sets.

### DIFF
--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -37,7 +37,8 @@ class Folder(AccessControlledModel):
 
     def initialize(self):
         self.name = 'folder'
-        self.ensureIndices(['parentId', 'name', 'lowerName'])
+        self.ensureIndices(('parentId', 'name', 'lowerName',
+                            ([('folderId', 1), ('name', 1)], {})))
         self.ensureTextIndex({
             'name': 10,
             'description': 1

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -34,7 +34,8 @@ class Item(Model):
 
     def initialize(self):
         self.name = 'item'
-        self.ensureIndices(('folderId', 'name', 'lowerName'))
+        self.ensureIndices(('folderId', 'name', 'lowerName',
+                            ([('folderId', 1), ('name', 1)], {})))
         self.ensureTextIndex({
             'name': 10,
             'description': 1


### PR DESCRIPTION
I noticed when working with a large collection (>100000 items), that the hierarchy widget was very slow to load a page of data.  Internally, mongo was using the folderId index, but not the name index.  By adding an index that uses both of these fields, mongo is more sensible and pages the data quickly.
