### PR TITLE
Use Travis container-based builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: cpp
 
 sudo: false
 
+# Build matrix
+env:
+    - MONGO_SOURCE=mongodb-linux-x86_64-2.6.8.tgz
+    - MONGO_SOURCE=mongodb-linux-x86_64-3.0.1.tgz
+
 compiler:
     - gcc
 before_install:
@@ -11,9 +16,7 @@ before_install:
     #- python scripts/vmtest.py
 
     - pushd "${HOME}"
-    # We can test with Mongo 2.6.8 or Mongo 3.0.1
-    #- curl -O https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.0.1.tgz | gunzip -c | tar x
-    - curl https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-2.6.8.tgz | gunzip -c | tar x
+    - curl "https://fastdl.mongodb.org/linux/${MONGO_SOURCE}" | gunzip -c | tar x
     - cd mongodb-*/bin && export PATH="${PWD}:${PATH}"
     - popd
     - mkdir /tmp/db
@@ -32,7 +35,6 @@ install:
     - pip install --user -r plugins/celery_jobs/requirements.txt -r plugins/hdfs_assetstore/requirements.txt
     # We have to upgrade six or requiring moto can cause other modules to fail
     - pip install --user -U six
-    - python -c "import bcrypt"
     - npm install grunt grunt-cli
     - npm install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,24 @@
 language: cpp
+
+sudo: false
+
 compiler:
     - gcc
 before_install:
     # Show the memory state; this lets us more quickly determine when the
     # travis environment is bad
     - vmstat
-    - python scripts/vmtest.py
-    - sudo apt-get install npm
-    - "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10"
-    - "echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list"
-    - "sudo apt-get update"
-    - "sudo apt-get install mongodb-org-server"
+    #- python scripts/vmtest.py
+
+    - pushd "${HOME}"
+    # We can test with Mongo 2.6.8 or Mongo 3.0.1
+    #- curl -O https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.0.1.tgz | gunzip -c | tar x
+    - curl https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-2.6.8.tgz | gunzip -c | tar x
+    - cd mongodb-*/bin && export PATH="${PWD}:${PATH}"
+    - popd
+    - mkdir /tmp/db
+    - mongod --dbpath=/tmp/db >/dev/null 2>/dev/null &
+
     - mongod --version
     - pushd "${HOME}"
     - curl "http://www.cmake.org/files/v3.1/cmake-3.1.0-rc3-Linux-x86_64.tar.gz" | gunzip -c | tar x
@@ -18,12 +26,14 @@ before_install:
     - popd
     - cmake --version
 install:
-    - sudo pip install -r requirements.txt -r requirements-dev.txt -r plugins/geospatial/requirements.txt -r plugins/metadata_extractor/requirements.txt
-    - sudo pip install -r plugins/celery_jobs/requirements.txt -r plugins/hdfs_assetstore/requirements.txt
+    - mkdir -p "${HOME}/.local/bin"
+    - export PATH="${HOME}/.local/bin:${PATH}"
+    - pip install --user -r requirements.txt -r requirements-dev.txt -r plugins/geospatial/requirements.txt -r plugins/metadata_extractor/requirements.txt
+    - pip install --user -r plugins/celery_jobs/requirements.txt -r plugins/hdfs_assetstore/requirements.txt
     # We have to upgrade six or requiring moto can cause other modules to fail
-    - sudo pip install -U six
-    - sudo python -c "import bcrypt"
-    - npm install -g grunt grunt-cli
+    - pip install --user -U six
+    - python -c "import bcrypt"
+    - npm install grunt grunt-cli
     - npm install
 script:
     - mkdir _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ sudo: false
 
 # Build matrix
 env:
-    - MONGO_SOURCE=mongodb-linux-x86_64-2.6.8.tgz
-    - MONGO_SOURCE=mongodb-linux-x86_64-3.0.1.tgz
+    - MONGO_VERSION=2.6.8 DEPLOY=true
+    - MONGO_VERSION=3.0.1
 
 compiler:
     - gcc
@@ -16,7 +16,7 @@ before_install:
     #- python scripts/vmtest.py
 
     - pushd "${HOME}"
-    - curl "https://fastdl.mongodb.org/linux/${MONGO_SOURCE}" | gunzip -c | tar x
+    - curl "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGO_SOURCE}.tgz" | gunzip -c | tar x
     - cd mongodb-*/bin && export PATH="${PWD}:${PATH}"
     - popd
     - mkdir /tmp/db
@@ -55,3 +55,4 @@ deploy:
     on:
         repo: girder/girder
         branch: master
+        condition: "$DEPLOY = true"

--- a/cmake/travis_continuous.cmake
+++ b/cmake/travis_continuous.cmake
@@ -3,7 +3,7 @@ set(CTEST_BINARY_DIRECTORY "$ENV{TRAVIS_BUILD_DIR}/_build")
 
 include(${CTEST_SOURCE_DIRECTORY}/CTestConfig.cmake)
 set(CTEST_SITE "Travis")
-set(CTEST_BUILD_NAME "Linux-$ENV{TRAVIS_BRANCH}")
+set(CTEST_BUILD_NAME "Linux-$ENV{TRAVIS_BRANCH}-Mongo-$ENV{MONGO_VERSION}")
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 
 ctest_start("Continuous")

--- a/plugins/user_quota/plugin_tests/user_quota_test.py
+++ b/plugins/user_quota/plugin_tests/user_quota_test.py
@@ -21,8 +21,7 @@ import json
 import os
 
 from tests import base
-from girder import events
-from girder.constants import AccessType, AssetstoreType, SettingKey
+from girder.constants import AssetstoreType, SettingKey
 from girder.models.model_base import ValidationException
 from girder.utility.system import formatSize
 from server import constants
@@ -176,7 +175,7 @@ class QuotaTestCase(base.TestCase):
         except ValidationException as err:
             if not error:
                 raise
-            if not error in err.message:
+            if error not in err.message:
                 raise
             return
         if testVal is not '__NOCHECK__':
@@ -314,7 +313,7 @@ class QuotaTestCase(base.TestCase):
             'name': 'Broken Store',
             'type': AssetstoreType.GRIDFS,
             'db': 'girder_assetstore_user_quota_test_broken',
-            'mongohost': 'mongodb://127.254.254.254:27017'
+            'mongohost': 'mongodb://127.254.254.254:27016'
         }
         resp = self.request(path='/assetstore', method='POST', user=self.admin,
                             params=params)


### PR DESCRIPTION
Our Travis builds were erroring-out because of intermittent problems with Travis's virtualization method.  The people at Travis recommended switching to their container-based builds.  This requires not using sudo, though you can still use apt-get from the default repositories.  I had to install Mongo manually, and, that change required a change to how testing for bad assetstores was done.