### PR TITLE
Add a format parameter to item downloads.

### DIFF
--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -248,14 +248,20 @@ class Item(Resource):
         user = self.getCurrentUser()
         files = [file for file in self.model('item').childFiles(
                  item=item, limit=2)]
-
-        if len(files) == 1:
+        format = params.get('format', '')
+        if format not in (None, '', 'zip'):
+            raise RestException('Unsupported format.')
+        if len(files) == 1 and format != 'zip':
             return self.model('file').download(files[0], offset)
         else:
             return self._downloadMultifileItem(item, user)
     download.description = (
         Description('Download the contents of an item.')
         .param('id', 'The ID of the item.', paramType='path')
+        .param('format', 'If unspecified, items with one file are downloaded '
+               'as that file, and other items are downloaded as a zip '
+               'archive.  If \'zip\', a zip archive is always sent',
+               required=False)
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403))
 

--- a/tests/cases/item_test.py
+++ b/tests/cases/item_test.py
@@ -118,9 +118,13 @@ class ItemTestCase(base.TestCase):
 
         self.assertEqual(contents[1:], resp.collapse_body())
 
-    def _testDownloadMultiFileItem(self, item, user, contents):
+    def _testDownloadMultiFileItem(self, item, user, contents, format=None):
+        params = None
+        if format:
+            params = {'format': format}
         resp = self.request(path='/item/{}/download'.format(item['_id']),
-                            method='GET', user=user, isJson=False)
+                            method='GET', user=user, isJson=False,
+                            params=params)
         self.assertStatusOk(resp)
         # cherrypy doesn't collapse the body properly when unicode is mixed
         # with binary data.  Instead of using
@@ -149,6 +153,8 @@ class ItemTestCase(base.TestCase):
         self._testUploadFileToItem(curItem, 'file_1', self.users[0], 'foobar')
 
         self._testDownloadSingleFileItem(curItem, self.users[0], 'foobar')
+        self._testDownloadMultiFileItem(curItem, self.users[0],
+                                        {'file_1': 'foobar'}, format='zip')
 
         self._testUploadFileToItem(curItem, 'file_2', self.users[0], 'foobz')
 


### PR DESCRIPTION
If this is 'zip', always return a zip archive.  If blank, continue with the current behavior.

This addresses issue #479.
