### PR TITLE
Fix javascript coverage reporting in aiur.

### DIFF
--- a/cmake/aiur_nightly_js_coverage.cmake
+++ b/cmake/aiur_nightly_js_coverage.cmake
@@ -15,9 +15,6 @@ set(CTEST_SITE "Aiur.kitware")
 set(CTEST_BUILD_NAME "Linux-master-nightly-js-cov")
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 
-# Copy compile plugin template files
-file(COPY "${CTEST_SOURCE_DIRECTORY}/clients/web/static/built/plugins/provenance/templates.js" DESTINATION "${CTEST_SOURCE_DIRECTORY}/plugins/provenance")
-
 ctest_start("Nightly")
 ctest_configure()
 file(RENAME "${CTEST_BINARY_DIRECTORY}/../coverage.xml" "${CTEST_BINARY_DIRECTORY}/coverage.xml")

--- a/cmake/run_aiur_dashboard.sh
+++ b/cmake/run_aiur_dashboard.sh
@@ -6,5 +6,8 @@ cd /home/cpatrick/Dashboards/girder
 pip install -r requirements.txt -r requirements-dev.txt -r plugins/metadata_extractor/requirements.txt -r plugins/geospatial/requirements.txt -r plugins/celery_jobs/requirements.txt
 npm install
 python setup.py install
+# Copy compile plugin template files so that the javascript coverage locates
+# them properly.  There are certainly nicer ways to do this.
+find /home/cpatrick/Dashboards/girder/clients/web/static/built/plugins/ -name templates.js -exec python -c 'import shutil;path = """{}""";shutil.copy(path, path.replace("/clients/web/static/built/plugins/","/plugins/"))' \;
 /usr/local/bin/ctest -VV -S /home/cpatrick/Dashboards/girder/cmake/aiur_nightly.cmake
 /usr/local/bin/ctest -VV -S /home/cpatrick/Dashboards/girder/cmake/aiur_nightly_js_coverage.cmake


### PR DESCRIPTION
Whenever we add coverage of the javascript of a plugin, we needed to copy the templates.js file to a particular location.  I've attempted to automate and generalize this so that next time adding coverage won't break the js coverage report.

I'm not sure I can truly test this outside of aiur.