### PR TITLE
Harden phantom timeouts

### DIFF
--- a/clients/web/test/spec/widgetsSpec.js
+++ b/clients/web/test/spec/widgetsSpec.js
@@ -101,12 +101,12 @@ describe('Test widgets that are not covered elsewhere', function () {
                    '.progress-status .progress-left:last').text());
         }, 'progress to show estimated time');
 
-        /* There is a five second timeout for fading out the success message.
-         * Because we waiting for 4% of the progress of the previous task,
-         * there should be less than a second left to wait for the first test
-         * to vanish. */
+        /* There is a 5 second timeout for fading out the success message.  We
+         * wait for 4% of the progress of the previous task, there should be
+         * less than a second left to wait for the two previous success
+         * messages to vanish (but the error message might still be around). */
         waitsFor(function () {
-            return $('.g-progress-widget-container').length < 3;
+            return $('.g-progress-widget-container').length < 4;
         }, 'at least the first progress to be hidden');
 
         runs(function () {

--- a/clients/web/test/specRunner.js
+++ b/clients/web/test/specRunner.js
@@ -170,9 +170,9 @@ page.onLoadFinished = function (status) {
 page.settings.resourceTimeout = 15000;
 
 page.onResourceTimeout = function (request) {
-    console.log('PHANTOM_TIMEOUT')
     console.log('Resource timed out.  (#' + request.id + '): ' +
                 JSON.stringify(request));
+    console.log('PHANTOM_TIMEOUT')
     /* The exit code doesn't get sent back from here, so setting this to a
      * non-zero value doesn't seem to have any benefit. */
     phantom.exit(0);


### PR DESCRIPTION
Improved restarting tests when phantomjs times out.  Phantomjs times out occasionally due to a bug.  We can retry tests when this happens, but we need to reset the databases and other services between tests.

When we added a test to check on callbacks throwing an exception, we needed to adjust one of the tests for progress notifications going away.