### PR TITLE
Fixed header and nav

### DIFF
--- a/clients/web/src/stylesheets/layout/global.styl
+++ b/clients/web/src/stylesheets/layout/global.styl
@@ -88,6 +88,12 @@ ul.dropdown-menu
 .modal-backdrop.in
   opacity .35
 
+/* By default bootstrap only applies form-inline rules at >=768px width */
+.form-inline .form-group
+  display inline-block
+  margin-bottom 0
+  vertical-align middle
+
 blockquote p
   font-size inherit
 

--- a/clients/web/src/stylesheets/layout/globalNav.styl
+++ b/clients/web/src/stylesheets/layout/globalNav.styl
@@ -7,6 +7,7 @@ $minHeight=500px
   background-image linear-gradient(to left, #f4f4f4 0%, #fff 7px)
   min-height $minHeight - 12px
   padding 15px 0 20px 6px
+
 .g-global-nav-fade
   height 12px
   box-shadow inset -1px 0 0 #f5f5f5
@@ -92,4 +93,3 @@ ul.g-global-nav
     min-height 0
   .g-global-nav-fade
     display none
-

--- a/clients/web/src/stylesheets/layout/header.styl
+++ b/clients/web/src/stylesheets/layout/header.styl
@@ -7,14 +7,14 @@
   display inline
   font-size 25px
   font-weight bold
-  margin-right 50px
+  margin-right 35px
   line-height 36px
   vertical-align middle
   cursor pointer
 
 .g-quick-search-form
   display inline
-  margin-right 60px
+  margin-right 15px
 
 #g-quick-search-input
   width 180px

--- a/clients/web/src/stylesheets/layout/layout.styl
+++ b/clients/web/src/stylesheets/layout/layout.styl
@@ -1,12 +1,21 @@
 $navWidth = 180px
 $minHeight = 500px
+$headerHeight = 52px
+$headerZ = 50
 
 #g-global-nav-container
-  float left
+  position fixed
+  top $headerHeight
   width $navWidth
 
+#g-app-header-container
+  position fixed
+  top 0
+  width 100%
+  z-index $headerZ
+
 #g-app-body-container
-  padding 10px
+  padding 10px + $headerHeight 10px 10px 10px
   margin-left $navWidth + 1px
   min-height $minHeight
 
@@ -43,7 +52,7 @@ $minHeight = 500px
   right 10px
   bottom 0
   width 400px
-  z-index 10
+  z-index $headerZ + 1
 
 .modal-body p
   overflow hidden
@@ -51,8 +60,10 @@ $minHeight = 500px
 
 @media (max-width: 720px)
   #g-global-nav-container
-    float none
     width 100%
+    position static
+    margin-top $headerHeight
 
   #g-app-body-container
     margin-left 0
+    padding 10px


### PR DESCRIPTION
@mgrauer was demoing monkey brains to me earlier and had a page where the body scrolled a very long way down, and we both agreed that it would be better for usability if the navbar and header were fixed in the viewport.

Even if we decide not to go through with this change, we should still merge the first commit on this topic, which fixes what I consider buggy behavior in bootstrap with inline forms.