### PR TITLE
Fix cdash js coverage reporting.

### DIFF
--- a/cmake/aiur_nightly_js_coverage.cmake
+++ b/cmake/aiur_nightly_js_coverage.cmake
@@ -15,6 +15,9 @@ set(CTEST_SITE "Aiur.kitware")
 set(CTEST_BUILD_NAME "Linux-master-nightly-js-cov")
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 
+# Copy compile plugin template files
+file(COPY "${CTEST_SOURCE_DIRECTORY}/clients/web/static/built/plugins/provenance/templates.js" DESTINATION "${CTEST_SOURCE_DIRECTORY}/plugins/provenance")
+
 ctest_start("Nightly")
 ctest_configure()
 file(RENAME "${CTEST_BINARY_DIRECTORY}/../coverage.xml" "${CTEST_BINARY_DIRECTORY}/coverage.xml")


### PR DESCRIPTION
When I added templates.js from the provenance plugin, this file isn't included where ctest_coverage was expecting it.  Copy it to the expected location.  In my test environment, this fixed the submission to cdash.
