### PR TITLE
Make some model methods into generators, instead of returning lists

### DIFF
--- a/girder/api/v1/assetstore.py
+++ b/girder/api/v1/assetstore.py
@@ -46,8 +46,8 @@ class Assetstore(Resource):
         """
         limit, offset, sort = self.getPagingParameters(params, 'name')
 
-        return self.model('assetstore').list(
-            offset=offset, limit=limit, sort=sort)
+        return list(self.model('assetstore').list(
+            offset=offset, limit=limit, sort=sort))
     find.description = (
         Description('List assetstores.')
         .param('limit', "Result set size limit (default=50).", required=False,

--- a/girder/api/v1/group.py
+++ b/girder/api/v1/group.py
@@ -147,7 +147,7 @@ class Group(Resource):
     @loadmodel(model='group', level=AccessType.READ)
     def getGroupInvitations(self, group, params):
         limit, offset, sort = self.getPagingParameters(params, 'lastName')
-        return self.model('group').getInvites(group, limit, offset, sort)
+        return list(self.model('group').getInvites(group, limit, offset, sort))
     getGroupInvitations.description = (
         Description('Show outstanding invitations for a group.')
         .responseClass('Group')
@@ -222,8 +222,8 @@ class Group(Resource):
         """
         limit, offset, sort = self.getPagingParameters(params, 'lastName')
 
