### PR TITLE
Fix parseQueryString

### DIFF
--- a/clients/web/src/utilities/MiscFunctions.js
+++ b/clients/web/src/utilities/MiscFunctions.js
@@ -136,22 +136,13 @@ girder.getModelClassByName = function (name) {
 girder.parseQueryString = function (queryString) {
     var params = {};
     if (queryString) {
-        _.each(
-            _.map(decodeURI(queryString).split(/&/g), function (el, i) {
-                var aux = el.split('='), o = {};
-                if (aux.length >= 1) {
-                    var val;
-                    if (aux.length === 2) {
-                        val = aux[1];
-                    }
-                    o[aux[0]] = val;
-                }
-                return o;
-            }),
-            function (o) {
-                _.extend(params, o);
+        _.each(queryString.replace(/\+/g, ' ').split(/&/g), function (el, i) {
+            var aux = el.split('='), o = {}, val;
+            if (aux.length > 1) {
+                val = decodeURIComponent(el.substr(aux[0].length + 1));
             }
-        );
+            params[decodeURIComponent(aux[0])] = val;
+        });
     }
     return params;
 };

--- a/clients/web/test/spec/routingSpec.js
+++ b/clients/web/test/spec/routingSpec.js
@@ -14,10 +14,12 @@ function _getFirstId(collection, ids, key, fetchParamsFunc)
 {
     var coll;
     runs(function () {
+        /* jshint -W055 */
         coll = new collection();
         var params;
-        if (fetchParamsFunc)
+        if (fetchParamsFunc) {
             params = fetchParamsFunc(coll);
+        }
         coll.fetch(params);
     });
     waitsFor(function () {
@@ -374,6 +376,23 @@ describe('Test routing paths', function () {
         girderTest.testRoute('assetstores?dialog=assetstoreedit&dialogid=' +
                              ids.assetstore, true, function () {
             return $('.modal-title').text() === 'Edit assetstore';
+        });
+    });
+});
+
+describe('Test internal javascript functions', function () {
+    it('check parseQueryString', function () {
+        runs(function () {
+            var testVals = [
+                {plain: 'strings'},
+                {altchar: 'a~`!@#$%^&*()_+{}|[]\\:";\'<>?,./'}
+            ];
+            for (var i = 0; i < testVals.length; i += 1) {
+                var encode = $.param(testVals[i]);
+                console.log($.param(testVals[i]));
+                console.log($.param(girder.parseQueryString($.param(testVals[i]))));
+                expect($.param(girder.parseQueryString(encode))).toBe(encode);
+            }
         });
     });
 });


### PR DESCRIPTION
parseQueryString didn't work as expected.  It should properly handle query parameters that include escaped characters, and it did not.  Specifically, it was decoding the string with decodeURI instead of decoding the query keys and values with decodeURIComponent.  Also, if a value contained an equals sign, it would not work.

This fixes issue #671.