### PR TITLE
Bound route handler

### DIFF
--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -93,12 +93,16 @@ If you want to add a new route to an existing core resource type, just call the
 route for ``GET /item/:id/cat`` to the system, ::
 
     from girder.api import access
+    from girder.api.rest import boundHandler
 
     @access.public
-    def myHandler(id, params):
+    @boundHandler()
+    def myHandler(self, id, params):
+        self.requireParams('cat', params)
+
         return {
            'itemId': id,
-           'cat': params.get('cat', 'No cat param passed')
+           'cat': params['cat']
         }
 
     def load(info):
@@ -109,6 +113,11 @@ indicate who can call the new route.  The decorator is one of ``@access.admin``
 (only administrators can call this endpoint), ``@access.user`` (any user who is
 logged in can call the endpoint), or ``@access.public`` (any client can call
 the endpoint).
+
+In the above example, the :py:obj:`girder.api.rest.boundHandler` decorator is
+used to make the unbound method ``myHandler`` behave as though it is a member method
+of a :py:class:`girder.api.rest.Resource` instance, which enables convenient access
+to methods like ``self.requireParams``.
 
 If you do not add an access decorator, a warning message appears:
 ``WARNING: No access level specified for route GET item/:id/cat``.  The access

--- a/girder/utility/plugin_utilities.py
+++ b/girder/utility/plugin_utilities.py
@@ -207,8 +207,8 @@ def findAllPlugins(curConfig=None):
                     data = json.load(conf)
                 except ValueError as e:
                     print(TerminalColor.error(
-                        'ERROR: Failed to load plugin "%s": plugin.json is not '
-                        'valid JSON.' % plugin))
+                        'ERROR: Plugin "%s": plugin.json is not valid JSON.' %
+                        plugin))
                     print e
                     continue
         elif os.path.isfile(configYml):
@@ -217,8 +217,8 @@ def findAllPlugins(curConfig=None):
                     data = yaml.safe_load(conf)
                 except yaml.YAMLError as e:
                     print(TerminalColor.error(
-                        'ERROR: Failed to load plugin "%s": plugin.yml is not '
-                        'valid YAML.' % plugin))
+                        'ERROR: Plugin "%s": plugin.yml is not valid YAML.' %
+                        plugin))
                     print e
                     continue
 

--- a/tests/cases/rest_decorator_test.py
+++ b/tests/cases/rest_decorator_test.py
@@ -18,13 +18,20 @@
 ###############################################################################
 
 import json
+import os
 
 from .. import base
-
 from girder.api.rest import endpoint
+from girder.utility import config
 
 
 def setUpModule():
+    pluginRoot = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                              'test_plugins')
+    conf = config.getConfig()
+    conf['plugins'] = {'plugin_directory': pluginRoot}
+    base.enabledPlugins = ['test_plugin']
+
     base.startServer()
 
 
@@ -47,18 +54,31 @@ class testEndpointDecoratorException(base.TestCase):
     def pointless_endpoint_bytes(self, path, params):
         raise Exception('\x80\x80 cannot be converted to unicode or ascii.')
 
-    def test_endpoint_exception_ascii(self):
+    def tes_endpoint_exception_ascii(self):
         resp = self.pointless_endpoint_ascii('', {})
         obj = json.loads(resp)
         self.assertEquals(obj['type'], 'internal')
 
-    def test_endpoint_exception_unicode(self):
+    def tes_endpoint_exception_unicode(self):
         resp = self.pointless_endpoint_unicode('', {})
         obj = json.loads(resp)
         self.assertEquals(obj['type'], 'internal')
 
-    def test_endpoint_exception_bytes(self):
+    def tes_endpoint_exception_bytes(self):
         resp = self.pointless_endpoint_bytes('', {})
-        print resp
         obj = json.loads(resp)
         self.assertEquals(obj['type'], 'internal')
+
+    def testBoundHandlerDecorator(self):
+        resp = self.request('/collection/unbound/default', params={
+            'val': False
+        })
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, True)
+
+        resp = self.request('/collection/unbound/explicit')
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, {
+            'name': 'collection',
+            'user': None
+        })

--- a/tests/cases/rest_decorator_test.py
+++ b/tests/cases/rest_decorator_test.py
@@ -54,17 +54,17 @@ class testEndpointDecoratorException(base.TestCase):
     def pointless_endpoint_bytes(self, path, params):
         raise Exception('\x80\x80 cannot be converted to unicode or ascii.')
 
-    def tes_endpoint_exception_ascii(self):
+    def test_endpoint_exception_ascii(self):
         resp = self.pointless_endpoint_ascii('', {})
         obj = json.loads(resp)
         self.assertEquals(obj['type'], 'internal')
 
-    def tes_endpoint_exception_unicode(self):
+    def test_endpoint_exception_unicode(self):
         resp = self.pointless_endpoint_unicode('', {})
         obj = json.loads(resp)
         self.assertEquals(obj['type'], 'internal')
 
-    def tes_endpoint_exception_bytes(self):
+    def test_endpoint_exception_bytes(self):
         resp = self.pointless_endpoint_bytes('', {})
         obj = json.loads(resp)
         self.assertEquals(obj['type'], 'internal')


### PR DESCRIPTION
@jeffbaumes I noticed in Romanesco that it was fairly awkward when extending core REST resources to add new routes. The handlers didn't have an easy way to take advantage of utilities in the ``Resource`` class because they were unbound, and binding them was previously awkward. This adds a simple decorator so that those extension functions can pretend like they are part of a ``Resource`` class. I've got a branch in Romanesco that uses this new decorator and I will reference this PR there when I push it.