### PR TITLE
Cookie-based authentication options for route handlers

### DIFF
--- a/clients/web/src/model.js
+++ b/clients/web/src/model.js
@@ -80,19 +80,20 @@ girder.Model = Backbone.Model.extend({
     },
 
     /**
-     * For models that can be downloaded, this method should be used to
+     * Get the path for downloading this resource via the API. Can be used
+     * as the href property of a direct download link.
+     */
+    downloadUrl: function () {
+        return girder.apiRoot + '/' + this.resourceName + '/' +
+            this.get('_id') + '/download';
+    },
+
+    /**
+     * For models that can be downloaded, this method can be used to
      * initiate the download in the browser.
      */
     download: function () {
-        var url = girder.apiRoot + '/' + this.resourceName + '/' +
-            this.get('_id') + '/download';
-
-        var token = girder.cookie.find('girderToken');
-        if (token) {
-            url += '?token=' + token;
-        }
-
-        window.location.assign(url);
+        window.location.assign(this.downloadUrl());
     },
 
     /**

--- a/clients/web/src/templates/body/itemPage.jade
+++ b/clients/web/src/templates/body/itemPage.jade
@@ -9,7 +9,7 @@
         i.icon-down-dir
     ul.g-item-actions-menu.dropdown-menu.pull-right(role="menu")
       li(role="presentation")
-        a.g-download-item(role="menuitem")
+        a.g-download-item(role="menuitem", href="#{item.downloadUrl()}")
           i.icon-download
           | Download item
       if (accessLevel >= girder.AccessType.WRITE)

--- a/clients/web/src/templates/widgets/fileList.jade
+++ b/clients/web/src/templates/widgets/fileList.jade
@@ -1,7 +1,9 @@
 ul.g-file-list
   each file in files
     li.g-file-list-entry
-      a.g-file-list-link(cid="#{file.cid}" target="#{file.get('linkUrl') ? '_blank' : '_self'}")
+      a.g-file-list-link(cid="#{file.cid}",
+                         target="#{file.get('linkUrl') ? '_blank' : '_self'}",
+                         href="#{file.downloadUrl()}")
         if (file.get('linkUrl'))
           i.icon-link
           span.g-file-name #{file.get('name')}

--- a/clients/web/src/templates/widgets/hierarchyWidget.jade
+++ b/clients/web/src/templates/widgets/hierarchyWidget.jade
@@ -33,7 +33,7 @@
               |  #{model.get('name') || model.name()}
             if (type == 'folder')
               li(role="presentation")
-                a.g-download-folder(role="menuitem")
+                a.g-download-folder(role="menuitem", href="#{model.downloadUrl()}")
                   i.icon-download
                   | Download folder
             if (level >= AccessType.WRITE)

--- a/clients/web/src/utilities/EventStream.js
+++ b/clients/web/src/utilities/EventStream.js
@@ -15,8 +15,7 @@
     prototype.open = function () {
         if (window.EventSource) {
             this._eventSource = new window.EventSource(
-                girder.apiRoot + '/notification/stream?token=' +
-                girder.cookie.find('girderToken'));
+                girder.apiRoot + '/notification/stream');
 
             var stream = this;
 

--- a/clients/web/src/views/body/ItemView.js
+++ b/clients/web/src/views/body/ItemView.js
@@ -5,15 +5,11 @@
      */
     girder.views.ItemView = girder.View.extend({
         events: {
-            'click .g-download-item': function () {
-                this.model.download();
-            },
             'click .g-edit-item': 'editItem',
             'click .g-delete-item': 'deleteItem'
         },
 
         initialize: function (settings) {
-
             girder.cancelRestRequests('fetch');
             this.edit = settings.edit || false;
             this.fileEdit = settings.fileEdit || false;
@@ -69,7 +65,6 @@
         },
 
         render: function () {
-
             // Fetch the access level asynchronously and render once we have
             // it. TODO: load the page and adjust only the action menu once
             // the access level is fetched.
@@ -148,5 +143,4 @@
             upload: params.dialog === 'upload' ? params.dialogid : false
         });
     });
-
 }());

