### PR TITLE
The GET group endpoint didn't use the text parameter.

### DIFF
--- a/tests/cases/group_test.py
+++ b/tests/cases/group_test.py
@@ -137,16 +137,32 @@ class GroupTestCase(base.TestCase):
         self.assertEqual(resp.json['name'], 'private')
 
         # Test listing all groups
-        resp = self.request(path='/group/', method='GET', user=self.users[0])
+        privateGroup2 = self.model('group').createGroup(
+            'private group', self.users[0], public=False)
+        resp = self.request(path='/group', method='GET', user=self.users[0])
         self.assertStatusOk(resp)
         self.assertEqual(type(resp.json), list)
-        self.assertEqual(len(resp.json), 2)
+        self.assertEqual(len(resp.json), 3)
 
-        resp = self.request(path='/group/', method='GET', user=self.users[1])
+        resp = self.request(path='/group', method='GET', user=self.users[1])
         self.assertStatusOk(resp)
         self.assertEqual(type(resp.json), list)
         self.assertEqual(len(resp.json), 1)
         self.assertEqual(resp.json[0]['_id'], str(publicGroup['_id']))
+        # Test searching by name
+        resp = self.request(path='/group', method='GET', user=self.users[0],
+                            params={'text': 'private'})
+        self.assertStatusOk(resp)
+        self.assertEqual(type(resp.json), list)
+        self.assertEqual(len(resp.json), 2)
+        self.assertEqual(resp.json[0]['_id'], str(privateGroup['_id']))
+        self.assertEqual(resp.json[1]['_id'], str(privateGroup2['_id']))
+        resp = self.request(path='/group', method='GET', user=self.users[0],
+                            params={'text': 'private', 'exact': True})
+        self.assertStatusOk(resp)
+        self.assertEqual(type(resp.json), list)
+        self.assertEqual(len(resp.json), 1)
+        self.assertEqual(resp.json[0]['_id'], str(privateGroup['_id']))
 
     def testUpdateGroup(self):
         """


### PR DESCRIPTION
I also added an 'exact' boolean, that, if true, does an exact name match with the text paramter.

Fixes issue #489.
