### PR TITLE
Added a temporary access token as an alternative to resetting a password.

### DIFF
--- a/clients/web/src/app.js
+++ b/clients/web/src/app.js
@@ -181,6 +181,7 @@ girder.App = girder.View.extend({
         girder.router.navigate(route, {trigger: true});
 
         if (girder.currentUser) {
+            girder.eventStream.close();
             girder.eventStream.open();
         } else {
             girder.eventStream.close();

--- a/clients/web/src/templates/body/userSettings.jade
+++ b/clients/web/src/templates/body/userSettings.jade
@@ -42,9 +42,12 @@ ul.g-account-tabs.nav.nav-tabs
   #g-account-tab-password.tab-pane
     .g-password-change-container
       form#g-password-change-form(role="form")
-        .form-group
-          label(for="g-password-old") Current password
-          input.input-sm.form-control#g-password-old(type="password", placeholder="Enter current password")
+        if temporaryToken
+            input.input-sm.form-control#g-password-old(type="hidden", value="#{temporaryToken}")
+        else
+          .form-group
+            label(for="g-password-old") Current password
+            input.input-sm.form-control#g-password-old(type="password", placeholder="Enter current password")
         .form-group
           label(for="g-password-new") New password
           input.input-sm.form-control#g-password-new(type="password", placeholder="Enter new password")

--- a/clients/web/src/templates/layout/resetPasswordDialog.jade
+++ b/clients/web/src/templates/layout/resetPasswordDialog.jade
@@ -3,12 +3,12 @@
     form#g-reset-password-form.modal-form(role="form")
       .modal-header
         button.close(data-dismiss="modal", aria-hidden="true", type="button") &times;
-        h4.modal-title Reset password
+        h4.modal-title Forgotten password
       .modal-body
         .g-password-reset-explanation
-          | If you have forgotten your password, you can enter your email address
-          | here. Your password will be reset and an email will be sent to that
-          | address with the new password.
+          | If you have forgotten your password, enter your email address here.
+          | You will be sent an email with a temporary access link, from
+          | which you can reset your password.
         .form-group
           label.control-label(for="g-email") Email
           input.input-sm#g-email.form-control(type="text", placeholder="Enter your email")
@@ -21,4 +21,4 @@
         a.btn.btn-default(data-dismiss="modal") Close
         button#g-reset-password-button.btn.btn-primary(type="submit")
           i.icon-mail
-          |  Reset
+          |  Submit

--- a/clients/web/src/utilities/EventStream.js
+++ b/clients/web/src/utilities/EventStream.js
@@ -37,6 +37,7 @@
     prototype.close = function () {
         if (this._eventSource) {
             this._eventSource.close();
+            this._eventSource = null;
         }
     };
 } ());

--- a/clients/web/src/views/body/UserSettingsView.js
+++ b/clients/web/src/views/body/UserSettingsView.js
@@ -73,6 +73,7 @@ girder.views.UserAccountView = girder.View.extend({
             settings.user.get('_id') === girder.currentUser.get('_id');
 
         this.model = this.user;
+        this.temporary = settings.temporary;
 
         if (!this.user ||
                 this.user.getAccessLevel() < girder.AccessType.WRITE) {
@@ -88,7 +89,6 @@ girder.views.UserAccountView = girder.View.extend({
     },
 
     render: function () {
-
         if (girder.currentUser === null) {
             girder.router.navigate('users', {trigger: true});
             return;
@@ -96,7 +96,8 @@ girder.views.UserAccountView = girder.View.extend({
 
         this.$el.html(girder.templates.userSettings({
             user: this.model,
-            girder: girder
+            girder: girder,
+            temporaryToken: this.temporary
         }));
 
         _.each($('.g-account-tabs>li>a'), function (el) {
@@ -141,4 +142,26 @@ girder.router.route('useraccount/:id/:tab', 'accountTab', function (id, tab) {
     }, this).on('g:error', function () {
         girder.router.navigate('users', {trigger: true});
     }, this).fetch();
+});
+
+girder.router.route('useraccount/:id/token/:token', 'accountToken', function (id, token) {
+    girder.restRequest({
+        path: 'user/password/temporary/' + id,
+        type: 'GET',
+        data: {token: token},
+        error: null
+    }).done(_.bind(function (resp) {
+        resp.user.token = resp.authToken.token;
+        girder.eventStream.close();
+        girder.currentUser = new girder.models.UserModel(resp.user);
+        girder.eventStream.open();
+        girder.events.trigger('g:login-changed');
+        girder.events.trigger('g:navigateTo', girder.views.UserAccountView, {
+            user: girder.currentUser,
+            tab: 'password',
+            temporary: token
+        });
+    }, this)).error(_.bind(function (err) {
+        girder.router.navigate('users', {trigger: true});
+    }, this));
 });

--- a/clients/web/src/views/layout/GlobalNavView.js
+++ b/clients/web/src/views/layout/GlobalNavView.js
@@ -18,6 +18,7 @@ girder.views.LayoutGlobalNavView = girder.View.extend({
     initialize: function (settings) {
         girder.events.on('g:highlightItem', this.selectForView, this);
         girder.events.on('g:login', this.render, this);
+        girder.events.on('g:login-changed', this.render, this);
 
         settings = settings || {};
         if (settings.navItems) {

--- a/clients/web/src/views/layout/HeaderUserView.js
+++ b/clients/web/src/views/layout/HeaderUserView.js
@@ -34,6 +34,7 @@ girder.views.LayoutHeaderUserView = girder.View.extend({
 
     initialize: function () {
         girder.events.on('g:login', this.render, this);
+        girder.events.on('g:login-changed', this.render, this);
     },
 
     render: function () {

--- a/clients/web/src/views/layout/ResetPasswordView.js
+++ b/clients/web/src/views/layout/ResetPasswordView.js
@@ -7,8 +7,9 @@ girder.views.ResetPasswordView = girder.View.extend({
             e.preventDefault();
 
             girder.restRequest({
-                path: 'user/password?email=' + this.$('#g-email').val().trim(),
-                type: 'DELETE',
+                path: 'user/password/temporary?email=' + this.$('#g-email')
+                    .val().trim(),
+                type: 'PUT',
                 error: null // don't do default error behavior
             }).done(_.bind(function (resp) {
                 this.$el.modal('hide');

--- a/clients/web/test/spec/routingSpec.js
+++ b/clients/web/test/spec/routingSpec.js
@@ -142,7 +142,7 @@ describe('Test routing paths', function () {
             return $('input#g-password2').length === 1;
         });
         girderTest.testRoute('?dialog=resetpassword', true, function () {
-            return $('.modal-title').text() === 'Reset password';
+            return $('.modal-title').text() === 'Forgotten password';
         });
         /* Navigate to a non-dialog so we can log in */
         girderTest.testRoute('collections', false, function () {

--- a/clients/web/test/specRunner.js
+++ b/clients/web/test/specRunner.js
@@ -40,23 +40,12 @@ var terminate = function () {
     });
 
     if (status) {
-        safePhantomExit(0);
+        phantom.exit(0);
     }
     else {
-        safePhantomExit(1);
+        phantom.exit(1);
     }
 };
-
-/* Exit phantom instance "safely" see
- * https://github.com/ariya/phantomjs/issues/12697
- * https://github.com/mammaldev/node-webshot-mammal/commit/9b26fb3
- */
-function safePhantomExit() {
-    var args = [].slice.call(arguments);
-    setTimeout(function () {
-        phantom.exit.apply(phantom, args);
-    }, 0);
-}
 
 // Set decent viewport size for screenshots.
 page.viewportSize = {
@@ -147,19 +136,19 @@ page.onError = function (msg, trace) {
     console.log('<DartMeasurementFile name="PhantomErrorScreenshot" type="image/png">' +
         fs.workingDirectory + '/phantom_error_screenshot.png</DartMeasurementFile>');
     page.render('phantom_error_screenshot.png');
-    safePhantomExit(1);
+    phantom.exit(1);
 };
 
 page.onLoadFinished = function (status) {
     if (status !== 'success') {
         console.error('Page load failed');
-        safePhantomExit(1);
+        phantom.exit(1);
     }
 
     page.injectJs('coverageHandler.js');
     if (!page.injectJs(spec)) {
         console.error('Could not load test spec into page: ' + spec);
-        safePhantomExit(1);
+        phantom.exit(1);
     }
 };
 
@@ -181,6 +170,6 @@ page.onResourceTimeout = function (request) {
 page.open(pageUrl, function (status) {
     if (status !== 'success') {
         console.error('Could not load page: ' + pageUrl);
-        safePhantomExit(1);
+        phantom.exit(1);
     }
 });

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -466,7 +466,7 @@ girderTest.waitForDialog = function (desc) {
 };
 
 /**
- * Import a javascript file and ask register it with the blanket coverage
+ * Import a javascript file and ask to register it with the blanket coverage
  * tests.
  */
 girderTest.addCoveredScript = function (url) {
@@ -577,6 +577,18 @@ girderTest.testRoute = function (route, hasDialog, testFunc)
     }
 };
 
+/* Determine a value used to keep tests using different files.
+ * @returns suffix: the suffix used in callPhantom actions.
+ */
+girderTest.getCallbackSuffix = function () {
+    girderTest._uploadSuffix = '';
+    var hostport = window.location.host.match(':([0-9]+)');
+    if (hostport && hostport.length === 2) {
+        girderTest._uploadSuffix = hostport[1];
+    }
+    return girderTest._uploadSuffix;
+}
+
 /* Upload tests require that we modify how xmlhttp requests are handled.  Check
  * that this has been done (but only do it once).
  */
@@ -587,11 +599,7 @@ function _prepareTestUpload() {
     girderTest._uploadData = null;
     /* used for resume testing */
     girderTest._uploadDataExtra = 0;
-    girderTest._uploadSuffix = '';
-    var hostport = window.location.host.match(':([0-9]+)');
-    if (hostport && hostport.length === 2) {
-        girderTest._uploadSuffix = hostport[1];
-    }
+    girderTest.getCallbackSuffix();
 
     (function (impl) {
         FormData.prototype.append = function (name, value, filename) {

--- a/girder/constants.py
+++ b/girder/constants.py
@@ -163,3 +163,4 @@ class TokenScope:
     """
     ANONYMOUS_SESSION = 'core.anonymous_session'
     USER_AUTH = 'core.user_auth'
+    TEMPORARY_USER_AUTH = 'core.user_auth.temporary'

--- a/girder/mail_templates/temporaryAccess.mako
+++ b/girder/mail_templates/temporaryAccess.mako
@@ -1,0 +1,16 @@
+<%include file="_header.mako"/>
+
+<p>
+A temporary access token was requested on your behalf.  You can access the
+girder system at
+<a href="${url}">${url}</a>.
+Once you access the system, you will have the option to update your password.
+</p>
+
+<p>
+If you did not initiate this temporary access request, you can ignore this
+email.  Temporary access is only available with the link provided and expires
+24 hours after it was requested.
+</p>
+
+<%include file="_footer.mako"/>

--- a/girder/utility/mail_utils.py
+++ b/girder/utility/mail_utils.py
@@ -24,6 +24,7 @@ import smtplib
 from email.mime.text import MIMEText
 from mako.lookup import TemplateLookup
 from girder import events
+from girder import logger
 from girder.constants import SettingKey, ROOT_DIR
 from .model_importer import ModelImporter
 
@@ -84,10 +85,13 @@ def addTemplateDirectory(dir):
 
 def _sendmail(event):
     msg = event.info
-    s = smtplib.SMTP(
-        ModelImporter().model('setting').get(SettingKey.SMTP_HOST, 'localhost'))
+    smtpHost = ModelImporter().model('setting').get(SettingKey.SMTP_HOST,
+                                                    'localhost')
+    logger.info('Sending email to %s through %s', msg['To'], smtpHost)
+    s = smtplib.SMTP(smtpHost)
     s.sendmail(msg['From'], (msg['To'],), msg.as_string())
     s.quit()
+    logger.info('Sent email to %s', msg['To'])
 
 
 _templateDir = os.path.join(ROOT_DIR, 'girder', 'mail_templates')

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "jshint": "2.5.5",
-    "phantomjs": "1.9.9",
+    "phantomjs": "1.9.13",
     "blanket": "1.1.6",
     "jscs": "1.6.1"
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "jshint": "2.5.5",
-    "phantomjs": "1.9.13",
+    "phantomjs": "1.9.9",
     "blanket": "1.1.6",
     "jscs": "1.6.1"
   },

--- a/tests/web_client_test.py
+++ b/tests/web_client_test.py
@@ -127,10 +127,16 @@ class WebClientTestCase(base.TestCase):
                                     stderr=subprocess.STDOUT)
             while task.poll() is None:
                 line = task.stdout.readline()
-                sys.stdout.write(line)
                 if ('PHANTOM_TIMEOUT' in line or
                         'error loading source script' in line):
                     retry = True
+                    sys.stdout.write(line)
+                elif '__FETCHEMAIL__' in line:
+                    msg = base.mockSmtp.getMail()
+                    open('phantom_temp_%s.tmp' % os.environ['GIRDER_PORT'],
+                         'wb').write(msg)
+                else:
+                    sys.stdout.write(line)
             returncode = task.wait()
             if not retry:
                 break

--- a/tests/web_client_test.py
+++ b/tests/web_client_test.py
@@ -119,7 +119,7 @@ class WebClientTestCase(base.TestCase):
         )
 
         # phantomjs occasionally fails to load javascript files.  This appears
-        # to be a known issue: https://github.com/ariya/phantomjs/issues/10652.i
+        # to be a known issue: https://github.com/ariya/phantomjs/issues/10652.
         # Retry several times if it looks like this has occurred.
         for tries in xrange(5):
             retry = False
@@ -130,16 +130,16 @@ class WebClientTestCase(base.TestCase):
                 if ('PHANTOM_TIMEOUT' in line or
                         'error loading source script' in line):
                     retry = True
-                    sys.stdout.write(line)
+                    sys.stderr.write(line)
                 elif '__FETCHEMAIL__' in line:
                     msg = base.mockSmtp.getMail()
                     open('phantom_temp_%s.tmp' % os.environ['GIRDER_PORT'],
                          'wb').write(msg)
                 else:
-                    sys.stdout.write(line)
+                    sys.stderr.write(line)
             returncode = task.wait()
             if not retry:
                 break
-            print 'Retrying test'
+            sys.stderr.write('Retrying test\n')
 
         self.assertEqual(returncode, 0)

--- a/tests/web_client_test.py
+++ b/tests/web_client_test.py
@@ -125,18 +125,17 @@ class WebClientTestCase(base.TestCase):
             retry = False
             task = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                     stderr=subprocess.STDOUT)
-            while task.poll() is None:
-                line = task.stdout.readline()
+            for line in iter(task.stdout.readline, ''):
                 if ('PHANTOM_TIMEOUT' in line or
                         'error loading source script' in line):
                     retry = True
-                    sys.stderr.write(line)
                 elif '__FETCHEMAIL__' in line:
                     msg = base.mockSmtp.getMail()
                     open('phantom_temp_%s.tmp' % os.environ['GIRDER_PORT'],
                          'wb').write(msg)
-                else:
-                    sys.stderr.write(line)
+                    continue  # we don't want to print this
+                sys.stdout.write(line)
+                sys.stdout.flush()
             returncode = task.wait()
             if not retry:
                 break


### PR DESCRIPTION
To support testing this, we can now check email from the mock smtp server in the web client tests.

I did not remove the reset password option, but it is no longer accessible via the web client.

This addresses issue #427.