### PR TITLE
Sanitize marked markdown output

### DIFF
--- a/clients/web/src/utilities/MiscFunctions.js
+++ b/clients/web/src/utilities/MiscFunctions.js
@@ -233,13 +233,16 @@ girder.restartServer._reloadWindow = function () {
  * @param el The element to render the output HTML into, or falsy to simply
  *        return the HTML value.
  */
-girder.renderMarkdown = function (val, el) {
-    if (el) {
-        $(el).html(marked(val));
-    } else {
-        return marked(val);
-    }
-};
+girder.renderMarkdown = (function () {
+    marked.setOptions({ sanitize: true });
+    return function (val, el) {
+        if (el) {
+            $(el).html(marked(val));
+        } else {
+            return marked(val);
+        }
+    };
+}());
 
 (function () {
     var _pluginConfigRoutes = {};


### PR DESCRIPTION
@zachmullen turning on the `sanitize` option prevents inline HTML or javascript links like this one that we saw

    [link](javascript:alert(alert))