### PR TITLE
Update PyMongo requirement to v2.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cffi==0.8.6
 CherryPy==3.3.0
-pymongo==2.7.1
+pymongo==2.8
 bcrypt==1.0.2
 boto==2.29.1
 Mako==1.0.0


### PR DESCRIPTION
Version 2.8 of PyMongo is necessary for full support of MongoDB 3.0.