### PR TITLE
Fix a Grunt failure when no "server" section is defined in the local config

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,8 +33,8 @@ module.exports = function (grunt) {
         }
         try {
             var cfg = JSON.parse(stdout);
-            apiRoot = (cfg.server.api_root || '/api/v1').replace(/\"/g, "");
-            staticRoot = (cfg.server.static_root || '/static').replace(/\"/g, "");
+            apiRoot = ((cfg.server && cfg.server.api_root) || '/api/v1').replace(/\"/g, "");
+            staticRoot = ((cfg.server && cfg.server.static_root) || '/static').replace(/\"/g, "");
             console.log('Static root: ' + staticRoot.bold);
             console.log('API root: ' + apiRoot.bold);
         }


### PR DESCRIPTION
The Grunt "shell:readServerConfig" task was failing with the error "TypeError: Cannot read property 'api_root' of undefined" when a local config file was provided without a "server" section. This fixes the issue.