### PR TITLE
Unset PYTHONPATH's before executing packaging tests

### DIFF
--- a/tests/packaging/pip_install_girder.sh
+++ b/tests/packaging/pip_install_girder.sh
@@ -2,6 +2,7 @@
 
 virtualenv_pip="${1}"
 PROJECT_SOURCE_DIR="${2}"
+unset PYTHONPATH
 
 "${virtualenv_pip}" uninstall girder > /dev/null
 "${virtualenv_pip}" install -U "${PROJECT_SOURCE_DIR}"/girder-[0-9].[0-9]*.tar.gz > /dev/null

--- a/tests/packaging/test_plugin_install.sh
+++ b/tests/packaging/test_plugin_install.sh
@@ -2,6 +2,7 @@
 
 virtualenv_activate="${1}"
 source_path="${2}"
+unset PYTHONPATH
 
 source "${virtualenv_activate}"
 

--- a/tests/packaging/test_rest_api.sh
+++ b/tests/packaging/test_rest_api.sh
@@ -3,6 +3,7 @@
 virtualenv_activate="${1}"
 CURL="${2}"
 GREP="${3}"
+unset PYTHONPATH
 
 source "${virtualenv_activate}"
 

--- a/tests/packaging/test_web_content.sh
+++ b/tests/packaging/test_web_content.sh
@@ -4,6 +4,7 @@ virtualenv_activate="${1}"
 source_path="${2}"
 CURL="${3}"
 GREP="${4}"
+unset PYTHONPATH
 
 source "${virtualenv_activate}"
 


### PR DESCRIPTION
When `PYTHONPATH` contains the repository directory, `girder-install` will detect the repository source as the install path.  Running the tests reinstalls plugins and web source and removes some files that don't go in the distribution tarball.  This takes the heavy handed approach of removing the `PYTHONPATH` variable entirely, but for the purpose of these tests it probably doesn't matter much.

Fixes #629