### PR TITLE
Allowing installation of plugins with no plugin.json

### DIFF
--- a/tests/cases/install_test.py
+++ b/tests/cases/install_test.py
@@ -117,6 +117,28 @@ class InstallTestCase(base.TestCase):
             )
         )
 
+    def testPluginWithYaml(self):
+        l = install.install_plugin(
+            os.path.join(pluginRoot, 'plugin_yaml')
+        )
+        self.assertEqual(l, ['plugin_yaml'])
+        self.assertTrue(
+            os.path.isfile(
+                os.path.join(self.pluginDir, 'plugin_yaml', 'plugin.yml')
+            )
+        )
+
+    def testPluginWithNoConfig(self):
+        l = install.install_plugin(
+            os.path.join(pluginRoot, 'test_plugin')
+        )
+        self.assertEqual(l, ['test_plugin'])
+        self.assertTrue(
+            os.path.isfile(
+                os.path.join(self.pluginDir, 'test_plugin', 'server.py')
+            )
+        )
+
     def testMultiPluginInstallFromTgz(self):
         self.assertEqual(
             sorted(install.install_plugin(self.combinedPluginTarball)),

--- a/tests/test_plugins/plugin_yaml/plugin.yml
+++ b/tests/test_plugins/plugin_yaml/plugin.yml
@@ -1,0 +1,4 @@
+"name": "my yaml plugin"
+"description": "Plugin with a valid file"
+"version": "2.0.1"
+}

--- a/tests/test_plugins/plugin_yaml/plugin.yml
+++ b/tests/test_plugins/plugin_yaml/plugin.yml
@@ -1,4 +1,3 @@
 "name": "my yaml plugin"
 "description": "Plugin with a valid file"
 "version": "2.0.1"
-}


### PR DESCRIPTION
After fix:
```
$ girder-install plugin
...
Installed 11 plugins:
  celery_jobs
  geospatial
  google_analytics
  jobs
  jquery_widgets
  metadata_extractor
  mongo_search
  oauth
  provenance
  user_quota
  vega
```

@zachmullen I realized that I never actually supported installing from the root plugin directory, so I just made that explicit in the docstring.