### PR TITLE
Adding a logic path to catch "parsererror" status

### DIFF
--- a/clients/web/src/init.js
+++ b/clients/web/src/init.js
@@ -65,7 +65,7 @@ _.extend(girder, {
             dataType: 'json',
             type: 'GET',
 
-            error: function (error) {
+            error: function (error, status) {
                 var info;
                 if (error.status === 401) {
                     girder.events.trigger('g:loginUi');
@@ -92,6 +92,15 @@ _.extend(girder, {
                         type: 'warning',
                         timeout: 5000,
                         icon: 'info'
+                    };
+                } else if (status === "parsererror") {
+                    info = {
+                        text: 'A parser error occurred while communicating with the ' +
+                              'server (did you use the correct value for `dataType`?). ' +
+                              'Details have been logged in the console.',
+                        type: 'danger',
+                        timeout: 5000,
+                        icon: 'attention'
                     };
                 } else {
                     info = {

--- a/clients/web/src/init.js
+++ b/clients/web/src/init.js
@@ -93,7 +93,7 @@ _.extend(girder, {
                         timeout: 5000,
                         icon: 'info'
                     };
-                } else if (status === "parsererror") {
+                } else if (status === 'parsererror') {
                     info = {
                         text: 'A parser error occurred while communicating with the ' +
                               'server (did you use the correct value for `dataType`?). ' +


### PR DESCRIPTION
This occurs when, e.g., you retrieve general text data from an endpoint (say,
``/file/<id>/download``), but forget to set ``dataType: 'text'`` in the request.