### PR TITLE
Remove arbitrary "limit=50" defaults from internal model API

### DIFF
--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -233,7 +233,7 @@ class System(Resource):
 
     @access.admin
     def discardPartialUploads(self, params):
-        uploadList = list(self.model('upload').list(filters=params, limit=0))
+        uploadList = list(self.model('upload').list(filters=params))
         # Move the results to list that isn't a cursor so we don't have to have
         # the cursor sitting around while we work on the data.
         for upload in uploadList:

--- a/girder/models/assetstore.py
+++ b/girder/models/assetstore.py
@@ -102,7 +102,7 @@ class Assetstore(Model):
                 first['current'] = True
                 self.save(first)
 
-    def list(self, limit=50, offset=0, sort=None):
+    def list(self, limit=0, offset=0, sort=None):
         """
         List all assetstores.
 

--- a/girder/models/collection.py
+++ b/girder/models/collection.py
@@ -82,7 +82,7 @@ class Collection(AccessControlledModel):
         folders = self.model('folder').find({
             'parentId': collection['_id'],
             'parentCollection': 'collection'
-        }, limit=0)
+        })
         for folder in folders:
             self.model('folder').remove(folder, progress=progress, **kwargs)
 
@@ -92,11 +92,11 @@ class Collection(AccessControlledModel):
             progress.update(increment=1, message='Deleted collection ' +
                             collection['name'])
 
-    def list(self, user=None, limit=50, offset=0, sort=None):
+    def list(self, user=None, limit=0, offset=0, sort=None):
         """
         Search for collections with full text search.
         """
-        cursor = self.find({}, limit=0, sort=sort)
+        cursor = self.find({}, sort=sort)
         return self.filterResultsByPermission(
             cursor=cursor, user=user, level=AccessType.READ, limit=limit,
             offset=offset)
@@ -185,7 +185,7 @@ class Collection(AccessControlledModel):
         folders = self.model('folder').find({
             'parentId': doc['_id'],
             'parentCollection': 'collection'
-        }, limit=0, timeout=False)
+        }, timeout=False)
         for folder in folders:
             for (filepath, file) in self.model('folder').fileList(
                     folder, user, path, includeMetadata, subpath=True):
@@ -202,7 +202,7 @@ class Collection(AccessControlledModel):
         folders = self.model('folder').find({
             'parentId': doc['_id'],
             'parentCollection': 'collection'
-        }, limit=0, timeout=False)
+        }, timeout=False)
         count += sum(self.model('folder').subtreeCount(folder)
                      for folder in folders)
         return count

--- a/girder/models/group.py
+++ b/girder/models/group.py
@@ -108,7 +108,7 @@ class Group(AccessControlledModel):
 
         return doc
 
-    def list(self, user=None, limit=50, offset=0, sort=None):
+    def list(self, user=None, limit=0, offset=0, sort=None):
         """
         Search for groups or simply list all visible groups.
 
@@ -120,13 +120,13 @@ class Group(AccessControlledModel):
         """
         # Perform the find; we'll do access-based filtering of the result
         # set afterward.
-        cursor = self.find({}, limit=0, sort=sort)
+        cursor = self.find({}, sort=sort)
 
         return self.filterResultsByPermission(
             cursor=cursor, user=user, level=AccessType.READ, limit=limit,
             offset=offset)
 
-    def listMembers(self, group, offset=0, limit=50, sort=None):
+    def listMembers(self, group, offset=0, limit=0, sort=None):
         """
         List members of the group, with names, ids, and logins.
         """
@@ -168,7 +168,7 @@ class Group(AccessControlledModel):
         # Finally, delete the document itself
         AccessControlledModel.remove(self, group)
 
-    def getMembers(self, group, offset=0, limit=50, sort=None):
+    def getMembers(self, group, offset=0, limit=0, sort=None):
         """
         Return the list of all users who belong to this group.
 
@@ -271,7 +271,7 @@ class Group(AccessControlledModel):
 
         return self.model('user').save(user, validate=False)
 
-    def getInvites(self, group, limit=50, offset=0, sort=None):
+    def getInvites(self, group, limit=0, offset=0, sort=None):
         """
         Return a page of outstanding invitations to a group. This is simply
         a list of users invited to the group currently.

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -187,7 +187,7 @@ class Model(ModelImporter):
         raise Exception('Must override initialize() in %s model'
                         % self.__class__.__name__)  # pragma: no cover
 
-    def find(self, query=None, offset=0, limit=50, **kwargs):
+    def find(self, query=None, offset=0, limit=0, **kwargs):
         """
         Search the collection by a set of parameters. Passes any kwargs
         through to the underlying pymongo.collection.find function.
@@ -227,7 +227,7 @@ class Model(ModelImporter):
             query = {}
         return self.collection.find_one(query, **kwargs)
 
-    def textSearch(self, query, offset=0, limit=50, sort=None, fields=None,
+    def textSearch(self, query, offset=0, limit=0, sort=None, fields=None,
                    filters=None):
         """
         Perform a full-text search against the text index for this collection.
@@ -839,7 +839,7 @@ class AccessControlledModel(Model):
             if count == limit:
                 break
 
-    def textSearch(self, query, user=None, filters=None, limit=50, offset=0,
+    def textSearch(self, query, user=None, filters=None, limit=0, offset=0,
                    sort=None, fields=None):
         """
         Custom override of Model.textSearch to also force permission-based
@@ -851,8 +851,7 @@ class AccessControlledModel(Model):
             filters = {}
 
         cursor = Model.textSearch(
-            self, query=query, filters=filters, limit=0, sort=sort,
-            fields=fields)
+            self, query=query, filters=filters, sort=sort, fields=fields)
         return self.filterResultsByPermission(
             cursor, user=user, level=AccessType.READ, limit=limit,
             offset=offset)

