### PR TITLE
System check.

### DIFF
--- a/clients/web/test/spec/adminSpec.js
+++ b/clients/web/test/spec/adminSpec.js
@@ -299,7 +299,7 @@ describe('Test the plugins page', function () {
             expect($('.g-plugin-list-item .bootstrap-switch').length > 0).toBe(true);
             expect($('.g-plugin-restart').css('visibility')).toBe('hidden');
             expect($('.g-plugin-list-item input[type=checkbox]:checked').length).toBe(0);
-            $('.g-plugin-list-item .bootstrap-switch-label').eq(0).click();
+            $('.g-plugin-list-item:contains(Metadata extractor) .bootstrap-switch-label').click();
         });
         waitsFor(function () {
             return $('.g-plugin-restart').css('visibility') !== 'hidden';
@@ -339,7 +339,7 @@ describe('Test the plugins page', function () {
     });
     it('Disable a plugin', function () {
         runs(function () {
-            $('.g-plugin-list-item .bootstrap-switch-label').eq(0).click();
+            $('.g-plugin-list-item:contains(Metadata extractor) .bootstrap-switch-label').click();
         });
         runs(function () {
             expect($('.g-plugin-list-item input[type=checkbox]:checked').length).toBe(0);

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -240,6 +240,7 @@ def endpoint(fun):
     @functools.wraps(fun)
     def endpointDecorator(self, *args, **kwargs):
         _setCommonCORSHeaders()
+        cherrypy.lib.caching.expires(0)
         try:
             val = fun(self, args, kwargs)
 
@@ -737,6 +738,7 @@ class Resource(ModelImporter):
     # behavior
     def OPTIONS(self, *path, **param):
         _setCommonCORSHeaders(True)
+        cherrypy.lib.caching.expires(0)
         # Get a list of allowed methods for this path
         if not self._routes:
             raise Exception('No routes defined for resource')

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -222,7 +222,7 @@ def _createResponse(val):
     # Default behavior will just be normal JSON output. Keep this
     # outside of the loop body in case no Accept header is passed.
     cherrypy.response.headers['Content-Type'] = 'application/json'
-    return json.dumps(val, default=str)
+    return json.dumps(val, sort_keys=True, default=str)
 
 
 def endpoint(fun):

--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -299,7 +299,7 @@ class System(Resource):
         .notes('Must be a system administrator to call this.')
         .errorResponse('You are not a system administrator.', 403))
 
-    @access.token
+    @access.public
     def systemStatus(self, params):
         mode = params.get('mode', 'basic')
         user = self.getCurrentUser()

--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -299,19 +299,23 @@ class System(Resource):
         .notes('Must be a system administrator to call this.')
         .errorResponse('You are not a system administrator.', 403))
 
-    @access.admin
+    @access.token
     def systemStatus(self, params):
-        mode = params.get('mode', 'quick')
-        status = system.getStatus(mode)
+        mode = params.get('mode', 'basic')
+        user = self.getCurrentUser()
+        if mode != 'basic':
+            self.requireAdmin(user)
+        status = system.getStatus(mode, user)
         status["requestBase"] = cherrypy.request.base.rstrip('/')
         return status
     systemStatus.description = (
         Description('Report the current system status.')
-        .notes("""Must be a system administrator to call this.""")
+        .notes('Must be a system administrator to call this with any mode '
+               'other than basic.')
         .param('mode', 'Select details to return.  "quick" are the details '
                'that can be answered without much load on the system.  "slow" '
                'also includes some resource-intensive queries.',
-               required=False, enum=['quick', 'slow'])
+               required=False, enum=['basic', 'quick', 'slow'])
         .errorResponse('You are not a system administrator.', 403))
 
     @access.admin

--- a/girder/utility/filesystem_assetstore_adapter.py
+++ b/girder/utility/filesystem_assetstore_adapter.py
@@ -19,6 +19,7 @@
 
 import cherrypy
 import os
+import psutil
 import stat
 import tempfile
 
@@ -88,17 +89,13 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
         For filesystem assetstores, we just need to report the free and total
         space on the filesystem where the assetstore lives.
         """
-        if hasattr(os, 'statvfs'):
-            try:
-                stat = os.statvfs(self.assetstore['root'])
-                return {
-                    'free': stat.f_bavail * stat.f_frsize,
-                    'total': stat.f_blocks * stat.f_frsize
-                }
-            except OSError:
-                logger.exception(
-                    'Failed to statvfs {}'.format(self.assetstore['root']))
-        # If we don't have statvfs or we can't query the assetstore's root
+        try:
+            usage = psutil.disk_usage(self.assetstore['root'])
+            return {'free': usage.free, 'total': usage.total}
+        except OSError:
+            logger.exception(
+                'Failed to get disk usage of %s' % self.assetstore['root'])
+        # If psutil.disk_usage fails or we can't query the assetstore's root
         # directory, just report nothing regarding disk capacity
         return {  # pragma: no cover
             'free': None,

--- a/girder/utility/system.py
+++ b/girder/utility/system.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright 2014 Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+import cherrypy
+import os
+import psutil
+import socket
+import threading
+import time
+
+import girder
+from girder import logger
+from girder.models import getDbConnection
+
+
+def _objectToDict(obj):
+    """
+    Convert an object to a dictionary.  Any non-private attribute that is an
+    integer, float, or string is returned in the dictionary.
+
+    :param obj: a python object or class.
+    :returns: objDict: a dictionary of values for the object.
+    """
+    return {key: getattr(obj, key) for key in dir(obj) if
+            not key.startswith('_') and
+            isinstance(getattr(obj, key),
+                       (int, long, float, basestring, tuple))}
+
+
+def getStatus(mode='quick'):
+    """
+    Get a dictionary of status information regarding the girder server.
+
+    :params mode: 'quick' returns only values that are cheap to acquire.
+        'slow' provides all of that information and adds additional
+    :returns: a status dictionary.
+    """
+    status = {}
+    status['virtualMemory'] = _objectToDict(psutil.virtual_memory())
+    status['swap'] = _objectToDict(psutil.swap_memory())
+    status['bootTime'] = psutil.boot_time()
+    status['currentTime'] = time.time()
+    status['cpuCount'] = psutil.cpu_count()
+
+    process = psutil.Process(os.getpid())
+    status['processMemory'] = _objectToDict(process.get_memory_info())
+    status['processName'] = process.name()
+    status['cmdline'] = process.cmdline()
+    status['exe'] = process.exe()
+    status['cwd'] = process.cwd()
+    status['processStartTime'] = process.create_time()
+    status['userName'] = process.username()
+    status['processCpuTimes'] = _objectToDict(process.cpu_times())
+    db = getDbConnection().get_default_database()
+    status['mongoBuildInfo'] = db.command('buildInfo')
+    status['cherrypyThreadsMaxUsed'] = len(cherrypy.tools.status.seenThreads)
+    status['cherrypyThreadsInUse'] = len([
+        True for threadId in cherrypy.tools.status.seenThreads
+        if 'end' not in cherrypy.tools.status.seenThreads[threadId]])
+    status['cherrypyThreadPoolSize'] = cherrypy.server.thread_pool
+
+    if mode == 'slow':
+        status['diskPartitions'] = [_objectToDict(part) for part in
+                                    psutil.disk_partitions()]
+        try:
+            # This fails in travis's environment, so guard it
+            status['diskIO'] = _objectToDict(psutil.disk_io_counters())
+        except Exception:
+            pass
+        # Report on the disk usage where the script is located
+        if hasattr(girder, '__file__'):
+            status['girderPath'] = os.path.abspath(girder.__file__)
+            status['girderDiskUsage'] = _objectToDict(
+                psutil.disk_usage(status['girderPath']))
+        # Report where our logs are and how much space is available for them
+        status['logs'] = []
+        for handler in logger.handlers:
+            try:
+                logInfo = {'path': handler.baseFilename}
+                logInfo['diskUsage'] = _objectToDict(
+                    psutil.disk_usage(logInfo['path']))
+                status['logs'].append(logInfo)
+            except Exception:
+                # If we can't read information about the log, don't throw an
+                # exception
+                pass
+        status['mongoDbStats'] = db.command('dbStats')
+        try:
+            # I don't know if this will work with a sharded database, so guard
+            # it and don't throw an exception
+            status['mongoDbPath'] = getDbConnection().admin.command(
+                'getCmdLineOpts')['parsed']['storage']['dbPath']
+            status['mongoDbDiskUsage'] = _objectToDict(
+                psutil.disk_usage(status['mongoDbPath']))
+        except Exception:
+            pass
+
+        status['processDirectChildrenCount'] = len(process.children())
+        status['processAllChildrenCount'] = len(process.children(True))
+        status['openFiles'] = [_objectToDict(file) for file in
+                               process.open_files()]
+        # I'd rather see textual names for the family and type of connections,
+        # so make a lookup table for them
+        connFamily = {getattr(socket, key): key for key in dir(socket)
+                      if key.startswith('AF_')}
+        connType = {getattr(socket, key): key for key in dir(socket)
+                    if key.startswith('SOCK_')}
+        connections = []
+        for conn in process.connections():
+            connDict = _objectToDict(conn)
+            connDict.pop('raddr', None)
+            connDict.pop('laddr', None)
+            connDict['family'] = connFamily.get(connDict['family'],
+                                                connDict['family'])
+            connDict['type'] = connType.get(connDict['type'],
+                                            connDict['type'])
+            connections.append(connDict)
+        status['connections'] = connections
+        status['ioCounters'] = _objectToDict(process.io_counters())
+
+        status['cherrypyThreads'] = {}
+        for threadId in cherrypy.tools.status.seenThreads:
+            info = cherrypy.tools.status.seenThreads[threadId].copy()
+            if 'end' in info:
+                info['duration'] = info['end'] - info['start']
+                info['idle'] = time.time() - info['end']
+            status['cherrypyThreads'][threadId] = info
+
+    return status
+
+
+# This class is used to monitor which threads in cherrypy are actively serving
+# responses, and what each was last used for.  It is based on the example at
+# http://tools.cherrypy.org/wiki/StatusTool, but has changes to handle yield-
+# based responses.
+class StatusMonitor(cherrypy.Tool):
+    """Register the status of each thread."""
+
+    def __init__(self):
+        self._point = 'on_start_resource'
+        self._name = 'status'
+        self._priority = 50
+        self.seenThreads = {}
+
+    def callable(self):
+        threadId = threading._get_ident()
+        self.seenThreads[threadId] = {
+            'start': cherrypy.response.time, 'url': cherrypy.url()}
+
+    def unregister(self):
+        """Unregister the current thread."""
+        threadID = threading._get_ident()
+        if threadID in self.seenThreads:
+            self.seenThreads[threadID]['end'] = time.time()
+
+    def _setup(self):
+        cherrypy.Tool._setup(self)
+        cherrypy.request.hooks.attach('on_end_request', self.unregister)
+
+
+cherrypy.tools.status = StatusMonitor()
+cherrypy.config.update({"tools.status.on": True})

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ bcrypt==1.0.2
 boto==2.29.1
 Mako==1.0.0
 requests==2.3.0
+psutil==2.1.3

--- a/tests/cases/system_test.py
+++ b/tests/cases/system_test.py
@@ -248,8 +248,12 @@ class SystemTestCase(base.TestCase):
         resp = self.request(path='/token/session', method='GET')
         self.assertStatusOk(resp)
         token = resp.json['token']
-        # 'basic' mode should work for a token
+        # 'basic' mode should work for a token or for anonymous
         resp = self.request(path='/system/check', token=token)
+        self.assertStatusOk(resp)
+        check = resp.json
+        self.assertLess(check['bootTime'], time.time())
+        resp = self.request(path='/system/check')
         self.assertStatusOk(resp)
         check = resp.json
         self.assertLess(check['bootTime'], time.time())


### PR DESCRIPTION
This adds a GET system/check endpoint to report the overall system status.  This includes showing log locations and how much space is available on the logs' drive(s).  This adds some tracking and reporting of cherrypy threads.

This adds a PUT system/check endpoint to perform a consistancy check.  This checks to make sure all items have valid sizes and valid folderIds.  This should eventually be extended to check other models (see TODO list).

Fixed the plugin enable/disable test (it was expecting toggling one plugin would only affect one plugin, but because plugins can have dependencies, this isn't necessarily true).

Order json output by default.

Convert to using psutil for disk space on filesystem assetstores.  This should make the capacity work more generically (not just on linux).

Increased item test coverage.

This addresses issue #577 and starts to add features for issue #496.