--- a/clients/web/src/views/widgets/FileListWidget.js
+++ b/clients/web/src/views/widgets/FileListWidget.js
@@ -7,11 +7,6 @@ girder.views.FileListWidget = girder.View.extend({
             this.collection.fetchNextPage();
         },
 
-        'click a.g-file-list-link': function (e) {
-            var cid = $(e.currentTarget).attr('cid');
-            this.collection.get(cid).download();
-        },
-
         'click a.g-update-contents': function (e) {
             var cid = $(e.currentTarget).parent().attr('file-cid');
             this.uploadDialog(cid);

--- a/clients/web/src/views/widgets/HierarchyWidget.js
+++ b/clients/web/src/views/widgets/HierarchyWidget.js
@@ -5,7 +5,6 @@ girder.views.HierarchyWidget = girder.View.extend({
     events: {
         'click a.g-create-subfolder': 'createFolderDialog',
         'click a.g-edit-folder': 'editFolderDialog',
-        'click a.g-download-folder': 'downloadFolder',
         'click a.g-delete-folder': 'deleteFolderDialog',
         'click a.g-create-item': 'createItemDialog',
         'click .g-upload-here-button': 'uploadDialog',
@@ -538,10 +537,6 @@ girder.views.HierarchyWidget = girder.View.extend({
         return this._describeResources(girder.pickedResources.resources);
     },
 
-    downloadFolder: function () {
-        this.parentModel.download();
-    },
-
     /**
      * Get a parameter that can be added to a url for the checked resources.
      */
@@ -575,10 +570,7 @@ girder.views.HierarchyWidget = girder.View.extend({
         var url = girder.apiRoot + '/resource/download';
         var resources = this._getCheckedResourceParam();
         var data = {resources: resources};
-        var token = girder.cookie.find('girderToken');
-        if (token) {
-            data.token = token;
-        }
+
         this.redirectViaForm('GET', url, data);
     },
 

--- a/clients/web/test/spec/dataSpec.js
+++ b/clients/web/test/spec/dataSpec.js
@@ -167,7 +167,7 @@ describe('Create a data hierarchy', function () {
 
         runs(function () {
             girderTest._redirect = null;
-            $('.g-file-list-link').click();
+            window.location.assign($('a.g-file-list-link').attr('href'));
         });
 
         waitsFor(function () {
@@ -175,7 +175,7 @@ describe('Create a data hierarchy', function () {
         }, 'redirect to the file download URL');
 
         runs(function () {
-            expect(/^http:\/\/localhost:.*\/api\/v1\/file\/.+\/download\?token=.*$/.test(
+            expect(/^http:\/\/localhost:.*\/api\/v1\/file\/.+\/download$/.test(
                 girderTest._redirect)).toBe(true);
         });
     });
@@ -229,7 +229,7 @@ describe('Create a data hierarchy', function () {
             for (var i=1; i<=4; i++) {
                 $('.g-quick-search-container input.g-search-field')
                     .val('john'.substr(0, i)).trigger('input');
-            }                    
+            }
         });
         waitsFor(function () {
             return $('.g-quick-search-container .g-search-results')
@@ -305,13 +305,13 @@ describe('Create a data hierarchy', function () {
         }, 'the folder down action to appear');
         runs(function () {
             girderTest._redirect = null;
-            $('.g-download-folder').click();
+            window.location.assign($('a.g-download-folder').attr('href'));
         });
         waitsFor(function () {
             return girderTest._redirect !== null;
         }, 'redirect to the resource download URL');
         runs(function () {
-            expect(/^http:\/\/localhost:.*\/api\/v1\/folder\/.+\/download\?token=.*$/.test(
+            expect(/^http:\/\/localhost:.*\/api\/v1\/folder\/.+\/download$/.test(
                 girderTest._redirect)).toBe(true);
         });
     });

--- a/docs/developer-cookbook.rst
+++ b/docs/developer-cookbook.rst
@@ -404,3 +404,28 @@ may be desirable. If you only want it to be served out of ``/api`` and not
 .. code-block:: python
 
     del info['serverRoot'].girder.api
+
+Supporting web browser operations where custom headers cannot be set
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Some aspects of the web browser make it infeasible to pass the usual
+``Girder-Token`` authentication header when making a request. For example,
+if using an ``EventSource`` object for SSE, or when you must redirect the user's
+browser to a download endpoint that serves its content as an attachment. In such
+cases, you may allow specific REST API routes to authenticate using the Cookie.
+You should only do this if the endpoint is "read-only", that is, in cases where
+it does not make modifications to data on the server, to avoid vulnerabilities
+to Cross-Site Request Forgery attacks. If your endpoint is not read-only and
+you are unable to pass the ``Girder-Token`` header to it, you can pass a ``token``
+query parameter containing the token as a last resort, but in practice this will
+probably never be the case.
+
+In order to allow cookie authentication for your route, simply set the
+``cookieAuth`` property on your route handler function to ``True``. Example:
+
+.. code-block:: python
+
+    @access.public
+    def download(self, params):
+        ...
+    download.cookieAuth = True

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -444,8 +444,7 @@ class Resource(ModelImporter):
     """
     exposed = True
 
-    def route(self, method, route, handler, nodoc=False, resource=None,
-              cookieAuth=False):
+    def route(self, method, route, handler, nodoc=False, resource=None):
         """
         Define a route for your REST resource.
 
@@ -458,14 +457,6 @@ class Resource(ModelImporter):
         :param handler: The method to be called if the route and method are
             matched by a request. Wildcards in the route will be expanded and
             passed as kwargs with the same name as the wildcard identifier.
-        :param cookieAuth: Normally, authentication via cookie is disallowed to
-            protect against CSRF attacks. If you want to expose an endpoint that
-            canbe authenticated with a token passed in the Cookie, set this to
-            True. This should only be used on read-only operations that will not
-            make any changes to data on the server, and only in cases where the
-            user agent behavior makes passing custom headers infeasible, such as
-            downloading data to disk in the browser.
-        :type cookieAuth: bool
         :type handler: function
         :param nodoc: If your route intentionally provides no documentation,
             set this to True to disable the warning on startup.

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -219,6 +219,7 @@ class File(Resource):
         self.model('item').load(id=file['itemId'], user=user,
                                 level=AccessType.READ, exc=True)
         return self.model('file').download(file, offset)
+    download.cookieAuth = True
     download.description = (
         Description('Download a file.')
         .param('id', 'The ID of the file.', paramType='path')
@@ -230,6 +231,7 @@ class File(Resource):
     @access.public
     def downloadWithName(self, id, name, params):
         return self.download(id=id, params=params)
+    downloadWithName.cookieAuth = True
     downloadWithName.description = (
         Description('Download a file.')
         .param('id', 'The ID of the file.', paramType='path')

--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -111,6 +111,7 @@ class Folder(Resource):
         .errorResponse()
         .errorResponse('Read access was denied on the parent resource.', 403))
 
+
     @access.public
     @loadmodel(model='folder', level=AccessType.READ)
     def downloadFolder(self, folder, params):
@@ -132,6 +133,7 @@ class Folder(Resource):
                     yield data
             yield zip.footer()
         return stream
+    downloadFolder.cookieAuth = True
     downloadFolder.description = (
         Description('Download an entire folder as a zip archive.')
         .param('id', 'The ID of the folder.', paramType='path')

--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -111,7 +111,6 @@ class Folder(Resource):
         .errorResponse()
         .errorResponse('Read access was denied on the parent resource.', 403))
 
-
     @access.public
     @loadmodel(model='folder', level=AccessType.READ)
     def downloadFolder(self, folder, params):

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -242,8 +242,7 @@ class Item(Resource):
     @loadmodel(model='item', level=AccessType.READ)
     def download(self, item, params):
         """
-        Defers to the underlying assetstore adapter to stream the file or
-        file out.
+        Defers to the underlying assetstore adapter to stream the file out.
         """
         offset = int(params.get('offset', 0))
         user = self.getCurrentUser()
@@ -256,6 +255,7 @@ class Item(Resource):
             return self.model('file').download(files[0], offset)
         else:
             return self._downloadMultifileItem(item, user)
+    download.cookieAuth = True
     download.description = (
         Description('Download the contents of an item.')
         .param('id', 'The ID of the item.', paramType='path')

--- a/girder/api/v1/notification.py
+++ b/girder/api/v1/notification.py
@@ -82,6 +82,7 @@ class Notification(Resource):
 
                 time.sleep(wait)
         return streamGen
+    stream.cookieAuth = True
     stream.description = (
         Description('Stream notifications for a given user via the SSE '
                     'protocol.')

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -173,6 +173,7 @@ class Resource(BaseResource):
                             yield data
             yield zip.footer()
         return stream
+    download.cookieAuth = True
     download.description = (
         Description('Download a set of items, folders, collections, and users '
                     'as a zip archive.')


### PR DESCRIPTION
By default, the token value in the cookie is not sufficient to
authenticate to Girder (to protect against CSRF). There are a few
read-only endpoints (i.e. not vulnerable to CSRF attacks) that
make sense to open up to cookie-based authentication to support
user agent (browser) tools that make it infeasible to pass the normal
Girder-Token custom HTTP header since they are not requested with
normal XHR mechanisms. Namely:

* The notification stream endpoint, since in our web client it is
requested with an EventSource that does not allow specification of
headers in its API at this time.
* The download endpoints, since we want those links to download
as attachments to the user's filesystem and therefore have no
good way of specifying headers.

By allowing cookie auth for these endpoints, we also avoid placing
secure token values into query strings that might end up in
access logs on the server. Additionally, this allows us to simply
use the href property for download direct links, making it easy
for users to copy and disseminate direct download links, even to
private data.