### PR TITLE
Let CORS accept an X-Forwarded-Host.

### DIFF
--- a/tests/cases/routes_test.py
+++ b/tests/cases/routes_test.py
@@ -126,9 +126,18 @@ class RoutesTestCase(base.TestCase):
         # If we specify an origin of ourselves, there should be no change
         self._testOrigin('http://127.0.0.1', {'OPTIONS': 405})
         # If we specify a different origin, simple queries are allowed and
-        # everything should be refused
+        # everything else should be refused
         self._testOrigin('http://kitware.com', {
             'PUT': 403, 'DELETE': 403, 'PATCH': 403, 'OPTIONS': 405})
+        # If we have a X-Forward-Host that contains ourselves, even thouugh
+        # the origin is different, then it should be just like coming from
+        # ourselves
+        self._testOrigin('http://kitware.com', {'OPTIONS': 405},
+                         headers={'X-Forwarded-Host': 'kitware.com'})
+        # But a different X-Forwarded-Host should be like a different origin
+        self._testOrigin('http://kitware.com', {
+            'PUT': 403, 'DELETE': 403, 'PATCH': 403, 'OPTIONS': 405},
+            headers={'X-Forwarded-Host': 'www.kitware.com'})
 
         # Set a single allowed origin
         self.model('setting').set(SettingKey.CORS_ALLOW_ORIGIN,


### PR DESCRIPTION
A common use case is to have girder behind a proxy.  In this case, X-Forwarded-Host is probably set.  If so, and it matches the Origin, then accept the data as from that origin, rather than triggering a cross-origin response.  Added some additional logging to help debug such issues.