### PR TITLE
Dialog container not always removed.

### DIFF
--- a/clients/web/src/view.js
+++ b/clients/web/src/view.js
@@ -40,6 +40,7 @@ girder.View = Backbone.View.extend({
                 }).modal('hide');
                 el.modal('removeBackdrop');
             } else {
+                el.modal('hideModal');
                 el.modal('removeBackdrop');
                 el.empty().off().removeData();
             }

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -422,8 +422,7 @@ girderTest.testMetadata = function () {
 girderTest.waitForLoad = function (desc) {
     desc = desc?' ('+desc+')':'';
     waitsFor(function() {
-        return $('#g-dialog-container:visible').length === 0 ||
-               $('#g-dialog-container:visible').children().length === 0;
+        return $('#g-dialog-container:visible').length === 0;
     }, 'for the dialog container to be hidden'+desc);
     /* It is faster to wait to make sure a dialog is being hidden than to wait
      * for it to be fully gone.  It is probably more reliable, too.  This had


### PR DESCRIPTION
When we dispose of certain dialogs, we weren't giving them a chance to fully clean up.  This could lead to the dialog container remaining present and consuming all clicks.  I've updated the tests so that they fail in this condition, and fixed the problem.  This fixes issue #604.