### PR TITLE
Add d3 to jshint global predefs

### DIFF
--- a/tests/jshint.cfg
+++ b/tests/jshint.cfg
@@ -101,6 +101,7 @@
         "console",
         "alert",
         "sprintf",
-        "marked"
+        "marked",
+        "d3"
     ]
 }


### PR DESCRIPTION
d3 was already included as a downloaded library in girder core.  this change adds it to the jshint globals predef.