### PR TITLE
Quota and assetstore policies for users and collections.

### DIFF
--- a/clients/web/src/init.js
+++ b/clients/web/src/init.js
@@ -17,8 +17,10 @@ _.extend(girder, {
     models: {},
     collections: {},
     views: {},
-    apiRoot: $('#g-global-info-apiroot').text(),
-    staticRoot: $('#g-global-info-staticroot').text(),
+    apiRoot: $('#g-global-info-apiroot').text().replace(
+        'TESTURL', 'http://' + window.location.host),
+    staticRoot: $('#g-global-info-staticroot').text().replace(
+        'TESTURL', 'http://' + window.location.host),
     currentUser: null,
     events: _.clone(Backbone.Events),
     uploadHandlers: {},
@@ -89,6 +91,14 @@ _.extend(girder, {
                 } else if (error.status === 0 && error.statusText === 'abort') {
                     /* We expected this abort, so do nothing. */
                     return;
+                } else if (error.status === 500 && error.responseJSON &&
+                           error.responseJSON.type === 'girder') {
+                    info = {
+                        text: error.responseJSON.message,
+                        type: 'warning',
+                        timeout: 5000,
+                        icon: 'info'
+                    };
                 } else {
                     info = {
                         text: 'An error occurred while communicating with the ' +

--- a/clients/web/src/init.js
+++ b/clients/web/src/init.js
@@ -18,9 +18,9 @@ _.extend(girder, {
     collections: {},
     views: {},
     apiRoot: $('#g-global-info-apiroot').text().replace(
-        'TESTURL', 'http://' + window.location.host),
+        '%HOST%', 'http://' + window.location.host),
     staticRoot: $('#g-global-info-staticroot').text().replace(
-        'TESTURL', 'http://' + window.location.host),
+        '%HOST%', 'http://' + window.location.host),
     currentUser: null,
     events: _.clone(Backbone.Events),
     uploadHandlers: {},

--- a/clients/web/src/models/FileModel.js
+++ b/clients/web/src/models/FileModel.js
@@ -84,15 +84,17 @@ girder.models.FileModel = girder.Model.extend({
                 this.trigger('g:upload.complete');
             }
         }, this)).error(_.bind(function (resp) {
-            var text = 'Error: ';
+            var text = 'Error: ', identifier;
 
             if (resp.status === 0) {
                 text += 'Connection to the server interrupted.';
             } else {
                 text += resp.responseJSON.message;
+                identifier = resp.responseJSON.identifier;
             }
             this.trigger('g:upload.errorStarting', {
-                message: text
+                message: text,
+                identifier: identifier
             });
         }, this));
     },
@@ -184,12 +186,13 @@ girder.models.FileModel = girder.Model.extend({
                 }
             },
             error: function (xhr) {
-                var text = 'Error: ';
+                var text = 'Error: ', identifier;
 
                 if (xhr.status === 0) {
                     text += 'Connection to the server interrupted.';
                 } else {
                     text += xhr.responseJSON.message;
+                    identifier = xhr.responseJSON.identifier;
                 }
 
                 model.resumeInfo = {
@@ -198,7 +201,8 @@ girder.models.FileModel = girder.Model.extend({
                 };
 
                 model.trigger('g:upload.error', {
-                    message: text
+                    message: text,
+                    identifier: identifier
                 });
 
             },

--- a/clients/web/src/stylesheets/body/assetstores.styl
+++ b/clients/web/src/stylesheets/body/assetstores.styl
@@ -11,7 +11,7 @@
   margin-top 10px
 
 .g-assetstore-capacity-chart
-  height 180px
+  height 150px
   width 280px
 
 .g-assetstore-container .panel-body
@@ -30,3 +30,6 @@
 
 .g-assetstore-button-container
   display inline-block
+
+.jqplot-data-label
+  color: black

--- a/clients/web/src/utilities/MiscFunctions.js
+++ b/clients/web/src/utilities/MiscFunctions.js
@@ -40,14 +40,17 @@ girder.formatDate = function (datestr, resolution) {
  * prefixes.
  */
 girder.formatSize = function (sizeBytes) {
+    if (sizeBytes < 20000) {
+        return sizeBytes + ' B';
+    }
     var i, sizeVal = sizeBytes, precision = 1;
     for (i = 0; sizeVal >= 1024; i += 1) {
         sizeVal /= 1024;
     }
-    // If we are just reporting bytes, no need for decimal places.
-    if (sizeBytes < 1024) {
-        precision = 0;
-    } else if (sizeVal < 10) {
+    // If we are just reporting a low number, no need for decimal places.
+    if (sizeVal < 10) {
+        precision = 3;
+    } else if (sizeVal < 100) {
         precision = 2;
     }
     return sizeVal.toFixed(precision) + ' ' +

--- a/clients/web/src/utilities/MiscFunctions.js
+++ b/clients/web/src/utilities/MiscFunctions.js
@@ -36,24 +36,22 @@ girder.formatDate = function (datestr, resolution) {
 };
 
 /**
- * Format a size in bytes into a human-readable string with metric unit prefixes.
+ * Format a size in bytes into a human-readable string with metric unit
+ * prefixes.
  */
 girder.formatSize = function (sizeBytes) {
-    // If it's > 1GB, report to two decimal places, otherwise just one.
-    var precision = sizeBytes > 1073741824 ? 2 : 1;
-
+    var i, sizeVal = sizeBytes, precision = 1;
+    for (i = 0; sizeVal >= 1024; i += 1) {
+        sizeVal /= 1024;
+    }
     // If we are just reporting bytes, no need for decimal places.
     if (sizeBytes < 1024) {
         precision = 0;
+    } else if (sizeVal < 10) {
+        precision = 2;
     }
-
-    var i;
-    for (i = 0; sizeBytes >= 1024; i += 1) {
-        sizeBytes /= 1024;
-    }
-
-    return sizeBytes.toFixed(precision) + ' ' +
-        ['B', 'KB', 'MB', 'GB', 'TB'][i];
+    return sizeVal.toFixed(precision) + ' ' +
+        ['B', 'kB', 'MB', 'GB', 'TB'][i];
 };
 
 /**

--- a/clients/web/src/views/body/AssetstoresView.js
+++ b/clients/web/src/views/body/AssetstoresView.js
@@ -64,8 +64,8 @@ girder.views.AssetstoresView = girder.View.extend({
         var assetstore = this.collection.get($(el).attr('cid'));
         var capacity = assetstore.get('capacity');
         var data = [
-            ['Free', capacity.free],
-            ['Used', capacity.total - capacity.free]
+            ['Used', capacity.total - capacity.free],
+            ['Free', capacity.free]
         ];
         var plot = $(el).jqplot([data], {
             seriesDefaults: {
@@ -73,7 +73,9 @@ girder.views.AssetstoresView = girder.View.extend({
                 rendererOptions: {
                     sliceMargin: 2,
                     shadow: false,
-                    highlightMouseOver: false
+                    highlightMouseOver: false,
+                    showDataLabels: true,
+                    padding: 5
                 }
             },
             legend: {
@@ -87,7 +89,8 @@ girder.views.AssetstoresView = girder.View.extend({
                 border: 'none',
                 borderWidth: 0,
                 shadow: false
-            }
+            },
+            gridPadding: {top: 10, right: 10, bottom: 10, left: 10}
         });
     },
 

--- a/clients/web/src/views/body/AssetstoresView.js
+++ b/clients/web/src/views/body/AssetstoresView.js
@@ -63,9 +63,10 @@ girder.views.AssetstoresView = girder.View.extend({
     capacityChart: function (el) {
         var assetstore = this.collection.get($(el).attr('cid'));
         var capacity = assetstore.get('capacity');
+        var used = capacity.total - capacity.free;
         var data = [
-            ['Used', capacity.total - capacity.free],
-            ['Free', capacity.free]
+            ['Used (' + girder.formatSize(used) + ')', used],
+            ['Free (' + girder.formatSize(capacity.free) + ')', capacity.free]
         ];
         var plot = $(el).jqplot([data], {
             seriesDefaults: {
@@ -75,7 +76,8 @@ girder.views.AssetstoresView = girder.View.extend({
                     shadow: false,
                     highlightMouseOver: false,
                     showDataLabels: true,
-                    padding: 5
+                    padding: 5,
+                    startAngle: 180
                 }
             },
             legend: {

--- a/clients/web/src/views/body/CollectionView.js
+++ b/clients/web/src/views/body/CollectionView.js
@@ -160,7 +160,8 @@
         _fetchAndInit(collectionId, {
             access: params.dialog === 'access',
             edit: params.dialog === 'edit',
-            folderCreate: params.dialog === 'foldercreate'
+            folderCreate: params.dialog === 'foldercreate',
+            dialog: params.dialog
         });
     });
 

--- a/clients/web/src/views/body/UserView.js
+++ b/clients/web/src/views/body/UserView.js
@@ -114,7 +114,8 @@
 
     girder.router.route('user/:id', 'user', function (userId, params) {
         _fetchAndInit(userId, {
-            folderCreate: params.dialog === 'foldercreate'
+            folderCreate: params.dialog === 'foldercreate',
+            dialog: params.dialog
         });
     });
 

--- a/clients/web/src/views/widgets/EditCollectionWidget.js
+++ b/clients/web/src/views/widgets/EditCollectionWidget.js
@@ -65,7 +65,7 @@ girder.views.EditCollectionWidget = girder.View.extend({
         collection.on('g:saved', function () {
             this.$el.modal('hide');
             this.trigger('g:saved', collection);
-        }, this).on('g:error', function (err) {
+        }, this).off('g:error').on('g:error', function (err) {
             this.$('.g-validation-failed-message').text(err.responseJSON.message);
             this.$('button.g-save-collection').removeClass('disabled');
             this.$('#g-' + err.responseJSON.field).focus();
@@ -77,7 +77,7 @@ girder.views.EditCollectionWidget = girder.View.extend({
         this.model.on('g:saved', function () {
             this.$el.modal('hide');
             this.trigger('g:saved', this.model);
-        }, this).on('g:error', function (err) {
+        }, this).off('g:error').on('g:error', function (err) {
             this.$('.g-validation-failed-message').text(err.responseJSON.message);
             this.$('button.g-save-collection').removeClass('disabled');
             this.$('#g-' + err.responseJSON.field).focus();

--- a/clients/web/test/spec/adminSpec.js
+++ b/clients/web/test/spec/adminSpec.js
@@ -265,11 +265,13 @@ describe('Test the assetstore page', function () {
                     {'g-new-gridfs-name': 'name',
                      'g-new-gridfs-db': 'girder_webclient_gridfs'});
 
+    /* The specified assetstore should NOT exist, and the specified mongohost
+     * should NOT be present (nothing should respond on those ports). */
     _testAssetstore('gridfs', 'g-create-gridfs-tab',
                     {'g-new-gridfs-name': 'name',
                      'g-new-gridfs-db': 'girder_webclient_gridfsrs',
-                     'g-new-gridfs-mongohost': 'mongodb://127.0.0.1:27070,'+
-                        '127.0.0.1:27071,127.0.0.1:27072',
+                     'g-new-gridfs-mongohost': 'mongodb://127.0.0.2:27080,'+
+                        '127.0.0.2:27081,127.0.0.2:27082',
                      'g-new-gridfs-replicaset': 'replicaset'});
 
     _testAssetstore('s3', 'g-create-s3-tab',

--- a/clients/web/test/spec/adminSpec.js
+++ b/clients/web/test/spec/adminSpec.js
@@ -70,7 +70,7 @@ describe('Test the settings page', function () {
 
     it('Settings should display their expected values', function () {
         expect($('#g-core-cookie-lifetime').val()).toBe('');
-        expect($('#g-core-smtp-host').val()).toMatch(/^localhost:500/);
+        expect($('#g-core-smtp-host').val()).toMatch(/^localhost:5/);
         expect($('#g-core-email-from-address').val()).toBe('');
         expect($('#g-core-registration-policy').val()).toBe('open');
         expect($('#g-core-upload-minimum-chunk-size').val()).toBe('');

--- a/clients/web/test/spec/dataSpec.js
+++ b/clients/web/test/spec/dataSpec.js
@@ -5,144 +5,16 @@
  * wrapping XHR.prototype.send.
  */
 
-var uploadData;
-/* used for resume testing */
-var uploadDataExtra = 0;
 /* used for adjusting minimum upload size */
 var minUploadSize;
 
-(function (impl) {
-    FormData.prototype.append = function (name, value, filename) {
-        this.vals = this.vals || {};
-        if (filename)
-            this.vals[name+'_filename'] = value;
-        this.vals[name] = value;
-        impl.call(this, name, value, filename);
-    };
-} (FormData.prototype.append));
 
-(function (impl) {
-    XMLHttpRequest.prototype.send = function (data) {
-        if (data && data instanceof FormData) {
-            var newdata = new FormData();
-            newdata.append('offset', data.vals.offset);
-            newdata.append('uploadId', data.vals.uploadId);
-            var len = data.vals.chunk.size;
-            /* Note that this appears to fail if uploadData contains certain
-             * characters, such as LF. */
-            if (uploadData.length && uploadData.length==len &&
-                    !uploadDataExtra)
-                newdata.append('chunk', uploadData);
-            else
-                newdata.append('chunk',
-                                new Array(len+1+uploadDataExtra).join('-'));
-            data = newdata;
-        }
-        else if (data && data instanceof Blob) {
-            if (uploadDataExtra)
-            {
-                /* Our mock S3 server will take extra data, so break it by
-                 * adding a faulty copy header.  This will throw an error so we
-                 * can test resumes. */
-                this.setRequestHeader('x-amz-copy-source', 'bad_value');
-            }
-            if (uploadData.length && uploadData.length==data.size &&
-                    !uploadDataExtra)
-                data = uploadData;
-            else
-                data = new Array(data.size+1+uploadDataExtra).join('-');
-        }
-        impl.call(this, data);
-    };
-} (XMLHttpRequest.prototype.send));
-
-function _testUpload(uploadItem, needResume)
-/* Upload a file and make sure it lands properly.
- * :param uploadItem: either the path to the file to upload or an integer to
- *                    create and upload a temporary file of that size.
- * :param needResume: if true, upload a partial file so that we are asked if we
- *                    want to resume, then resume.  If 'abort', then abort the
- *                    upload instead of resuming it.
- */
-{
-    var orig_len;
-
-    waitsFor(function () {
-        return $('.g-upload-here-button').length > 0;
-    }, 'the upload here button to appear');
-
-    runs(function () {
-        orig_len = $('.g-item-list-entry').length;
-        $('.g-upload-here-button').click();
-    });
-
-    waitsFor(function () {
-        return $('.g-drop-zone:visible').length > 0 &&
-               $('.modal-dialog:visible').length > 0;
-    }, 'the upload dialog to appear');
-
-    runs(function () {
-        if (needResume)
-            uploadDataExtra = 1024 * 20;
-        else
-            uploadDataExtra = 0;
-
-        // Incantation that causes the phantom environment to send us a File.
-        $('#g-files').parent().removeClass('hide');
-        var params = {action: 'uploadFile', selector: '#g-files'};
-        if (uploadItem === parseInt(uploadItem))
-        {
-            params.size = uploadItem;
-        }
-        else
-        {
-            params.path = uploadItem;
-        }
-        uploadData = window.callPhantom(params);
-    });
-
-    waitsFor(function () {
-        return $('.g-overall-progress-message i.icon-ok').length > 0;
-    }, 'the file to be received');
-
-    runs(function () {
-        $('#g-files').parent().addClass('hide');
-        $('.g-start-upload').click();
-    });
-
-    if (needResume)
-    {
-        waitsFor(function () {
-            return $('.g-resume-upload:visible').length > 0;
-        }, 'the resume link to appear');
-        runs(function () {
-            uploadDataExtra = 0;
-
-            if (needResume == 'abort') {
-                $('.btn-default').click();
-                orig_len -= 1;
-            } else {
-                $('.g-resume-upload').click();
-            }
-        });
-    }
-
-    waitsFor(function () {
-        return $('.modal-content:visible').length === 0 &&
-               $('.g-item-list-entry').length === orig_len+1;
-    }, 'the upload to finish');
-    girderTest.waitForLoad();
-
-    window.callPhantom({action: 'uploadCleanup'});
-}
-
-function _setMinimumChunkSize(minSize)
 /* Set the minimum chunk size in the server settings, the upload handler, and
  *  the S3 asset store handler.
  * :param minSize: the new minimum size.  If null, revert to the original
  *                 minimums.
  */
-{
+function _setMinimumChunkSize(minSize) {
     if (!minUploadSize)
     {
         minUploadSize = {UPLOAD_CHUNK_SIZE: girder.UPLOAD_CHUNK_SIZE};
@@ -281,7 +153,7 @@ describe('Create a data hierarchy', function () {
     });
 
     it('upload a file into the current folder', function () {
-        _testUpload('clients/web/test/testFile.txt');
+        girderTest.testUpload('clients/web/test/testFile.txt');
     });
 
     it('download the file', function () {
@@ -348,19 +220,19 @@ describe('Create a data hierarchy', function () {
             return $('.g-loading-block').length == 0;
         }, 'for all blocks to load');
 
-        _testUpload('clients/web/test/testFile2');
+        girderTest.testUpload('clients/web/test/testFile2');
     });
 
     it('upload another file by size', function () {
-        _testUpload(11);
+        girderTest.testUpload(11);
     });
 
     it('upload requiring resume', function () {
-        _testUpload(1024 * 32, true);
+        girderTest.testUpload(1024 * 32, true);
     });
 
     it('upload requiring resume that is aborted', function () {
-        _testUpload(1024 * 32, 'abort');
+        girderTest.testUpload(1024 * 32, 'abort');
     });
 
     it('upload a large file', function () {
@@ -372,11 +244,11 @@ describe('Create a data hierarchy', function () {
          * this test will fail unless phantomjs is run with
          * --web-security=false */
         _setMinimumChunkSize(1024 * 256);
-        _testUpload(1024 * 513);
+        girderTest.testUpload(1024 * 513);
     });
     it('upload a large file requiring resume', function () {
         _setMinimumChunkSize(1024 * 256);
-        _testUpload(1024 * 513, true);
+        girderTest.testUpload(1024 * 513, true);
     });
 
     it('download a folder', function () {

--- a/clients/web/test/spec/dataSpec.js
+++ b/clients/web/test/spec/dataSpec.js
@@ -503,6 +503,10 @@ describe('Create a data hierarchy', function () {
         waitsFor(function () {
             return $('.g-list-checkbox').length == 0;
         }, 'items to be deleted');
+        runs(function () {
+            window.callPhantom({action: 'uploadCleanup',
+                                suffix: girderTest._uploadSuffix});
+        });
     });
     /* Create a second user so that we can test move/copy permissions */
     it('logout from first account', girderTest.logout('logout from first account'));

--- a/clients/web/test/spec/routingSpec.js
+++ b/clients/web/test/spec/routingSpec.js
@@ -28,34 +28,6 @@ function _getFirstId(collection, ids, key, fetchParamsFunc)
     });
 }
 
-function _testRoute(route, hasDialog, testFunc)
-/* Test going to a particular route, waiting for the dialog or page to load
- *  fully, and then testing that we have what we expect.
- * Enter: route: the hash url fragment to go to.
- *        hasDialog: true if we should wait for a dialog to appear.
- *        testFunc: a function with an expect call to validate the route.  If
- *                  this is not specified, jut navigate to the specified route.
- */
-{
-    runs(function() {
-        window.location.hash = route;
-    });
-    /* We need to let the window have a chance to reload, so we just release
-     * our time slice. */
-    waits(1);
-    if (hasDialog) {
-        girderTest.waitForDialog('route: '+route);
-    } else {
-        girderTest.waitForLoad('route: '+route);
-    }
-    if (testFunc) {
-        waitsFor(testFunc, 'route: '+route);
-        runs(function () {
-            expect(testFunc()).toBe(true);
-        });
-    }
-}
-
 describe('Test routing paths', function () {
     var ids = {};
 
@@ -152,251 +124,255 @@ describe('Test routing paths', function () {
     /* Now test various routes */
     it('logout', girderTest.logout());
     it('test routes without being logged in', function () {
-        _testRoute('', false, function () {
+        girderTest.testRoute('', false, function () {
             return $('a.g-login-link:first').text() === ' Log In';
         });
-        _testRoute('useraccount/'+ids.admin+'/info', false, function () {
+        girderTest.testRoute('useraccount/'+ids.admin+'/info', false,
+                             function () {
             return window.location.hash === '#users';
         });
-        _testRoute('useraccount/'+ids.admin+'/password', false, function () {
+        girderTest.testRoute('useraccount/'+ids.admin+'/password', false,
+                             function () {
             return window.location.hash === '#users';
         });
-        _testRoute('?dialog=login', true, function () {
+        girderTest.testRoute('?dialog=login', true, function () {
             return $('label[for=g-login]').text() === 'Login or email';
         });
-        _testRoute('?dialog=register', true, function () {
+        girderTest.testRoute('?dialog=register', true, function () {
             return $('input#g-password2').length === 1;
         });
-        _testRoute('?dialog=resetpassword', true, function () {
+        girderTest.testRoute('?dialog=resetpassword', true, function () {
             return $('.modal-title').text() === 'Reset password';
         });
         /* Navigate to a non-dialog so we can log in */
-        _testRoute('collections', false, function () {
+        girderTest.testRoute('collections', false, function () {
             return $('.g-collection-title:first').text() === 'Test Collection';
         });
     });
 
     it('login', girderTest.login('admin', 'Admin', 'Admin', 'adminpassword!'));
     it('test routes while logged in', function () {
-        _testRoute('', false, function () {
+        girderTest.testRoute('', false, function () {
             return $('a.g-my-folders-link:first').text() ===
                    ' personal data space';
         });
-        _testRoute('useraccount/'+ids.admin+'/info', false, function () {
+        girderTest.testRoute('useraccount/'+ids.admin+'/info', false,
+                             function () {
             return $('input#g-email').val() === 'admin@email.com';
         });
-        _testRoute('useraccount/'+ids.admin+'/password', false, function () {
+        girderTest.testRoute('useraccount/'+ids.admin+'/password', false,
+                             function () {
             return $('input#g-password-old:visible').length === 1;
         });
-        _testRoute('?dialog=login', false, function () {
+        girderTest.testRoute('?dialog=login', false, function () {
             return $('a.g-my-folders-link:first').text() ===
                    ' personal data space';
         });
-        _testRoute('?dialog=register', false, function () {
+        girderTest.testRoute('?dialog=register', false, function () {
             return $('a.g-my-folders-link:first').text() ===
                    ' personal data space';
         });
-        _testRoute('?dialog=resetpassword', false, function () {
+        girderTest.testRoute('?dialog=resetpassword', false, function () {
             return $('a.g-my-folders-link:first').text() ===
                    ' personal data space';
         });
     });
 
     it('test collection routes', function () {
-        _testRoute('collections', false, function () {
+        girderTest.testRoute('collections', false, function () {
             return $('.g-collection-title:first').text() === 'Test Collection';
         });
-        _testRoute('collections?dialog=create', true, function () {
+        girderTest.testRoute('collections?dialog=create', true, function () {
             return $('input#g-name').attr('placeholder') ===
                    'Enter collection name';
         });
 
         var collPath = 'collection/'+ids.collection;
-        _testRoute(collPath, false, function () {
+        girderTest.testRoute(collPath, false, function () {
             return $('.g-collection-actions-menu').length === 1;
         });
-        _testRoute(collPath+'?dialog=edit', true,
+        girderTest.testRoute(collPath+'?dialog=edit', true,
                    function () {
             return $('.modal-title').text() === 'Edit collection';
         });
-        _testRoute(collPath+'?dialog=access', true,
+        girderTest.testRoute(collPath+'?dialog=access', true,
                    function () {
             return $('.g-dialog-subtitle').text() === 'Test Collection';
         });
-        _testRoute(collPath+'?dialog=foldercreate', true,
+        girderTest.testRoute(collPath+'?dialog=foldercreate', true,
                    function () {
             return $('.modal-title').text() === 'Create folder';
         });
 
         var collFolderPath = collPath+'/folder/'+ids.collectionFolder;
-        _testRoute(collFolderPath, false, function () {
+        girderTest.testRoute(collFolderPath, false, function () {
             return $('.g-collection-actions-menu').length === 1 &&
                    $('.g-folder-access-button').length === 1;
         });
-        _testRoute(collFolderPath+'?dialog=edit', true,
+        girderTest.testRoute(collFolderPath+'?dialog=edit', true,
                    function () {
             return $('.modal-title').text() === 'Edit collection';
         });
-        _testRoute(collFolderPath+'?dialog=access', true,
+        girderTest.testRoute(collFolderPath+'?dialog=access', true,
                    function () {
             return $('.g-dialog-subtitle').text() === 'Test Collection';
         });
-        _testRoute(collFolderPath+'?dialog=foldercreate', true,
+        girderTest.testRoute(collFolderPath+'?dialog=foldercreate', true,
                    function () {
             return $('.modal-title').text() === 'Create folder';
         });
-        _testRoute(collFolderPath+'?dialog=folderedit', true,
+        girderTest.testRoute(collFolderPath+'?dialog=folderedit', true,
                    function () {
             return $('.modal-title').text() === 'Edit folder' &&
                    $('input#g-name').val() === 'Private';
         });
-        _testRoute(collFolderPath+'?dialog=folderaccess', true,
+        girderTest.testRoute(collFolderPath+'?dialog=folderaccess', true,
                    function () {
             return $('.g-dialog-subtitle').text() === 'Private';
         });
-        _testRoute(collFolderPath+'?dialog=itemcreate', true,
+        girderTest.testRoute(collFolderPath+'?dialog=itemcreate', true,
                    function () {
             return $('.modal-title').text() === 'Create item';
         });
-        _testRoute(collFolderPath+'?dialog=upload', true,
+        girderTest.testRoute(collFolderPath+'?dialog=upload', true,
                    function () {
             return $('.modal-title').text() === 'Upload files';
         });
     });
 
     it('test user routes', function () {
-        _testRoute('users', false, function () {
+        girderTest.testRoute('users', false, function () {
             return $('.g-user-link:first').text() === 'Admin Admin';
         });
 
         var userPath = 'user/'+ids.admin;
-        _testRoute(userPath, false, function () {
+        girderTest.testRoute(userPath, false, function () {
             return $('.g-user-actions-button').length === 1;
         });
-        _testRoute(userPath+'?dialog=foldercreate', true,
+        girderTest.testRoute(userPath+'?dialog=foldercreate', true,
                    function () {
             return $('.modal-title').text() === 'Create folder';
         });
 
         var userFolderPath = userPath+'/folder/'+ids.userFolder;
-        _testRoute(userFolderPath, false, function () {
+        girderTest.testRoute(userFolderPath, false, function () {
             return $('.g-user-actions-button').length === 1 &&
                    $('.g-folder-access-button').length === 1;
         });
-        _testRoute(userFolderPath+'?dialog=foldercreate', true,
+        girderTest.testRoute(userFolderPath+'?dialog=foldercreate', true,
                    function () {
             return $('.modal-title').text() === 'Create folder';
         });
-        _testRoute(userFolderPath+'?dialog=folderedit', true,
+        girderTest.testRoute(userFolderPath+'?dialog=folderedit', true,
                    function () {
             return $('.modal-title').text() === 'Edit folder' &&
                    $('input#g-name').val() === 'Private';
         });
-        _testRoute(userFolderPath+'?dialog=folderaccess', true,
+        girderTest.testRoute(userFolderPath+'?dialog=folderaccess', true,
                    function () {
             return $('.g-dialog-subtitle').text() === 'Private';
         });
-        _testRoute(userFolderPath+'?dialog=itemcreate', true,
+        girderTest.testRoute(userFolderPath+'?dialog=itemcreate', true,
                    function () {
             return $('.modal-title').text() === 'Create item';
         });
-        _testRoute(userFolderPath+'?dialog=upload', true,
+        girderTest.testRoute(userFolderPath+'?dialog=upload', true,
                    function () {
             return $('.modal-title').text() === 'Upload files';
         });
 
         var folderPath = 'folder/'+ids.userFolder;
-        _testRoute(folderPath, false, function () {
+        girderTest.testRoute(folderPath, false, function () {
             return $('.g-user-actions-button').length === 0 &&
                    $('.g-folder-access-button').length === 1;
         });
-        _testRoute(folderPath+'?dialog=foldercreate', true,
+        girderTest.testRoute(folderPath+'?dialog=foldercreate', true,
                    function () {
             return $('.modal-title').text() === 'Create folder';
         });
-        _testRoute(folderPath+'?dialog=folderedit', true,
+        girderTest.testRoute(folderPath+'?dialog=folderedit', true,
                    function () {
             return $('.modal-title').text() === 'Edit folder' &&
                    $('input#g-name').val() === 'Private';
         });
-        _testRoute(folderPath+'?dialog=folderaccess', true,
+        girderTest.testRoute(folderPath+'?dialog=folderaccess', true,
                    function () {
             return $('.g-dialog-subtitle').text() === 'Private';
         });
-        _testRoute(folderPath+'?dialog=itemcreate', true,
+        girderTest.testRoute(folderPath+'?dialog=itemcreate', true,
                    function () {
             return $('.modal-title').text() === 'Create item';
         });
-        _testRoute(folderPath+'?dialog=upload', true,
+        girderTest.testRoute(folderPath+'?dialog=upload', true,
                    function () {
             return $('.modal-title').text() === 'Upload files';
         });
     });
 
     it('test group routes', function () {
-        _testRoute('groups', false, function () {
+        girderTest.testRoute('groups', false, function () {
             return $('.g-group-link:first').text() === 'Public Group';
         });
-        _testRoute('groups?dialog=create', true, function () {
+        girderTest.testRoute('groups?dialog=create', true, function () {
             return $('input#g-name').attr('placeholder') ===
                    'Enter group name';
         });
 
         var groupPath = 'group/'+ids.group;
-        _testRoute(groupPath+'/roles', false, function () {
+        girderTest.testRoute(groupPath+'/roles', false, function () {
             return $('.g-member-name:visible').length === 2 &&
                    $('#g-group-tab-roles .g-member-list-empty:visible')
                    .length === 1 &&
                    $('.g-member-list-empty:hidden').length === 2;
         });
-        _testRoute(groupPath+'/pending', false, function () {
+        girderTest.testRoute(groupPath+'/pending', false, function () {
             return $('.g-group-requests-container:visible').length === 1 &&
                    $('#g-group-tab-pending .g-member-list-empty:visible')
                    .length === 2 &&
                    $('.g-member-list-empty:hidden').length === 1;
         });
-        _testRoute(groupPath+'?dialog=edit', true, function () {
+        girderTest.testRoute(groupPath+'?dialog=edit', true, function () {
             return $('.modal-title').text() === 'Edit group';
         });
     });
 
     it('test item routes', function () {
         var itemPath = 'item/'+ids.item;
-        _testRoute(itemPath, false, function () {
+        girderTest.testRoute(itemPath, false, function () {
             return $('.g-item-header .g-item-name').text() == 'Link File';
         });
-        _testRoute(itemPath+'?dialog=itemedit', true, function () {
+        girderTest.testRoute(itemPath+'?dialog=itemedit', true, function () {
             return $('.modal-title').text() === 'Edit item';
         });
-        _testRoute(itemPath+'?dialog=fileedit&dialogid='+ids.file, true,
-                   function () {
+        girderTest.testRoute(itemPath+'?dialog=fileedit&dialogid='+ids.file,
+                             true, function () {
             return $('.modal-title').text() === 'Edit file';
         });
-        _testRoute(itemPath+'?dialog=upload&dialogid='+ids.file, true,
-                   function () {
+        girderTest.testRoute(itemPath+'?dialog=upload&dialogid='+ids.file,
+                             true, function () {
             return $('.modal-title').text() === 'Replace file contents';
         });
-        _testRoute(itemPath+'?dialog=fileedit&dialogid='+ids.file, true,
-                   function () {
+        girderTest.testRoute(itemPath+'?dialog=fileedit&dialogid='+ids.file,
+                             true, function () {
             return $('.modal-title').text() === 'Edit file';
         });
     });
 
     it('test admin routes', function () {
-        _testRoute('admin', false, function () {
+        girderTest.testRoute('admin', false, function () {
             return $('.g-server-config').length === 1;
         });
-        _testRoute('settings', false, function () {
+        girderTest.testRoute('settings', false, function () {
             return $('input#g-core-cookie-lifetime').length === 1;
         });
-        _testRoute('plugins', false, function () {
+        girderTest.testRoute('plugins', false, function () {
             return $('.g-body-title').text() === 'Plugins';
         });
-        _testRoute('assetstores', false, function () {
+        girderTest.testRoute('assetstores', false, function () {
             return $('.g-assetstore-container').length === 1;
         });
-        _testRoute('assetstores?dialog=assetstoreedit&dialogid='+ids.assetstore,
-                    true, function () {
+        girderTest.testRoute('assetstores?dialog=assetstoreedit&dialogid=' +
+                             ids.assetstore, true, function () {
             return $('.modal-title').text() === 'Edit assetstore';
         });
     });

--- a/clients/web/test/specRunner.js
+++ b/clients/web/test/specRunner.js
@@ -92,7 +92,11 @@ page.onCallback = function (data) {
      * :param data: an object with an 'action', as listed above.
      * :returns: depends on the action.
      */
-    var uploadTemp = fs.workingDirectory + fs.separator + 'phantom_upload.tmp';
+    var uploadTemp = fs.workingDirectory + fs.separator + 'phantom_upload';
+    if (data.suffix) {
+        uploadTemp += '_' + data.suffix;
+    }
+    uploadTemp += '.tmp';
     switch (data.action)
     {
         case 'uploadFile':

--- a/clients/web/test/testEnv.jadehtml
+++ b/clients/web/test/testEnv.jadehtml
@@ -31,5 +31,5 @@ html(lang="en")
       })();
 
   body
-    #g-global-info-apiroot.hide http://localhost:50001#{apiRoot}
-    #g-global-info-staticroot.hide http://localhost:50001#{staticRoot}
+    #g-global-info-apiroot.hide TESTURL#{apiRoot}
+    #g-global-info-staticroot.hide TESTURL#{staticRoot}

--- a/clients/web/test/testEnv.jadehtml
+++ b/clients/web/test/testEnv.jadehtml
@@ -31,5 +31,5 @@ html(lang="en")
       })();
 
   body
-    #g-global-info-apiroot.hide TESTURL#{apiRoot}
-    #g-global-info-staticroot.hide TESTURL#{staticRoot}
+    #g-global-info-apiroot.hide %HOST%#{apiRoot}
+    #g-global-info-staticroot.hide %HOST%#{staticRoot}

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -588,6 +588,11 @@ function _prepareTestUpload() {
     girderTest._uploadData = null;
     /* used for resume testing */
     girderTest._uploadDataExtra = 0;
+    girderTest._uploadSuffix = '';
+    var hostport = window.location.host.match(':([0-9]+)');
+    if (hostport && hostport.length === 2) {
+        girderTest._uploadSuffix = hostport[1];
+    }
 
     (function (impl) {
         FormData.prototype.append = function (name, value, filename) {
@@ -678,7 +683,8 @@ girderTest.testUpload = function (uploadItem, needResume, error) {
 
         // Incantation that causes the phantom environment to send us a File.
         $('#g-files').parent().removeClass('hide');
-        var params = {action: 'uploadFile', selector: '#g-files'};
+        var params = {action: 'uploadFile', selector: '#g-files',
+                      suffix: girderTest._uploadSuffix};
         if (uploadItem === parseInt(uploadItem)) {
             params.size = uploadItem;
         } else {
@@ -723,5 +729,6 @@ girderTest.testUpload = function (uploadItem, needResume, error) {
     }, 'the upload to finish');
     girderTest.waitForLoad();
 
-    window.callPhantom({action: 'uploadCleanup'});
+    window.callPhantom({action: 'uploadCleanup',
+                        suffix: girderTest._uploadSuffix});
 };

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -181,7 +181,6 @@ girderTest.createCollection = function (collName, collDesc) {
             $('#g-description').val(collDesc);
             $('.g-save-collection').click();
         });
-
         waitsFor(function () {
             return $('.g-collection-name').text() === collName &&
                    $('.g-collection-description').text() === collDesc;
@@ -472,7 +471,6 @@ girderTest.waitForDialog = function (desc) {
  * tests.
  */
 girderTest.addCoveredScript = function (url) {
-    $('<script/>', {src: url}).appendTo('head');
     blanket.utils.cache[url] = {};
     blanket.utils.attachScript({url:url}, function (content) {
         blanket.instrument({inputFile: content, inputFileName: url},
@@ -482,7 +480,7 @@ girderTest.addCoveredScript = function (url) {
             blanket.requiringFile(url, true);
         });
    });
-}
+};
 
 /**
  * For the current folder, check if it is public or private and take an action.
@@ -546,4 +544,184 @@ girderTest.folderAccessControl = function (current, action) {
     waitsFor(function () {
         return !$('#g-dialog-container').hasClass('in');
     }, 'access dialog to be hidden');
+};
+
+girderTest.testRoute = function (route, hasDialog, testFunc)
+/* Test going to a particular route, waiting for the dialog or page to load
+ *  fully, and then testing that we have what we expect.
+ * Enter: route: the hash url fragment to go to.
+ *        hasDialog: true if we should wait for a dialog to appear.
+ *        testFunc: a function with an expect call to validate the route.  If
+ *                  this is not specified, just navigate to the specified
+ *                  route.
+ */
+{
+    runs(function() {
+        if (route.indexOf('#') === 0) {
+            route = route.substr(1);
+        }
+        window.location.hash = route;
+    });
+    /* We need to let the window have a chance to reload, so we just release
+     * our time slice. */
+    waits(1);
+    if (hasDialog) {
+        girderTest.waitForDialog('route: '+route);
+    } else {
+        girderTest.waitForLoad('route: '+route);
+    }
+    if (testFunc) {
+        waitsFor(testFunc, 'route: '+route);
+        runs(function () {
+            expect(testFunc()).toBe(true);
+        });
+    }
+};
+
+/* Upload tests require that we modify how xmlhttp requests are handled.  Check
+ * that this has been done (but only do it once).
+ */
+function _prepareTestUpload() {
+    if (girderTest._preparedTestUpload) {
+        return;
+    }
+    girderTest._uploadData = null;
+    /* used for resume testing */
+    girderTest._uploadDataExtra = 0;
+
+    (function (impl) {
+        FormData.prototype.append = function (name, value, filename) {
+            this.vals = this.vals || {};
+            if (filename)
+                this.vals[name+'_filename'] = value;
+            this.vals[name] = value;
+            impl.call(this, name, value, filename);
+        };
+    } (FormData.prototype.append));
+
+    (function (impl) {
+        XMLHttpRequest.prototype.send = function (data) {
+            if (data && data instanceof FormData) {
+                var newdata = new FormData();
+                newdata.append('offset', data.vals.offset);
+                newdata.append('uploadId', data.vals.uploadId);
+                var len = data.vals.chunk.size;
+                /* Note that this appears to fail if _uploadData contains
+                 * certain characters, such as LF. */
+                if (girderTest._uploadData.length &&
+                        girderTest._uploadData.length==len &&
+                        !girderTest._uploadDataExtra) {
+                    newdata.append('chunk', girderTest._uploadData);
+                } else {
+                    newdata.append('chunk', new Array(
+                        len + 1 + girderTest._uploadDataExtra).join('-'));
+                }
+                data = newdata;
+            }
+            else if (data && data instanceof Blob) {
+                if (girderTest._uploadDataExtra) {
+                    /* Our mock S3 server will take extra data, so break it
+                     * by adding a faulty copy header.  This will throw an
+                     * error so we can test resumes. */
+                    this.setRequestHeader('x-amz-copy-source', 'bad_value');
+                }
+                if (girderTest._uploadData.length &&
+                        girderTest._uploadData.length==data.size &&
+                        !girderTest._uploadDataExtra) {
+                    data = girderTest._uploadData;
+                } else {
+                    data = new Array(
+                        data.size + 1 + girderTest._uploadDataExtra
+                        ).join('-');
+                }
+            }
+            impl.call(this, data);
+        };
+    } (XMLHttpRequest.prototype.send));
+
+    girderTest._preparedTestUpload = true;
 }
+
+/* Upload a file and make sure it lands properly.
+ * @param uploadItem: either the path to the file to upload or an integer to
+ *                    create and upload a temporary file of that size.
+ * @param needResume: if true, upload a partial file so that we are asked if we
+ *                    want to resume, then resume.  If 'abort', then abort the
+ *                    upload instead of resuming it.
+ * @param error: if present and the needResume is set, then we expect the
+ *               upload to fail with an error that includes this string.
+ */
+girderTest.testUpload = function (uploadItem, needResume, error) {
+    var orig_len;
+
+    _prepareTestUpload()
+
+    waitsFor(function () {
+        return $('.g-upload-here-button').length > 0;
+    }, 'the upload here button to appear');
+
+    runs(function () {
+        orig_len = $('.g-item-list-entry').length;
+        $('.g-upload-here-button').click();
+    });
+
+    waitsFor(function () {
+        return $('.g-drop-zone:visible').length > 0 &&
+               $('.modal-dialog:visible').length > 0;
+    }, 'the upload dialog to appear');
+
+    runs(function () {
+        if (needResume)
+            girderTest._uploadDataExtra = 1024 * 20;
+        else
+            girderTest._uploadDataExtra = 0;
+
+        // Incantation that causes the phantom environment to send us a File.
+        $('#g-files').parent().removeClass('hide');
+        var params = {action: 'uploadFile', selector: '#g-files'};
+        if (uploadItem === parseInt(uploadItem)) {
+            params.size = uploadItem;
+        } else {
+            params.path = uploadItem;
+        }
+        girderTest._uploadData = window.callPhantom(params);
+    });
+
+    waitsFor(function () {
+        return $('.g-overall-progress-message i.icon-ok').length > 0;
+    }, 'the file to be received');
+
+    runs(function () {
+        $('#g-files').parent().addClass('hide');
+        $('.g-start-upload').click();
+    });
+
+    if (needResume) {
+        waitsFor(function () {
+            return $('.g-resume-upload:visible').length > 0 ||
+                   $('.g-restart-upload:visible').length > 0;
+        }, 'the resume link to appear');
+        runs(function () {
+            if (error) {
+                expect($('.g-upload-error-message').text().indexOf(
+                    error) >= 0).toBe(true);
+            }
+            girderTest._uploadDataExtra = 0;
+
+            if (needResume == 'abort') {
+                $('.btn-default').click();
+                orig_len -= 1;
+            } else {
+                $('.g-resume-upload').click();
+            }
+        });
+    }
+
+    waitsFor(function () {
+        return $('.modal-content:visible').length === 0 &&
+               $('.g-item-list-entry').length === orig_len+1;
+    }, 'the upload to finish');
+    girderTest.waitForLoad();
+
+    window.callPhantom({action: 'uploadCleanup'});
+};

--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -287,6 +287,23 @@ successfully authenticate the user, it should perform the logic it needs and
 then ``preventDefault`` on the event and ``addResponse`` containing the
 authenticated user document.
 
+*  **Before file upload**
+
+This event is triggered as an upload is being initialized.  The event
+``model.upload.assetstore`` is sent before the ``model.upload.save`` event.
+The event information is a dictionary containing ``model`` and ``resource``
+with the resource model type and resource document of the upload parent.  For
+new uploads, the model type will be either ``item`` or ``folder``.  When the
+contents of a file are being replaced, this will be a ``file``.  To change from
+the current assetstore, add an ``assetstore`` key to the event information
+dictionary that contains an assetstore model document.
+
+*  **Just before a file upload completes**
+
+The event ``model.upload.finalize`` after the upload is completed but before
+the new file is saved.  This can be used if the file needs to be altered or the
+upload should be cancelled at the last moment.
+
 *  **On file upload**
 
 This event is always triggered asynchronously and is fired after a file has

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -23,7 +23,7 @@ import errno
 from ..describe import Description
 from ..rest import Resource, RestException, loadmodel
 from ...constants import AccessType
-from girder.models.model_base import AccessException
+from girder.models.model_base import AccessException, GirderException
 from girder.api import access
 
 
@@ -77,7 +77,9 @@ class File(Resource):
                     parent=parent, size=int(params['size']), mimeType=mimeType)
             except OSError as exc:
                 if exc[0] in (errno.EACCES,):
-                    raise Exception('Failed to create upload.')
+                    raise GirderException(
+                        'Failed to create upload.',
+                        'girder.api.v1.file.create-upload-failed')
                 raise
             if upload['size'] > 0:
                 return upload

--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -24,6 +24,7 @@ import json
 
 from girder.api import access
 from girder.constants import SettingKey, VERSION
+from girder.models.model_base import GirderException
 from girder.utility import plugin_utilities
 from girder.utility import system
 from girder.utility.progress import ProgressContext
@@ -239,7 +240,9 @@ class System(Resource):
                 self.model('upload').cancelUpload(upload)
             except OSError as exc:
                 if exc[0] in (errno.EACCES,):
-                    raise Exception('Failed to delete upload.')
+                    raise GirderException(
+                        'Failed to delete upload.',
+                        'girder.api.v1.system.delete-upload-failed')
                 raise
         untracked = self.boolParam('includeUntracked', params, default=True)
         if untracked:

--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -77,7 +77,10 @@ class System(Resource):
                 value = None
             else:
                 try:
-                    value = json.loads(setting['value'])
+                    if isinstance(setting['value'], basestring):
+                        value = json.loads(setting['value'])
+                    else:
+                        value = setting['value']
                 except ValueError:
                     value = setting['value']
 

--- a/girder/models/__init__.py
+++ b/girder/models/__init__.py
@@ -62,7 +62,8 @@ def getDbConnection(uri=None, replicaSet=None):
         # This is the maximum time between when we fetch data from a cursor.
         # If it times out, the cursor is lost and we can't reconnect.  If it
         # isn't set, we have issues with replica sets when the primary goes
-        # down.
+        # down.  This value can be overridden in the mongodb uri connection
+        # string with the socketTimeoutMS.
         'socketTimeoutMS': 60000,
         }
     if uri is None:

--- a/girder/models/assetstore.py
+++ b/girder/models/assetstore.py
@@ -20,7 +20,7 @@
 import datetime
 import pymongo
 
-from .model_base import Model, ValidationException
+from .model_base import Model, ValidationException, GirderException
 from girder.utility import assetstore_utilities
 from girder.utility.filesystem_assetstore_adapter import\
     FilesystemAssetstoreAdapter
@@ -161,6 +161,8 @@ class Assetstore(Model):
         """
         current = self.findOne({'current': True})
         if current is None:
-            raise Exception('No current assetstore is set.')
+            raise GirderException(
+                'No current assetstore is set.',
+                'girder.model.assetstore.no-current-assetstore')
 
         return current

--- a/girder/models/collection.py
+++ b/girder/models/collection.py
@@ -67,7 +67,7 @@ class Collection(AccessControlledModel):
             q['_id'] = {'$ne': doc['_id']}
         duplicate = self.findOne(q, fields=['_id'])
         if duplicate is not None:
-            raise ValidationException('A collection with that name already'
+            raise ValidationException('A collection with that name already '
                                       'exists.', 'name')
 
         return doc

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -23,7 +23,8 @@ import json
 import os
 
 from bson.objectid import ObjectId
-from .model_base import AccessControlledModel, ValidationException
+from .model_base import AccessControlledModel, ValidationException, \
+    GirderException
 from girder import events
 from girder.constants import AccessType
 from girder.utility.progress import setResponseTimeLimit
@@ -81,8 +82,9 @@ class Folder(AccessControlledModel):
 
         if not doc['parentCollection'] in ('folder', 'user', 'collection'):
             # Internal error; this shouldn't happen
-            raise Exception('Invalid folder parent type: %s.' %
-                            doc['parentCollection'])
+            raise GirderException('Invalid folder parent type: %s.' %
+                                  doc['parentCollection'],
+                                  'girder.models.folder.invalid-parent-type')
         name = doc['name']
         n = 0
         while True:

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -23,7 +23,7 @@ import json
 import os
 
 from bson.objectid import ObjectId
-from .model_base import Model, ValidationException
+from .model_base import Model, ValidationException, GirderException
 from girder import events
 from girder import logger
 from girder.constants import AccessType
@@ -335,7 +335,8 @@ class Item(Model):
 
         if not type(creator) is dict or '_id' not in creator:
             # Internal error -- this shouldn't be called without a user.
-            raise Exception('Creator must be a user.')
+            raise GirderException('Creator must be a user.',
+                                  'girder.models.item.creator-not-user')
 
         if 'baseParentType' not in folder:
             pathFromRoot = self.parentsToRoot({'folderId': folder['_id']},
@@ -495,9 +496,10 @@ class Item(Model):
         Check all of the items and make sure they are valid.  This operates in
         stages, since some actions should be done before other models that rely
         on items and some need to be done after.  The stages are:
-            count - count how many items need to be checked.
-            remove - remove lost items
-            verify - verify and fix existing items
+        * count - count how many items need to be checked.
+        * remove - remove lost items
+        * verify - verify and fix existing items
+
         :param stage: which stage of the check to run.  See above.
         :param progress: an option progress context to update.
         :returns: numItems: number of items to check or processed,

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -750,6 +750,22 @@ class AccessException(Exception):
     pass
 
 
+class GirderException(Exception):
+    """
+    Represents a general exception that might occur in regular use.  From the
+    user perspective, these are failures, but not catastrophic ones.  An
+    identifier can be passed, which allows receivers to check the exception
+    without relying on the text of the message.  It is recommended that
+    identifiers are a dot-separated string consisting of the originating
+    python module and a distinct error.  For example,
+    'girder.model.assetstore.no-current-assetstore'.
+    """
+    def __init__(self, message, identifier=None):
+        self.identifier = identifier
+
+        Exception.__init__(self, message)
+
+
 class ValidationException(Exception):
     """
     Represents validation failure in the model layer. Raise this with

--- a/girder/models/upload.py
+++ b/girder/models/upload.py
@@ -81,6 +81,7 @@ class Upload(Model):
         This should only be called manually in the case of creating an
         empty file, i.e. one that has no chunks.
         """
+        events.trigger('model.upload.finalize', upload)
         if assetstore is None:
             assetstore = self.model('assetstore').load(upload['assetstoreId'])
 
@@ -144,7 +145,11 @@ class Upload(Model):
         :param user: The user performing this upload.
         :param size: The size of the new file contents.
         """
-        assetstore = self.model('assetstore').getCurrent()
+        eventParams = {'model': 'file', 'resource': file}
+        events.trigger('model.upload.assetstore', eventParams)
+        assetstore = eventParams.get('assetstore',
+                                     self.model('assetstore').getCurrent())
+
         adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
         now = datetime.datetime.utcnow()
 
@@ -182,7 +187,11 @@ class Upload(Model):
         :type mimeType: str
         :returns: The upload document that was created.
         """
-        assetstore = self.model('assetstore').getCurrent()
+        eventParams = {'model': parentType, 'resource': parent}
+        events.trigger('model.upload.assetstore', eventParams)
+        assetstore = eventParams.get('assetstore',
+                                     self.model('assetstore').getCurrent())
+
         adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
         now = datetime.datetime.utcnow()
 

--- a/girder/utility/filesystem_assetstore_adapter.py
+++ b/girder/utility/filesystem_assetstore_adapter.py
@@ -28,7 +28,7 @@ from hashlib import sha512
 from . import sha512_state
 from .abstract_assetstore_adapter import AbstractAssetstoreAdapter
 from .model_importer import ModelImporter
-from girder.models.model_base import ValidationException
+from girder.models.model_base import ValidationException, GirderException
 from girder import logger
 
 BUF_SIZE = 65536
@@ -202,7 +202,10 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
         """
         path = os.path.join(self.assetstore['root'], file['path'])
         if not os.path.isfile(path):
-            raise Exception('File %s does not exist.' % path)
+            raise GirderException(
+                'File %s does not exist.' % path,
+                'girder.utility.filesystem_assetstore_adapter.'
+                'file-does-not-exist')
 
         if headers:
             mimeType = file.get('mimeType', 'application/octet-stream')

--- a/girder/utility/gridfs_assetstore_adapter.py
+++ b/girder/utility/gridfs_assetstore_adapter.py
@@ -73,11 +73,13 @@ class GridFsAssetstoreAdapter(AbstractAssetstoreAdapter):
             logger.error('Failed to connect to GridFS assetstore %s',
                          assetstore['db'])
             self.chunkColl = 'Failed to connect'
+            self.unavailable = True
             return
         except pymongo.errors.ConfigurationError:
             logger.exception('Failed to configure GridFS assetstore %s',
                              assetstore['db'])
             self.chunkColl = 'Failed to configure'
+            self.unavailable = True
             return
         self.chunkColl.ensure_index([
             ('uuid', pymongo.ASCENDING),

--- a/girder/utility/system.py
+++ b/girder/utility/system.py
@@ -162,14 +162,16 @@ def formatSize(sizeBytes):
     :returns formatedSize: the formatted size string.
     """
     suffixes = ['B', 'kB', 'MB', 'GB', 'TB']
+    if sizeBytes < 20000:
+        return '%d %s' % (sizeBytes, suffixes[0])
     idx = 0
     sizeVal = float(sizeBytes)
     while sizeVal >= 1024 and idx + 1 < len(suffixes):
         sizeVal /= 1024
         idx += 1
-    if sizeBytes < 1024:
-        precision = 0
-    elif sizeVal < 10:
+    if sizeVal < 10:
+        precision = 3
+    elif sizeVal < 100:
         precision = 2
     else:
         precision = 1

--- a/girder/utility/system.py
+++ b/girder/utility/system.py
@@ -153,6 +153,29 @@ def getStatus(mode='basic', user=None):
     return status
 
 
+def formatSize(sizeBytes):
+    """
+    Format a size in bytes into a human-readable string with metric unit
+    prefixes.
+
+    :param sizeBytes: the size in bytes to format.
+    :returns formatedSize: the formatted size string.
+    """
+    suffixes = ['B', 'kB', 'MB', 'GB', 'TB']
+    idx = 0
+    sizeVal = float(sizeBytes)
+    while sizeVal >= 1024 and idx + 1 < len(suffixes):
+        sizeVal /= 1024
+        idx += 1
+    if sizeBytes < 1024:
+        precision = 0
+    elif sizeVal < 10:
+        precision = 2
+    else:
+        precision = 1
+    return '%.*f %s' % (precision, sizeVal, suffixes[idx])
+
+
 # This class is used to monitor which threads in cherrypy are actively serving
 # responses, and what each was last used for.  It is based on the example at
 # http://tools.cherrypy.org/wiki/StatusTool, but has changes to handle yield-

--- a/plugins/user_quota/plugin.cmake
+++ b/plugins/user_quota/plugin.cmake
@@ -20,7 +20,6 @@ add_python_style_test(pep8_style_user_quota
 add_web_client_test(
     user_quota
     "${PROJECT_SOURCE_DIR}/plugins/user_quota/plugin_tests/userQuotaSpec.js"
-    PLUGIN user_quota
-    RESOURCE_LOCKS uploadtest)
+    PLUGIN user_quota)
 add_javascript_style_test(
     user_quota "${PROJECT_SOURCE_DIR}/plugins/user_quota/web_client/js")

--- a/plugins/user_quota/plugin.cmake
+++ b/plugins/user_quota/plugin.cmake
@@ -1,0 +1,26 @@
+###############################################################################
+#  Copyright 2015 Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+add_python_test(user_quota PLUGIN user_quota)
+add_python_style_test(pep8_style_user_quota
+                      "${PROJECT_SOURCE_DIR}/plugins/user_quota/server")
+add_web_client_test(
+    user_quota
+    "${PROJECT_SOURCE_DIR}/plugins/user_quota/plugin_tests/userQuotaSpec.js"
+    PLUGIN user_quota
+    RESOURCE_LOCKS uploadtest)
+add_javascript_style_test(
+    user_quota "${PROJECT_SOURCE_DIR}/plugins/user_quota/web_client/js")

--- a/plugins/user_quota/plugin.json
+++ b/plugins/user_quota/plugin.json
@@ -1,5 +1,5 @@
 {
-"name": "User and Collection Quotas and Policies",
+"name": "User and collection quotas and policies",
 "description": "Limits total file size stored for individual users and collections and can direct all files to a specific assetstore",
 "version": "0.1.0"
 }

--- a/plugins/user_quota/plugin.json
+++ b/plugins/user_quota/plugin.json
@@ -1,0 +1,5 @@
+{
+"name": "User and Collection Quotas and Policies",
+"description": "Limits total file size stored for individual users and collections and can direct all files to a specific assetstore",
+"version": "0.1.0"
+}

--- a/plugins/user_quota/plugin_tests/userQuotaSpec.js
+++ b/plugins/user_quota/plugin_tests/userQuotaSpec.js
@@ -1,0 +1,291 @@
+$(function () {
+    /* Include the built version of the our templates.  This means that grunt
+     * must be run to generate these before the test. */
+    girderTest.addCoveredScript(
+        '/static/built/plugins/user_quota/templates.js');
+    girderTest.addCoveredScript(
+        '/plugins/user_quota/web_client/js/userQuota.js');
+    $('<link/>', {rel: 'stylesheet', type: 'text/css',
+                  href: '/static/built/plugins/user_quota/plugin.min.css'
+    }).appendTo('head');
+    girder.events.trigger('g:appload.before');
+    var app = new girder.App({
+        el: 'body',
+        parentView: null
+    });
+    girder.events.trigger('g:appload.after');
+});
+
+/* Go to the collections page.  If a collection is specified, go to that
+ * collection's page.
+ * @param collection: the name of the collection to go to.
+ */
+function _goToCollection(collection) {
+    runs(function () {
+        $("a.g-nav-link[g-target='collections']").click();
+    });
+    waitsFor(function () {
+        return $('.g-collections-search-container:visible').length > 0;
+    }, 'navigate to collections page');
+    girderTest.waitForLoad();
+    if (collection) {
+        runs(function () {
+            $('a.g-collection-link').has('b:contains(' + collection +
+                                         ')').click()
+        });
+        waitsFor(function () {
+            return $('.g-collection-actions-button:visible').is(':enabled');
+        }, 'collection actions link to appear');
+        girderTest.waitForLoad();
+    }
+}
+
+/* Go to the users page.  If a user is specified, go to that user's page.
+ * @param user: the full name of the user to go to.
+ */
+function _goToUser(user) {
+    girderTest.goToUsersPage()();
+    if (user) {
+        runs(function () {
+            $("a.g-user-link:contains('" + user + "')").click();
+        });
+        waitsFor(function () {
+            return $('.g-user-name').text() === user;
+        }, 'user page to appear');
+        girderTest.waitForLoad();
+    }
+}
+
+/* Test the quota dialog, expecting that this is an admin and can set the
+ * quota.
+ * @param: hasChart: if true, we expect a pie chart.  If false, we don't.
+ * @param capacity: the capacity in bytes to set.
+ */
+function _testQuotaDialogAsAdmin(hasChart, capacity) {
+    girderTest.waitForDialog('quota dialog to appear');
+    waitsFor(function () {
+        return $(".g-quota-capacity").length == 1;
+    }, 'capacity to appear');
+    waitsFor(function () {
+        return $('a.btn-default').length == 1;
+    }, 'the cancel button to appear');
+    waitsFor(function () {
+        return $(hasChart ? '.g-has-chart' : '.g-no-chart').length == 1;
+    }, 'the chart to be determined');
+    runs(function () {
+        expect($("#g-fileSizeQuota").length).toBe(1);
+        $("#g-fileSizeQuota").val('abc');
+        $('.g-save-policies').click();
+    });
+    waitsFor(function () {
+        return $('.g-validation-failed-message').text()
+            indexOf('Invalid fileSizeQuota') >= 0;
+    }, 'an error message to appear');
+    runs(function () {
+        $("#g-fileSizeQuota").val(capacity ? capacity : '');
+    });
+    runs(function () {
+        $('.g-save-policies').click();
+    });
+    girderTest.waitForLoad('quota dialog to hide');
+}        
+
+/* Test the quota dialog, expecting that this is a user and can not set the
+ * quota.
+ * @param: hasChart: if true, we expect a pie chart.  If false, we don't.
+ */
+function _testQuotaDialogAsUser(hasChart) {
+    girderTest.waitForDialog();
+    waitsFor(function () {
+        return $(".g-quota-capacity").length == 1;
+    }, 'capacity to appear');
+    waitsFor(function () {
+        return $('a.btn-default').length == 1;
+    }, 'the cancel button to appear');
+    waitsFor(function () {
+        return $(hasChart ? '.g-has-chart' : '.g-no-chart').length == 1;
+    }, 'the chart to be determined');
+    runs(function () {
+        expect($("#g-fileSizeQuota").length).toBe(0);
+    });
+    runs(function () {
+        $('a.btn-default').click();
+    });
+    girderTest.waitForLoad();
+}        
+
+describe('test the user quota plugin', function () {
+    var collectionDialogRoute, userDialogRoute, userRoute;
+    it('create reources', function () {
+        girderTest.createUser(
+            'admin', 'admin@email.com', 'Quota', 'Admin', 'testpassword')();
+        _goToCollection();
+        girderTest.createCollection('Collection A', 'ColDescription')();
+        girderTest.logout('logout from admin')();
+        girderTest.createUser(
+            'user1', 'user@email.com', 'Quota', 'User', 'testpassword')();
+        girderTest.logout('logout from user1')();
+        girderTest.createUser(
+            'user2', 'user2@email.com', 'Another', 'User', 'testpassword')();
+    });
+    it('make the collection public', function () {
+        girderTest.logout('logout from user2')();
+        girderTest.login('admin', 'Quota', 'Admin', 'testpassword')();
+        _goToCollection('Collection A');
+        runs(function () {
+            $('.g-collection-actions-button').click();
+        });
+        waitsFor(function () {
+            return $(".g-collection-access-control[role='menuitem']:visible").length == 1;
+        }, 'access control menu item to appear');
+        runs(function () {
+            $('.g-collection-access-control').click();
+        });
+        girderTest.waitForDialog();
+        waitsFor(function () {
+            return $('#g-dialog-container').hasClass('in') &&
+                   $('#g-access-public:visible').is(':enabled');
+        }, 'dialog and public access radio button to appear');
+        runs(function () {
+            $('#g-access-public').click();
+            $('#g-dialog-container .g-search-field').val('user1');
+            $('#g-dialog-container input.g-search-field').trigger('input');
+        });
+        waitsFor(function () {
+            return $('.g-search-result').length === 1;
+        }, 'user1 to be listed');
+        runs(function () {
+            $('.g-search-result a').click();
+        });
+        waitsFor(function () {
+            return $('.g-user-access-entry').length === 2;
+        }, 'user1 to be in the access list');
+        runs(function () {
+            $('.g-access-col-right select').eq(1).val(2);
+        });
+        waitsFor(function () {
+            return $('.g-save-access-list:visible').is(':enabled') &&
+                   $('.radio.g-selected').text().match("Public").length > 0;
+        }, 'access save button to appear');
+        runs(function () {
+            $('.g-save-access-list').click();
+        });
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            return !$('#g-dialog-container').hasClass('in');
+        }, 'access dialog to be hidden');
+    });
+    it('check that admin can set quota for collections and users', function () {
+        girderTest.logout('logout from user')();
+        girderTest.login('admin', 'Quota', 'Admin', 'testpassword')();
+        _goToCollection('Collection A');
+        runs(function () {
+            $('.g-collection-actions-button').click();
+        });
+        waitsFor(function () {
+            return $(".g-collection-policies[role='menuitem']:visible").length == 1;
+        }, 'collection actions menu to appear');
+        runs(function () {
+            $('.g-collection-policies').click();
+        });
+        girderTest.waitForDialog();
+        runs(function () {
+            collectionDialogRoute = window.location.hash;
+        });
+        _testQuotaDialogAsAdmin(false, 2048);
+        runs(function () {
+            $('.g-collection-policies').click();
+        });
+        /* We should now have a chart */
+        _testQuotaDialogAsAdmin(true, 16384);
+        _goToUser('Quota User');
+        runs(function () {
+            userRoute = window.location.hash;
+            $('.g-user-actions-button').click();
+        });
+        waitsFor(function () {
+            return $(".g-user-policies[role='menuitem']:visible").length == 1;
+        }, 'user actions menu to appear');
+        runs(function () {
+            $('.g-user-policies').click();
+        });
+        girderTest.waitForDialog();
+        runs(function () {
+            userDialogRoute = window.location.hash;
+        });
+        _testQuotaDialogAsAdmin(false, 2048);
+    });
+    it('test routes', function () {
+        girderTest.testRoute(collectionDialogRoute, true, function () {
+            return $(".g-quota-capacity").length == 1;
+        });
+        girderTest.testRoute(userRoute, false, function () {
+            return $('.g-user-name').text() === 'Quota User';
+        });
+        girderTest.testRoute(userDialogRoute, true, function () {
+            return $(".g-quota-capacity").length == 1;
+        });
+        runs(function() {
+            $('a[data-dismiss="modal"]').click();
+        });
+        girderTest.waitForLoad();
+    });
+    it('upload', function () {
+        runs(function() {
+            $('a.g-folder-list-link').eq(0).click();
+        });
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('li.g-folder-list-entry').length === 0;
+        }, 'my folders list to display');
+        girderTest.testUpload(2048);
+        girderTest.testUpload(2048, 'abort', 'file storage quota');
+    });
+    it('check that user2 can view but not set quota', function () {
+        girderTest.logout('logout from admin')();
+        girderTest.login('user1', 'Quota', 'User', 'testpassword')();
+        _goToCollection('Collection A');
+        runs(function () {
+            $('.g-collection-actions-button').click();
+        });
+        waitsFor(function () {
+            return $(".g-collection-policies[role='menuitem']:visible").length == 1;
+        }, 'collection actions menu to appear');
+        runs(function () {
+            $('.g-collection-policies').click();
+        });
+        _testQuotaDialogAsUser(true);
+        _goToUser('Quota User');
+        runs(function () {
+            $('.g-user-actions-button').click();
+        });
+        waitsFor(function () {
+            return $(".g-user-policies[role='menuitem']:visible").length == 1;
+        }, 'user actions menu to appear');
+        runs(function () {
+            $('.g-user-policies').click();
+        });
+        _testQuotaDialogAsUser(true);
+    });
+    it('check that a different user does not see quota', function () {
+        girderTest.logout('logout from user1')();
+        girderTest.login('user2', 'Another', 'User', 'testpassword')();
+        _goToCollection('Collection A');
+        waitsFor(function () {
+            return $('.g-collection-actions-button:visible').is(':enabled');
+        }, 'collection actions link to appear');
+        runs(function () {
+            $('.g-collection-actions-button').click();
+        });
+        waitsFor(function () {
+            return $(".g-download-collection[role='menuitem']:visible").length == 1;
+        }, 'collection actions menu to appear');
+        runs(function () {
+            expect($('.g-collection-policies').length).toBe(0);
+        });
+        _goToUser('Quota User');
+        runs(function () {
+            expect($("button:contains('Actions')").length).toBe(0);
+        });
+    });
+});

--- a/plugins/user_quota/plugin_tests/userQuotaSpec.js
+++ b/plugins/user_quota/plugin_tests/userQuotaSpec.js
@@ -197,7 +197,7 @@ describe('test the user quota plugin', function () {
             $('.g-collection-policies').click();
         });
         /* We should now have a chart */
-        _testQuotaDialogAsAdmin(true, 16384);
+        _testQuotaDialogAsAdmin(true, 32768);
         _goToUser('Quota User');
         runs(function () {
             userRoute = window.location.hash;
@@ -240,6 +240,10 @@ describe('test the user quota plugin', function () {
         }, 'my folders list to display');
         girderTest.testUpload(2048);
         girderTest.testUpload(2048, 'abort', 'file storage quota');
+        runs(function () {
+            window.callPhantom({action: 'uploadCleanup',
+                                suffix: girderTest._uploadSuffix});
+        });
     });
     it('check that user2 can view but not set quota', function () {
         girderTest.logout('logout from admin')();

--- a/plugins/user_quota/plugin_tests/userQuotaSpec.js
+++ b/plugins/user_quota/plugin_tests/userQuotaSpec.js
@@ -73,8 +73,8 @@ function _testQuotaDialogAsAdmin(hasChart, capacity) {
         return $(hasChart ? '.g-has-chart' : '.g-no-chart').length == 1;
     }, 'the chart to be determined');
     runs(function () {
-        expect($("#g-fileSizeQuota").length).toBe(1);
-        $("#g-fileSizeQuota").val('abc');
+        expect($("#g-sizeValue").length).toBe(1);
+        $("#g-sizeValue").val('abc');
         $('.g-save-policies').click();
     });
     waitsFor(function () {
@@ -82,7 +82,7 @@ function _testQuotaDialogAsAdmin(hasChart, capacity) {
             indexOf('Invalid fileSizeQuota') >= 0;
     }, 'an error message to appear');
     runs(function () {
-        $("#g-fileSizeQuota").val(capacity ? capacity : '');
+        $("#g-sizeValue").val(capacity ? capacity : '');
     });
     runs(function () {
         $('.g-save-policies').click();
@@ -106,7 +106,7 @@ function _testQuotaDialogAsUser(hasChart) {
         return $(hasChart ? '.g-has-chart' : '.g-no-chart').length == 1;
     }, 'the chart to be determined');
     runs(function () {
-        expect($("#g-fileSizeQuota").length).toBe(0);
+        expect($("#g-sizeValue").length).toBe(0);
     });
     runs(function () {
         $('a.btn-default').click();
@@ -197,7 +197,7 @@ describe('test the user quota plugin', function () {
             $('.g-collection-policies').click();
         });
         /* We should now have a chart */
-        _testQuotaDialogAsAdmin(true, 32768);
+        _testQuotaDialogAsAdmin(true, '32 kB');
         _goToUser('Quota User');
         runs(function () {
             userRoute = window.location.hash;

--- a/plugins/user_quota/plugin_tests/user_quota_test.py
+++ b/plugins/user_quota/plugin_tests/user_quota_test.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright 2015 Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+import json
+import os
+
+from tests import base
+from girder import events
+from girder.constants import AccessType, AssetstoreType, SettingKey
+
+
+def setUpModule():
+    base.enabledPlugins.append('user_quota')
+    base.startServer()
+
+
+def tearDownModule():
+    base.stopServer()
+
+
+class QuotaTestCase(base.TestCase):
+    def setUp(self):
+        base.TestCase.setUp(self)
+        admin = {
+            'email': 'admin@email.com',
+            'login': 'adminlogin',
+            'firstName': 'Admin',
+            'lastName': 'Last',
+            'password': 'adminpassword',
+            'admin': True
+        }
+        self.admin = self.model('user').createUser(**admin)
+        user = {
+            'email': 'good@email.com',
+            'login': 'goodlogin',
+            'firstName': 'First',
+            'lastName': 'Last',
+            'password': 'goodpassword',
+            'admin': False
+        }
+        self.user = self.model('user').createUser(**user)
+        coll = {
+            'name': 'Test Collection',
+            'description': 'The description',
+            'public': True,
+            'creator': self.admin
+        }
+        self.collection = self.model('collection').createCollection(**coll)
+
+    def _uploadFile(self, name, parent, parentType='folder', size=1024,
+                    error=None, partial=False):
+        """
+        Upload a random file to an item.
+
+        :param name: name of the file.
+        :param parent: parent document to upload the file to.
+        :param parentType: type of parent to upload to.
+        :param size: size of the file to upload
+        :param error: if set, expect this error.
+        :param partial: if set, return before uploading the data.  This returns
+                        a kwargs for multipartRequest so that the caller can
+                        finishe the upload later.
+        :returns: file: the created file object
+        """
+        contents = os.urandom(size)
+        if parentType != 'file':
+            resp = self.request(
+                path='/file', method='POST', user=self.admin, params={
+                    'parentType': parentType,
+                    'parentId': parent['_id'],
+                    'name': name,
+                    'size': len(contents),
+                    'mimeType': 'application/octet-stream'
+                }, exception=error is not None)
+        else:
+            resp = self.request(
+                path='/file/%s/contents' % str(parent['_id']), method='PUT',
+                user=self.admin, params={
+                    'size': len(contents),
+                }, exception=error is not None)
+        if error:
+            self.assertStatus(resp, 500)
+            self.assertEqual(resp.json['type'], 'girder')
+            self.assertEqual(resp.json['message'][:len(error)], error)
+            return None
+        self.assertStatusOk(resp)
+        upload = resp.json
+        fields = [('offset', 0), ('uploadId', upload['_id'])]
+        if not partial:
+            files = [('chunk', name, contents)]
+        else:
+            files = [('chunk', name, contents[:-1])]
+        resp = self.multipartRequest(path='/file/chunk', user=self.admin,
+                                     fields=fields, files=files)
+        self.assertStatusOk(resp)
+        if partial:
+            fields = [('offset', len(contents)-1), ('uploadId', upload['_id'])]
+            files = [('chunk', name, contents[-1:])]
+            kwargs = {'path': '/file/chunk', 'user': self.admin,
+                      'fields': fields, 'files': files}
+            return kwargs
+        return resp.json
+
+    def _setPolicy(self, policy, model, resource, user, error=None,
+                   results=None):
+        """
+        Set the quota or assetstore policy and check that it was set.
+
+        :param policy: dictionary of values to set.
+        :param model: either 'user' or 'collection'.
+        :param resource: the document for the resource to test.
+        :param user: user to use for authorization.
+        :param error: if set, this is a substring expected in an error message.
+        :param results: if not specified, we expect policy to match the set
+                        results.  Otherwise, these are the expected results.
+        """
+        if isinstance(policy, dict):
+            policyJSON = json.dumps(policy)
+        else:
+            policyJSON = policy
+        path = '/%s/%s/quota' % (model, resource['_id'])
+        resp = self.request(path=path, method='PUT', user=user,
+                            params={'policy': policyJSON})
+        if error:
+            self.assertStatus(resp, 400)
+            self.assertTrue(error in resp.json['message'])
+            return
+        self.assertStatusOk(resp)
+        resp = self.request(path=path, method='GET', user=user)
+        self.assertStatusOk(resp)
+        currentPolicy = resp.json['quota']
+        if not results:
+            results = policy
+        for key in results:
+            self.assertEqual(currentPolicy[key], results[key] or None)
+
+    def _testAssetstores(self, model, resource, user):
+        """
+        Test assetstore policies for a specified resource.
+
+        :param model: either 'user' or 'collection'.
+        :param resource: the document for the resource to test.
+        :param user: user to use for authorization.
+        """
+        resp = self.request(path='/folder', method='GET', user=user,
+                            params={'parentType': model,
+                                    'parentId': resource['_id']})
+        self.assertStatusOk(resp)
+        self.assertGreaterEqual(len(resp.json), 1)
+        folder = resp.json[0]
+        curAssetstoreId = str(self.currentAssetstore['_id'])
+        altAssetstoreId = str(self.alternateAssetstore['_id'])
+        badAssetstoreId = str(self.brokenAssetstore['_id'])
+        invalidAssetstoreId = str(folder['_id'])
+        file = self._uploadFile('Upload to Current', folder)
+        self.assertEqual(file['assetstoreId'], curAssetstoreId)
+        # A simple preferredASsetstore policy should work
+        self._setPolicy({'preferredAssetstore': altAssetstoreId},
+                        model, resource, user)
+        file = self._uploadFile('Upload to Alt', folder)
+        self.assertEqual(file['assetstoreId'], altAssetstoreId)
+        # Uploading to an invalid preferredAssetstore policy should send the
+        # data to the current asssetstore
+        self._setPolicy({'preferredAssetstore': invalidAssetstoreId},
+                        model, resource, user)
+        file = self._uploadFile('Upload to Invalid', folder)
+        self.assertEqual(file['assetstoreId'], curAssetstoreId)
+        # Uploading to an unreachable preferredAssetstore policy should send
+        # the data to the current asssetstore
+        self._setPolicy({'preferredAssetstore': badAssetstoreId},
+                        model, resource, user)
+        file = self._uploadFile('Upload to Bad', folder)
+        self.assertEqual(file['assetstoreId'], curAssetstoreId)
+        # We can specify a fallback
+        self._setPolicy({'fallbackAssetstore': altAssetstoreId},
+                        model, resource, user)
+        file = self._uploadFile('Upload to Bad with fallback', folder)
+        self.assertEqual(file['assetstoreId'], altAssetstoreId)
+        # Or say there shouldn't be a fallback
+        self._setPolicy({'fallbackAssetstore': 'none'},
+                        model, resource, user)
+        self._uploadFile('Upload to Bad with no fallback', folder,
+                         error='Required assetstore is unavailable')
+        # if we clear the preferred policy, the fallback shouldn't matter.
+        self._setPolicy({'preferredAssetstore': ''},
+                        model, resource, user)
+        file = self._uploadFile('Upload with not preferred', folder)
+        self.assertEqual(file['assetstoreId'], curAssetstoreId)
+
+    def _testQuota(self, model, resource, user):
+        """
+        Test quota policies for a specified resource.
+
+        :param model: either 'user' or 'collection'.
+        :param resource: the document for the resource to test.
+        :param user: user to use for authorization.
+        """
+        self.model('setting').set(SettingKey.UPLOAD_MINIMUM_CHUNK_SIZE, 0)
+        resp = self.request(path='/folder', method='GET', user=user,
+                            params={'parentType': model,
+                                    'parentId': resource['_id']})
+        self.assertStatusOk(resp)
+        self.assertGreaterEqual(len(resp.json), 1)
+        folder = resp.json[0]
+        # Start by uploading one file so that there is some use
+        self._uploadFile('First upload', folder, size=1024)
+        # Set a policy limiting things to 4 kb, then a 4 kb file should fail
+        self._setPolicy({'fileSizeQuota': 4096}, model, resource, user)
+        self._uploadFile('File too large', folder, size=4096,
+                         error='Upload would exceed file storage quota')
+        # But a 2 kb file will succeed
+        file = self._uploadFile('Second upload', folder, size=2048)
+        # And a second 2 kb file will fail
+        self._uploadFile('File too large', folder, size=2048,
+                         error='Upload would exceed file storage quota')
+        # If we start uploading two files, only one should complete
+        file1kwargs = self._uploadFile('First partial', folder, size=768,
+                                       partial=True)
+        file2kwargs = self._uploadFile('Second partial', folder, size=768,
+                                       partial=True)
+        resp = self.multipartRequest(**file1kwargs)
+        self.assertStatusOk(resp)
+        try:
+            resp = self.multipartRequest(**file2kwargs)
+            self.assertStatus(resp, 500)
+        except AssertionError as exc:
+            self.assertTrue('Upload exceeded' in exc.message)
+        # Shrink the quota to smaller than all of our files.  Replacing an
+        # existing file should still work, though
+        self._setPolicy({'fileSizeQuota': 2048}, model, resource, user)
+        self._uploadFile('Second upload', file, 'file', size=1536)
+
+    def testAssetstorePolicy(self):
+        """
+        Test assetstore policies for a user and a collection.
+        """
+        # We want three assetstores for testing, one of which is unreachable.
+        # We already have one, which is the current assetstore.
+        base.dropGridFSDatabase('girder_assetstore_user_quota_test')
+        params = {
+            'name': 'Non-current Store',
+            'type': AssetstoreType.GRIDFS,
+            'db': 'girder_assetstore_user_quota_test'
+        }
+        resp = self.request(path='/assetstore', method='POST', user=self.admin,
+                            params=params)
+        self.assertStatusOk(resp)
+        params = {
+            'name': 'Broken Store',
+            'type': AssetstoreType.GRIDFS,
+            'db': 'girder_assetstore_user_quota_test_broken',
+            'mongohost': 'mongodb://127.254.254.254:27017'
+        }
+        resp = self.request(path='/assetstore', method='POST', user=self.admin,
+                            params=params)
+        self.assertStatusOk(resp)
+        # Now get the assetstores and save their ids for later
+        resp = self.request(path='/assetstore', method='GET', user=self.admin,
+                            params={'sort': 'created'})
+        self.assertStatusOk(resp)
+        assetstores = resp.json
+        self.assertEqual(len(assetstores), 3)
+        self.currentAssetstore = assetstores[0]
+        self.alternateAssetstore = assetstores[1]
+        self.brokenAssetstore = assetstores[2]
+        self._testAssetstores('user', self.user, self.user)
+        self._testAssetstores('collection', self.collection, self.admin)
+
+    def testQuotaPolicy(self):
+        """
+        Test quota policies for a user and a collection.
+        """
+        self._testQuota('user', self.user, self.user)
+        self._testQuota('collection', self.collection, self.admin)
+
+    def testPolicySettings(self):
+        """
+        Test validation of policy settings.
+        """
+        # We have to send a json dictionary
+        # We can only set certain keys
+        self._setPolicy('this is not json',
+                        'user', self.user, self.user,
+                        error='The policy parameter must be JSON.')
+        self._setPolicy(json.dumps(['this is not a dictionary']),
+                        'user', self.user, self.user,
+                        error='The policy parameter must be a dictionary.')
+        # We can only set certain keys
+        self._setPolicy({'notAKey': 'notAValue'},
+                        'user', self.user, self.user,
+                        error='not a valid quota policy key')
+        # We need to pass None, current, or an ObjectId to preferredAssetstore
+        self._setPolicy({'preferredAssetstore': 'current'},
+                        'user', self.user, self.user,
+                        results={'preferredAssetstore': None})
+        self._setPolicy({'preferredAssetstore': 'not an id'},
+                        'user', self.user, self.user,
+                        error='Invalid preferredAssetstore')
+        self._setPolicy({'preferredAssetstore': None},
+                        'user', self.user, self.user)
+        # fallbackAssetstore can also take 'none'
+        self._setPolicy({'fallbackAssetstore': 'current'},
+                        'user', self.user, self.user,
+                        results={'fallbackAssetstore': None})
+        self._setPolicy({'fallbackAssetstore': 'none'},
+                        'user', self.user, self.user)
+        self._setPolicy({'fallbackAssetstore': 'not an id'},
+                        'user', self.user, self.user,
+                        error='Invalid fallbackAssetstore')
+        self._setPolicy({'fallbackAssetstore': None},
+                        'user', self.user, self.user)
+        # fileSizeQuota can be None, blank, 0, or a positive integer
+        self._setPolicy({'fileSizeQuota': 0},
+                        'user', self.user, self.user,
+                        results={'fileSizeQuota': None})
+        self._setPolicy({'fileSizeQuota': '00'},
+                        'user', self.user, self.user,
+                        results={'fileSizeQuota': None})
+        self._setPolicy({'fileSizeQuota': ''},
+                        'user', self.user, self.user,
+                        results={'fileSizeQuota': None})
+        self._setPolicy({'fileSizeQuota': 'not an integer'},
+                        'user', self.user, self.user,
+                        error='Invalid fileSizeQuota')
+        self._setPolicy({'fileSizeQuota': -1},
+                        'user', self.user, self.user,
+                        error='Invalid fileSizeQuota')
+        self._setPolicy({'fileSizeQuota': None},
+                        'user', self.user, self.user)

--- a/plugins/user_quota/server/__init__.py
+++ b/plugins/user_quota/server/__init__.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright 2015 Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+from quota import QuotaPolicy
+from girder import events
+
+
+def load(info):
+    quota = QuotaPolicy()
+    info['apiRoot'].collection.route('GET', (':id', 'quota'),
+                                     quota.getCollectionQuota)
+    info['apiRoot'].collection.route('PUT', (':id', 'quota'),
+                                     quota.setCollectionQuota)
+    info['apiRoot'].user.route('GET', (':id', 'quota'), quota.getUserQuota)
+    info['apiRoot'].user.route('PUT', (':id', 'quota'), quota.setUserQuota)
+    events.bind('model.upload.assetstore', 'userQuota',
+                quota.getUploadAssetstore)
+    events.bind('model.upload.save', 'userQuota', quota.checkUploadStart)
+    events.bind('model.upload.finalize', 'userQuota',
+                quota.checkUploadFinalize)

--- a/plugins/user_quota/server/constants.py
+++ b/plugins/user_quota/server/constants.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright 2014 Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+
+# Constants representing the setting keys for this plugin
+class PluginSettings:
+    QUOTA_DEFAULT_USER_QUOTA = 'user_quota.default_user_quota'
+    QUOTA_DEFAULT_COLLECTION_QUOTA = 'user_quota.default_collection_quota'

--- a/plugins/user_quota/server/quota.py
+++ b/plugins/user_quota/server/quota.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright 2015 Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+from bson.objectid import ObjectId, InvalidId
+import json
+
+from girder import logger
+from girder.api import access
+from girder.api.describe import Description
+from girder.api.rest import Resource, RestException, loadmodel
+from girder.constants import AccessType
+from girder.models.model_base import GirderException
+from girder.utility import assetstore_utilities
+from girder.utility.system import formatSize
+
+
+QUOTA_FIELD = 'quota'
+
+
+class QuotaPolicy(Resource):
+    def _filter(self, model, resource):
+        """
+        Filter a resource to include only the ordinary data and the quota
+        field.
+
+        :param model: the type of resource (e.g., user or collection)
+        :param resource: the resource document.
+        :return: filtered field of the resource with the quota data, if any.
+        """
+        filtered = self.model(model).filter(resource, self.getCurrentUser())
+        filtered[QUOTA_FIELD] = resource.get(QUOTA_FIELD, {})
+        return filtered
+
+    def _setResourceQuota(self, model, resource, params):
+        """
+        Handle setting quota policies for any resource that supports them.
+
+        :param model: the type of resource (e.g., user or collection)
+        :param resource: the resource document.
+        :param params: the query parameters.  'policy' is required and used.
+        :return resource: the updated resource document.
+        """
+        self.requireParams(('policy', ), params)
+        policy = self._validatePolicy(params['policy'])
+        if QUOTA_FIELD not in resource:
+            resource[QUOTA_FIELD] = {}
+        resource[QUOTA_FIELD].update(policy)
+        self.model(model).save(resource, validate=False)
+        return self._filter(model, resource)
+
+    def _validate_fallbackAssetstore(self, value):
+        """Validate the fallbackAssetstore parameter.
+
+        :param value: the proposed value.
+        :returns value: the validated value: either None or 'current' to use
+                        the current assetstore, 'none' to disable a fallback
+                        assetstore, or an assetstore ID.
+        """
+        if not value or value == 'current':
+            return None
+        if value == 'none':
+            return value
+        try:
+            value = ObjectId(value)
+        except InvalidId:
+            raise RestException(
+                'Invalid fallbackAssetstore.  Must either be an assetstore '
+                'ID, be blank or "current" to use the current assetstore, or '
+                'be "none" to disable fallback usage.',
+                extra='fallbackAssetstore')
+        return value
+
+    def _validate_fileSizeQuota(self, value):
+        """Validate the fileSizeQuota parameter.
+
+        :param value: the proposed value.
+        :returns value: the validated value: either None or an integer
+        """
+        if value is None or value == '' or value == 0:
+            return None
+        error = False
+        try:
+            value = int(value)
+            if value < 0:
+                error = True
+        except ValueError:
+            error = True
+        if error:
+            raise RestException(
+                'Invalid fileSizeQuota.  Must be blank or a positive integer '
+                'representing the limit in bytes.', extra='fileSizeQuota')
+        if value == 0:
+            return None
+        return value
+
+    def _validate_preferredAssetstore(self, value):
+        """Validate the preferredAssetstore parameter.
+
+        :param value: the proposed value.
+        :returns value: the validated value: either None or 'current' to use
+                        the current assetstore or an assetstore ID.
+        """
+        if not value or value == 'current':
+            return None
+        try:
+            value = ObjectId(value)
+        except InvalidId:
+            raise RestException(
+                'Invalid preferredAssetstore.  Must either be an assetstore '
+                'ID, or be blank or "current" to use the current assetstore.',
+                extra='preferredAssetstore')
+        return value
+
+    def _validatePolicy(self, policy):
+        """
+        Validate a policy JSON object.  Only a limited set of keys is
+        supported, and each of them has a restricted data type.
+
+        :param policy: json object to validate.  This may also be a python
+                           dictionary as if the JSON was already decoded.
+        :returns policyDict: a validate policy dictionary.
+        """
+        if not isinstance(policy, dict):
+            try:
+                policy = json.loads(policy)
+            except ValueError:
+                raise RestException('The policy parameter must be JSON.')
+        if not isinstance(policy, dict):
+            raise RestException('The policy parameter must be a dictionary.')
+        validKeys = []
+        for key in dir(self):
+            if key.startswith('_validate_'):
+                validKeys.append(key.split('_validate_', 1)[1])
+        for key in policy:
+            if key not in validKeys:
+                raise RestException(
+                    '%s is not a valid quota policy key.  Valid keys are '
+                    '%s.' % (key, ', '.join(sorted(validKeys))))
+            funcName = '_validate_' + key
+            policy[key] = getattr(self, funcName)(policy[key])
+        return policy
+
+    @access.public
+    @loadmodel(model='collection', level=AccessType.READ)
+    def getCollectionQuota(self, collection, params):
+        return self._filter('collection', collection)
+    getCollectionQuota.description = (
+        Description('Get quota and assetstore policies for the collection.')
+        .param('id', 'The collection ID', paramType='path')
+        .errorResponse('ID was invalid.')
+        .errorResponse('Read permission denied on the collection.', 403))
+
+    @access.public
+    @loadmodel(model='collection', level=AccessType.ADMIN)
+    def setCollectionQuota(self, collection, params):
+        return self._setResourceQuota('collection', collection, params)
+    setCollectionQuota.description = (
+        Description('Set quota and assetstore policies for the collection.')
+        .param('id', 'The collection ID', paramType='path')
+        .param('policy', 'A JSON object containing the policies.  This is a '
+               'dictionary of keys and values.  Any key that is not specified '
+               'does not change.', required=True)
+        .errorResponse('ID was invalid.')
+        .errorResponse('Read permission denied on the collection.', 403))
+
+    @access.public
+    @loadmodel(model='user', level=AccessType.READ)
+    def getUserQuota(self, user, params):
+        return self._filter('user', user)
+    getUserQuota.description = (
+        Description('Get quota and assetstore policies for the user.')
+        .param('id', 'The user ID', paramType='path')
+        .errorResponse('ID was invalid.')
+        .errorResponse('Read permission denied on the user.', 403))
+
+    @access.public
+    @loadmodel(model='user', level=AccessType.ADMIN)
+    def setUserQuota(self, user, params):
+        return self._setResourceQuota('user', user, params)
+    setUserQuota.description = (
+        Description('Set quota and assetstore policies for the user.')
+        .param('id', 'The user ID', paramType='path')
+        .param('policy', 'A JSON object containing the policies.  This is a '
+               'dictionary of keys and values.  Any key that is not specified '
+               'does not change.', required=True)
+        .errorResponse('ID was invalid.')
+        .errorResponse('Read permission denied on the user.', 403))
+
+    def _checkAssetstore(self, assetstoreSpec):
+        """
+        Check is a specified assetstore is available.
+
+        :param assetstoreSpec: None for use current assetstore, 'none' to
+                               disallow the assetstore, or an assetstore ID to
+                               check if that assetstore exists and is nominally
+                               available.
+        :returns assetstore: None to use the current assetstore, False to
+                             indicate no assetstore is allowed, or an
+                             assetstore document of an allowed assetstore.
+        """
+        if assetstoreSpec is None:
+            return None
+        if assetstoreSpec == 'none':
+            return False
+        assetstore = self.model('assetstore').load(id=assetstoreSpec)
+        if not assetstore:
+            return False
+        adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
+        if getattr(adapter, 'unavailable', False):
+            return False
+        return assetstore
+
+    def _getBaseResource(self, model, resource):
+        """
+        Get the base resource for something pertaining to quota policies.  If
+        the base resource has no quota policy, return (None, None).
+
+        :param model: the initial model type.  Could be file, item, folder,
+                      user, or collection.
+        :param resource: the initial resource document.
+        :return model: the base model type, either 'user' or 'collection'.
+        :return resource: the base resource document or the id of that
+                          document.
+        """
+        if isinstance(resource, (basestring, ObjectId)):
+            resource = self.model(model).load(id=resource, force=True)
+        if model == 'file':
+            model = 'item'
+            resource = self.model('item').load(id=resource['itemId'],
+                                               force=True)
+        if model in ('folder', 'item'):
+            if ('baseParentType' not in resource or
+                    'baseParentId' not in resource):
+                resource = self.model(model).load(id=resource['_id'],
+                                                  force=True)
+            if ('baseParentType' not in resource or
+                    'baseParentId' not in resource):
+                return None, None
+            model = resource['baseParentType']
+            resourceId = resource['baseParentId']
+            resource = self.model(model).load(id=resourceId, force=True)
+        if QUOTA_FIELD not in resource:
+            return None, None
+        return model, resource
+
+    def getUploadAssetstore(self, event):
+        """
+        Handle the model.upload.assetstore event.  This event passes a
+        dictionary consisting of a model type and resource document.  If the
+        base document has an assetstore policy, then set an assetstore key of
+        this dictionary to an assetstore document that should be used or
+        prevent the default action if no appropriate assetstores are allowed.
+
+        :param event: event record.
+        """
+        model, resource = self._getBaseResource(event.info['model'],
+                                                event.info['resource'])
+        if resource is None:
+            return
+        policy = resource[QUOTA_FIELD]
+        assetstore = self._checkAssetstore(
+            policy.get('preferredAssetstore', None))
+        if assetstore is False:
+            assetstore = self._checkAssetstore(
+                policy.get('fallbackAssetstore', None))
+            if assetstore is not False:
+                logger.info('preferredAssetstore not available for %s %s, '
+                            'using fallbackAssetstore', model, resource['_id'])
+        if assetstore is False:
+            raise GirderException('Required assetstore is unavailable')
+        if assetstore:
+            event.info['assetstore'] = assetstore
+
+    def _checkUploadSize(self, upload):
+        """
+        Check if an upload will fit within a quota restriction.
+
+        :param upload: an upload document.
+        :returns quotaInfo: None if the upload is allowed, otherwise a
+                            dictionary of information about the quota
+                            restriction.
+        """
+        origSize = 0
+        if 'fileId' in upload:
+            file = self.model('file').load(id=upload['fileId'])
+            origSize = int(file.get('size', 0))
+            model, resource = self._getBaseResource('file', file)
+        else:
+            model, resource = self._getBaseResource(upload['parentType'],
+                                                    upload['parentId'])
+        if resource is None:
+            return None
+        fileSizeQuota = resource[QUOTA_FIELD].get('fileSizeQuota', None)
+        if not fileSizeQuota or fileSizeQuota < 0:
+            return None
+        newSize = resource['size'] + upload['size'] - origSize
+        # always allow replacement with a smaller object
+        if newSize <= fileSizeQuota or upload['size'] < origSize:
+            return None
+        left = fileSizeQuota - resource['size']
+        if left < 0:
+            left = 0
+        return {'fileSizeQuota': fileSizeQuota,
+                'sizeNeeded': upload['size'] - origSize,
+                'quotaLeft': left,
+                'quotaUsed': resource['size']}
+
+    def checkUploadStart(self, event):
+        """
+        Check if an upload will fit within a quota restriction.  This is before
+        the upload occurs, but since multiple uploads can be started
+        concurrently, we also have to check when the upload is being completed.
+
+        :param event: event record.
+        """
+        if '_id' in event.info:
+            return
+        quotaInfo = self._checkUploadSize(event.info)
+        if quotaInfo:
+            raise GirderException(
+                'Upload would exceed file storage quota (need %s, only %s '
+                'available - used %s out of %s)' %
+                (formatSize(quotaInfo['sizeNeeded']),
+                 formatSize(quotaInfo['quotaLeft']),
+                 formatSize(quotaInfo['quotaUsed']),
+                 formatSize(quotaInfo['fileSizeQuota'])),
+                'user_quota.upload-exceeds-quota')
+
+    def checkUploadFinalize(self, event):
+        """
+        Check if an upload will fit within a quota restriction before
+        finalizing it.  If it doesn't, discard it.
+
+        :param event: event record.
+        """
+        upload = event.info
+        quotaInfo = self._checkUploadSize(upload)
+        if quotaInfo:
+            # Delete the upload
+            self.model('upload').cancelUpload(upload)
+            raise GirderException(
+                'Upload exceeded file storage quota (need %s, only %s '
+                'available - used %s out of %s)' %
+                (formatSize(quotaInfo['sizeNeeded']),
+                 formatSize(quotaInfo['quotaLeft']),
+                 formatSize(quotaInfo['quotaUsed']),
+                 formatSize(quotaInfo['fileSizeQuota'])),
+                'user_quota.upload-exceeds-quota')

--- a/plugins/user_quota/web_client/js/configView.js
+++ b/plugins/user_quota/web_client/js/configView.js
@@ -1,0 +1,95 @@
+/**
+ * Show the default quota settings for users and collections.
+ */
+girder.views.userQuota_ConfigView = girder.View.extend({
+    events: {
+        'submit #g-user-quota-form': function (event) {
+            event.preventDefault();
+            this.$('#g-user-quota-error-message').empty();
+            this._saveSettings([{
+                key: 'user_quota.default_user_quota',
+                value: girder.userQuota.valueAndUnitsToSize(
+                    this.$('.g-sizeValue[model=user]').val(),
+                    this.$('.g-sizeUnits[model=user]').val())
+            }, {
+                key: 'user_quota.default_collection_quota',
+                value: girder.userQuota.valueAndUnitsToSize(
+                    this.$('.g-sizeValue[model=collection]').val(),
+                    this.$('.g-sizeUnits[model=collection]').val())
+            }]);
+        }
+    },
+    initialize: function () {
+        girder.restRequest({
+            type: 'GET',
+            path: 'system/setting',
+            data: {
+                list: JSON.stringify(['user_quota.default_user_quota',
+                'user_quota.default_collection_quota'])
+            }
+        }).done(_.bind(function (resp) {
+            this.settings = resp;
+            this.render();
+        }, this));
+    },
+
+    render: function () {
+        var userSizeInfo = girder.userQuota.sizeToValueAndUnits(
+            this.settings['user_quota.default_user_quota']);
+        var collectionSizeInfo = girder.userQuota.sizeToValueAndUnits(
+            this.settings['user_quota.default_collection_quota']);
+        this.$el.html(girder.templates.userQuotaConfig({resources: {
+            user: {
+                model: 'user',
+                name: 'User',
+                sizeValue: userSizeInfo.sizeValue,
+                sizeUnits: userSizeInfo.sizeUnits
+            },
+            collection: {
+                model: 'collection',
+                name: 'Collection',
+                sizeValue: collectionSizeInfo.sizeValue,
+                sizeUnits: collectionSizeInfo.sizeUnits
+            }
+        }}));
+        if (!this.breadcrumb) {
+            this.breadcrumb = new girder.views.PluginConfigBreadcrumbWidget({
+                pluginName: 'User and collection quotas and policies',
+                el: this.$('.g-config-breadcrumb-container'),
+                parentView: this
+            }).render();
+        }
+
+        return this;
+    },
+
+    _saveSettings: function (settings) {
+        girder.restRequest({
+            type: 'PUT',
+            path: 'system/setting',
+            data: {
+                list: JSON.stringify(settings)
+            },
+            error: null
+        }).done(_.bind(function (resp) {
+            girder.events.trigger('g:alert', {
+                icon: 'ok',
+                text: 'Settings saved.',
+                type: 'success',
+                timeout: 4000
+            });
+        }, this)).error(_.bind(function (resp) {
+            this.$('#g-user-quota-error-message').text(
+                resp.responseJSON.message
+            );
+        }, this));
+    }
+});
+
+girder.router.route(
+    'plugins/user_quota/config', 'userQuotaConfig', function () {
+        girder.events.trigger('g:navigateTo',
+                              girder.views.userQuota_ConfigView);
+    });
+
+girder.exposePluginConfig('user_quota', 'plugins/user_quota/config');

--- a/plugins/user_quota/web_client/js/userQuota.js
+++ b/plugins/user_quota/web_client/js/userQuota.js
@@ -1,0 +1,251 @@
+/* Quota and assetstore policy user interface */
+
+(function () {
+    _.each({user: 'User', collection: 'Collection'}, function (
+            modelName, modelType) {
+        var viewName = modelName + 'View';
+        girder.views[viewName] = girder.views[viewName].extend({
+            events: function () {
+                var eventSelector = 'click .g-' + modelType + '-policies';
+                var addedEvents = {};
+                addedEvents[eventSelector] = 'editPolicies';
+                return $.extend(girder.views[viewName].__super__.events,
+                                addedEvents);
+            },
+            initialize: function (settings) {
+                this.quota = ((settings || {}).dialog === 'quota');
+                girder.views[viewName].__super__.initialize.apply(this,
+                                                                  arguments);
+            },
+            render: function () {
+                /* Add the quota menu item to the resource menu as needed */
+                girder.views[viewName].__super__.render.call(this);
+                var el = $('.g-' + modelType + '-header a.g-delete-' +
+                           modelType).closest('li');
+                var settings = {girder: girder};
+                settings[modelType] = this.model;
+                el.before(girder.templates[modelType + 'PoliciesMenu'](
+                    settings));
+                if (this.quota) {
+                    this.quota = null;
+                    this.editPolicies();
+                }
+            },
+            editPolicies: function () {
+                new girder.views.QuotaPolicies({
+                    el: $('#g-dialog-container'),
+                    model: this.model,
+                    modelType: modelType,
+                    parentView: this
+                }).on('g:saved', function (resource) {
+                    this.render();
+                }, this);
+            }
+        });
+        var fullModelName = modelName + 'Model';
+        girder.models[fullModelName] = girder.models[fullModelName].extend({
+            /* Saves the quota policy on this model to the server.  Saves the
+             * state of whatever this model's "quotaPolicy" parameter is set
+             * to.  When done, triggers the 'g:quotaPolicySaved' event on the
+             * model.
+             */
+            updateQuotaPolicy: function () {
+                girder.restRequest({
+                    path: this.resourceName + '/' + this.get('_id') + '/quota',
+                    type: 'PUT',
+                    error: null,
+                    data: {
+                        policy: JSON.stringify(this.get('quotaPolicy'))
+                    }
+                }).done(_.bind(function () {
+                    this.trigger('g:quotaPolicySaved');
+                }, this)).error(_.bind(function (err) {
+                    this.trigger('g:error', err);
+                }, this));
+
+                return this;
+            },
+            /* Fetches the quota policy from the server, and sets it as the
+             * quotaPolicy property.
+             * @param force: By default, this only fetches quotaPolicy if it
+             *               hasn't already been set on the model.  If you want
+             *               to force a refresh anyway, set this param to true.
+             */
+            fetchQuotaPolicy: function (force) {
+                this.off('g:fetched').on('g:fetched', function () {
+                    this.fetchAssetstores(force);
+                });
+                if (!this.get('quotaPolicy') || force) {
+                    girder.restRequest({
+                        path: this.resourceName + '/' + this.get('_id') + '/quota',
+                        type: 'GET'
+                    }).done(_.bind(function (resp) {
+                        this.set('quotaPolicy', resp.quota);
+                        this.fetch();
+                    }, this)).error(_.bind(function (err) {
+                        this.trigger('g:error', err);
+                    }, this));
+                } else {
+                    this.fetch();
+                }
+                return this;
+            },
+            /* Fetches the list of assetstores from the server, and sets it as
+             * the assetstoreList property.  This is the second part of
+             * fetching quota policy, as we need to know the assetstores for
+             * the user interface.
+             * @param force: By default, this only fetches assetstoreList if it
+             *               hasn't already been set on the model.  If you want
+             *               to force a refresh anyway, set this param to true.
+             */
+            fetchAssetstores: function (force) {
+                if (girder.currentUser.get('admin') &&
+                        (!this.get('assetstoreList') || force)) {
+                    this.set('assetstoreList', new girder.collections.AssetstoreCollection());
+                    this.get('assetstoreList').on('g:changed', function () {
+                        this.trigger('g:quotaPolicyFetched');
+                    }, this).fetch();
+                } else {
+                    this.trigger('g:quotaPolicyFetched');
+                }
+                return this;
+            }
+        });
+    });
+    girder.views.UploadWidget = girder.views.UploadWidget.extend({
+        uploadNextFile: function () {
+            this.$('.g-drop-zone').addClass('hide');
+            girder.views.UploadWidget.__super__.uploadNextFile.call(this);
+            this.currentFile.on('g:upload.error', function (info) {
+                if (info.identifier === 'user_quota.upload-exceeds-quota') {
+                    this.$('.g-drop-zone').removeClass('hide');
+                }
+            }, this).on('g:upload.errorStarting', function (info) {
+                if (info.identifier === 'user_quota.upload-exceeds-quota') {
+                    this.$('.g-drop-zone').removeClass('hide');
+                }
+            }, this);
+        }
+    });
+}());
+
+girder.views.QuotaPolicies = girder.View.extend({
+    events: {
+        'submit #g-policies-edit-form': function (e) {
+            e.preventDefault();
+            var fields = {
+                fileSizeQuota: this.$('#g-fileSizeQuota').val(),
+                preferredAssetstore: this.$('#g-preferredAssetstore').val(),
+                fallbackAssetstore: this.$('#g-fallbackAssetstore').val()
+            };
+            this.updateQuotaPolicies(fields);
+            this.$('button.g-save-policies').addClass('disabled');
+            this.$('.g-validation-failed-message').text('');
+        }
+    },
+
+    initialize: function (settings) {
+        this.model = settings.model;
+        this.modelType = settings.modelType;
+        this.model.on('g:quotaPolicyFetched', function () {
+            this.render();
+        }, this).fetchQuotaPolicy();
+    },
+
+    capacityChart: function (view, el) {
+        var quota = view.model.get('quotaPolicy').fileSizeQuota;
+        if (!quota) {
+            $(el).addClass('g-no-chart');
+            return;
+        }
+        $(el).addClass('g-has-chart');
+        var used = view.model.get('size');
+        var free = used < quota ? quota - used : 0;
+        var data = [
+            ['Used', used],
+            ['Free', free]
+        ];
+        var plot = $(el).jqplot([data], {
+            seriesDefaults: {
+                renderer: $.jqplot.PieRenderer,
+                rendererOptions: {
+                    sliceMargin: 2,
+                    shadow: false,
+                    highlightMouseOver: false,
+                    showDataLabels: true,
+                    padding: 5
+                }
+            },
+            legend: {
+                show: true,
+                location: 'e',
+                background: 'transparent',
+                border: 'none'
+            },
+            grid: {
+                background: 'transparent',
+                border: 'none',
+                borderWidth: 0,
+                shadow: false
+            },
+            gridPadding: {top: 10, right: 10, bottom: 10, left: 10}
+        });
+    },
+
+    capacityString: function () {
+        var quota = this.model.get('quotaPolicy').fileSizeQuota;
+        if (!quota) {
+            return 'Unlimited';
+        }
+        var used = this.model.get('size');
+        var free = quota - used;
+        if (free > 0) {
+            return girder.formatSize(free) + ' free of ' +
+                girder.formatSize(quota);
+        }
+        return 'No space left of ' + girder.formatSize(quota);
+    },
+
+    render: function () {
+        var view = this;
+        var name = view.model.attributes.name;
+        if (view.modelType === 'user') {
+            name = view.model.attributes.firstName + ' ' +
+                   view.model.attributes.lastName;
+        }
+        var modal = this.$el.html(girder.templates.quotaPolicies({
+            girder: girder,
+            model: view.model,
+            modelType: view.modelType,
+            name: name,
+            quotaPolicy: view.model.get('quotaPolicy'),
+            assetstoreList: (girder.currentUser.get('admin') ?
+                view.model.get('assetstoreList').models : undefined),
+            capacityString: ' ' + this.capacityString()
+        })).girderModal(this).on('shown.bs.modal', function () {
+            view.$('#g-fileSizeQuota').focus();
+            view.capacityChart(view, '.g-quota-capacity-chart');
+        }).on('hidden.bs.modal', function () {
+            girder.dialogs.handleClose('quota');
+        });
+        modal.trigger($.Event('ready.girder.modal', {relatedTarget: modal}));
+        view.$('#g-fileSizeQuota').focus();
+        girder.dialogs.handleOpen('quota');
+        return this;
+    },
+
+    updateQuotaPolicies: function (fields) {
+        var view = this;
+        _.each(fields, function (value, key) {
+            view.model.get('quotaPolicy')[key] = value;
+        });
+        this.model.on('g:quotaPolicySaved', function () {
+            this.$el.modal('hide');
+            this.trigger('g:saved', this.model);
+        }, this).off('g:error').on('g:error', function (err) {
+            this.$('.g-validation-failed-message').text(err.responseJSON.message);
+            this.$('button.g-save-policies').removeClass('disabled');
+            this.$('#g-' + err.responseJSON.field).focus();
+        }, this).updateQuotaPolicy();
+    }
+});

--- a/plugins/user_quota/web_client/stylesheets/quotaPolicies.styl
+++ b/plugins/user_quota/web_client/stylesheets/quotaPolicies.styl
@@ -1,0 +1,8 @@
+.g-quota-description
+  font-size 12px
+  margin 0 0 2px 0
+.g-quota-capacity-chart
+  height 15px
+  width 280px
+  &.g-has-chart
+    height 150px

--- a/plugins/user_quota/web_client/stylesheets/quotaPolicies.styl
+++ b/plugins/user_quota/web_client/stylesheets/quotaPolicies.styl
@@ -1,8 +1,16 @@
-.g-quota-description
-  font-size 12px
-  margin 0 0 2px 0
-.g-quota-capacity-chart
-  height 15px
-  width 280px
-  &.g-has-chart
-    height 150px
+#g-policies-edit-form
+  .g-quota-description
+    font-size 12px
+    margin 0 0 2px 0
+  .g-quota-capacity-chart
+    height 15px
+    width 280px
+    &.g-has-chart
+      height 150px
+  #g-sizeValue
+    display inline-block
+    width 200px
+    margin-right 10px
+  #g-sizeUnits
+    display inline-block
+    width 100px

--- a/plugins/user_quota/web_client/stylesheets/quotaPolicies.styl
+++ b/plugins/user_quota/web_client/stylesheets/quotaPolicies.styl
@@ -1,4 +1,4 @@
-#g-policies-edit-form
+#g-policies-edit-form,#g-user-quota-form
   .g-quota-description
     font-size 12px
     margin 0 0 2px 0
@@ -7,10 +7,13 @@
     width 280px
     &.g-has-chart
       height 150px
-  #g-sizeValue
+  .g-sizeValue
     display inline-block
-    width 200px
+    width 150px
     margin-right 10px
-  #g-sizeUnits
+  .g-sizeUnits
     display inline-block
-    width 100px
+    width auto
+  .g-customQuota
+    display inline-block
+    margin 0 10px 0 0

--- a/plugins/user_quota/web_client/templates/collectionPoliciesMenu.jade
+++ b/plugins/user_quota/web_client/templates/collectionPoliciesMenu.jade
@@ -1,0 +1,8 @@
+if collection.getAccessLevel() >= girder.AccessType.ADMIN
+  li(role="presentation")
+    a.g-collection-policies(role="menuitem")
+      i.icon-box
+      if girder.currentUser.get('admin')
+        | Quota and Assetstore Policies
+      else
+        | Quota

--- a/plugins/user_quota/web_client/templates/quotaPolicies.jade
+++ b/plugins/user_quota/web_client/templates/quotaPolicies.jade
@@ -17,10 +17,16 @@
           .form-group
             label.control-label(for="g-fileSizeQuota") File Size Quota
             p.g-quota-description
-              | This is the maximum allowed size of all files in bytes.
-            input.input-sm#g-fileSizeQuota.form-control(type="text",
-              value="#{quotaPolicy.fileSizeQuota ? quotaPolicy.fileSizeQuota : ''}",
-              placeholder="Maximum allowed size of all files in bytes, or blank for no limit")
+              | This is the maximum allowed size of all files.
+            input.input-sm#g-sizeValue.form-control(type="text",
+              value="#{sizeValue ? sizeValue : ''}",
+              placeholder="Maximum allowed size of all files, or blank for no limit")
+            select#g-sizeUnits.form-control.input-sm
+              option(value='0', selected=(sizeUnits === 0)) bytes
+              option(value='1', selected=(sizeUnits === 1)) kB
+              option(value='2', selected=(sizeUnits === 2)) MB
+              option(value='3', selected=(sizeUnits === 3)) GB
+              option(value='4', selected=(sizeUnits === 4)) TB
           .form-group
             label.control-label(for="g-preferredAssetstore") Preferred Assetstore
             p.g-quota-description

--- a/plugins/user_quota/web_client/templates/quotaPolicies.jade
+++ b/plugins/user_quota/web_client/templates/quotaPolicies.jade
@@ -1,0 +1,51 @@
+.modal-dialog
+  .modal-content
+    form#g-policies-edit-form.modal-form(role="form")
+      .modal-header
+        button.close(data-dismiss="modal", aria-hidden="true", type="button") &times;
+        h4.modal-title
+          if girder.currentUser.get('admin')
+            | Quota and Assetstore Policies for #{name}
+          else
+            | Quota for #{name}
+      .modal-body
+        div
+          b Quota:
+          span.g-quota-capacity #{capacityString}
+          .g-quota-capacity-chart
+        if girder.currentUser.get('admin')
+          .form-group
+            label.control-label(for="g-fileSizeQuota") File Size Quota
+            p.g-quota-description
+              | This is the maximum allowed size of all files in bytes.
+            input.input-sm#g-fileSizeQuota.form-control(type="text",
+              value="#{quotaPolicy.fileSizeQuota ? quotaPolicy.fileSizeQuota : ''}",
+              placeholder="Maximum allowed size of all files in bytes, or blank for no limit")
+          .form-group
+            label.control-label(for="g-preferredAssetstore") Preferred Assetstore
+            p.g-quota-description
+              | Any file that is upload will be sent to this assetstore.
+              | Existing files are not moved.
+            select#g-preferredAssetstore.form-control.input-sm
+              option(value='current', selected=(!quotaPolicy.preferredAssetstore)) Current Assetstore
+              each assetstore in assetstoreList
+                option(value='#{assetstore.get("_id")}', selected=(quotaPolicy.preferredAssetstore == assetstore.get('_id'))) #{assetstore.get('name')}
+          .form-group
+            label.control-label(for="g-fallbackAssetstore") Fallback Assetstore
+            p.g-quota-description
+              | This assetstore is used if the preferred assetstore is offline or
+              | unavailable.
+            select#g-fallbackAssetstore.form-control.input-sm
+              option(value='current', selected=(!quotaPolicy.fallbackAssetstore)) Current Assetstore
+              each assetstore in assetstoreList
+                option(value='#{assetstore.get("_id")}', selected=(quotaPolicy.fallbackAssetstore == assetstore.get('_id'))) #{assetstore.get('name')}
+              option(value='none', selected=(quotaPolicy.fallbackAssetstore == 'none')) None
+          .g-validation-failed-message
+      .modal-footer
+        if girder.currentUser.get('admin')
+          a.btn.btn-small.btn-default(data-dismiss="modal") Cancel
+          button.g-save-policies.btn.btn-small.btn-primary(type="submit")
+            i.icon-edit
+            | Save
+        else
+          a.btn.btn-small.btn-default(data-dismiss="modal") Close

--- a/plugins/user_quota/web_client/templates/quotaPolicies.jade
+++ b/plugins/user_quota/web_client/templates/quotaPolicies.jade
@@ -15,13 +15,25 @@
           .g-quota-capacity-chart
         if girder.currentUser.get('admin')
           .form-group
-            label.control-label(for="g-fileSizeQuota") File Size Quota
+            label.control-label(for="g-sizeValue") File Size Quota
             p.g-quota-description
               | This is the maximum allowed size of all files.
-            input.input-sm#g-sizeValue.form-control(type="text",
+            .radio
+              label
+                input#g-defaultQuota(type="radio", name="defaultQuota",
+                  value="True",
+                  checked=(quotaPolicy.useQuotaDefault !== false))
+                | Use the default quota: #{defaultQuotaString}
+            .radio.g-customQuota
+              label
+                input#g-customQuota(type="radio", name="defaultQuota",
+                  value="False",
+                  checked=(quotaPolicy.useQuotaDefault === false))
+                | Use a specific quota:
+            input.input-sm#g-sizeValue.g-sizeValue.form-control(type="text",
               value="#{sizeValue ? sizeValue : ''}",
               placeholder="Maximum allowed size of all files, or blank for no limit")
-            select#g-sizeUnits.form-control.input-sm
+            select#g-sizeUnits.form-control.input-sm.g-sizeUnits
               option(value='0', selected=(sizeUnits === 0)) bytes
               option(value='1', selected=(sizeUnits === 1)) kB
               option(value='2', selected=(sizeUnits === 2)) MB

--- a/plugins/user_quota/web_client/templates/userPoliciesMenu.jade
+++ b/plugins/user_quota/web_client/templates/userPoliciesMenu.jade
@@ -1,0 +1,8 @@
+if user.getAccessLevel() >= girder.AccessType.ADMIN
+  li(role="presentation")
+    a.g-user-policies(role="menuitem")
+      i.icon-box
+      if girder.currentUser.get('admin')
+        | Quota and Assetstore Policies
+      else
+        | Quota

--- a/plugins/user_quota/web_client/templates/userQuotaConfig.jade
+++ b/plugins/user_quota/web_client/templates/userQuotaConfig.jade
@@ -1,0 +1,25 @@
+.g-config-breadcrumb-container
+p.g-quota-description
+  | Quotas limit the maximum storage space available for each user and
+  | collection.
+form#g-user-quota-form(role="form")
+  each resource in resources
+    .form-group
+      label.control-label(for="g-#{resource.model}SizeValue")
+        | Default #{resource.name} File Size Quota
+      p.g-quota-description
+        | This is the maximum allowed size of all files for individual
+        | #{resource.model}s, unless that #{resource.model}'s quota is
+        | explicitly set.
+      input.input-sm.g-sizeValue.form-control(
+        type="text", value="#{resource.sizeValue ? resource.sizeValue : ''}",
+        placeholder="Maximum allowed size of all files, or blank for no limit",
+        model="#{resource.model}")
+      select.form-control.input-sm.g-sizeUnits(model="#{resource.model}")
+        option(value='0', selected=(resource.sizeUnits === 0)) bytes
+        option(value='1', selected=(resource.sizeUnits === 1)) kB
+        option(value='2', selected=(resource.sizeUnits === 2)) MB
+        option(value='3', selected=(resource.sizeUnits === 3)) GB
+        option(value='4', selected=(resource.sizeUnits === 4)) TB
+  p#g-user-quota-error-message.g-validation-failed-message
+  input.btn.btn-sm.btn-primary(type="submit", value="Save")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,13 +35,11 @@ add_python_test(user)
 add_python_test(webroot)
 
 
-add_web_client_test(data_filesystem "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE filesystem RESOURCE_LOCKS uploadtest)
-add_web_client_test(data_gridfs "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE gridfs RESOURCE_LOCKS uploadtest)
-add_web_client_test(data_gridfsrs "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE gridfsrs RESOURCE_LOCKS replicaset uploadtest)
-add_web_client_test(data_s3 "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE s3 WEBSECURITY false RESOURCE_LOCKS uploadtest)
-# We don't use the replicaset for the admin test, but if it comes or goes
-# during the test, it can cause a failure
-add_web_client_test(admin "${PROJECT_SOURCE_DIR}/clients/web/test/spec/adminSpec.js" ASSETSTORE s3 WEBSECURITY false RESOURCE_LOCKS replicaset)
+add_web_client_test(data_filesystem "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE filesystem)
+add_web_client_test(data_gridfs "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE gridfs)
+add_web_client_test(data_gridfsrs "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE gridfsrs RESOURCE_LOCKS replicaset)
+add_web_client_test(data_s3 "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE s3 WEBSECURITY false)
+add_web_client_test(admin "${PROJECT_SOURCE_DIR}/clients/web/test/spec/adminSpec.js" ASSETSTORE s3 WEBSECURITY false)
 add_web_client_test(collection "${PROJECT_SOURCE_DIR}/clients/web/test/spec/collectionSpec.js")
 add_web_client_test(group "${PROJECT_SOURCE_DIR}/clients/web/test/spec/groupSpec.js")
 add_web_client_test(user "${PROJECT_SOURCE_DIR}/clients/web/test/spec/userSpec.js")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,13 +35,13 @@ add_python_test(user)
 add_python_test(webroot)
 
 
-add_web_client_test(data_filesystem "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE filesystem)
-add_web_client_test(data_gridfs "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE gridfs)
-add_web_client_test(data_gridfsrs "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE gridfsrs RESOURCE_LOCKS replicaset mongo cherrypy)
-add_web_client_test(data_s3 "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE s3 WEBSECURITY false)
+add_web_client_test(data_filesystem "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE filesystem RESOURCE_LOCKS uploadtest)
+add_web_client_test(data_gridfs "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE gridfs RESOURCE_LOCKS uploadtest)
+add_web_client_test(data_gridfsrs "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE gridfsrs RESOURCE_LOCKS replicaset uploadtest)
+add_web_client_test(data_s3 "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE s3 WEBSECURITY false RESOURCE_LOCKS uploadtest)
 # We don't use the replicaset for the admin test, but if it comes or goes
 # during the test, it can cause a failure
-add_web_client_test(admin "${PROJECT_SOURCE_DIR}/clients/web/test/spec/adminSpec.js" ASSETSTORE s3 WEBSECURITY false RESOURCE_LOCKS replicaset mongo cherrypy)
+add_web_client_test(admin "${PROJECT_SOURCE_DIR}/clients/web/test/spec/adminSpec.js" ASSETSTORE s3 WEBSECURITY false RESOURCE_LOCKS replicaset)
 add_web_client_test(collection "${PROJECT_SOURCE_DIR}/clients/web/test/spec/collectionSpec.js")
 add_web_client_test(group "${PROJECT_SOURCE_DIR}/clients/web/test/spec/groupSpec.js")
 add_web_client_test(user "${PROJECT_SOURCE_DIR}/clients/web/test/spec/userSpec.js")

--- a/tests/JavascriptTests.cmake
+++ b/tests/JavascriptTests.cmake
@@ -1,3 +1,5 @@
+set(web_client_port 50001)
+
 function(javascript_tests_init)
   add_test(
     NAME js_coverage_reset
@@ -89,14 +91,21 @@ function(add_web_client_test case specFile)
     "WEB_SECURITY=${webSecurity}"
     "ENABLED_PLUGINS=${plugins}"
     "COVERAGE_FILE=${PROJECT_BINARY_DIR}/js_coverage/${case}.cvg"
-    "GIRDER_TEST_DB=mongodb://localhost:27017/girder_test_webclient"
-    "GIRDER_TEST_ASSETSTORE=webclient"
+    "GIRDER_TEST_DB=mongodb://localhost:27017/girder_test_${testname}"
+    "GIRDER_TEST_ASSETSTORE=webclient_${testname}"
+    "GIRDER_PORT=${web_client_port}"
   )
+  math(EXPR next_web_client_port "${web_client_port} + 1")
+  set(web_client_port ${next_web_client_port} PARENT_SCOPE)
+
   if(fn_RESOURCE_LOCKS)
     set_property(TEST ${testname} PROPERTY RESOURCE_LOCK ${fn_RESOURCE_LOCKS})
-  else()
-    set_property(TEST ${testname} PROPERTY RESOURCE_LOCK mongo cherrypy)
   endif()
+  #if(fn_RESOURCE_LOCKS)
+  #  set_property(TEST ${testname} PROPERTY RESOURCE_LOCK mongo cherrypy ${fn_RESOURCE_LOCKS})
+  #else()
+  #  set_property(TEST ${testname} PROPERTY RESOURCE_LOCK mongo cherrypy)
+  #endif()
   if(fn_TIMEOUT)
     set_property(TEST ${testname} PROPERTY TIMEOUT ${fn_TIMEOUT})
   endif()

--- a/tests/base.py
+++ b/tests/base.py
@@ -138,7 +138,8 @@ class TestCase(unittest.TestCase, model_importer.ModelImporter):
             ROOT_DIR, 'tests', 'assetstore',
             os.environ.get('GIRDER_TEST_ASSETSTORE', 'test'))
         if assetstoreType == 'gridfs':
-            gridfsDbName = 'gridfs_assetstore_test'
+            gridfsDbName = os.environ.get('GIRDER_TEST_ASSETSTORE',
+                                          'gridfs_assetstore_test')
             dropGridFSDatabase(gridfsDbName)
             self.assetstore = self.model('assetstore'). \
                 createGridFsAssetstore(name='Test', db=gridfsDbName)

--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -143,7 +143,7 @@ class AssetstoreTestCase(base.TestCase):
         # current assetstore will be switched to the second one.
         secondStore = self.model('assetstore').createFilesystemAssetstore(
             'Another Store',  os.path.join(ROOT_DIR, 'tests', 'assetstore',
-                                           'test2'))
+                                           'server_assetstore_test2'))
         # make sure our original asset store is the current one
         current = self.model('assetstore').getCurrent()
         self.assertEqual(current['_id'], assetstore['_id'])

--- a/tests/mock_s3.py
+++ b/tests/mock_s3.py
@@ -31,7 +31,7 @@ import moto.s3
 from girder.utility.s3_assetstore_adapter import makeBotoConnectParams, \
     botoConnectS3, S3AssetstoreAdapter
 
-_startPort = 50100
+_startPort = 51100
 _maxTries = 100
 
 

--- a/tests/mock_smtp.py
+++ b/tests/mock_smtp.py
@@ -23,8 +23,8 @@ import smtpd
 import threading
 import time
 
-_startPort = 50002
-_maxTries = 98
+_startPort = 51000
+_maxTries = 100
 
 
 class MockSmtpServer(smtpd.SMTPServer):

--- a/tests/web_client_test.py
+++ b/tests/web_client_test.py
@@ -23,7 +23,7 @@ import sys
 import time
 
 # Need to set the environment variable before importing girder
-os.environ['GIRDER_PORT'] = '50001'
+os.environ['GIRDER_PORT'] = os.environ.get('GIRDER_PORT', '50001')
 
 from girder.api import access
 from girder.api.describe import Description
@@ -112,7 +112,8 @@ class WebClientTestCase(base.TestCase):
                 ROOT_DIR, 'node_modules', 'phantomjs', 'bin', 'phantomjs'),
             '--web-security=%s' % self.webSecurity,
             os.path.join(ROOT_DIR, 'clients', 'web', 'test', 'specRunner.js'),
-            'http://localhost:50001/static/built/testEnv.html',
+            'http://localhost:%s/static/built/testEnv.html' % os.environ[
+                'GIRDER_PORT'],
             self.specFile,
             self.coverageFile
         )


### PR DESCRIPTION
Added support for preferred and fallback assetstores on users and collections.

Added user interface for quota and assetstore policies for users and collections.  This includes pie charts for capacity.  Non admins can check their own user and collection capacities.

Implemented quotas for total file size for users and collections.

Added a GirderException so that errors that aren't strictly RestExceptions, are failures, but aren't catastrophic, can be handled distinctly.  For instance, if the assetstore for a particular user is unavailable, there is not necessarily anything wrong with the system (just with the assetstore).  These have an optional 'identifier' that can get passed through to a rest consumer or other error handler.  This obviates the need to parse the error text to determine the type of error.

Updated documentation for new events.

Parallelized web_client tests.  Most web_client tests can now be run in parallel.  Those involving monog replicasets cannot.  Those that upload via the phantomjs hook in the specRunner cannot.  These ones could be parallelized by using distinct file names so as not to clobber one another.

Adjusted some doc strings to fix some sphinx warnings.

Added tests for quota and assetstore policies for both server and web client.

Format sizes the same way in javascipt and python.

Offer to repick files from the upload widget if it fails due to space.

Moved testUpload to the general javascript testUtils so that more than one test can use it.