--- a/girder/models/upload.py
+++ b/girder/models/upload.py
@@ -208,7 +208,7 @@ class Upload(Model):
         upload = adapter.initUpload(upload)
         return self.save(upload)
 
-    def list(self, limit=50, offset=0, sort=None, filters=None):
+    def list(self, limit=0, offset=0, sort=None, filters=None):
         """
         Search for uploads or simply list all visible uploads.
 
@@ -271,9 +271,9 @@ class Upload(Model):
         :returns: a list of items that were removed or could be removed.
         """
         results = []
-        knownUploads = list(self.list(limit=0))
+        knownUploads = list(self.list())
         # Iterate through all assetstores
-        for assetstore in self.model('assetstore').list(limit=0):
+        for assetstore in self.model('assetstore').list():
             if assetstoreId and assetstoreId != assetstore['_id']:
                 continue
             adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -151,7 +151,7 @@ class User(AccessControlledModel):
         folders = self.model('folder').find({
             'parentId': user['_id'],
             'parentCollection': 'user'
-        }, limit=0)
+        })
         for folder in folders:
             self.model('folder').remove(folder, progress=progress, **kwargs)
 
@@ -167,9 +167,9 @@ class User(AccessControlledModel):
         admins is assumed to be small enough that we will not need to page the
         results for now.
         """
-        return self.find({'admin': True}, limit=0)
+        return self.find({'admin': True})
 
-    def search(self, text=None, user=None, limit=50, offset=0, sort=None):
+    def search(self, text=None, user=None, limit=0, offset=0, sort=None):
         """
         List all users. Since users are access-controlled, this will filter
         them by access policy.
@@ -185,9 +185,9 @@ class User(AccessControlledModel):
         # Perform the find; we'll do access-based filtering of the result set
         # afterward.
         if text is not None:
-            cursor = self.textSearch(text, limit=0, sort=sort)
+            cursor = self.textSearch(text, sort=sort)
         else:
-            cursor = self.find({}, limit=0, sort=sort)
+            cursor = self.find({}, sort=sort)
 
         return self.filterResultsByPermission(
             cursor=cursor, user=user, level=AccessType.READ, limit=limit,
@@ -277,7 +277,7 @@ class User(AccessControlledModel):
         folders = self.model('folder').find({
             'parentId': doc['_id'],
             'parentCollection': 'user'
-        }, limit=0, timeout=False)
+        }, timeout=False)
         for folder in folders:
             for (filepath, file) in self.model('folder').fileList(
                     folder, user, path, includeMetadata, subpath=True):
@@ -293,7 +293,7 @@ class User(AccessControlledModel):
         folders = self.model('folder').find({
             'parentId': doc['_id'],
             'parentCollection': 'user'
-        }, limit=0, timeout=False)
+        }, timeout=False)
         count += sum(self.model('folder').subtreeCount(folder)
                      for folder in folders)
         return count

--- a/plugins/geospatial/server/geospatial.py
+++ b/plugins/geospatial/server/geospatial.py
@@ -540,7 +540,7 @@ class GeospatialItem(Resource):
         :rtype : list[dict[str, unknown]]
         """
         user = self.getCurrentUser()
-        cursor = self.model('item').find(query, limit=0, sort=sort)
+        cursor = self.model('item').find(query, sort=sort)
 
         return [self._filter(result) for result in
                 self.model('item')

--- a/plugins/jobs/server/models/job.py
+++ b/plugins/jobs/server/models/job.py
@@ -44,7 +44,7 @@ class Job(AccessControlledModel):
 
         return job
 
-    def list(self, user=None, limit=50, offset=0, sort=None, currentUser=None):
+    def list(self, user=None, limit=0, offset=0, sort=None, currentUser=None):
         """
         List a page of jobs for a given user.
 
@@ -56,7 +56,7 @@ class Job(AccessControlledModel):
         :param currentUser: User for access filtering.
         """
         userId = user['_id'] if user else None
-        cursor = self.find({'userId': userId}, limit=0, sort=sort)
+        cursor = self.find({'userId': userId}, sort=sort)
 
         for r in self.filterResultsByPermission(cursor=cursor, user=currentUser,
                                                 level=AccessType.READ,

--- a/plugins/mongo_search/server/__init__.py
+++ b/plugins/mongo_search/server/__init__.py
@@ -53,7 +53,7 @@ class ResourceExt(Resource):
         model = ModelImporter().model(coll)
         if hasattr(model, 'filterResultsByPermission'):
             cursor = model.find(
-                query, fields=allowed[coll] + ['public', 'access'], limit=0)
+                query, fields=allowed[coll] + ['public', 'access'])
             return list(model.filterResultsByPermission(
                 cursor, user=self.getCurrentUser(), level=AccessType.READ,
                 limit=limit, offset=offset, removeKeys=('public', 'access')))


### PR DESCRIPTION
Internal model methods should return iterators, so there is no reason to place an arbitrary limit of 50 on such methods. Changing all relevant model methods to use "limit=0" provides for the full result set by default, while retaining the ability to limit results if explicitly desired.

The HTTP API remains unchanged. All relevant HTTP API methods use "Resource.getPagingParameters" to extract the "limit" parameter, which returns "50" by default. This also has the benefit of placing the magic value of "50" into a single place in the code.