### PR TITLE
Simplify configuration disabling C/CXX compiler detection in girder CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.6)
 
-project(Girder)
+project(Girder NONE)
 
 include(CTest)
 enable_testing()


### PR DESCRIPTION
Since CMake is used only to setup the "CTest" testing framework, this
commit disables the C/CXX compiler detection.

On Ubuntu 14.04, it also speeds up the initial configuration by ~ x10.

Note that the "NONE" special keyword is supported by the CMake minimum
version (2.8.6) required by girder.
See http://www.cmake.org/cmake/help/v2.8.6/cmake.html#command:project

Before:

8<----8<----8<----8<----8<----8<----8<----8<----8<----8<----8<----
$ time cmake ../girder
-- The C compiler identification is GNU 4.8.2
-- The CXX compiler identification is GNU 4.8.2
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Including plugin.cmake from "oauth"
-- Including plugin.cmake from "covalic"
-- Including plugin.cmake from "google_analytics"
-- Including plugin.cmake from "gravatar"
-- Including plugin.cmake from "celery_jobs"
-- Including plugin.cmake from "provenance"
-- Including plugin.cmake from "jobs"
-- Including plugin.cmake from "metadata_extractor"
-- Including plugin.cmake from "user_quota"
-- Including plugin.cmake from "challenge"
-- Including plugin.cmake from "mongo_search"
-- Including plugin.cmake from "geospatial"
-- Configuring done
-- Generating done
-- Build files have been written to: /home/jcfr/Projects/girder-build

real	0m1.168s
user	0m0.659s
sys	0m0.517s
8<----8<----8<----8<----8<----8<----8<----8<----8<----8<----8<----


After:

8<----8<----8<----8<----8<----8<----8<----8<----8<----8<----8<----
$ time cmake ../girder
-- Including plugin.cmake from "oauth"
-- Including plugin.cmake from "covalic"
-- Including plugin.cmake from "google_analytics"
-- Including plugin.cmake from "gravatar"
-- Including plugin.cmake from "celery_jobs"
-- Including plugin.cmake from "provenance"
-- Including plugin.cmake from "jobs"
-- Including plugin.cmake from "metadata_extractor"
-- Including plugin.cmake from "user_quota"
-- Including plugin.cmake from "challenge"
-- Including plugin.cmake from "mongo_search"
-- Including plugin.cmake from "geospatial"
-- Configuring done
-- Generating done
-- Build files have been written to: /home/jcfr/Projects/girder-build

real	0m0.120s
user	0m0.073s
sys	0m0.048s
8<----8<----8<----8<----8<----8<----8<----8<----8<----8<----8<----