### PR TITLE
Using find_package() for Python rather than find_program

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(Girder NONE)
 include(CTest)
 enable_testing()
 
-find_program(PYTHON_EXECUTABLE python)
+find_package(PythonInterp 2.7 REQUIRED)
 
 option(PYTHON_STATIC_ANALYSIS "Run Python static analysis tests with flake8" ON)
 option(PYTHON_COVERAGE "Run tests with coverage.py" ON)


### PR DESCRIPTION
This allows the build to work properly for OSes with nonstandard names for, e.g., the Python 2.7 executable, such as Arch Linux (``python2`` instead of ``python``).

CMake documentation for this module: http://www.cmake.org/cmake/help/v3.0/module/FindPythonInterp.html