### PR TITLE
Group interface changes

### DIFF
--- a/clients/web/src/stylesheets/body/groupPage.styl
+++ b/clients/web/src/stylesheets/body/groupPage.styl
@@ -34,7 +34,7 @@
   > a
     font-weight bold
 
-.g-group-members-container,.g-group-requests-container
+.g-group-members-container,.g-group-requests-container,.g-group-admins-container,.g-group-mods-container
   margin-top 15px
 
 .g-group-members,.g-group-mods,.g-group-admins,.g-group-requests,.g-group-invites
@@ -103,3 +103,6 @@
 #g-invite-role-container
   .g-add-user-button
     margin-left 10px
+
+#g-group-tab-pending-status
+  display inline

--- a/clients/web/src/templates/body/groupPage.jade
+++ b/clients/web/src/templates/body/groupPage.jade
@@ -1,38 +1,39 @@
 .g-group-header
   .btn-group.pull-right
-    button.g-group-actions-button.btn.btn-default.dropdown-toggle(
-        data-toggle="dropdown", title="Group actions")
-        i.icon-users
-        |  Actions
-        i.icon-down-dir
-    ul.g-group-actions-menu.dropdown-menu.pull-right(role="menu")
-      if (isMember)
-        li(role="presentation")
-          a.g-group-leave(role="menuitem")
-            i.icon-block
-            | Leave group
-      else if (isInvited)
-        li(role="presentation")
-          a.g-group-join(role="menuitem")
-            i.icon-login
-            | Join group
-      else if (girder.currentUser)
-        li(role="presentation")
-          a.g-group-request-invite(role="menuitem")
-            i.icon-export
-            | Request membership
-      if (group.get('_accessLevel') >= girder.AccessType.WRITE)
-        li.divider(role="presentation")
-        li(role="presentation")
-          a.g-edit-group(role="menuitem")
-            i.icon-edit
-            | Edit group
-      if (group.get('_accessLevel') >= girder.AccessType.ADMIN)
-        li.divider(role="presentation")
-        li(role="presentation")
-          a.g-group-delete(role="menuitem")
-            i.icon-trash
-            | Delete group
+    if (isMember || isInvited || girder.currentUser || group.get('_accessLevel') >= girder.AccessType.ADMIN)
+      button.g-group-actions-button.btn.btn-default.dropdown-toggle(
+          data-toggle="dropdown", title="Group actions")
+          i.icon-users
+          |  Actions
+          i.icon-down-dir
+      ul.g-group-actions-menu.dropdown-menu.pull-right(role="menu")
+        if (isMember)
+          li(role="presentation")
+            a.g-group-leave(role="menuitem")
+              i.icon-block
+              | Leave group
+        else if (isInvited)
+          li(role="presentation")
+            a.g-group-join(role="menuitem")
+              i.icon-login
+              | Join group
+        else if (girder.currentUser)
+          li(role="presentation")
+            a.g-group-request-invite(role="menuitem")
+              i.icon-export
+              | Request membership
+        if (group.get('_accessLevel') >= girder.AccessType.ADMIN)
+          li.divider(role="presentation")
+          li(role="presentation")
+            a.g-edit-group(role="menuitem")
+              i.icon-edit
+              | Edit group
+        if (group.get('_accessLevel') >= girder.AccessType.ADMIN)
+          li.divider(role="presentation")
+          li(role="presentation")
+            a.g-group-delete(role="menuitem")
+              i.icon-trash
+              | Delete group
 
   .g-group-name.g-body-title #{group.get('name')}
   .g-group-description.g-body-subtitle #{group.get('description')}
@@ -76,12 +77,13 @@ ul.g-group-tabs.nav.nav-tabs
     a(href="#g-group-tab-pending", data-toggle="tab", name="pending")
       i.icon-inbox
       | Pending
+      #g-group-tab-pending-status
 
 .tab-content
   #g-group-tab-roles.tab-pane.active
-    .g-group-members-container
-    .g-group-mods-container
     .g-group-admins-container
+    .g-group-mods-container
+    .g-group-members-container
   #g-group-tab-pending.tab-pane
     .g-group-requests-container
       .g-group-requests-header.g-group-list-header

--- a/clients/web/src/templates/widgets/groupAdminList.jade
+++ b/clients/web/src/templates/widgets/groupAdminList.jade
@@ -1,4 +1,4 @@
-.g-group-admins-header.g-group-list-header
+.g-group-admins-header.g-group-list-header(title="Group administrators can edit group properties and can add, invite, and remove group members, moderators, and administrators.")
   i.icon-star
   |  Administrators
 
@@ -11,8 +11,20 @@
           |  #{userAccess.name} (#{userAccess.login})
         .g-group-member-controls.pull-right
           if level >= accessType.ADMIN
-            a.g-group-admin-demote(title="Demote to member")
-              i.icon-down-big
+            span.dropdown
+              a.g-group-admin-demote.dropdown-toggle(title="Demote user",
+                data-toggle="dropdown")
+                i.icon-down-big
+                i.icon-down-dir
+              ul.dropdown-menu.pull-right(role="menu")
+                li(role="presentation"): a.g-demote-moderator(role="menuitem")
+                  i.icon-minus
+                  | Demote to moderator
+                li(role="presentation"): a.g-demote-member(role="menuitem")
+                  i.icon-minus
+                  | Demote to member
+            a.g-group-admin-remove(title="Remove user from the group")
+              i.icon-block
     if (!admins.length)
       .g-member-list-empty
         i.icon-info-circled

--- a/clients/web/src/templates/widgets/groupInviteDialog.jade
+++ b/clients/web/src/templates/widgets/groupInviteDialog.jade
@@ -27,25 +27,25 @@
                   i.icon-plus
                   | Add as member
 
-        .panel.panel-default
-          .panel-heading: .panel-title
-            a(data-toggle="collapse", data-parent="#g-invite-role-container",
-              href="#g-invite-role-moderator") Invite as moderator
-          #g-invite-role-moderator.panel-collapse.collapse
-            .panel-body
-              p.
-                Group moderators are members of the group who are also granted
-                the power to add and remove users from the group, and edit
-                group properties.
-              .g-invite-as-moderator.btn.btn-primary
-                i.icon-mail
-                |  Invite as moderator
-              if isAdmin
-                .g-add-as-moderator.btn.btn-warning.g-add-user-button
-                  i.icon-plus
-                  | Add as moderator
+        if (level >= accessType.ADMIN)
+          .panel.panel-default
+            .panel-heading: .panel-title
+              a(data-toggle="collapse", data-parent="#g-invite-role-container",
+                href="#g-invite-role-moderator") Invite as moderator
+            #g-invite-role-moderator.panel-collapse.collapse
+              .panel-body
+                p.
+                  Group moderators are members of the group who are also
+                  granted the power to add and remove users from the group.
+                .g-invite-as-moderator.btn.btn-primary
+                  i.icon-mail
+                  |  Invite as moderator
+                if isAdmin
+                  .g-add-as-moderator.btn.btn-warning.g-add-user-button
+                    i.icon-plus
+                    | Add as moderator
 
