### PR TITLE
Several changes to make deployment easier.

### DIFF
--- a/clients/web/src/init.js
+++ b/clients/web/src/init.js
@@ -18,9 +18,9 @@ _.extend(girder, {
     collections: {},
     views: {},
     apiRoot: $('#g-global-info-apiroot').text().replace(
-        '%HOST%', 'http://' + window.location.host),
+        '%HOST%', window.location.origin),
     staticRoot: $('#g-global-info-staticroot').text().replace(
-        '%HOST%', 'http://' + window.location.host),
+        '%HOST%', window.location.origin),
     currentUser: null,
     events: _.clone(Backbone.Events),
     uploadHandlers: {},

--- a/clients/web/static/girder-swagger.js
+++ b/clients/web/static/girder-swagger.js
@@ -1,6 +1,11 @@
 $(function () {
+    var apiRoot = $('#g-global-info-apiroot').text().replace(
+        '%HOST%', 'http://' + window.location.host);
+    if (!apiRoot) {
+        apiRoot = window.location.origin + window.location.pathname;
+    }
     window.swaggerUi = new SwaggerUi({
-        url: window.location.origin + window.location.pathname + '/describe',
+        url: apiRoot + '/describe',
         dom_id: 'swagger-ui-container',
         supportHeaderParams: false,
         supportedSubmitMethods: ['get', 'post', 'put', 'delete'],

--- a/clients/web/static/girder-swagger.js
+++ b/clients/web/static/girder-swagger.js
@@ -1,6 +1,6 @@
 $(function () {
     var apiRoot = $('#g-global-info-apiroot').text().replace(
-        '%HOST%', 'http://' + window.location.host);
+        '%HOST%', window.location.origin);
     if (!apiRoot) {
         apiRoot = window.location.origin + window.location.pathname;
     }

--- a/clients/web/test/testEnv.jadehtml
+++ b/clients/web/test/testEnv.jadehtml
@@ -10,8 +10,8 @@ html(lang="en")
     each css in cssFiles
       link(href="#{css}", rel="stylesheet", type="text/css")
   body
-    #g-global-info-apiroot.hide %HOST%#{apiRoot}
-    #g-global-info-staticroot.hide %HOST%#{staticRoot}
+    #g-global-info-apiroot.hide %HOST%/#{apiRoot}
+    #g-global-info-staticroot.hide %HOST%/#{staticRoot}
 
     each js in jsFiles
       script(src="#{js}", data-cover)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -163,7 +163,8 @@ html_favicon = 'favicon.ico'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# Example: html_static_path = ['_static']
+html_static_path = []
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -64,6 +64,8 @@ we have the following:
 
 The ``tools.proxy.base`` and ``tools.proxy.local`` aren't necessary if the
 proxy service adds the appropriate X-Forwarded-Host header to proxied requests.
+For this purpose, the X-Forwarded-Host should be the host used in http
+requests, including any non-default port.
 
 After modifying the configuration, always remember to rebuild Girder by changing to
 the main Girder directory and issuing the following command: ::

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -62,6 +62,9 @@ we have the following:
     api_root: "/girder/api/v1"
     static_root: "/girder/static"
 
+The ``tools.proxy.base`` and ``tools.proxy.local`` aren't necessary if the
+proxy service adds the appropriate X-Forwarded-Host header to proxied requests.
+
 After modifying the configuration, always remember to rebuild Girder by changing to
 the main Girder directory and issuing the following command: ::
 

--- a/girder/__init__.py
+++ b/girder/__init__.py
@@ -66,7 +66,7 @@ def _setupLogger():
     # Determine log paths
     cur_config = config.getConfig()
     log_config = cur_config.get('logging', {})
-    log_root = log_config.get('log_root', LOG_ROOT)
+    log_root = os.path.expanduser(log_config.get('log_root', LOG_ROOT))
     error_log_file = log_config.get('error_log_file',
                                     os.path.join(log_root, 'error.log'))
     info_log_file = log_config.get('info_log_file',

--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -172,7 +172,7 @@ class ApiDocs(object):
     <div class="docs-header">
       <span>Girder REST API Documentation</span>
       <i class="icon-book-alt right"></i>
-      <div id="g-global-info-apiroot" class="hide">${apiRoot}</div>
+      <div id="g-global-info-apiroot" style="display: none">${apiRoot}</div>
     </div>
     <div class="docs-body">
       <p>Below you will find the list of all of the resource types exposed

--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -139,76 +139,83 @@ class ApiDocs(object):
     indexHtml = None
 
     vars = {
+        'apiRoot': '',
         'staticRoot': '',
         'title': 'Girder - REST API Documentation'
     }
 
     template = r"""
-    <!DOCTYPE html>
-    <html lang="en">
-      <head>
-        <title>${title}</title>
-        <link rel="stylesheet"
-            href="//fonts.googleapis.com/css?family=Droid+Sans:400,700">
-        <link rel="stylesheet"
-            href="${staticRoot}/lib/fontello/css/fontello.css">
-        <link rel="stylesheet"
-            href="${staticRoot}/built/swagger/css/reset.css">
-        <link rel="stylesheet"
-            href="${staticRoot}/built/swagger/css/screen.css">
-        <link rel="stylesheet"
-            href="${staticRoot}/built/swagger/docs.css">
-        <link rel="icon"
-            type="image/png"
-            href="${staticRoot}/img/Girder_Favicon.png">
-      </head>
-      <body>
-        <div class="docs-header">
-          <span>Girder REST API Documentation</span>
-          <i class="icon-book-alt right"></i>
-        </div>
-        <div class="docs-body">
-          <p>Below you will find the list of all of the resource types exposed
-          by the Girder RESTful Web API. Click any of the resource links to open
-          up a list of all available endpoints related to each resource type.
-          </p>
-          <p>Clicking any of those endpoints will display detailed documentation
-          about the purpose of each endpoint and the input parameters and output
-          values. You can also call API endpoints directly from this page by
-          typing in the parameters you wish to pass and then clicking the "Try
-          it out!" button.</p>
-          <p><b>Warning:</b> This is not a sandbox&mdash;calls that you make
-          from this page are the same as calling the API with any other client,
-          so update or delete calls that you make will affect the actual data on
-          the server.</p>
-        </div>
-        <div class="swagger-section">
-          <div id="swagger-ui-container"
-              class="swagger-ui-wrap docs-swagger-container">
-          </div>
-        </div>
-        <script src="${staticRoot}/built/swagger/lib/jquery-1.8.0.min.js">
-        </script>
-        <script src="${staticRoot}/built/swagger/lib/jquery.slideto.min.js">
-        </script>
-        <script src="${staticRoot}/built/swagger/lib/jquery.wiggle.min.js">
-        </script>
-        <script src="${staticRoot}/built/swagger/lib/jquery.ba-bbq.min.js">
-        </script>
-        <script src="${staticRoot}/built/swagger/lib/handlebars-1.0.0.js">
-        </script>
-        <script src="${staticRoot}/built/swagger/lib/underscore-min.js">
-        </script>
-        <script src="${staticRoot}/built/swagger/lib/backbone-min.js"></script>
-        <script src="${staticRoot}/built/swagger/lib/shred.bundle.js"></script>
-        <script src="${staticRoot}/built/swagger/lib/swagger.js"></script>
-        <script src="${staticRoot}/built/swagger/swagger-ui.min.js"></script>
-        <script src="${staticRoot}/built/swagger/lib/highlight.7.3.pack.js">
-        </script>
-        <script src="${staticRoot}/girder-swagger.js"></script>
-      </body>
-    </html>
-    """
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>${title}</title>
+    <link rel="stylesheet"
+        href="//fonts.googleapis.com/css?family=Droid+Sans:400,700">
+    <link rel="stylesheet"
+        href="${staticRoot}/lib/fontello/css/fontello.css">
+    <link rel="stylesheet"
+        href="${staticRoot}/built/swagger/css/reset.css">
+    <link rel="stylesheet"
+        href="${staticRoot}/built/swagger/css/screen.css">
+    <link rel="stylesheet"
+        href="${staticRoot}/built/swagger/docs.css">
+    <link rel="icon"
+        type="image/png"
+        href="${staticRoot}/img/Girder_Favicon.png">
+    <style type="text/css">
+.response_throbber {
+  content:url("${staticRoot}/built/swagger/images/throbber.gif");
+}
+    </style>
+  </head>
+  <body>
+    <div class="docs-header">
+      <span>Girder REST API Documentation</span>
+      <i class="icon-book-alt right"></i>
+      <div id="g-global-info-apiroot" class="hide">${apiRoot}</div>
+    </div>
+    <div class="docs-body">
+      <p>Below you will find the list of all of the resource types exposed
+      by the Girder RESTful Web API. Click any of the resource links to open
+      up a list of all available endpoints related to each resource type.
+      </p>
+      <p>Clicking any of those endpoints will display detailed documentation
+      about the purpose of each endpoint and the input parameters and output
+      values. You can also call API endpoints directly from this page by
+      typing in the parameters you wish to pass and then clicking the "Try
+      it out!" button.</p>
+      <p><b>Warning:</b> This is not a sandbox&mdash;calls that you make
+      from this page are the same as calling the API with any other client,
+      so update or delete calls that you make will affect the actual data on
+      the server.</p>
+    </div>
+    <div class="swagger-section">
+      <div id="swagger-ui-container"
+          class="swagger-ui-wrap docs-swagger-container">
+      </div>
+    </div>
+    <script src="${staticRoot}/built/swagger/lib/jquery-1.8.0.min.js">
+    </script>
+    <script src="${staticRoot}/built/swagger/lib/jquery.slideto.min.js">
+    </script>
+    <script src="${staticRoot}/built/swagger/lib/jquery.wiggle.min.js">
+    </script>
+    <script src="${staticRoot}/built/swagger/lib/jquery.ba-bbq.min.js">
+    </script>
+    <script src="${staticRoot}/built/swagger/lib/handlebars-1.0.0.js">
+    </script>
+    <script src="${staticRoot}/built/swagger/lib/underscore-min.js">
+    </script>
+    <script src="${staticRoot}/built/swagger/lib/backbone-min.js"></script>
+    <script src="${staticRoot}/built/swagger/lib/shred.bundle.js"></script>
+    <script src="${staticRoot}/built/swagger/lib/swagger.js"></script>
+    <script src="${staticRoot}/built/swagger/swagger-ui.min.js"></script>
+    <script src="${staticRoot}/built/swagger/lib/highlight.7.3.pack.js">
+    </script>
+    <script src="${staticRoot}/girder-swagger.js"></script>
+  </body>
+</html>
+"""
 
     def updateHtmlVars(self, vars):
         self.vars.update(vars)

--- a/girder/conf/girder.dist.cfg
+++ b/girder/conf/girder.dist.cfg
@@ -11,7 +11,6 @@ hash_alg: "bcrypt"
 # Don't change this unless you know what it means.
 bcrypt_rounds: 12
 
-
 [database]
 uri: "mongodb://localhost:27017/girder"
 replica_set: None
@@ -19,8 +18,10 @@ replica_set: None
 [server]
 # Set to "production" or "development"
 mode: "development"
-api_root: "/api/v1"
-static_root: "/static"
+api_root: "api/v1"
+static_root: "static"
+# The api_static_root is the route from the 'api' path to the 'static' path
+api_static_root: "../static"
 
 # [plugins]
 # plugin_directory="/path/to/girder/plugins"

--- a/girder/utility/server.py
+++ b/girder/utility/server.py
@@ -81,8 +81,9 @@ def configureServer(test=False, plugins=None, curConfig=None):
         # Force some config params in testing mode
         curConfig.update({'server': {
             'mode': 'testing',
-            'api_root': '/api/v1',
-            'static_root': '/static'
+            'api_root': 'api/v1',
+            'static_root': 'static',
+            'api_static_root': '../static'
         }})
 
     # Don't import this until after the configs have been read; some module
@@ -106,8 +107,12 @@ def configureServer(test=False, plugins=None, curConfig=None):
         'plugins': plugins
     })
 
+    apiStaticRoot = curConfig['server'].get('api_static_root', '')
+    if not apiStaticRoot:
+        apiStaticRoot = curConfig['server']['static_root']
     root.api.v1.updateHtmlVars({
-        'staticRoot': curConfig['server']['static_root']
+        'apiRoot': curConfig['server']['api_root'],
+        'staticRoot': apiStaticRoot,
     })
 
     root, appconf, _ = plugin_utilities.loadPlugins(


### PR DESCRIPTION
The swagger api pages would only work if the static_root was absolute, because this was otherwise treated as relative to the api path.  I've added a new api_static_root parameter, which now allows all of the paths to be relative.  This makes it easier, for instance, for proxies to get to these locations.

The api_root is placed in the swagger page as well, as this also also the sub-describe calls to use a relative path instead of the entire query path.

Fixed the swagger throbber using css to override its path.  This still throws a 404 in the browser's console, when the original location is requested, but the throbber is properly displayed.  This fixes issue #446.

Add documentation that you don't need to specify a tools.proxy.base or tools.proxy.local if the proxy server adds X-Forwarded-Host.

Expand the user path element when parsing the log root, not just in the constants.  This allows a conf file to use ~ in the log root.