### PR TITLE
Folders showed wrong metadata.

### DIFF
--- a/clients/web/src/views/widgets/HierarchyWidget.js
+++ b/clients/web/src/views/widgets/HierarchyWidget.js
@@ -179,6 +179,7 @@ girder.views.HierarchyWidget = girder.View.extend({
 
         if (this.parentModel.resourceName === 'folder') {
             this.itemListView.setElement(this.$('.g-item-list-container')).render();
+            this.metadataWidget.setItem(this.parentModel);
             this.metadataWidget.setElement(this.$('.g-folder-metadata')).render();
         }
 

--- a/clients/web/src/views/widgets/MetadataWidget.js
+++ b/clients/web/src/views/widgets/MetadataWidget.js
@@ -72,6 +72,10 @@ girder.views.MetadataWidget = girder.View.extend({
         });
 
         return this;
-    }
+    },
 
+    setItem: function (item) {
+        this.item = item;
+        return this;
+    }
 });

--- a/clients/web/test/spec/folderSpec.js
+++ b/clients/web/test/spec/folderSpec.js
@@ -225,6 +225,7 @@ describe('Test folder creation, editing, and deletion', function () {
         girderTest.waitForLoad();
 
         runs(function () {
+            expect($(".g-widget-metadata-row").length).toNotBe(0);
             $('i.icon-level-up').click();
         });
 
@@ -234,6 +235,8 @@ describe('Test folder creation, editing, and deletion', function () {
         girderTest.waitForLoad();
 
         runs(function () {
+            /* This folder shouldn't show any metadata */
+            expect($(".g-widget-metadata-row").length).toBe(0);
             $('a.g-breadcrumb-link').click();
         });
 


### PR DESCRIPTION
We didn't change the resource associated with the metadata widget when changing folders.  I've fixed the bug and added a test that would have caught it.

This fixes issue #608.