### PR TITLE
Allow group admins and mods to directly add users to groups.

### DIFF
--- a/clients/web/src/templates/body/systemConfiguration.jade
+++ b/clients/web/src/templates/body/systemConfiguration.jade
@@ -32,6 +32,19 @@ form.g-settings-form(role="form")
              "open")) Open registration
       option(value="closed", selected=(settings['core.registration_policy'] ==
              "closed")) Closed registration
+  .form-group
+    label(for="g-core-add-to-group-policy") Allow members to be directly added to groups
+    select#g-core-add-to-group-policy.form-control.input-sm
+      option(value="never", selected=(settings['core.add_to_group_policy'] ==
+             "never")) No - members must be invited and accept invitations
+      option(value="noadmin", selected=(settings['core.add_to_group_policy'] ==
+             "noadmin")) No, except for group administrators when enabled per group
+      option(value="nomod", selected=(settings['core.add_to_group_policy'] ==
+             "nomod")) No, except for group administrators and moderators when enabled per group
+      option(value="yesadmin", selected=(settings['core.add_to_group_policy'] ==
+             "yesadmin")) Yes, by group administrators unless disabled per group
+      option(value="yesmod", selected=(settings['core.add_to_group_policy'] ==
+             "yesmod")) Yes by group administrators and moderators unless disabled per group
 
   .panel-group#g-configuration-accordion
     .panel.panel-default

--- a/clients/web/src/templates/widgets/editGroupWidget.jade
+++ b/clients/web/src/templates/widgets/editGroupWidget.jade
@@ -28,6 +28,20 @@
         .form-group
           label.control-label(for="g-description") Description (optional)
           textarea#g-description.input-sm.form-control(placeholder="Enter group description")
+        if groupAddAllowed
+            .form-group
+              label.control-label(for="g-add-to-group") Allow members to be directly added to this group
+              select#g-add-to-group.form-control.input-sm
+                if addToGroupPolicy == 'yesadmin'
+                    option(value='default', selected=(addAllowed === 'default')) Default - Yes, allow group administrators to add members
+                else if addToGroupPolicy == 'yesmod'
+                    option(value='default', selected=(addAllowed === 'default')) Default - Yes, allow group administrators and moderators to add members
+                else
+                    option(value='default', selected=(addAllowed === 'default')) Default - No
+                option(value='no', selected=(addAllowed === 'no')) No - members must be invited and accept invitations
+                if groupAddAllowed === 'mod'
+                    option(value='yesmod', selected=(addAllowed === 'yesmod')) Yes - allow group administrators and moderators to directly add members
+                option(value='yesadmin', selected=(addAllowed === 'yesadmin')) Yes - allow group administrators to directly add members
         .g-validation-failed-message
       .modal-footer
         a.btn.btn-small.btn-default(data-dismiss="modal") Cancel

--- a/clients/web/src/templates/widgets/groupInviteDialog.jade
+++ b/clients/web/src/templates/widgets/groupInviteDialog.jade
@@ -22,7 +22,7 @@
               .g-invite-as-member.btn.btn-primary
                 i.icon-mail
                 |  Invite as member
-              if isAdmin
+              if mayAdd
                 .g-add-as-member.btn.btn-warning.g-add-user-button
                   i.icon-plus
                   | Add as member
@@ -40,7 +40,7 @@
                 .g-invite-as-moderator.btn.btn-primary
                   i.icon-mail
                   |  Invite as moderator
-                if isAdmin
+                if mayAdd
                   .g-add-as-moderator.btn.btn-warning.g-add-user-button
                     i.icon-plus
                     | Add as moderator
@@ -60,7 +60,7 @@
                 .g-invite-as-admin.btn.btn-primary
                   i.icon-mail
                   |  Invite as administrator
-                if isAdmin
+                if mayAdd
                   .g-add-as-admin.btn.btn-warning.g-add-user-button
                     i.icon-plus
                     | Add as administrator

