### PR TITLE
Make all PyMongo "find" queries not timeout

### DIFF
--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -307,7 +307,7 @@ class User(Resource):
         self.requireParams('email', params)
         email = params['email'].lower().strip()
 
-        users = self.model('user').find({'email': email}, timeout=False)
+        users = self.model('user').find({'email': email})
 
         if not users.count():
             raise RestException('That email is not registered.')

--- a/girder/models/collection.py
+++ b/girder/models/collection.py
@@ -185,7 +185,7 @@ class Collection(AccessControlledModel):
         folders = self.model('folder').find({
             'parentId': doc['_id'],
             'parentCollection': 'collection'
-        }, timeout=False)
+        })
         for folder in folders:
             for (filepath, file) in self.model('folder').fileList(
                     folder, user, path, includeMetadata, subpath=True):
@@ -202,7 +202,7 @@ class Collection(AccessControlledModel):
         folders = self.model('folder').find({
             'parentId': doc['_id'],
             'parentCollection': 'collection'
-        }, timeout=False)
+        })
         count += sum(self.model('folder').subtreeCount(folder)
                      for folder in folders)
         return count

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -210,7 +210,7 @@ class Folder(AccessControlledModel):
             'parentId': folderId,
             'parentCollection': 'folder'
         }
-        for child in self.find(q, timeout=False):
+        for child in self.find(q):
             self._updateDescendants(
                 child['_id'], updateQuery)
 
@@ -296,7 +296,7 @@ class Folder(AccessControlledModel):
         # Delete all child items
         items = self.model('item').find({
             'folderId': folder['_id']
-        }, timeout=False)
+        })
         for item in items:
             setResponseTimeLimit()
             self.model('item').remove(item, progress=progress, **kwargs)
@@ -310,7 +310,7 @@ class Folder(AccessControlledModel):
         folders = self.find({
             'parentId': folder['_id'],
             'parentCollection': 'folder'
-        }, timeout=False)
+        })
         for subfolder in folders:
             self.remove(subfolder, progress=progress, **kwargs)
         folders.close()
@@ -535,7 +535,7 @@ class Folder(AccessControlledModel):
         folders = self.find({
             'parentId': folder['_id'],
             'parentCollection': 'folder'
-        }, fields=(), timeout=False)
+        }, fields=())
         count += sum(self.subtreeCount(subfolder) for subfolder in folders)
 
         return count
@@ -559,13 +559,13 @@ class Folder(AccessControlledModel):
             path = os.path.join(path, doc['name'])
         metadataFile = "girder-folder-metadata.json"
         for sub in self.childFolders(parentType='folder', parent=doc,
-                                     user=user, timeout=False):
+                                     user=user):
             if sub['name'] == metadataFile:
                 metadataFile = None
             for (filepath, file) in self.fileList(
                     sub, user, path, includeMetadata, subpath=True):
                 yield (filepath, file)
