### PR TITLE
Fix race condition in jobs plugin phantom test

### DIFF
--- a/plugins/jobs/plugin_tests/jobsSpec.js
+++ b/plugins/jobs/plugin_tests/jobsSpec.js
@@ -20,11 +20,8 @@ $(function () {
 
     describe('Unit test the job widget.', function () {
         it('Show a job detail widget.', function () {
-            waitsFor('scripts to load', function () {
-                return girder.views.jobs_JobDetailsWidget &&
-                       girder.models.JobModel &&
-                       girder.jobs_JobStatus &&
-                       girder.templates.jobs_jobDetails;
+            waitsFor('app to render', function () {
+                return $('#g-app-body-container').length > 0;
             });
 
             runs(function () {


### PR DESCRIPTION
I couldn't recreate this failure locally, but I've seen it several times on travis and the [screenshots](http://my.cdash.org/testDetails.php?test=18817932&build=743273) from the failure case make it fairly clear what's happening. The app has not yet loaded due to waiting on the `/user/me` xhr to finish.