### PR TITLE
Fixing testing problems that occur in asyncore loop

### DIFF
--- a/tests/mock_smtp.py
+++ b/tests/mock_smtp.py
@@ -64,7 +64,12 @@ class MockSmtpReceiver(object):
         exit.
         """
         while len(asyncore.socket_map):
-            asyncore.loop(timeout=1, use_poll=True)
+            try:
+                asyncore.loop(timeout=1, use_poll=True)
+            except asyncore.select.error as e:
+                if getattr(e, 'args', [None])[0] == 9:
+                    return
+                raise e
 
     def stop(self):
         """Stop the mock STMP server"""


### PR DESCRIPTION
While running tests locally, I get messages like this popping up:
```python
15: Exception in thread Thread-3:
15: Traceback (most recent call last):
15:   File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 810, in __bootstrap_inner
15:     self.run()
15:   File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 763, in run
15:     self.__target(*self.__args, **self.__kwargs)
15:   File "tests/mock_smtp.py", line 69, in loop
15:     asyncore.loop(timeout=1, use_poll=True)
15:   File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/asyncore.py", line 216, in loop
15:     poll_fun(timeout, map)
15:   File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/asyncore.py", line 145, in poll
15:     r, w, e = select.select(r, w, e, timeout)
15: error: (9, 'Bad file descriptor')
```
It appears to be the same issue mentioned [here](http://bugs.python.org/issue10878).

The tests pass, but file descriptors aren't closed causing the ctest process to hang eventually.  This seems to fix the problem on my end.