### PR TITLE
Item validation can result in a wrong lowerName.

### DIFF
--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -53,9 +53,22 @@ class Item(Model):
 
         return filtered
 
+    def _validateString(self, value):
+        """
+        Make sure a value is an instance of basestring and is stripped of
+        whitespace.
+        :param value: the value to coerce into a string if it isn't already.
+        :return stringValue: the string version of the value.
+        """
+        if value is None:
+            value = ''
+        if not isinstance(value, basestring):
+            value = str(value)
+        return value.strip()
+
     def validate(self, doc):
-        doc['name'] = doc['name'].strip()
-        doc['description'] = doc['description'].strip()
+        doc['name'] = self._validateString(doc.get('name', ''))
+        doc['description'] = self._validateString(doc.get('description', ''))
 
         if not doc['name']:
             raise ValidationException('Item name must not be empty.', 'name')
@@ -304,12 +317,9 @@ class Item(Model):
             folder['baseParentType'] = pathFromRoot[0]['type']
             folder['baseParentId'] = pathFromRoot[0]['object']['_id']
 
-        if description is None:
-            description = ''
-
         return self.save({
-            'name': name.strip(),
-            'description': description.strip(),
+            'name': self._validateString(name),
+            'description': self._validateString(description),
             'folderId': ObjectId(folder['_id']),
             'creatorId': creator['_id'],
             'baseParentType': folder['baseParentType'],

--- a/tests/cases/item_test.py
+++ b/tests/cases/item_test.py
@@ -494,6 +494,18 @@ class ItemTestCase(base.TestCase):
             description=None)
         self.assertEqual(item['lowerName'], 'my item name (1)')
         self.assertEqual(item['description'], '')
+        # test if non-strings are coerced and if just missing lowerName is
+        # corrected.
+        item['description'] = 1
+        del item['lowerName']
+        self.model('item').save(item, validate=False)
+        item = self.model('item').find({'_id': item['_id']}).next()
+        self.assertNotHasKeys(item, ('lowerName', ))
+        self.model('item').load(item['_id'], force=True)
+        item = self.model('item').find({'_id': item['_id']}).next()
+        self.assertHasKeys(item, ('lowerName', ))
+        self.assertEqual(item['lowerName'], 'my item name (1)')
+        self.assertEqual(item['description'], '1')
 
     def testItemCopy(self):
         origItem = self._createItem(self.publicFolder['_id'],


### PR DESCRIPTION
When an item is validated, its name can be automatically changed to make it unique.  We store a lowerName value for the name, but this was calculated before the name change rather than after.  Also, added a guard in createItem to avoid a description that was None and to strip whitespace from the name and description as the item is created, rather than just on validation.
