### PR TITLE
Specify the version of the McCabe pip module.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ sphinx_rtd_theme==0.1.6
 six==1.8.0
 Sphinx==1.2.2
 virtualenv==1.11.6
+mccabe==0.3


### PR DESCRIPTION
Specify the version of the complexity module used in flake8.  Otherwise, different build platforms may fail complexity tests because they are using a different version of the test.