### PR TITLE
README.rst: Fix title underline too short

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 Girder |build-status| |docs-status| |license-badge|
-===================================
+===================================================
 
 *High-Performance Data Management Platform*
 


### PR DESCRIPTION
This prevents the description from rendering nicely on PyPI.

Merge this and then do `python setup.py register` to update the description.

See
https://bitbucket.org/pypa/pypi/pull-request/60/fix-bb-214-make-rst-rendering-not-fail-for/diff