### PR TITLE
Fix the dockerfile for girder.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ COPY Gruntfile.js /girder/Gruntfile.js
 COPY requirements.txt /girder/requirements.txt
 COPY requirements-dev.txt /girder/requirements-dev.txt
 COPY setup.py /girder/setup.py
+COPY config_parse.py /girder/config_parse.py
 COPY package.json /girder/package.json
 COPY README.rst /girder/README.rst
 
@@ -35,4 +36,5 @@ RUN pip install \
 RUN pip install -U six
 RUN npm install -g grunt-cli
 RUN npm install
+RUN grunt init && grunt
 ENTRYPOINT ["python", "-m", "girder"]


### PR DESCRIPTION
We weren't automatically running grunt (npm install wasn't invoking this at the end).  Also, we needed to copy over another script to allow grunt to properly build girder.

Fixes #661.

I've manually tested this, but would love to have another set of eyes on it.