### PR TITLE
Add a model type field to models when filtering them

### DIFF
--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -418,6 +418,8 @@ class Model(ModelImporter):
         if '_textScore' in doc:
             out['_textScore'] = doc['_textScore']
 
+        out['_modelType'] = self.name
+
         return out
 
     def subtreeCount(self, doc):

--- a/tests/cases/filter_test.py
+++ b/tests/cases/filter_test.py
@@ -125,10 +125,11 @@ class FilterTestCase(base.TestCase):
         # Test Model implementation
         fake = self.model('fake').save(fields)
         filtered = self.model('fake').filter(fake, self.user)
-        self.assertEqual(filtered, {'read': 1})
+        self.assertEqual(filtered, {'read': 1, '_modelType': 'fake'})
 
         filtered = self.model('fake').filter(fake, self.admin)
         self.assertEqual(filtered, {
             'read': 1,
-            'sa': 1
+            'sa': 1,
+            '_modelType': 'fake'
         })

--- a/tests/cases/item_test.py
+++ b/tests/cases/item_test.py
@@ -227,6 +227,7 @@ class ItemTestCase(base.TestCase):
                             user=self.users[0])
         self.assertStatusOk(resp)
         self.assertEqual(resp.json['_id'], item['_id'])
+        self.assertEqual(resp.json['_modelType'], 'item')
 
         # Also from the children call
         resp = self.request(path='/item', method='GET', user=self.users[0],


### PR DESCRIPTION
I'm putting this up as a straw man; I could see this field being helpful when objects are returned via the REST API to identify what types are being dealt with. Can anyone come up with a good reason *not* to add this field?