### PR TITLE
Static service util

### DIFF
--- a/clients/python/girder_client.py
+++ b/clients/python/girder_client.py
@@ -327,10 +327,10 @@ class GirderClient(object):
         Tests whether the passed in filepath exists in the item with itemId,
         with a name of filename, and with the same contents as the file at
         filepath.  Returns a tuple (file_id, current) where
-            file_id: id of the file with that filename under the item, or
-            None if no such file exists under the item.
-            current: boolean if the file with that filename under the item
-            has the same contents as the file at filepath.
+        file_id = id of the file with that filename under the item, or
+        None if no such file exists under the item.
+        current = boolean if the file with that filename under the item
+        has the same contents as the file at filepath.
 
         :param itemId: ID of parent item for file.
         :param filename: name of file to look for under the parent item.

--- a/docs/developer-cookbook.rst
+++ b/docs/developer-cookbook.rst
@@ -216,6 +216,31 @@ body would be ``0123456789``.
                 yield str(i)
         return gen
 
+Serving a static file
+^^^^^^^^^^^^^^^^^^^^^
+
+If you are building a plugin that needs to serve up a static file from a path
+on disk, you can make use of the ``staticFile`` utility, as in the following
+example:
+
+.. code-block:: python
+
+    import os
+    from girder.utility.server import staticFile
+
+    def load(info):
+        path = os.path.join(PLUGIN_ROOT_DIR, 'static', 'index.html')
+        info['serverRoot'].static_route = staticFile(path)
+
+The ``staticFile`` utility should be assigned to the route corresponding to
+where the static file should be served from.
+
+.. note:: If a relative path is passed to ``staticFile``, it will be interpreted
+  relative to the current working directory, which may vary. If your static
+  file resides within your plugin, it is recommended to use the special
+  ``PLUGIN_ROOT_DIR`` property of your server module, or the equivalent
+  ``info['pluginRootDir']`` value passed to the ``load`` method.
+
 Sending Emails
 ^^^^^^^^^^^^^^
 

--- a/docs/python-client.rst
+++ b/docs/python-client.rst
@@ -20,5 +20,5 @@ The Python Client Library
 For those wishing to write their own python scripts that interact with Girder, we
 recommend using the Girder python client library, documented below.
 
-.. automodule:: girderclient
+.. automodule:: girder_client
     :members:

--- a/girder/utility/plugin_utilities.py
+++ b/girder/utility/plugin_utilities.py
@@ -137,7 +137,8 @@ def loadPlugin(name, root, appconf, apiRoot=None, curConfig=None):
                     'name': name,
                     'config': appconf,
                     'serverRoot': root,
-                    'apiRoot': apiRoot
+                    'apiRoot': apiRoot,
+                    'pluginRootDir': os.path.abspath(pluginDir)
                 }
                 module.load(info)
 

--- a/girder/utility/server.py
+++ b/girder/utility/server.py
@@ -131,3 +131,23 @@ def setup(test=False, plugins=None, curConfig=None):
         application.merge({'server': {'mode': 'testing'}})
 
     return application
+
+
+class _StaticFileRoute(object):
+    exposed = True
+
+    def __init__(self, path):
+        self.path = path
+
+    def GET(self):
+        return cherrypy.lib.static.serve_file(self.path)
+
+
+def staticFile(path):
+    """
+    Helper function to serve a static file. This should be bound as the route
+    object, i.e. info['serverRoot'].route_name = staticFile('...')
+
+    :param path: The path of the static file to serve from this route.
+    """
+    return _StaticFileRoute(path)

--- a/girder/utility/server.py
+++ b/girder/utility/server.py
@@ -18,6 +18,7 @@
 ###############################################################################
 
 import cherrypy
+import os
 
 import girder.events
 from girder import constants
@@ -137,7 +138,7 @@ class _StaticFileRoute(object):
     exposed = True
 
     def __init__(self, path):
-        self.path = path
+        self.path = os.path.abspath(path)
 
     def GET(self):
         return cherrypy.lib.static.serve_file(self.path)

--- a/tests/cases/custom_root_test.py
+++ b/tests/cases/custom_root_test.py
@@ -79,3 +79,7 @@ class CustomRootTestCase(base.TestCase):
         # Api should not be served out of /girder/api/v1
         resp = self.request('/girder/api/v1', prefix='', isJson=False)
         self.assertStatus(resp, 404)
+
+        # Test our staticFile method
+        resp = self.request('/static_route', prefix='', isJson=False)
+        self.assertEqual(resp.collapse_body(), 'Hello world!\n')

--- a/tests/test_plugins/test_plugin/server.py
+++ b/tests/test_plugins/test_plugin/server.py
@@ -53,6 +53,5 @@ def load(info):
     del info['serverRoot'].girder.api
 
     info['apiRoot'].other = Other()
-
-    path = os.path.join(os.path.dirname(__file__), 'static.txt')
+    path = os.path.join(PLUGIN_ROOT_DIR, 'static.txt')
     info['serverRoot'].static_route = staticFile(path)

--- a/tests/test_plugins/test_plugin/server.py
+++ b/tests/test_plugins/test_plugin/server.py
@@ -53,5 +53,5 @@ def load(info):
     del info['serverRoot'].girder.api
 
     info['apiRoot'].other = Other()
-    path = os.path.join(PLUGIN_ROOT_DIR, 'static.txt')
+    path = os.path.join(globals()['PLUGIN_ROOT_DIR'], 'static.txt')
     info['serverRoot'].static_route = staticFile(path)

--- a/tests/test_plugins/test_plugin/server.py
+++ b/tests/test_plugins/test_plugin/server.py
@@ -16,10 +16,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ###############################################################################
+import os
 
 from girder.api import access
 from girder.api.describe import Description
 from girder.api.rest import Resource
+from girder.utility.server import staticFile
 
 
 class CustomAppRoot(object):
@@ -51,3 +53,7 @@ def load(info):
     del info['serverRoot'].girder.api
 
     info['apiRoot'].other = Other()
+
+    path = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                        'static.txt')
+    info['serverRoot'].static_route = staticFile(path)

--- a/tests/test_plugins/test_plugin/server.py
+++ b/tests/test_plugins/test_plugin/server.py
@@ -54,6 +54,5 @@ def load(info):
 
     info['apiRoot'].other = Other()
 
-    path = os.path.join(os.path.abspath(os.path.dirname(__file__)),
-                        'static.txt')
+    path = os.path.join(os.path.dirname(__file__), 'static.txt')
     info['serverRoot'].static_route = staticFile(path)

--- a/tests/test_plugins/test_plugin/static.txt
+++ b/tests/test_plugins/test_plugin/static.txt
@@ -1,0 +1,1 @@
+Hello world!


### PR DESCRIPTION
@brianhelba This simplifies the code required to serve a static file from a cherrypy route. Now you can simply do

```
from girder.utility.server import staticFile


def load(info):
    info['serverRoot'].test_route2 = staticFile('/Users/zach/Desktop/Screen Shot 2015-01-14 at 11.45.30 AM.png')
```