### PR TITLE
Raise http error if authentication returns with 404

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -156,8 +156,11 @@ class GirderClient(object):
         if username is None or password is None:
             raise Exception('A user name and password are required')
 
-        authResponse = requests.get(self.urlBase + 'user/authentication',
-                                    auth=(username, password))
+        url = self.urlBase + 'user/authentication'
+        authResponse = requests.get(url, auth=(username, password))
+
+        if authResponse.status_code == 404:
+            raise HttpError(404, authResponse.text, url, "GET")
 
         resp = authResponse.json()
         if 'authToken' not in resp:


### PR DESCRIPTION
If, e.g., the ``apiRoot`` is bad, attempting authentication would fail with an error about decoding JSON; now, the code explicitly checks for a 404 response (which, of course, carries no JSON data with it, resulting in the original error) and raises an ``HttpError`` as appropriate.

This results in a better error message, as well as a way to guard against things like bad API roots in client code.