-        if (level > accessType.WRITE)
+        if (level >= accessType.ADMIN)
           .panel.panel-default
             .panel-heading: .panel-title
               a(data-toggle="collapse", data-parent="#g-invite-role-container",

--- a/clients/web/src/templates/widgets/groupMemberList.jade
+++ b/clients/web/src/templates/widgets/groupMemberList.jade
@@ -30,3 +30,7 @@
           if level >= accessType.WRITE
             a.g-group-member-remove(title="Remove user from the group")
               i.icon-block
+    if (!members.length)
+      .g-member-list-empty
+        i.icon-info-circled
+        |  There are no members in this group.

--- a/clients/web/src/templates/widgets/groupModList.jade
+++ b/clients/web/src/templates/widgets/groupModList.jade
@@ -1,4 +1,4 @@
-.g-group-mods-header.g-group-list-header
+.g-group-mods-header.g-group-list-header(title="Group moderators can invite and approve group members.")
   i.icon-shield
   |  Moderators
 
@@ -11,8 +11,12 @@
           |  #{userAccess.name} (#{userAccess.login})
         .g-group-member-controls.pull-right
           if level >= accessType.ADMIN
+            a.g-group-mod-promote(title="Promote to administrator")
+              i.icon-up-big
             a.g-group-mod-demote(title="Demote to member")
               i.icon-down-big
+            a.g-group-mod-remove(title="Remove user from the group")
+              i.icon-block
     if (!moderators.length)
       .g-member-list-empty
         i.icon-info-circled

--- a/clients/web/src/views/widgets/GroupAdminsWidget.js
+++ b/clients/web/src/views/widgets/GroupAdminsWidget.js
@@ -3,8 +3,26 @@
  */
 girder.views.GroupAdminsWidget = girder.View.extend({
     events: {
-        'click .g-group-admin-demote': function (e) {
-            var li = $(e.currentTarget).parents('li');
+        'click .g-demote-moderator': function (e) {
+            var li = $(e.currentTarget).parents('.g-group-admins>li');
+            var userid = li.attr('userid');
+            var view = this;
+
+            girder.confirm({
+                text: 'Are you sure you want to demote <b>' +
+                    _.escape(li.attr('username')) + '</b> to a moderator?',
+                escapedHtml: true,
+                confirmCallback: function () {
+                    var user = new girder.models.UserModel({_id: userid});
+                    view.model.off('g:promoted').on('g:promoted', function () {
+                        this.trigger('g:moderatorAdded');
+                    }, view).promoteUser(user, girder.AccessType.WRITE);
+                }
+            });
+        },
+
+        'click .g-demote-member': function (e) {
+            var li = $(e.currentTarget).parents('.g-group-admins>li');
             var view = this;
 
             girder.confirm({
@@ -13,6 +31,21 @@ girder.views.GroupAdminsWidget = girder.View.extend({
                 escapedHtml: true,
                 confirmCallback: function () {
                     view.trigger('g:demoteUser', li.attr('userid'));
+                }
+            });
+        },
+
+        'click a.g-group-admin-remove': function (e) {
+            var view = this;
+            var li = $(e.currentTarget).parents('li');
+
+            girder.confirm({
+                text: 'Are you sure you want to remove <b> ' +
+                    _.escape(li.attr('username')) +
+                    '</b> from this group?',
+                escapedHtml: true,
+                confirmCallback: function () {
+                    view.trigger('g:removeMember', li.attr('userid'));
                 }
             });
         },

--- a/clients/web/src/views/widgets/GroupInvitesWidget.js
+++ b/clients/web/src/views/widgets/GroupInvitesWidget.js
@@ -16,6 +16,7 @@ girder.views.GroupInvitesWidget = girder.View.extend({
                     view.group.off('g:removed').on('g:removed', function () {
                         view.collection.remove(user);
                         view.render();
+                        view.parentView.render();
                     }).removeMember(user.get('_id'));
                 }
             });

--- a/clients/web/src/views/widgets/GroupMembersWidget.js
+++ b/clients/web/src/views/widgets/GroupMembersWidget.js
@@ -47,6 +47,14 @@ girder.views.GroupMembersWidget = girder.View.extend({
 
     initialize: function (settings) {
         this.model = settings.group;
+        this.modsAndAdmins = [];
+        var view = this;
+        _.each(settings.admins, function (user) {
+            view.modsAndAdmins.push(user.id);
+        });
+        _.each(settings.moderators, function (user) {
+            view.modsAndAdmins.push(user.id);
+        });
         this.membersColl = new girder.collections.UserCollection();
         this.membersColl.altUrl =
             'group/' + this.model.get('_id') + '/member';
@@ -56,9 +64,16 @@ girder.views.GroupMembersWidget = girder.View.extend({
     },
 
     render: function () {
+        var members = [];
+        for (var i = 0; i < this.membersColl.models.length; i += 1) {
+            var member = this.membersColl.models[i];
+            if ($.inArray(member.id, this.modsAndAdmins) < 0) {
+                members.push(member);
+            }
+        }
         this.$el.html(girder.templates.groupMemberList({
             group: this.model,
-            members: this.membersColl.models,
+            members: members,
             level: this.model.get('_accessLevel'),
             accessType: girder.AccessType
         }));

--- a/clients/web/src/views/widgets/GroupModsWidget.js
+++ b/clients/web/src/views/widgets/GroupModsWidget.js
@@ -3,6 +3,14 @@
  */
 girder.views.GroupModsWidget = girder.View.extend({
     events: {
+        'click .g-group-mod-promote': function (e) {
+            var userid = $(e.currentTarget).parents('li').attr('userid');
+            var user = new girder.models.UserModel({_id: userid});
+            this.model.off('g:promoted').on('g:promoted', function () {
+                this.trigger('g:adminAdded');
+            }, this).promoteUser(user, girder.AccessType.ADMIN);
+        },
+
         'click .g-group-mod-demote': function (e) {
             var li = $(e.currentTarget).parents('li');
             var view = this;
@@ -13,6 +21,21 @@ girder.views.GroupModsWidget = girder.View.extend({
                 escapedHtml: true,
                 confirmCallback: function () {
                     view.trigger('g:demoteUser', li.attr('userid'));
+                }
+            });
+        },
+
+        'click a.g-group-mod-remove': function (e) {
+            var view = this;
+            var li = $(e.currentTarget).parents('li');
+
+            girder.confirm({
+                text: 'Are you sure you want to remove <b> ' +
+                    _.escape(li.attr('username')) +
+                    '</b> from this group?',
+                escapedHtml: true,
+                confirmCallback: function () {
+                    view.trigger('g:removeMember', li.attr('userid'));
                 }
             });
         },
@@ -37,7 +60,7 @@ girder.views.GroupModsWidget = girder.View.extend({
             accessType: girder.AccessType
         }));
 
-        this.$('.g-group-mod-demote').tooltip({
+        this.$('.g-group-mod-demote.g-group-mod-promote,.g-group-mod-remove').tooltip({
             container: 'body',
             placement: 'left',
             animation: false,

--- a/clients/web/test/spec/groupSpec.js
+++ b/clients/web/test/spec/groupSpec.js
@@ -10,6 +10,49 @@ $(function () {
     girder.events.trigger('g:appload.after');
 });
 
+/* Search for a name on the members search panel, and invite or add the first
+ * found user as a member, moderator, or admin.
+ *
+ * @param name: name to search for.
+ * @param level: 'member', 'moderator', or 'admin'.
+ * @param action: 'invite' or 'add.
+ */
+function _invite(name, level, action) {
+    // Search for the named user in user search box
+    runs(function () {
+        $('.g-group-invite-container input.g-search-field')
+            .val(name).trigger('input');
+    });
+    girderTest.waitForLoad();
+    waitsFor(function () {
+        return $('.g-group-invite-container .g-search-results').hasClass('open');
+    }, 'search to return');
+    runs(function () {
+        var results = $('.g-group-invite-container li.g-search-result');
+        expect(results.length).toBe(1);
+
+        expect(results.find('a[resourcetype="user"]').length).toBe(1);
+
+        results.find('a[resourcetype="user"]').click();
+    });
+    girderTest.waitForDialog();
+    waitsFor(function () {
+        return $('.g-add-as-member.btn-warning').length === 1;
+    }, 'invitation dialog to appear with direct add button');
+    runs(function () {
+        var sel = 'member';
+        switch (level) {
+            case 'moderator': sel = 'moderator'; break;
+            case 'admin': sel = 'administrarot'; break;
+        }
+        $('.panel-title:contains("Invite as ' + sel + '") a').click();
+    });
+    runs(function () {
+        $('.g-' + action + '-as-' + level).click();
+    });
+    girderTest.waitForLoad();
+}
+
 describe('Test group actions', function () {
 
     it('register a user (first is admin)',
@@ -69,7 +112,7 @@ describe('Test group actions', function () {
 
     it('have the admin remove and then force add himself to the group', function () {
         runs(function () {
-            $('.g-group-member-remove').click();
+            $('.g-group-admin-remove').click();
         });
 
         girderTest.waitForDialog();
@@ -88,45 +131,15 @@ describe('Test group actions', function () {
             return $('ul.g-group-members>li').length === 0;
         });
 
-        // Search for admin user in user search box
-        runs(function () {
-            $('.g-group-invite-container input.g-search-field')
-                .val('admin').trigger('input');
-        });
-        girderTest.waitForLoad();
+        _invite('admin', 'member', 'add');
 
-        waitsFor(function () {
-            return $('.g-group-invite-container .g-search-results').hasClass('open');
-        }, 'search to return');
-
-        runs(function () {
-            var results = $('.g-group-invite-container li.g-search-result');
-            expect(results.length).toBe(1);
-
-            expect(results.find('a[resourcetype="user"]').length).toBe(1);
-
-            results.find('a[resourcetype="user"]').click();
-        });
-
-        girderTest.waitForDialog();
-        waitsFor(function () {
-            return $('.g-add-as-member.btn-warning').length === 1;
-        }, 'invitation dialog to appear with direct add button');
-
-        // Admin force adds himself as a member
-        runs(function () {
-            $('.g-add-as-member').click();
-        });
-
-        girderTest.waitForLoad();
         waitsFor(function () {
             return $('ul.g-group-members>li').length === 1;
         }, 'admin user to appear in the member list');
     });
 
-    it('go back to groups page', girderTest.goToGroupsPage());
-
     it('check that the groups page has both groups for admin', function () {
+        girderTest.goToGroupsPage()();
         waitsFor(function () {
             return $('.g-group-list-entry').length === 2;
         }, 'the two groups to show up');
@@ -139,9 +152,8 @@ describe('Test group actions', function () {
         });
     });
 
-    it('logout to become anonymous', girderTest.logout());
-
     it('check that the groups page has only the public groups for anon', function () {
+        girderTest.logout()();
         waitsFor(function () {
             return $('.g-group-list-entry').length === 1;
         }, 'the two groups to show up');
@@ -157,4 +169,133 @@ describe('Test group actions', function () {
         }, 'the group page to load');
     });
 
+    it('check promotion and demotion', function () {
+        girderTest.login('admin', 'Admin', 'Admin', 'adminpassword!')();
+        girderTest.goToGroupsPage()();
+        waitsFor(function () {
+            return $('.g-group-list-entry').length === 2 &&
+                   $('.g-group-list-entry:contains("pubGroup") .g-group-link').length === 1;
+        }, 'the two groups to show up');
+        runs(function () {
+            $('.g-group-list-entry:contains("pubGroup") .g-group-link').click();
+        });
+        waitsFor(function () {
+            return $('.g-group-name').text() === 'pubGroup' &&
+                   $('.g-group-mods .g-member-list-empty').length === 1 &&
+                   $('.g-group-admins .g-member-list-empty').length === 1 &&
+                   $('.g-group-members-body').length === 1 &&
+                   $('.g-group-members .g-member-name').length === 1;
+        }, 'the group page to load');
+        runs(function () {
+            $('.g-group-members .g-group-member-controls .dropdown .g-group-member-promote').click();
+        });
+        waitsFor(function () {
+            return $('.g-group-members .g-group-member-controls .g-promote-moderator:visible').length === 1;
+        }, 'wait for member drop down dialog to appear');
+        runs(function () {
+            $('.g-group-members .g-group-member-controls .g-promote-moderator').click();
+        });
+        waitsFor(function () {
+            return $('.g-group-members .g-member-list-empty').length === 1 &&
+                   $('.g-group-mods').length === 1 &&
+                   $('.g-group-mod-promote').length === 1;
+        }, 'the member to become a moderator');
+        runs(function () {
+            $('.g-group-mod-promote').click();
+        });
+        waitsFor(function () {
+            return $('.g-group-members .g-member-list-empty').length === 1 &&
+                   $('.g-group-mods .g-member-list-empty').length === 1 &&
+                   $('.g-group-admins').length === 1 &&
+                   $('.g-group-admin-demote').length === 1;
+        }, 'the member to become an admin');
+        runs(function () {
+            $('.g-group-admin-demote').click();
+        });
+        waitsFor(function () {
+            return $('.g-group-admins .g-demote-member:visible').length === 1;
+        }, 'wait for admin drop down dialog to appear');
+        runs(function () {
+            $('.g-group-admins .g-demote-moderator').click();
+        });
+        girderTest.confirmDialog();
+        waitsFor(function () {
+            return $('.g-group-members .g-member-list-empty').length === 1 &&
+                   $('.g-group-admins .g-member-list-empty').length === 1 &&
+                   $('.g-group-mods').length === 1 &&
+                   $('.g-group-mod-promote').length === 1;
+        }, 'the member to become a moderator');
+        runs(function () {
+            $('.g-group-mod-demote').click();
+        });
+        girderTest.confirmDialog();
+        waitsFor(function () {
+            return $('.g-group-admins .g-member-list-empty').length === 1 &&
+                   $('.g-group-mods .g-member-list-empty').length === 1 &&
+                   $('.g-group-members .g-member-name').length === 1;
+        }, 'the member to be a plain member');
+        runs(function () {
+            $('.g-group-members .g-group-member-controls .dropdown .g-group-member-promote').click();
+        });
+        waitsFor(function () {
+            return $('.g-group-members .g-group-member-controls .g-promote-admin:visible').length === 1;
+        }, 'wait for member drop down dialog to appear');
+        runs(function () {
+            $('.g-group-members .g-group-member-controls .g-promote-admin').click();
+        });
+        waitsFor(function () {
+            return $('.g-group-members .g-member-list-empty').length === 1 &&
+                   $('.g-group-mods .g-member-list-empty').length === 1 &&
+                   $('.g-group-admins').length === 1 &&
+                   $('.g-group-admin-demote').length === 1;
+        }, 'the member to become an admin');
+        runs(function () {
+            $('.g-group-admin-demote').click();
+        });
+        waitsFor(function () {
+            return $('.g-group-admins .g-demote-member:visible').length === 1;
+        }, 'wait for admin drop down dialog to appear');
+        runs(function () {
+            $('.g-group-admins .g-demote-member').click();
+        });
+        girderTest.confirmDialog();
+        waitsFor(function () {
+            return $('.g-group-admins .g-member-list-empty').length === 1 &&
+                   $('.g-group-mods .g-member-list-empty').length === 1 &&
+                   $('.g-group-members .g-member-name').length === 1;
+        }, 'the member to be a plain member');
+    });
+
+    it('check member addition and removal', function () {
+        runs(function () {
+            $('.g-group-member-remove').click();
+        });
+        girderTest.confirmDialog();
+        _invite('admin', 'member', 'invite');
+        _invite('admin', 'moderator', 'invite');
+        _invite('admin', 'admin', 'invite');
+        _invite('admin', 'moderator', 'add');
+        waitsFor(function () {
+            return $('.g-group-members .g-member-list-empty').length === 1 &&
+                   $('.g-group-admins .g-member-list-empty').length === 1 &&
+                   $('.g-group-mods').length === 1 &&
+                   $('.g-group-mod-promote').length === 1;
+        }, 'the member to become a moderator');
+        runs(function () {
+            $('.g-group-mod-remove').click();
+        });
+        girderTest.confirmDialog();
+        _invite('admin', 'admin', 'add');
+        waitsFor(function () {
+            return $('.g-group-members .g-member-list-empty').length === 1 &&
+                   $('.g-group-mods .g-member-list-empty').length === 1 &&
+                   $('.g-group-admins').length === 1 &&
+                   $('.g-group-admin-demote').length === 1;
+        }, 'the member to become an admin');
+        runs(function () {
+            $('.g-group-admin-remove').click();
+        });
+        girderTest.confirmDialog();
+        _invite('admin', 'admin', 'add');
+    });
 });

--- a/clients/web/test/spec/routingSpec.js
+++ b/clients/web/test/spec/routingSpec.js
@@ -10,8 +10,7 @@ $(function () {
     girder.events.trigger('g:appload.after');
 });
 
-function _getFirstId(collection, ids, key, fetchParamsFunc)
-{
+function _getFirstId(collection, ids, key, fetchParamsFunc) {
     var coll;
     runs(function () {
         /* jshint -W055 */
@@ -94,13 +93,14 @@ describe('Test routing paths', function () {
         _getFirstId(girder.collections.UserCollection, ids, 'admin');
         _getFirstId(girder.collections.CollectionCollection, ids, 'collection');
         _getFirstId(girder.collections.FolderCollection, ids,
-                    'collectionFolder', function(){
-            return {parentId: ids.collection, parentType: 'collection'};
-        });
+                    'collectionFolder',
+            function () {
+                return {parentId: ids.collection, parentType: 'collection'};
+            });
         _getFirstId(girder.collections.FolderCollection, ids, 'userFolder',
             function () {
-            return {parentId: ids.admin, parentType: 'user'};
-        });
+                return {parentId: ids.admin, parentType: 'user'};
+            });
         _getFirstId(girder.collections.GroupCollection, ids, 'group');
         _getFirstId(girder.collections.AssetstoreCollection, ids, 'assetstore');
     });
@@ -115,12 +115,12 @@ describe('Test routing paths', function () {
         });
         _getFirstId(girder.collections.ItemCollection, ids, 'item',
             function () {
-            return {folderId: ids.userFolder};
-        });
+                return {folderId: ids.userFolder};
+            });
         _getFirstId(girder.collections.ItemCollection, ids, 'file',
             function (coll) {
-                coll.resourceName = 'item/'+ids.item+'/files';
-        });
+                coll.resourceName = 'item/' + ids.item + '/files';
+            });
     });
 
     /* Now test various routes */
@@ -129,14 +129,14 @@ describe('Test routing paths', function () {
         girderTest.testRoute('', false, function () {
             return $('a.g-login-link:first').text() === ' Log In';
         });
-        girderTest.testRoute('useraccount/'+ids.admin+'/info', false,
-                             function () {
-            return window.location.hash === '#users';
-        });
-        girderTest.testRoute('useraccount/'+ids.admin+'/password', false,
-                             function () {
-            return window.location.hash === '#users';
-        });
+        girderTest.testRoute('useraccount/' + ids.admin + '/info', false,
+            function () {
+                return window.location.hash === '#users';
+            });
+        girderTest.testRoute('useraccount/' + ids.admin + '/password', false,
+            function () {
+                return window.location.hash === '#users';
+            });
         girderTest.testRoute('?dialog=login', true, function () {
             return $('label[for=g-login]').text() === 'Login or email';
         });
@@ -158,14 +158,14 @@ describe('Test routing paths', function () {
             return $('a.g-my-folders-link:first').text() ===
                    ' personal data space';
         });
-        girderTest.testRoute('useraccount/'+ids.admin+'/info', false,
-                             function () {
-            return $('input#g-email').val() === 'admin@email.com';
-        });
-        girderTest.testRoute('useraccount/'+ids.admin+'/password', false,
-                             function () {
-            return $('input#g-password-old:visible').length === 1;
-        });
+        girderTest.testRoute('useraccount/' + ids.admin + '/info', false,
+            function () {
+                return $('input#g-email').val() === 'admin@email.com';
+            });
+        girderTest.testRoute('useraccount/' + ids.admin + '/password', false,
+            function () {
+                return $('input#g-password-old:visible').length === 1;
+            });
         girderTest.testRoute('?dialog=login', false, function () {
             return $('a.g-my-folders-link:first').text() ===
                    ' personal data space';
@@ -189,57 +189,57 @@ describe('Test routing paths', function () {
                    'Enter collection name';
         });
 
-        var collPath = 'collection/'+ids.collection;
+        var collPath = 'collection/' + ids.collection;
         girderTest.testRoute(collPath, false, function () {
             return $('.g-collection-actions-menu').length === 1;
         });
-        girderTest.testRoute(collPath+'?dialog=edit', true,
-                   function () {
-            return $('.modal-title').text() === 'Edit collection';
-        });
-        girderTest.testRoute(collPath+'?dialog=access', true,
-                   function () {
-            return $('.g-dialog-subtitle').text() === 'Test Collection';
-        });
-        girderTest.testRoute(collPath+'?dialog=foldercreate', true,
-                   function () {
-            return $('.modal-title').text() === 'Create folder';
-        });
+        girderTest.testRoute(collPath + '?dialog=edit', true,
+            function () {
+                return $('.modal-title').text() === 'Edit collection';
+            });
+        girderTest.testRoute(collPath + '?dialog=access', true,
+            function () {
+                return $('.g-dialog-subtitle').text() === 'Test Collection';
+            });
+        girderTest.testRoute(collPath + '?dialog=foldercreate', true,
+            function () {
+                return $('.modal-title').text() === 'Create folder';
+            });
 
-        var collFolderPath = collPath+'/folder/'+ids.collectionFolder;
+        var collFolderPath = collPath + '/folder/' + ids.collectionFolder;
         girderTest.testRoute(collFolderPath, false, function () {
             return $('.g-collection-actions-menu').length === 1 &&
                    $('.g-folder-access-button').length === 1;
         });
-        girderTest.testRoute(collFolderPath+'?dialog=edit', true,
-                   function () {
-            return $('.modal-title').text() === 'Edit collection';
-        });
-        girderTest.testRoute(collFolderPath+'?dialog=access', true,
-                   function () {
-            return $('.g-dialog-subtitle').text() === 'Test Collection';
-        });
-        girderTest.testRoute(collFolderPath+'?dialog=foldercreate', true,
-                   function () {
-            return $('.modal-title').text() === 'Create folder';
-        });
-        girderTest.testRoute(collFolderPath+'?dialog=folderedit', true,
-                   function () {
-            return $('.modal-title').text() === 'Edit folder' &&
-                   $('input#g-name').val() === 'Private';
-        });
-        girderTest.testRoute(collFolderPath+'?dialog=folderaccess', true,
-                   function () {
-            return $('.g-dialog-subtitle').text() === 'Private';
-        });
-        girderTest.testRoute(collFolderPath+'?dialog=itemcreate', true,
-                   function () {
-            return $('.modal-title').text() === 'Create item';
-        });
-        girderTest.testRoute(collFolderPath+'?dialog=upload', true,
-                   function () {
-            return $('.modal-title').text() === 'Upload files';
-        });
+        girderTest.testRoute(collFolderPath + '?dialog=edit', true,
+            function () {
+                return $('.modal-title').text() === 'Edit collection';
+            });
+        girderTest.testRoute(collFolderPath + '?dialog=access', true,
+            function () {
+                return $('.g-dialog-subtitle').text() === 'Test Collection';
+            });
+        girderTest.testRoute(collFolderPath + '?dialog=foldercreate', true,
+            function () {
+                return $('.modal-title').text() === 'Create folder';
+            });
+        girderTest.testRoute(collFolderPath + '?dialog=folderedit', true,
+            function () {
+                return $('.modal-title').text() === 'Edit folder' &&
+                       $('input#g-name').val() === 'Private';
+            });
+        girderTest.testRoute(collFolderPath + '?dialog=folderaccess', true,
+            function () {
+                return $('.g-dialog-subtitle').text() === 'Private';
+            });
+        girderTest.testRoute(collFolderPath + '?dialog=itemcreate', true,
+            function () {
+                return $('.modal-title').text() === 'Create item';
+            });
+        girderTest.testRoute(collFolderPath + '?dialog=upload', true,
+            function () {
+                return $('.modal-title').text() === 'Upload files';
+            });
     });
 
     it('test user routes', function () {
@@ -247,68 +247,68 @@ describe('Test routing paths', function () {
             return $('.g-user-link:first').text() === 'Admin Admin';
         });
 
-        var userPath = 'user/'+ids.admin;
+        var userPath = 'user/' + ids.admin;
         girderTest.testRoute(userPath, false, function () {
             return $('.g-user-actions-button').length === 1;
         });
-        girderTest.testRoute(userPath+'?dialog=foldercreate', true,
-                   function () {
-            return $('.modal-title').text() === 'Create folder';
-        });
+        girderTest.testRoute(userPath + '?dialog=foldercreate', true,
+            function () {
+                return $('.modal-title').text() === 'Create folder';
+            });
 
-        var userFolderPath = userPath+'/folder/'+ids.userFolder;
+        var userFolderPath = userPath + '/folder/' + ids.userFolder;
         girderTest.testRoute(userFolderPath, false, function () {
             return $('.g-user-actions-button').length === 1 &&
                    $('.g-folder-access-button').length === 1;
         });
-        girderTest.testRoute(userFolderPath+'?dialog=foldercreate', true,
-                   function () {
-            return $('.modal-title').text() === 'Create folder';
-        });
-        girderTest.testRoute(userFolderPath+'?dialog=folderedit', true,
-                   function () {
-            return $('.modal-title').text() === 'Edit folder' &&
-                   $('input#g-name').val() === 'Private';
-        });
-        girderTest.testRoute(userFolderPath+'?dialog=folderaccess', true,
-                   function () {
-            return $('.g-dialog-subtitle').text() === 'Private';
-        });
-        girderTest.testRoute(userFolderPath+'?dialog=itemcreate', true,
-                   function () {
-            return $('.modal-title').text() === 'Create item';
-        });
-        girderTest.testRoute(userFolderPath+'?dialog=upload', true,
-                   function () {
-            return $('.modal-title').text() === 'Upload files';
-        });
+        girderTest.testRoute(userFolderPath + '?dialog=foldercreate', true,
+            function () {
+                return $('.modal-title').text() === 'Create folder';
+            });
+        girderTest.testRoute(userFolderPath + '?dialog=folderedit', true,
+            function () {
+                return $('.modal-title').text() === 'Edit folder' &&
+                       $('input#g-name').val() === 'Private';
+            });
+        girderTest.testRoute(userFolderPath + '?dialog=folderaccess', true,
+            function () {
+                return $('.g-dialog-subtitle').text() === 'Private';
+            });
+        girderTest.testRoute(userFolderPath + '?dialog=itemcreate', true,
+            function () {
+                return $('.modal-title').text() === 'Create item';
+            });
+        girderTest.testRoute(userFolderPath + '?dialog=upload', true,
+            function () {
+                return $('.modal-title').text() === 'Upload files';
+            });
 
-        var folderPath = 'folder/'+ids.userFolder;
+        var folderPath = 'folder/' + ids.userFolder;
         girderTest.testRoute(folderPath, false, function () {
             return $('.g-user-actions-button').length === 0 &&
                    $('.g-folder-access-button').length === 1;
         });
-        girderTest.testRoute(folderPath+'?dialog=foldercreate', true,
-                   function () {
-            return $('.modal-title').text() === 'Create folder';
-        });
-        girderTest.testRoute(folderPath+'?dialog=folderedit', true,
-                   function () {
-            return $('.modal-title').text() === 'Edit folder' &&
-                   $('input#g-name').val() === 'Private';
-        });
-        girderTest.testRoute(folderPath+'?dialog=folderaccess', true,
-                   function () {
-            return $('.g-dialog-subtitle').text() === 'Private';
-        });
-        girderTest.testRoute(folderPath+'?dialog=itemcreate', true,
-                   function () {
-            return $('.modal-title').text() === 'Create item';
-        });
-        girderTest.testRoute(folderPath+'?dialog=upload', true,
-                   function () {
-            return $('.modal-title').text() === 'Upload files';
-        });
+        girderTest.testRoute(folderPath + '?dialog=foldercreate', true,
+            function () {
+                return $('.modal-title').text() === 'Create folder';
+            });
+        girderTest.testRoute(folderPath + '?dialog=folderedit', true,
+            function () {
+                return $('.modal-title').text() === 'Edit folder' &&
+                       $('input#g-name').val() === 'Private';
+            });
+        girderTest.testRoute(folderPath + '?dialog=folderaccess', true,
+            function () {
+                return $('.g-dialog-subtitle').text() === 'Private';
+            });
+        girderTest.testRoute(folderPath + '?dialog=itemcreate', true,
+            function () {
+                return $('.modal-title').text() === 'Create item';
+            });
+        girderTest.testRoute(folderPath + '?dialog=upload', true,
+            function () {
+                return $('.modal-title').text() === 'Upload files';
+            });
     });
 
     it('test group routes', function () {
@@ -320,44 +320,45 @@ describe('Test routing paths', function () {
                    'Enter group name';
         });
 
-        var groupPath = 'group/'+ids.group;
-        girderTest.testRoute(groupPath+'/roles', false, function () {
-            return $('.g-member-name:visible').length === 2 &&
+        var groupPath = 'group/' + ids.group;
+        girderTest.testRoute(groupPath + '/roles', false, function () {
+            return $('.g-member-name:visible').length === 1 &&
                    $('#g-group-tab-roles .g-member-list-empty:visible')
-                   .length === 1 &&
+                   .length === 2 &&
                    $('.g-member-list-empty:hidden').length === 2;
         });
-        girderTest.testRoute(groupPath+'/pending', false, function () {
+        girderTest.testRoute(groupPath + '/pending', false, function () {
             return $('.g-group-requests-container:visible').length === 1 &&
                    $('#g-group-tab-pending .g-member-list-empty:visible')
                    .length === 2 &&
-                   $('.g-member-list-empty:hidden').length === 1;
+                   $('.g-member-list-empty:hidden').length === 2;
         });
-        girderTest.testRoute(groupPath+'?dialog=edit', true, function () {
+        girderTest.testRoute(groupPath + '?dialog=edit', true, function () {
             return $('.modal-title').text() === 'Edit group';
         });
     });
 
     it('test item routes', function () {
-        var itemPath = 'item/'+ids.item;
+        var itemPath = 'item/' + ids.item;
         girderTest.testRoute(itemPath, false, function () {
             return $('.g-item-header .g-item-name').text() == 'Link File';
         });
-        girderTest.testRoute(itemPath+'?dialog=itemedit', true, function () {
-            return $('.modal-title').text() === 'Edit item';
-        });
-        girderTest.testRoute(itemPath+'?dialog=fileedit&dialogid='+ids.file,
-                             true, function () {
-            return $('.modal-title').text() === 'Edit file';
-        });
-        girderTest.testRoute(itemPath+'?dialog=upload&dialogid='+ids.file,
-                             true, function () {
-            return $('.modal-title').text() === 'Replace file contents';
-        });
-        girderTest.testRoute(itemPath+'?dialog=fileedit&dialogid='+ids.file,
-                             true, function () {
-            return $('.modal-title').text() === 'Edit file';
-        });
+        girderTest.testRoute(itemPath + '?dialog=itemedit', true,
+            function () {
+                return $('.modal-title').text() === 'Edit item';
+            });
+        girderTest.testRoute(itemPath + '?dialog=fileedit&dialogid=' +
+            ids.file, true, function () {
+                return $('.modal-title').text() === 'Edit file';
+            });
+        girderTest.testRoute(itemPath + '?dialog=upload&dialogid=' +
+            ids.file, true, function () {
+                return $('.modal-title').text() === 'Replace file contents';
+            });
+        girderTest.testRoute(itemPath + '?dialog=fileedit&dialogid=' +
+            ids.file, true, function () {
+                return $('.modal-title').text() === 'Edit file';
+            });
     });
 
     it('test admin routes', function () {
@@ -374,9 +375,9 @@ describe('Test routing paths', function () {
             return $('.g-assetstore-container').length === 1;
         });
         girderTest.testRoute('assetstores?dialog=assetstoreedit&dialogid=' +
-                             ids.assetstore, true, function () {
-            return $('.modal-title').text() === 'Edit assetstore';
-        });
+            ids.assetstore, true, function () {
+                return $('.modal-title').text() === 'Edit assetstore';
+            });
     });
 });
 

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -289,7 +289,6 @@ girderTest.createGroup = function (groupName, groupDesc, pub) {
  * metadata editing options.
  */
 girderTest.testMetadata = function () {
-    function _editMetadata(origKey, key, value, action, errorMessage)
     /* Add metadata and check that the value is actually set for the item.
      * :param origKey: null to create a new metadata item.  Otherwise, edit the
      *                 metadata item with this key.
@@ -301,11 +300,10 @@ girderTest.testMetadata = function () {
      * :param errorMessage: if present, expect an information message with
      *                      regex.
      */
-    {
+    function _editMetadata(origKey, key, value, action, errorMessage) {
         var expectedNum, elem;
 
-        if (origKey === null)
-        {
+        if (origKey === null) {
             waitsFor(function () {
                 return $('.g-widget-metadata-add-button:visible').length === 1;
             }, 'the add metadata button to appear');
@@ -313,11 +311,9 @@ girderTest.testMetadata = function () {
                 expectedNum = $(".g-widget-metadata-row").length;
                 $('.g-widget-metadata-add-button:visible').click();
             });
-        }
-        else
-        {
+        } else {
             runs(function () {
-                elem = $('.g-widget-metadata-key:contains("'+origKey+'")').closest('.g-widget-metadata-row');
+                elem = $('.g-widget-metadata-key:contains("' + origKey + '")').closest('.g-widget-metadata-row');
                 expect(elem.length).toBe(1);
                 expect($('.g-widget-metadata-edit-button', elem).length).toBe(1);
                 expectedNum = $(".g-widget-metadata-row").length;
@@ -349,7 +345,7 @@ girderTest.testMetadata = function () {
             });
             waitsFor(function () {
                 return $('.alert').text().match(errorMessage);
-            }, 'alert with "'+errorMessage+'" to appear');
+            }, 'alert with "' + errorMessage + '" to appear');
         }
         switch (action)
         {
@@ -392,7 +388,7 @@ girderTest.testMetadata = function () {
         runs(function () {
             expect($(".g-widget-metadata-row").length).toBe(expectedNum);
             if (action === 'save') {
-                expect(elem.text()).toBe(key+value);
+                expect(elem.text()).toBe(key + value);
             }
         });
     }
@@ -402,8 +398,8 @@ girderTest.testMetadata = function () {
         _editMetadata(null, 'simple_key', 'duplicate_key_should_fail', 'cancel', /.*simple_key is already a metadata key/);
         _editMetadata(null, '', 'no_key', 'cancel', /.*A key is required for all metadata/);
         _editMetadata(null, 'cancel_me', 'this will be cancelled', 'cancel');
-        _editMetadata(null, 'long_key', 'long_value'+new Array(2048).join('-'));
-        _editMetadata(null, 'json_key', JSON.stringify({'sample_json': 'value'}));
+        _editMetadata(null, 'long_key', 'long_value' + new Array(2048).join('-'));
+        _editMetadata(null, 'json_key', JSON.stringify({sample_json: 'value'}));
         _editMetadata(null, 'unicode_key\u00A9\uD834\uDF06', 'unicode_value\u00A9\uD834\uDF06');
         _editMetadata('simple_key', null, 'new_value', 'cancel');
         _editMetadata('long_key', 'json_key', null, 'cancel', /.*json_key is already a metadata key/);
@@ -419,10 +415,10 @@ girderTest.testMetadata = function () {
  * called on dialogs.
  */
 girderTest.waitForLoad = function (desc) {
-    desc = desc?' ('+desc+')':'';
-    waitsFor(function() {
+    desc = desc ? ' (' + desc + ')' : '';
+    waitsFor(function () {
         return $('#g-dialog-container:visible').length === 0;
-    }, 'for the dialog container to be hidden'+desc);
+    }, 'for the dialog container to be hidden' + desc);
     /* It is faster to wait to make sure a dialog is being hidden than to wait
      * for it to be fully gone.  It is probably more reliable, too.  This had
      * been:
@@ -439,20 +435,20 @@ girderTest.waitForLoad = function (desc) {
             return false;
         }
         return !$('.modal').data('bs.modal').$backdrop;
-    }, 'for any modal dialog to be hidden'+desc);
+    }, 'for any modal dialog to be hidden' + desc);
     waitsFor(function () {
         return girder.numberOutstandingRestRequests() === 0;
-    }, 'rest requests to finish'+desc);
-    waitsFor(function() {
+    }, 'rest requests to finish' + desc);
+    waitsFor(function () {
         return $('.g-loading-block').length === 0;
-    }, 'all blocks to finish loading'+desc);
+    }, 'all blocks to finish loading' + desc);
 };
 
 /**
  * Wait for a dialog to be visible.
  */
 girderTest.waitForDialog = function (desc) {
-    desc = desc?' ('+desc+')':'';
+    desc = desc ? ' (' + desc + ')' : '';
     /* It is faster to wait until the dialog is officially shown than to wait
      * for the backdrop.  This had been:
     waitsFor(function() {
@@ -464,10 +460,10 @@ girderTest.waitForDialog = function (desc) {
         return $('.modal').data('bs.modal') &&
                $('.modal').data('bs.modal').isShown === true &&
                $('#g-dialog-container:visible').length > 0;
-    }, 'a dialog to fully render'+desc);
+    }, 'a dialog to fully render' + desc);
     waitsFor(function () {
         return girder.numberOutstandingRestRequests() === 0;
-    }, 'dialog rest requests to finish'+desc);
+    }, 'dialog rest requests to finish' + desc);
 };
 
 /**
@@ -479,12 +475,12 @@ girderTest.addCoveredScript = function (url) {
         blanket.utils.cache[url] = {};
         blanket.utils.attachScript({url:url}, function (content) {
             blanket.instrument({inputFile: content, inputFileName: url},
-                               function (instrumented) {
-                blanket.utils.cache[url].loaded = true;
-                blanket.utils.blanketEval(instrumented);
-                blanket.requiringFile(url, true);
-            });
-       });
+                function (instrumented) {
+                    blanket.utils.cache[url].loaded = true;
+                    blanket.utils.blanketEval(instrumented);
+                    blanket.requiringFile(url, true);
+                });
+        });
     } else {
         $('<script/>', {src: url}).appendTo('head');
     }
@@ -550,12 +546,14 @@ girderTest.folderAccessControl = function (current, action) {
     waitsFor(function () {
         switch (action) {
             case 'private':
-                if (!$('.radio.g-selected').text().match("Private").length)
+                if (!$('.radio.g-selected').text().match("Private").length) {
                     return false;
+                }
                 break;
             case 'public':
-                if (!$('.radio.g-selected').text().match("Public").length)
+                if (!$('.radio.g-selected').text().match("Public").length) {
                     return false;
+                }
                 break;
         }
         return $('.g-save-access-list:visible').is(':enabled');
@@ -572,7 +570,6 @@ girderTest.folderAccessControl = function (current, action) {
     }, 'access dialog to be hidden');
 };
 
-girderTest.testRoute = function (route, hasDialog, testFunc)
 /* Test going to a particular route, waiting for the dialog or page to load
  *  fully, and then testing that we have what we expect.
  * Enter: route: the hash url fragment to go to.
@@ -581,8 +578,8 @@ girderTest.testRoute = function (route, hasDialog, testFunc)
  *                  this is not specified, just navigate to the specified
  *                  route.
  */
-{
-    runs(function() {
+girderTest.testRoute = function (route, hasDialog, testFunc) {
+    runs(function () {
         if (route.indexOf('#') === 0) {
             route = route.substr(1);
         }
@@ -592,12 +589,12 @@ girderTest.testRoute = function (route, hasDialog, testFunc)
      * our time slice. */
     waits(1);
     if (hasDialog) {
-        girderTest.waitForDialog('route: '+route);
+        girderTest.waitForDialog('route: ' + route);
     } else {
-        girderTest.waitForLoad('route: '+route);
+        girderTest.waitForLoad('route: ' + route);
     }
     if (testFunc) {
-        waitsFor(testFunc, 'route: '+route);
+        waitsFor(testFunc, 'route: ' + route);
         runs(function () {
             expect(testFunc()).toBe(true);
         });
@@ -614,7 +611,7 @@ girderTest.getCallbackSuffix = function () {
         girderTest._uploadSuffix = hostport[1];
     }
     return girderTest._uploadSuffix;
-}
+};
 
 /* Upload tests require that we modify how xmlhttp requests are handled.  Check
  * that this has been done (but only do it once).
@@ -631,8 +628,9 @@ function _prepareTestUpload() {
     (function (impl) {
         FormData.prototype.append = function (name, value, filename) {
             this.vals = this.vals || {};
-            if (filename)
-                this.vals[name+'_filename'] = value;
+            if (filename) {
+                this.vals[name + '_filename'] = value;
+            }
             this.vals[name] = value;
             impl.call(this, name, value, filename);
         };
@@ -648,7 +646,7 @@ function _prepareTestUpload() {
                 /* Note that this appears to fail if _uploadData contains
                  * certain characters, such as LF. */
                 if (girderTest._uploadData.length &&
-                        girderTest._uploadData.length==len &&
+                        girderTest._uploadData.length == len &&
                         !girderTest._uploadDataExtra) {
                     newdata.append('chunk', girderTest._uploadData);
                 } else {
@@ -656,8 +654,7 @@ function _prepareTestUpload() {
                         len + 1 + girderTest._uploadDataExtra).join('-'));
                 }
                 data = newdata;
-            }
-            else if (data && data instanceof Blob) {
+            } else if (data && data instanceof Blob) {
                 if (girderTest._uploadDataExtra) {
                     /* Our mock S3 server will take extra data, so break it
                      * by adding a faulty copy header.  This will throw an
@@ -665,7 +662,7 @@ function _prepareTestUpload() {
                     this.setRequestHeader('x-amz-copy-source', 'bad_value');
                 }
                 if (girderTest._uploadData.length &&
-                        girderTest._uploadData.length==data.size &&
+                        girderTest._uploadData.length == data.size &&
                         !girderTest._uploadDataExtra) {
                     data = girderTest._uploadData;
                 } else {
@@ -706,7 +703,7 @@ girderTest.sendFile = function (uploadItem) {
 girderTest.testUpload = function (uploadItem, needResume, error) {
     var orig_len;
 
-    _prepareTestUpload()
+    _prepareTestUpload();
 
     waitsFor(function () {
         return $('.g-upload-here-button').length > 0;
@@ -723,10 +720,11 @@ girderTest.testUpload = function (uploadItem, needResume, error) {
     }, 'the upload dialog to appear');
 
     runs(function () {
-        if (needResume)
+        if (needResume) {
             girderTest._uploadDataExtra = 1024 * 20;
-        else
+        } else {
             girderTest._uploadDataExtra = 0;
+        }
 
         girderTest.sendFile(uploadItem);
     });
@@ -763,10 +761,25 @@ girderTest.testUpload = function (uploadItem, needResume, error) {
 
     waitsFor(function () {
         return $('.modal-content:visible').length === 0 &&
-               $('.g-item-list-entry').length === orig_len+1;
+               $('.g-item-list-entry').length === orig_len + 1;
     }, 'the upload to finish');
     girderTest.waitForLoad();
 
-    window.callPhantom({action: 'uploadCleanup',
-                        suffix: girderTest._uploadSuffix});
+    window.callPhantom(
+        {action: 'uploadCleanup',
+        suffix: girderTest._uploadSuffix});
+};
+
+/* Wait for a dialog to be present with a confirm button, then select the
+ * confirm button and wait for teh dialog to be hidden.
+ */
+girderTest.confirmDialog = function () {
+    girderTest.waitForDialog('wait for confirmation');
+    waitsFor(function () {
+        return $('#g-confirm-button:visible').length > 0;
+    }, 'confirmation to appear');
+    runs(function () {
+        $('#g-confirm-button').click();
+    });
+    girderTest.waitForLoad();
 };

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -357,9 +357,8 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
         for upload in knownUploads:
             if ('s3' in upload and 'uploadId' in upload['s3'] and
                     'key' in upload['s3']):
-                if (multipartUpload.id == upload['s3']['uploadId']
-                        and multipartUpload.key_name ==
-                        upload['s3']['key']):
+                if (multipartUpload.id == upload['s3']['uploadId'] and
+                        multipartUpload.key_name == upload['s3']['key']):
                     return True
         return False
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 coverage==3.7.1
 flake8==2.2.2
+pep8==1.6.2
 httmock==1.2.2
 moto==0.3.6
 sphinx_rtd_theme==0.1.6

--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -130,8 +130,9 @@ class AssetstoreTestCase(base.TestCase):
         self.model('assetstore').save(assetstore, validate=False)
         assetstoresAfter = list(self.model('assetstore').list())
         self.assertEqual(len(assetstoresBefore), len(assetstoresAfter))
-        self.assertIsNone([store for store in assetstoresAfter if store['_id']
-                           == assetstore['_id']][0]['capacity']['free'])
+        self.assertIsNone([
+            store for store in assetstoresAfter
+            if store['_id'] == assetstore['_id']][0]['capacity']['free'])
         # restore the original root
         assetstore['root'] = oldroot
         self.model('assetstore').save(assetstore, validate=False)


### PR DESCRIPTION
The members of a group are now only listed in one place: admin, moderator, or member.  The admin and moderator lines have promotion, demotion, and removal controls.

The Pending tab lists how many actions are pending.

Moderators can no longer edit a group.

Updated and added tests for all changes.  Groups are still under-tested, but they have greater coverage now than before.  Also, I'm working on gradually getting some of the test code to match our main code's style guidelines, even though this isn't currently enforced.

This fixes issues #91, #92, and #673.