### PR TITLE
Add hdfs assetstore requirements to aiur dashboard.

### DIFF
--- a/cmake/run_aiur_dashboard.sh
+++ b/cmake/run_aiur_dashboard.sh
@@ -3,7 +3,7 @@
 source /usr/share/virtualenvwrapper/virtualenvwrapper.sh
 workon girder
 cd /home/cpatrick/Dashboards/girder
-pip install -r requirements.txt -r requirements-dev.txt -r plugins/metadata_extractor/requirements.txt -r plugins/geospatial/requirements.txt -r plugins/celery_jobs/requirements.txt
+pip install -r requirements.txt -r requirements-dev.txt -r plugins/metadata_extractor/requirements.txt -r plugins/geospatial/requirements.txt -r plugins/celery_jobs/requirements.txt -r plugins/hdfs_assetstore/requirements.txt
 npm install
 python setup.py install
 # Copy compile plugin template files so that the javascript coverage locates


### PR DESCRIPTION
@zachmullen Aiur dashboards have been failing the HDFS assetstore tests because they didn't have install snakebite.