### PR TITLE
gitignore: Exclude testing artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ girder.egg-info
 .*.swp
 .*.swo
 .vagrant
+phantom-*.png
+girder-*.tar.gz


### PR DESCRIPTION
This commit will prevent files like the following from showing
as untracked or modified files by git:

  girder-1.2.2.tar.gz
  girder-plugins-1.2.2.tar.gz
  girder-web-1.2.2.tar.gz
  phantom-2015-03-23T15.35.42.714Z.png
  phantom-2015-03-23T15.35.44.868Z.png
  phantom-2015-03-23T15.35.45.316Z.png
  phantom-2015-03-23T15.36.30.899Z.png