### PR TITLE
Move to an official release of cmake.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 
     - mongod --version
     - pushd "${HOME}"
-    - curl "http://www.cmake.org/files/v3.1/cmake-3.1.0-rc3-Linux-x86_64.tar.gz" | gunzip -c | tar x
+    - curl "http://www.cmake.org/files/v3.1/cmake-3.1.0-Linux-x86_64.tar.gz" | gunzip -c | tar x
     - cd cmake-*/bin && export PATH="${PWD}:${PATH}"
     - popd
     - cmake --version


### PR DESCRIPTION
We were on a release candidate.  This is the first official release that supports everything we want.  The only relatively new feature we need from cmake is the ability to report our coverage files to cdash.