### PR TITLE
Alphabetize the plugins on the admin page.

### DIFF
--- a/clients/web/src/templates/body/plugins.jade
+++ b/clients/web/src/templates/body/plugins.jade
@@ -16,7 +16,7 @@ div.g-plugin-restart
         | #{plugin.value.name}
         if (plugin.value.version)
           span.g-plugin-version
-            | Version #{plugin.value.version)
+            | Version #{plugin.value.version}
         if(plugin.value.configRoute)
           a.g-plugin-config-link(g-route="#{plugin.value.configRoute}",
                                  title="Configure Plugin")

--- a/clients/web/src/templates/body/plugins.jade
+++ b/clients/web/src/templates/body/plugins.jade
@@ -8,17 +8,17 @@ div.g-plugin-restart
     | changes to take effect.
   .g-plugin-clear
 .g-plugin-list-container
-  each plugin, key in allPlugins
+  each plugin in allPlugins
     .g-plugin-list-item
-      input.g-plugin-switch(type="checkbox", key="#{key}",
-                            checked=(plugin.enabled ? "checked" : undefined))
+      input.g-plugin-switch(type="checkbox", key="#{plugin.key}",
+                            checked=(plugin.value.enabled ? "checked" : undefined))
       .g-plugin-name
-        | #{plugin.name}
-        if (plugin.version)
+        | #{plugin.value.name}
+        if (plugin.value.version)
           span.g-plugin-version
-            | Version #{plugin.version)
-        if(plugin.configRoute)
-          a.g-plugin-config-link(g-route="#{plugin.configRoute}",
+            | Version #{plugin.value.version)
+        if(plugin.value.configRoute)
+          a.g-plugin-config-link(g-route="#{plugin.value.configRoute}",
                                  title="Configure Plugin")
             i.icon-cog
-      .g-plugin-description #{plugin.description}
+      .g-plugin-description #{plugin.value.description}

--- a/clients/web/src/views/body/PluginsView.js
+++ b/clients/web/src/views/body/PluginsView.js
@@ -83,9 +83,9 @@ girder.views.PluginsView = girder.View.extend({
         /* Sort a dictionary of plugins alphabetically so that the appear in a
          * predictable order to the user.
          *
-         * :param plugins: a dictionary to sort.  Each entry has a .name
+         * @param plugins: a dictionary to sort.  Each entry has a .name
          *                 attribute used for sorting.
-         * :returns sortedPlugins: the sorted list. */
+         * @returns sortedPlugins: the sorted list. */
         var sortedPlugins = [];
         _.each(plugins, function (value, key) {
             sortedPlugins.push({key: key, value: value});

--- a/clients/web/src/views/body/PluginsView.js
+++ b/clients/web/src/views/body/PluginsView.js
@@ -46,7 +46,7 @@ girder.views.PluginsView = girder.View.extend({
         }, this);
 
         this.$el.html(girder.templates.plugins({
-            allPlugins: this.allPlugins
+            allPlugins: this._sortPlugins(this.allPlugins)
         }));
 
         var view = this;
@@ -77,6 +77,23 @@ girder.views.PluginsView = girder.View.extend({
         }
 
         return this;
+    },
+
+    _sortPlugins: function (plugins) {
+        /* Sort a dictionary of plugins alphabetically so that the appear in a
+         * predictable order to the user.
+         *
+         * :param plugins: a dictionary to sort.  Each entry has a .name
+         *                 attribute used for sorting.
+         * :returns sortedPlugins: the sorted list. */
+        var sortedPlugins = [];
+        _.each(plugins, function (value, key) {
+            sortedPlugins.push({key: key, value: value});
+        });
+        sortedPlugins.sort(function (a, b) {
+            return a.value.name.localeCompare(b.value.name);
+        });
+        return sortedPlugins;
     },
 
     _updatePlugins: function () {

--- a/clients/web/test/spec/adminSpec.js
+++ b/clients/web/test/spec/adminSpec.js
@@ -302,7 +302,7 @@ describe('Test the plugins page', function () {
             expect($('.g-plugin-list-item .bootstrap-switch').length > 0).toBe(true);
             expect($('.g-plugin-restart').css('visibility')).toBe('hidden');
             expect($('.g-plugin-list-item input[type=checkbox]:checked').length).toBe(0);
-            $('.g-plugin-list-item .bootstrap-switch-label').eq(0).click();
+            $('.g-plugin-list-item:contains(Metadata extractor) .bootstrap-switch-label').click();
         });
         waitsFor(function () {
             return $('.g-plugin-restart').css('visibility') !== 'hidden';
@@ -342,7 +342,7 @@ describe('Test the plugins page', function () {
     });
     it('Disable a plugin', function () {
         runs(function () {
-            $('.g-plugin-list-item .bootstrap-switch-label').eq(0).click();
+            $('.g-plugin-list-item:contains(Metadata extractor) .bootstrap-switch-label').click();
         });
         runs(function () {
             expect($('.g-plugin-list-item input[type=checkbox]:checked').length).toBe(0);


### PR DESCRIPTION
Plugins were in no consistent order, and they could get shuffled by the addition of an additional plugin.