### PR TITLE
Add a model removal event that also passes kwargs down

### DIFF
--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -330,7 +330,7 @@ class Folder(AccessControlledModel):
         uploads.close()
 
         # Delete this folder
-        AccessControlledModel.remove(self, folder)
+        AccessControlledModel.remove(self, folder, progress=progress, **kwargs)
         if progress:
             progress.update(increment=1, message='Deleted folder ' +
                             folder['name'])

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -274,7 +274,12 @@ class Model(ModelImporter):
 
         event = events.trigger('.'.join(('model', self.name, 'remove')),
                                document)
-        if not event.defaultPrevented:
+        kwargsEvent = events.trigger(
+            '.'.join(('model', self.name, 'remove_with_kwargs')), {
+                'document': document,
+                'kwargs': kwargs
+            })
+        if not event.defaultPrevented and not kwargsEvent.defaultPrevented:
             return self.collection.remove({'_id': document['_id']})
 
     def removeWithQuery(self, query):


### PR DESCRIPTION
This supports callbacks that need to handle progress, or any other
special arguments to remove(). The old event is still triggered
to preserve backward compatibility.