### PR TITLE
CORS simple requests should be restricted to the CORS policy.

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -30,10 +30,8 @@ Cross-Origin request, Girder only responds that the specific origin is allowed,
 and does not reveal what other origins can be accessed.
 
 If desired, cross-origin requests can be further restricted by specifying a
-list of permitted endpoint methods.  The `CORS specification
-<http://www.w3.org/TR/cors>`_ always permits ``GET``, ``HEAD``, and a subset
-of ``POST`` requests.  If set in the System Configuration, other methods can be
-restricted or allowed as desired.
+list of permitted endpoint methods in the System Configuration.  See the `CORS
+specification <http://www.w3.org/TR/cors>`_ for more information.
 
 CORS policy accepts requests with simple headers.  If requests include other
 headers, they must be listed in the System Configuration, or the request will
@@ -42,14 +40,14 @@ headers that are typically needed when accessing the default web client from a
 different origin than the Girder server.  Some configurations require
 additional headers to be allowed.  For instance, if the Girder server is behind
 a proxy, the ``X-Requested-With``, ``X-Forwarded-Server``, ``X-Forwarded-For``,
-``X-Forwarded-Host``, and ``Remote-Addr`` headers may also be needed.  Changing
-the allowed headers overrides the default values.  Therefore, to have the
-default allowed headers **and** the additional headers, the allowed headers
-should be changed to the combined list of the two: ::
+``X-Forwarded-Host``, ``X-Forwarded-Proto``, and ``Remote-Addr`` headers may
+also be needed.  Changing the allowed headers overrides the default values.
+Therefore, to have the default allowed headers **and** the additional headers,
+the allowed headers should be changed to the combined list of the two: ::
 
     Accept-Encoding, Authorization, Content-Disposition, Content-Type, Cookie,
     Girder-Token, X-Requested-With, X-Forwarded-Server, X-Forwarded-For,
-    X-Forwarded-Host, Remote-Addr
+    X-Forwarded-Host, X-Forwarded-Proto, Remote-Addr
 
 Although the server always allows the ``Content-Type`` header, some
 cross-origin browsers may require it to be listed in the allowed headers.  If

--- a/tests/cases/routes_test.py
+++ b/tests/cases/routes_test.py
@@ -127,9 +127,9 @@ class RoutesTestCase(base.TestCase):
         self._testOrigin(None, {'OPTIONS': 405})
         # If we specify an origin of ourselves, there should be no change
         self._testOrigin('http://127.0.0.1', {'OPTIONS': 405})
-        # If we specify a different origin, simple queries are allowed and
-        # everything else should be refused
+        # If we specify a different origin, everything should be refused
         self._testOrigin('http://kitware.com', {
+            'GET': 403, 'HEAD': 403, 'POST': 403,
             'PUT': 403, 'DELETE': 403, 'PATCH': 403, 'OPTIONS': 405})
         # If we have a X-Forward-Host that contains ourselves, even thouugh
         # the origin is different, then it should be just like coming from
@@ -138,6 +138,7 @@ class RoutesTestCase(base.TestCase):
                          headers={'X-Forwarded-Host': 'kitware.com'})
         # But a different X-Forwarded-Host should be like a different origin
         self._testOrigin('http://kitware.com', {
+            'GET': 403, 'HEAD': 403, 'POST': 403,
             'PUT': 403, 'DELETE': 403, 'PATCH': 403, 'OPTIONS': 405},
             headers={'X-Forwarded-Host': 'www.kitware.com'})
 
@@ -150,9 +151,9 @@ class RoutesTestCase(base.TestCase):
         self._testOrigin('http://127.0.0.1')
         # As should the allowed origin
         self._testOrigin('http://kitware.com')
-        # If we specify a different origin, non-simple queries should be
-        # refused
+        # If we specify a different origin, everything should be refused
         self._testOrigin('http://girder.kitware.com', {
+            'GET': 403, 'HEAD': 403, 'POST': 403,
             'PUT': 403, 'DELETE': 403, 'PATCH': 403, 'OPTIONS': 405})
 
         # Set a list of allowed origins
@@ -170,6 +171,9 @@ class RoutesTestCase(base.TestCase):
         self._testOrigin('https://secure.kitware.com',
                          headers={'X-Forwarded-Host': 'secure.kitware.com'},
                          useHttps=True)
+        self._testOrigin('https://secure.kitware.com', headers={
+            'X-Forwarded-Host': 'secure.kitware.com',
+            'X-Forwarded-Proto': 'https'}, useHttps=True)
         self._testOrigin('http://secure.kitware.com',
                          headers={'X-Forwarded-Host': 'secure.kitware.com'},
                          useHttps=False)
@@ -178,6 +182,7 @@ class RoutesTestCase(base.TestCase):
 
         # If we specify a different origin, everything should be refused
         self._testOrigin('http://girder2.kitware.com', {
+            'GET': 403, 'HEAD': 403, 'POST': 403,
             'PUT': 403, 'DELETE': 403, 'PATCH': 403, 'OPTIONS': 405})
 
         # Specifying the wildcard should allow everything
@@ -201,8 +206,9 @@ class RoutesTestCase(base.TestCase):
         # Custom headers should fail until we approve them.  Case shouldn't
         # matter
         headers = {'x-cUstom': 'test'}
-        self._testOrigin('http://kitware.com',
-                         {'PUT': 403, 'DELETE': 403, 'PATCH': 403}, headers)
+        self._testOrigin('http://kitware.com', {
+            'GET': 403, 'HEAD': 403, 'POST': 403,
+            'PUT': 403, 'DELETE': 403, 'PATCH': 403}, headers)
         # Before we specify anything, a few headers should go through
         headersDefault = {'Authorization': 'password'}
         self._testOrigin('http://kitware.com', headers=headersDefault)
@@ -210,9 +216,9 @@ class RoutesTestCase(base.TestCase):
         self.model('setting').set(SettingKey.CORS_ALLOW_HEADERS, 'X-Custom')
         self._testOrigin('http://kitware.com', headers=headers)
         # And now our default is no longer there
-        self._testOrigin('http://kitware.com',
-                         {'PUT': 403, 'DELETE': 403, 'PATCH': 403},
-                         headersDefault)
+        self._testOrigin('http://kitware.com', {
+            'GET': 403, 'HEAD': 403, 'POST': 403,
+            'PUT': 403, 'DELETE': 403, 'PATCH': 403}, headersDefault)
         # Our header can be one in a list
         self.model('setting').set(SettingKey.CORS_ALLOW_HEADERS,
                                   'X-Test,X-Custom,Authorization')


### PR DESCRIPTION
I had misinterpretted the documentation on CORS that simple requests were always allowed.  Rather, they just don't require "preflighting" with an OPTIONS request.  This change subjects them to the same restriction as other requests.

For maximum compliance, we should cache approved OPTIONS requests, and non-simple requests should be denied if they haven't sent a corresponding OPTIONS request recently.