### PR TITLE
Sort the rest API routes so that they are in a stable order.

### DIFF
--- a/tests/cases/api_describe_test.py
+++ b/tests/cases/api_describe_test.py
@@ -19,11 +19,41 @@
 
 from .. import base
 
-from girder.api import describe
+from girder.api import access, describe
+from girder.api.rest import Resource
+
+OrderedRoutes = [
+    ('GET', (), ''),
+    ('GET', (':id',), '/{id}'),
+    ('UNKNOWN', (':id',), '/{id}'),
+    ('GET', (':id', 'action'), '/{id}/action'),
+    ('GET', ('action',), '/action'),
+    ('PUT', ('action',), '/action'),
+    ('POST', ('action',), '/action'),
+    ('PATCH', ('action',), '/action'),
+    ('DELETE', ('action',), '/action'),
+    ('NEWMETHOD', ('action',), '/action'),
+    ('UNKNOWN', ('action',), '/action'),
+    ('GET', ('action', ':id'), '/action/{id}'),
+    ('GET', ('noaction',), '/noaction'),
+    ]
+
+
+class DummyResource(Resource):
+    def __init__(self):
+        self.resourceName = 'foo'
+        for method, pathElements, testPath in OrderedRoutes:
+            self.route(method, pathElements, self.handler)
+
+    @access.public
+    def handler(self, **kwargs):
+        return kwargs
+    handler.description = describe.Description('Does nothing')
 
 
 def setUpModule():
-    base.startServer()
+    server = base.startServer()
+    server.root.api.v1.accesstest = DummyResource()
 
 
 def tearDownModule():
@@ -50,11 +80,11 @@ class ApiDescribeTestCase(base.TestCase):
     def testApiDescribe(self):
         # Get coverage for serving the static swagger page
         resp = self.request(path='', method='GET', isJson=False)
-        self.assertStatus(resp, 200)
+        self.assertStatusOk(resp)
 
         # Test top level describe endpoint
         resp = self.request(path='/describe', method='GET')
-        self.assertStatus(resp, 200)
+        self.assertStatusOk(resp)
         self.assertTrue('/api/v1/describe' in resp.json['basePath'])
         self.assertEqual(resp.json['swaggerVersion'], describe.SWAGGER_VERSION)
         self.assertEqual(resp.json['apiVersion'], describe.API_VERSION)
@@ -62,7 +92,24 @@ class ApiDescribeTestCase(base.TestCase):
 
         # Request a specific resource's description, sanity check
         resp = self.request(path='/describe/user', method='GET')
-        self.assertStatus(resp, 200)
+        self.assertStatusOk(resp)
         for routeDoc in resp.json['apis']:
             self.assertHasKeys(('path', 'operations'), routeDoc)
             self.assertTrue(len(routeDoc['operations']) > 0)
+
+        # Request an unknown resource's description to get an error
+        resp = self.request(path='/describe/unknown', method='GET')
+        self.assertStatus(resp, 400)
+        self.assertEqual(resp.json['message'], 'Invalid resource: unknown')
+
+    def testRouteOrder(self):
+        # Check that the resources and operations are listed in the order we
+        # expect
+        resp = self.request(path='/describe/foo', method='GET')
+        self.assertStatusOk(resp)
+        listedRoutes = [(method['httpMethod'], route['path'])
+                        for route in resp.json['apis']
+                        for method in route['operations']]
+        expectedRoutes = [(method, '/foo'+testPath)
+                          for method, pathElements, testPath in OrderedRoutes]
+        self.assertEqual(listedRoutes, expectedRoutes)


### PR DESCRIPTION
Addresses issue #494.
