### PR TITLE
Jasmine timeouts and retry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
     - mkdir _build
     - cd _build
     - cmake ..
-    - ctest -VV -S ../cmake/travis_continuous.cmake || true
+    - JASMINE_TIMEOUT=15000 ctest -VV -S ../cmake/travis_continuous.cmake || true
     - if [ -f test_failed ] ; then false ; fi
     - cd ..
     - git fetch --unshallow

--- a/cmake/run_aiur_dashboard.sh
+++ b/cmake/run_aiur_dashboard.sh
@@ -9,5 +9,5 @@ python setup.py install
 # Copy compile plugin template files so that the javascript coverage locates
 # them properly.  There are certainly nicer ways to do this.
 find /home/cpatrick/Dashboards/girder/clients/web/static/built/plugins/ -name templates.js -exec python -c 'import shutil;path = """{}""";shutil.copy(path, path.replace("/clients/web/static/built/plugins/","/plugins/"))' \;
-/usr/local/bin/ctest -VV -S /home/cpatrick/Dashboards/girder/cmake/aiur_nightly.cmake
+JASMINE_TIMEOUT=15000 /usr/local/bin/ctest -VV -S /home/cpatrick/Dashboards/girder/cmake/aiur_nightly.cmake
 /usr/local/bin/ctest -VV -S /home/cpatrick/Dashboards/girder/cmake/aiur_nightly_js_coverage.cmake

--- a/tests/web_client_test.py
+++ b/tests/web_client_test.py
@@ -127,6 +127,7 @@ class WebClientTestCase(base.TestCase):
             task = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                     stderr=subprocess.STDOUT)
             hasJasmine = False
+            jasmineFinished = False
             for line in iter(task.stdout.readline, ''):
                 if ('PHANTOM_TIMEOUT' in line or
                         'error loading source script' in line):
@@ -140,10 +141,12 @@ class WebClientTestCase(base.TestCase):
                     continue  # we don't want to print this
                 if 'Jasmine' in line:
                     hasJasmine = True
+                if 'Testing Finished' in line:
+                    jasmineFinished = True
                 sys.stdout.write(line)
                 sys.stdout.flush()
             returncode = task.wait()
-            if not retry and hasJasmine:
+            if not retry and hasJasmine and jasmineFinished:
                 break
             if not hasJasmine:
                 time.sleep(1)


### PR DESCRIPTION
For automated builds (travis, dashboard), set the Jasmine timeout to 15 seconds.  I've noticed that when the build computer is loaded or has none of the necessary files in the file system cache, that builds succeed with larger timeouts.

Also, if we don't get a report that Jasmine tests were finished, retry the test.  This appears to be a Jasmine bug (at least, the failure usually occurs within the Jasmine javascript).