### PR TITLE
The file/{id}/download/{name} endpoint didn't allow a name in swagger.

### DIFF
--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -20,6 +20,7 @@
 import io
 import os
 import shutil
+import urllib
 import zipfile
 
 from hashlib import sha512
@@ -220,6 +221,17 @@ class FileTestCase(base.TestCase):
         self.assertStatusOk(resp)
 
         self.assertEqual(contents[1:], resp.collapse_body())
+
+        # Test downloading with a name
+        resp = self.request(
+            path='/file/%s/download/%s' % (
+                str(file['_id']), urllib.quote(file['name']).encode('utf8')),
+            method='GET', user=self.user, isJson=False)
+        self.assertStatusOk(resp)
+        if contents:
+            self.assertEqual(resp.headers['Content-Type'],
+                             'text/plain;charset=utf-8')
+        self.assertEqual(contents, resp.collapse_body())
 
     def _testDownloadFolder(self):
         """


### PR DESCRIPTION
Added documentation that we ignore the name parameter and why it is useful.  The offset parameter for file downloads was also not in swagger (though was being tested).
