### PR TITLE
Improve styling on the access editor widget

### DIFF
--- a/clients/web/src/stylesheets/widgets/accessWidget.styl
+++ b/clients/web/src/stylesheets/widgets/accessWidget.styl
@@ -36,12 +36,12 @@
   .g-access-icon
     color #666
     font-size 25px
-    vertical-align top
-    display inline-block
+    position absolute
 
   .g-access-desc
-    margin-left 7px
-    display inline-block
+    position relative
+    left 42px
+    width 310px
     .g-desc-title
       font-size 14px
     .g-desc-subtitle
@@ -51,7 +51,8 @@
   .g-access-col-left
     display inline-block
     vertical-align top
-    width 300px
+    width 360px
+    word-wrap break-word
 
   .g-access-col-right
     display inline-block
@@ -59,8 +60,10 @@
 
     .g-action-remove-access
       color #999
-      margin-left 20px
+      margin-left 15px
       font-size 16px
+      position relative
+      top 1px
 
     .g-action-remove-access:hover
       color #d02344

--- a/clients/web/src/views/widgets/AccessWidget.js
+++ b/clients/web/src/views/widgets/AccessWidget.js
@@ -69,7 +69,6 @@ girder.views.AccessWidget = girder.View.extend({
         }, this);
 
         this.$('.g-action-remove-access').tooltip({
-            container: '.modal',
             placement: 'bottom',
             animation: false,
             delay: {show: 100}


### PR DESCRIPTION
* More width for name/description text
* For long names, make text always appear right of icon
* Wrap long text even if no whitespace present
* Fix tooltip display on removal icon