-        return [g for g in self.model('group').listMembers(
-            group, offset=offset, limit=limit, sort=sort)]
+        return list(self.model('group').listMembers(
+            group, offset=offset, limit=limit, sort=sort))
     listMembers.description = (
         Description('List members of a group.')
         .param('id', 'The ID of the group.', paramType='path')

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -223,8 +223,8 @@ class Item(Resource):
     def getFiles(self, item, params):
         """Get a page of files in an item."""
         limit, offset, sort = self.getPagingParameters(params, 'name')
-        return [file for file in self.model('item').childFiles(
-                item=item, limit=limit, offset=offset, sort=sort)]
+        return list(self.model('item').childFiles(item=item, limit=limit,
+                                                  offset=offset, sort=sort))
     getFiles.description = (
         Description('Get the files within an item.')
         .responseClass('File')
@@ -246,8 +246,7 @@ class Item(Resource):
         """
         offset = int(params.get('offset', 0))
         user = self.getCurrentUser()
-        files = [file for file in self.model('item').childFiles(
-                 item=item, limit=2)]
+        files = list(self.model('item').childFiles(item=item, limit=2))
         format = params.get('format', '')
         if format not in (None, '', 'zip'):
             raise RestException('Unsupported format.')

--- a/girder/models/assetstore.py
+++ b/girder/models/assetstore.py
@@ -112,15 +112,12 @@ class Assetstore(Model):
         :returns: List of users.
         """
         cursor = self.find({}, limit=limit, offset=offset, sort=sort)
-        assetstores = []
         for assetstore in cursor:
             adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
             assetstore['capacity'] = adapter.capacityInfo()
             assetstore['hasFiles'] = (self.model('file').findOne(
                 {'assetstoreId': assetstore['_id']}) is not None)
-            assetstores.append(assetstore)
-
-        return assetstores
+            yield assetstore
 
     def createFilesystemAssetstore(self, name, root):
         return self.save({

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -176,12 +176,12 @@ class Folder(AccessControlledModel):
             folder['meta'] = {}
 
         # Add new metadata to existing metadata
-        folder['meta'].update(metadata.items())
+        folder['meta'].update(metadata.iteritems())
 
         # Remove metadata fields that were set to null (use items in py3)
-        toDelete = [k for k, v in folder['meta'].iteritems() if v is None]
-        for key in toDelete:
-            del folder['meta'][key]
+        folder['meta'] = {k: v
+                          for k, v in folder['meta'].iteritems()
+                          if v is not None}
 
         folder['updated'] = datetime.datetime.utcnow()
 

--- a/plugins/mongo_search/server/__init__.py
+++ b/plugins/mongo_search/server/__init__.py
@@ -54,12 +54,12 @@ class ResourceExt(Resource):
         if hasattr(model, 'filterResultsByPermission'):
             cursor = model.find(
                 query, fields=allowed[coll] + ['public', 'access'], limit=0)
-            return [r for r in model.filterResultsByPermission(
+            return list(model.filterResultsByPermission(
                 cursor, user=self.getCurrentUser(), level=AccessType.READ,
-                limit=limit, offset=offset, removeKeys=('public', 'access'))]
+                limit=limit, offset=offset, removeKeys=('public', 'access')))
         else:
-            return [r for r in model.find(query, fields=allowed[coll],
-                                          limit=limit, offset=offset)]
+            return list(model.find(query, fields=allowed[coll], limit=limit,
+                                   offset=offset))
 
     mongoSearch.description = (
         Description('Run any search against a set of mongo collections.')

--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -122,13 +122,13 @@ class AssetstoreTestCase(base.TestCase):
         self.assertFalse(oldAssetstore['current'])
 
         # List the assetstores
-        assetstoresBefore = self.model('assetstore').list()
+        assetstoresBefore = list(self.model('assetstore').list())
         # Now break the root of the new assetstore and make sure we can still
         # list it
         oldroot = assetstore['root']
         assetstore['root'] = '///invalidpath'
         self.model('assetstore').save(assetstore, validate=False)
-        assetstoresAfter = self.model('assetstore').list()
+        assetstoresAfter = list(self.model('assetstore').list())
         self.assertEqual(len(assetstoresBefore), len(assetstoresAfter))
         self.assertIsNone([store for store in assetstoresAfter if store['_id']
                            == assetstore['_id']][0]['capacity']['free'])

--- a/tests/cases/group_test.py
+++ b/tests/cases/group_test.py
@@ -252,7 +252,8 @@ class GroupTestCase(base.TestCase):
         self.assertFalse(self.model('group').hasAccess(
             privateGroup, self.users[1], AccessType.READ))
 
-        self.assertEqual(len(self.model('group').getMembers(privateGroup)), 1)
+        self.assertEqual(
+            len(list(self.model('group').getMembers(privateGroup))), 1)
 
         # Invite user 1 to join the private group as member
         self.assertTrue(base.mockSmtp.isMailQueueEmpty())
@@ -288,7 +289,8 @@ class GroupTestCase(base.TestCase):
         # User 1 should now be able to see the group, but should not be in it.
         self.assertTrue(self.model('group').hasAccess(
             privateGroup, self.users[1], AccessType.READ))
-        self.assertEqual(len(self.model('group').getMembers(privateGroup)), 1)
+        self.assertEqual(
+            len(list(self.model('group').getMembers(privateGroup))), 1)
 
         # Removing user 1 from the group before they join it should remove the
         # invitation.
@@ -441,12 +443,14 @@ class GroupTestCase(base.TestCase):
 
         # User 0 should be able to remove user 1
         params['userId'] = self.users[1]['_id']
-        self.assertEqual(len(self.model('group').getMembers(privateGroup)), 2)
+        self.assertEqual(
+            len(list(self.model('group').getMembers(privateGroup))), 2)
         resp = self.request(
             path='/group/%s/member' % privateGroup['_id'], user=self.users[0],
             method='DELETE', params=params)
         self.assertStatusOk(resp)
-        self.assertEqual(len(self.model('group').getMembers(privateGroup)), 1)
+        self.assertEqual(
+            len(list(self.model('group').getMembers(privateGroup))), 1)
 
         # User 0 should be able to delete the group
         self.users[0] = self.model('user').load(


### PR DESCRIPTION
Also ensure that API endpoints do return lists, instead of generators, and do so using the simpler list constructor syntax when possible.