### PR TITLE
Ensure boolean return value from _hasGroupAccess

### DIFF
--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -371,6 +371,7 @@ class AccessControlledModel(Model):
         for groupAccess in perms:
             if groupAccess['id'] in groupIds and groupAccess['level'] >= level:
                 return True
+        return False
 
     def _hasUserAccess(self, perms, userId, level):
         """


### PR DESCRIPTION
This isn't very impactful since it's just a private method, but it still can't hurt to make it consistent.