### PR TITLE
Validate plugin.json rather than failing.

### DIFF
--- a/girder/utility/plugin_utilities.py
+++ b/girder/utility/plugin_utilities.py
@@ -194,7 +194,13 @@ def findAllPlugins():
         configFile = os.path.join(pluginsDir, plugin, 'plugin.json')
         if os.path.isfile(configFile):
             with open(configFile) as conf:
-                data = json.load(conf)
+                try:
+                    data = json.load(conf)
+                except ValueError:
+                    print TerminalColor.error(
+                        'ERROR: Failed to load plugin "{}": plugin.json is '
+                        'not valid JSON'.format(plugin))
+                    continue
 
         allPlugins[plugin] = {
             'name': data.get('name', plugin),

--- a/tests/cases/system_test.py
+++ b/tests/cases/system_test.py
@@ -204,3 +204,19 @@ class SystemTestCase(base.TestCase):
         enabled = resp.json['value']
         self.assertEqual(len(enabled), 2)
         self.assertTrue('test_plugin' in enabled)
+
+    def testBadPlugin(self):
+        pluginRoot = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                                  'test_plugins')
+        conf = config.getConfig()
+        conf['plugins'] = {'plugin_directory': pluginRoot}
+        # Try to enable a good plugin and a bad plugin.  Only the good plugin
+        # should be enabled.
+        resp = self.request(
+            path='/system/plugins', method='PUT', user=self.users[0],
+            params={'plugins': '["test_plugin","bad_json"]'})
+        self.assertStatusOk(resp)
+        enabled = resp.json['value']
+        self.assertEqual(len(enabled), 1)
+        self.assertTrue('test_plugin' in enabled)
+        self.assertTrue('bad_json' not in enabled)

--- a/tests/test_plugins/bad_json/plugin.json
+++ b/tests/test_plugins/bad_json/plugin.json
@@ -1,0 +1,6 @@
+{
+"name": "Bad plugin.json",
+"description": "Plugin with invalid plugin.json file",
+"version": "0.1.0"  
+make_this_bad_json
+}


### PR DESCRIPTION
If a plugin's plugin.json file is not valid json, print a warning to the terminal and skip that plugin.  Prior to this, the import script would throw an uncaught exception, halting girder.
