### PR TITLE
javascript_tests_init: Update CMake function to check if directory exists

### DIFF
--- a/tests/JavascriptTests.cmake
+++ b/tests/JavascriptTests.cmake
@@ -31,6 +31,7 @@ function(add_javascript_style_test name input)
   endif()
   add_test(
     NAME "jshint_${name}"
+    WORKING_DIRECTORY ${input}
     COMMAND "${JSHINT_EXECUTABLE}" --config "${PROJECT_SOURCE_DIR}/tests/jshint.cfg" "${input}"
   )
   add_test(

--- a/tests/JavascriptTests.cmake
+++ b/tests/JavascriptTests.cmake
@@ -21,14 +21,20 @@ function(javascript_tests_init)
 endfunction()
 
 function(add_javascript_style_test name input)
+  set(working_dir "${PROJECT_SOURCE_DIR}/clients/web")
+  if(NOT IS_ABSOLUTE ${input})
+    set(input ${working_dir}/${input})
+  endif()
+  if(NOT EXISTS ${input})
+    message(FATAL_ERROR "Failed to add javascript style tests."
+                        "Directory '${input}' does not exist.")
+  endif()
   add_test(
     NAME "jshint_${name}"
-    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/clients/web"
     COMMAND "${JSHINT_EXECUTABLE}" --config "${PROJECT_SOURCE_DIR}/tests/jshint.cfg" "${input}"
   )
   add_test(
     NAME "jsstyle_${name}"
-    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/clients/web"
     COMMAND "${JSSTYLE_EXECUTABLE}" --config "${PROJECT_SOURCE_DIR}/tests/jsstyle.cfg" "${input}"
   )
 endfunction()

--- a/tests/jsstyle.cfg
+++ b/tests/jsstyle.cfg
@@ -2,5 +2,6 @@
     "preset": "crockford",
     "disallowDanglingUnderscores": null,
     "requireMultipleVarDecl": null,
-    "requireCamelCaseOrUpperCaseIdentifiers": null
+    "requireCamelCaseOrUpperCaseIdentifiers": null,
+    "excludeFiles": ["../**/ext/**.js"]
 }


### PR DESCRIPTION
If the input parameter is a relative directory, it is prepended with
the expected working directory.

See girder/covalic#93