### PR TITLE
In general, default to break-word wrapping behavior

### DIFF
--- a/clients/web/src/stylesheets/layout/global.styl
+++ b/clients/web/src/stylesheets/layout/global.styl
@@ -11,6 +11,7 @@ i
 
 body
   padding 0
+  word-wrap break-word
 
 a
   cursor pointer


### PR DESCRIPTION
This fixes the issue described by @manthey earlier. Now all elements
will default to word-wrap break-word behavior.