--- a/clients/web/src/views/body/SystemConfigurationView.js
+++ b/clients/web/src/views/body/SystemConfigurationView.js
@@ -49,7 +49,8 @@ girder.views.SystemConfigurationView = girder.View.extend({
             'core.upload_minimum_chunk_size',
             'core.cors.allow_origin',
             'core.cors.allow_methods',
-            'core.cors.allow_headers'
+            'core.cors.allow_headers',
+            'core.add_to_group_policy'
         ];
         this.settingsKeys = keys;
         girder.restRequest({

--- a/clients/web/src/views/widgets/EditGroupWidget.js
+++ b/clients/web/src/views/widgets/EditGroupWidget.js
@@ -11,6 +11,9 @@ girder.views.EditGroupWidget = girder.View.extend({
                 description: this.$('#g-description').val(),
                 public: this.$('#g-access-public').is(':checked')
             };
+            if (this.$('#g-add-to-group').length) {
+                fields.addAllowed = this.$('#g-add-to-group').val();
+            }
 
             if (this.model) {
                 this.updateGroup(fields);
@@ -27,14 +30,27 @@ girder.views.EditGroupWidget = girder.View.extend({
 
     initialize: function (settings) {
         this.model = settings.model || null;
+
     },
 
     render: function () {
         var view = this;
         var pub = this.model ? this.model.get('public') : false;
+        var groupAddAllowed;
+        var addToGroupPolicy = this.model ? this.model.get('_addToGroupPolicy') : null;
+        if (girder.currentUser.get('admin')) {
+            if (addToGroupPolicy === 'nomod' || addToGroupPolicy === 'yesmod') {
+                groupAddAllowed = 'mod';
+            } else if (addToGroupPolicy === 'noadmin' || addToGroupPolicy === 'yesadmin') {
+                groupAddAllowed = 'admin';
+            }
+        }
         var modal = this.$el.html(girder.templates.editGroupWidget({
             group: this.model,
-            public: pub
+            public: pub,
+            addToGroupPolicy: addToGroupPolicy,
+            groupAddAllowed: groupAddAllowed,
+            addAllowed: this.model ? this.model.get('addAllowed') : false
         })).girderModal(this).on('shown.bs.modal', function () {
             view.$('#g-name').focus();
             if (view.model) {

--- a/clients/web/src/views/widgets/GroupMembersWidget.js
+++ b/clients/web/src/views/widgets/GroupMembersWidget.js
@@ -157,7 +157,7 @@ girder.views.InviteUserDialog = girder.View.extend({
             user: this.user,
             level: this.group.get('_accessLevel'),
             accessType: girder.AccessType,
-            isAdmin: girder.currentUser.get('admin')
+            mayAdd: this.group.mayAddMembers()
         })).girderModal(this);
 
         return this;

--- a/girder/constants.py
+++ b/girder/constants.py
@@ -132,6 +132,7 @@ class SettingKey:
     CORS_ALLOW_ORIGIN = 'core.cors.allow_origin'
     CORS_ALLOW_METHODS = 'core.cors.allow_methods'
     CORS_ALLOW_HEADERS = 'core.cors.allow_headers'
+    ADD_TO_GROUP_POLICY = 'core.add_to_group_policy'
 
 
 class SettingDefault:
@@ -150,10 +151,11 @@ class SettingDefault:
         # changes to the CORS origin
         SettingKey.CORS_ALLOW_HEADERS:
             'Accept-Encoding, Authorization, Content-Disposition, '
-            'Content-Type, Cookie, Girder-Token'
+            'Content-Type, Cookie, Girder-Token',
             # An apache server using reverse proxy would also need
             #  X-Requested-With, X-Forwarded-Server, X-Forwarded-For,
             #  X-Forwarded-Host, Remote-Addr
+        SettingKey.ADD_TO_GROUP_POLICY: 'never',
     }
 
 

--- a/girder/models/group.py
+++ b/girder/models/group.py
@@ -62,7 +62,8 @@ class Group(AccessControlledModel):
         })
 
         self.exposeFields(level=AccessType.READ, fields=(
-            '_id', 'name', 'public', 'description', 'created', 'updated'))
+            '_id', 'name', 'public', 'description', 'created', 'updated',
+            'addAllowed'))
 
     def filter(self, group, user, accessList=False, requests=False):
         """

--- a/girder/models/setting.py
+++ b/girder/models/setting.py
@@ -79,6 +79,14 @@ class Setting(Model):
 
         doc['value'] = list(doc['value'])
 
+    def validateCoreAddToGroupPolicy(self, doc):
+        doc['value'] = doc['value'].lower()
+        if doc['value'] not in ('never', 'noadmin', 'nomod', 'yesadmin',
+                                'yesmod', ''):
+            raise ValidationException(
+                'Add to group policy must be one of "never", "noadmin", '
+                '"nomod", "yesadmin", or "yesmod".', 'value')
+
     def validateCoreCookieLifetime(self, doc):
         try:
             doc['value'] = int(doc['value'])

--- a/plugins/user_quota/web_client/templates/collectionPoliciesMenu.jade
+++ b/plugins/user_quota/web_client/templates/collectionPoliciesMenu.jade
@@ -3,6 +3,6 @@ if collection.getAccessLevel() >= girder.AccessType.ADMIN
     a.g-collection-policies(role="menuitem")
       i.icon-box
       if girder.currentUser.get('admin')
-        | Quota and Assetstore Policies
+        | Quota and assetstore policies
       else
         | Quota

--- a/plugins/user_quota/web_client/templates/userPoliciesMenu.jade
+++ b/plugins/user_quota/web_client/templates/userPoliciesMenu.jade
@@ -3,6 +3,6 @@ if user.getAccessLevel() >= girder.AccessType.ADMIN
     a.g-user-policies(role="menuitem")
       i.icon-box
       if girder.currentUser.get('admin')
-        | Quota and Assetstore Policies
+        | Quota and assetstore policies
       else
         | Quota

--- a/tests/cases/group_test.py
+++ b/tests/cases/group_test.py
@@ -37,7 +37,7 @@ class GroupTestCase(base.TestCase):
         # an admin
         self.users = [self.model('user').createUser(
             'usr%s' % num, 'passwd', 'tst', 'usr', 'u%s@u.com' % num)
-            for num in [0, 1, 2, 3, 4, 5]]
+            for num in xrange(6)]
 
     def testDirectAdd(self):
         """


### PR DESCRIPTION
Added a setting to pick whether group admins and mods are allowed to directly add users to groups.  If enable, individual group's have a property that further modifies this option.

Updated system tests and javascript tests.

This completes issue #690.