### PR TITLE
Replace markedown with marked.  Fixes #715.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -231,7 +231,7 @@ module.exports = function (grunt) {
                         'node_modules/jade/runtime.js',
                         'node_modules/underscore/underscore.js',
                         'node_modules/backbone/backbone.js',
-                        'node_modules/markdown/lib/markdown.js',
+                        'node_modules/marked/lib/marked.js',
                         'clients/web/lib/js/d3.js',
                         'clients/web/lib/js/bootstrap.js',
                         'clients/web/lib/js/bootstrap-switch.js',

--- a/clients/web/src/utilities/MiscFunctions.js
+++ b/clients/web/src/utilities/MiscFunctions.js
@@ -226,13 +226,19 @@ girder.restartServer._reloadWindow = function () {
 };
 
 /**
- * Transform markdown into HTML and render it into the given element.
+ * Transform markdown into HTML and render it into the given element. If no
+ * element is provided, simply returns the HTML.
  *
  * @param val The markdown text input.
- * @param el The element to render the output HTML into.
+ * @param el The element to render the output HTML into, or falsy to simply
+ *        return the HTML value.
  */
 girder.renderMarkdown = function (val, el) {
-    $(el).html(marked(val));
+    if (el) {
+        $(el).html(marked(val));
+    } else {
+        return marked(val);
+    }
 };
 
 (function () {

--- a/clients/web/src/utilities/MiscFunctions.js
+++ b/clients/web/src/utilities/MiscFunctions.js
@@ -232,7 +232,7 @@ girder.restartServer._reloadWindow = function () {
  * @param el The element to render the output HTML into.
  */
 girder.renderMarkdown = function (val, el) {
-    $(el).html(markdown.toHTML(val));
+    $(el).html(marked(val));
 };
 
 (function () {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "grunt-gitinfo": "~0.1.0",
     "grunt-file-creator": "~0.1.0",
     "grunt-contrib-compress": "~0.12.0",
-    "markdown": "0.5.0",
+    "marked": "0.3.3",
     "jade": "1.3.1",
     "jquery": "2.1.1",
     "swagger-ui": "2.0.22",

--- a/tests/jshint.cfg
+++ b/tests/jshint.cfg
@@ -101,6 +101,6 @@
         "console",
         "alert",
         "sprintf",
-        "markdown"
+        "marked"
     ]
 }


### PR DESCRIPTION
This branch adds support for marked as a markdown parser.  I'm not saying we should go with marked, but you can play with it here.