### PR TITLE
cherrypy request.base can contain paths.

### DIFF
--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -395,7 +395,7 @@ def _setCommonCORSHeaders(isOptions=False):
         logAltBase = ', forwarded base origin is ' + baselist[-1]
         if baseparse.scheme != cherrypy.request.scheme:
             baselist.append('%s://%s' % (baseparse.scheme, altbase))
-            logAltBase(', also allowing ' + baselist[-1])
+            logAltBase += ', also allowing ' + baselist[-1]
     else:
         logAltBase = ''
     # If we don't have any allowed origins, return that OPTIONS isn't a

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -26,6 +26,7 @@ import pymongo
 import sys
 import traceback
 import types
+import urlparse
 
 from . import docs
 from girder import events, logger
@@ -366,11 +367,13 @@ def _setCommonCORSHeaders(isOptions=False):
 
     :param isOptions: True if this call is from the options method
     """
-    origin = cherrypy.request.headers.get('origin', '').rstrip('/')
+    origin = cherrypy.request.headers.get('origin', '')
     if not origin:
         if isOptions:
             raise cherrypy.HTTPError(405)
         return
+    originparse = urlparse.urlparse(origin)
+    origin = '%s://%s' % (originparse.scheme, originparse.netloc)
     cherrypy.response.headers['Access-Control-Allow-Origin'] = origin
     cherrypy.response.headers['Vary'] = 'Origin'
     # Some requests do not require further checking
@@ -381,14 +384,19 @@ def _setCommonCORSHeaders(isOptions=False):
                 'multipart/form-data', 'text/plain'))):
         return
     cors = ModelImporter.model('setting').corsSettingsDict()
-    base = cherrypy.request.base.rstrip('/')
+    baseparse = urlparse.urlparse(cherrypy.request.base)
+    base = '%s://%s' % (baseparse.scheme, baseparse.netloc)
+    baselist = [base]
     # We want to handle X-Forwarded-Host be default
     altbase = cherrypy.request.headers.get('X-Forwarded-Host', '')
     if altbase:
-        altbase = '%s://%s' % (cherrypy.request.scheme, altbase)
-        logAltBase = ', forwarded base origin is ' + altbase
+        altbase = altbase.strip('/').split('/')[0]
+        baselist.append('%s://%s' % (cherrypy.request.scheme, altbase))
+        logAltBase = ', forwarded base origin is ' + baselist[-1]
+        if baseparse.scheme != cherrypy.request.scheme:
+            baselist.append('%s://%s' % (baseparse.scheme, altbase))
+            logAltBase(', also allowing ' + baselist[-1])
     else:
-        altbase = base
         logAltBase = ''
     # If we don't have any allowed origins, return that OPTIONS isn't a
     # valid method.  If the request specified an origin, fail.
@@ -397,14 +405,14 @@ def _setCommonCORSHeaders(isOptions=False):
             logger.info('CORS 405 error: no allowed origins (request origin '
                         'is %s, base origin is %s%s', origin, base, logAltBase)
             raise cherrypy.HTTPError(405)
-        if origin not in (base, altbase):
+        if origin not in baselist:
             logger.info('CORS 403 error: no allowed origins (request origin '
                         'is %s, base origin is %s%s', origin, base, logAltBase)
             raise cherrypy.HTTPError(403)
         return
     # If this origin is not allowed, return an error
     if ('*' not in cors['allowOrigin'] and origin not in cors['allowOrigin']
-            and origin not in (base, altbase)):
+            and origin not in baselist):
         if isOptions:
             logger.info('CORS 405 error: origin not allowed (request origin '
                         'is %s, base origin is %s%s', origin, base, logAltBase)
@@ -413,7 +421,7 @@ def _setCommonCORSHeaders(isOptions=False):
                     'is %s, base origin is %s%s', origin, base, logAltBase)
         raise cherrypy.HTTPError(403)
     # If possible, send back the requesting origin.
-    if origin not in (base, altbase) and not isOptions:
+    if origin not in baselist and not isOptions:
         _validateCORSMethodAndHeaders(cors)
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -325,7 +325,7 @@ class TestCase(unittest.TestCase, model_importer.ModelImporter):
     def request(self, path='/', method='GET', params=None, user=None,
                 prefix='/api/v1', isJson=True, basicAuth=None, body=None,
                 type=None, exception=False, cookie=None, token=None,
-                additionalHeaders=None):
+                additionalHeaders=None, useHttps=False):
         """
         Make an HTTP request.
 
@@ -347,6 +347,7 @@ class TestCase(unittest.TestCase, model_importer.ModelImporter):
         :param additionalHeaders: a list of headers to add to the
                                   request.  Each item is a tuple of the form
                                   (header-name, header-value).
+        :param useHttps: if True, pretend to use https
         :returns: The cherrypy response object from the request.
         """
         if not params:
@@ -372,7 +373,8 @@ class TestCase(unittest.TestCase, model_importer.ModelImporter):
             qs = urllib.urlencode(params)
 
         app = cherrypy.tree.apps['']
-        request, response = app.get_serving(local, remote, 'http', 'HTTP/1.1')
+        request, response = app.get_serving(
+            local, remote, 'http' if not useHttps else 'https', 'HTTP/1.1')
         request.show_tracebacks = True
 
         self._buildHeaders(headers, cookie, user, token, basicAuth)


### PR DESCRIPTION
The CORs logic could fail is this occurred.  Also, sometimes the cherrypy.request.base's scheme is NOT the same as the cherrypy.request.scheme value.

ping @zachmullen 