-        for item in self.childItems(folder=doc, timeout=False):
+        for item in self.childItems(folder=doc):
             if item['name'] == metadataFile:
                 metadataFile = None
             for (filepath, file) in self.model('item').fileList(
@@ -663,7 +663,7 @@ class Folder(AccessControlledModel):
         # Give listeners a chance to change things
         events.trigger('model.folder.copy.prepare', (srcFolder, newFolder))
         # copy items
-        for item in self.childItems(folder=srcFolder, timeout=False):
+        for item in self.childItems(folder=srcFolder):
             setResponseTimeLimit()
             self.model('item').copyItem(item, creator, folder=newFolder)
             if progress:
@@ -671,7 +671,7 @@ class Folder(AccessControlledModel):
                                 item['name'])
         # copy subfolders
         for sub in self.childFolders(parentType='folder', parent=srcFolder,
-                                     user=creator, timeout=False):
+                                     user=creator):
             if firstFolder and firstFolder['_id'] == sub['_id']:
                 continue
             self.copyFolder(sub, parent=newFolder, parentType='folder',

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -188,8 +188,8 @@ class Item(Model):
 
     def childFiles(self, item, limit=0, offset=0, sort=None, **kwargs):
         """
-        Generator function that yields child files in the item.  Passes any
-        kwargs to the find function.
+        Returns child files of the item.  Passes any kwargs to the find
+        function.
 
         :param item: The parent item.
         :param limit: Result limit.
@@ -200,10 +200,8 @@ class Item(Model):
             'itemId': item['_id']
         }
 
-        cursor = self.model('file').find(
+        return self.model('file').find(
             q, limit=limit, offset=offset, sort=sort, **kwargs)
-        for file in cursor:
-            yield file
 
     def remove(self, item, **kwargs):
         """

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -172,7 +172,7 @@ class Item(Model):
         :returns: the recalculated size in bytes
         """
         size = 0
-        for file in self.childFiles(item, timeout=False):
+        for file in self.childFiles(item):
             # We could add a recalculateSize to the file model, in which case
             # this would be:
             # size += self.model('file').recalculateSize(file)
@@ -445,7 +445,7 @@ class Item(Model):
                     (includeMetadata and len(doc.get('meta', {})))):
                 path = os.path.join(path, doc['name'])
         metadataFile = "girder-item-metadata.json"
-        for file in self.childFiles(item=doc, timeout=False):
+        for file in self.childFiles(item=doc):
             if file['name'] == metadataFile:
                 metadataFile = None
             yield (os.path.join(path, file['name']),
@@ -470,17 +470,16 @@ class Item(Model):
                   numChanged: number of items changed.
         """
         if stage == 'count':
-            numItems = self.find(limit=1, timeout=False).count()
+            numItems = self.find(limit=1).count()
             return numItems, 0
         elif stage == 'remove':
             # Check that all items are in existing folders.  Any that are not
             # can be deleted.  Perhaps we should put them in a lost+found
             # instead
             folderIds = self.model('folder').collection.distinct('_id')
-            lostItems = self.find(
-                timeout=False,
-                query={'$or': [{'folderId': {'$nin': folderIds}},
-                               {'folderId': {'$exists': False}}]})
+            lostItems = self.find({
+                '$or': [{'folderId': {'$nin': folderIds}},
+                        {'folderId': {'$exists': False}}]})
             numItems = itemsLeft = lostItems.count()
             if numItems:
                 if progress is not None:
@@ -495,7 +494,7 @@ class Item(Model):
             return numItems, numItems
         elif stage == 'verify':
             # Check items sizes
-            items = self.find(timeout=False)
+            items = self.find()
             numItems = itemsLeft = items.count()
             itemsCorrected = 0
             if progress is not None:

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -208,7 +208,7 @@ class Model(ModelImporter):
             query = {}
 
         return self.collection.find(
-            spec=query, skip=offset, limit=limit, **kwargs)
+            spec=query, skip=offset, limit=limit, timeout=False, **kwargs)
 
     def findOne(self, query=None, **kwargs):
         """

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -277,7 +277,7 @@ class User(AccessControlledModel):
         folders = self.model('folder').find({
             'parentId': doc['_id'],
             'parentCollection': 'user'
-        }, timeout=False)
+        })
         for folder in folders:
             for (filepath, file) in self.model('folder').fileList(
                     folder, user, path, includeMetadata, subpath=True):
@@ -293,7 +293,7 @@ class User(AccessControlledModel):
         folders = self.model('folder').find({
             'parentId': doc['_id'],
             'parentCollection': 'user'
-        }, timeout=False)
+        })
         count += sum(self.model('folder').subtreeCount(folder)
                      for folder in folders)
         return count


### PR DESCRIPTION
A PyMongo cursor will always be deallocated by the server when it is exhausted or when it is closed by the client (typically by going out of scope). This change will ensure that cursors held open longer than 10 minutes will not be automatically closed by the server prematurely, which could affect long-running batch jobs.

See: http://docs.mongodb.org/manual/core/cursors/#closure-of-inactive-cursors

Developers are still advised to manually close cursors that will not quickly go out of scope, to ensure that both client and server-side resources are freed as soon as possible.

Thanks to @manthey for bringing up this topic.