### PR TITLE
Fixed some swagger issues with proxies.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -150,7 +150,7 @@ module.exports = function (grunt) {
                         callback();
                     }
                 }
-            },
+            }
         },
 
         compress: {
@@ -243,6 +243,10 @@ module.exports = function (grunt) {
                         'clients/web/test/lib/jasmine-1.3.1/jasmine.js',
                         'node_modules/blanket/dist/jasmine/blanket_jasmine.js',
                         'clients/web/test/lib/jasmine-1.3.1/ConsoleReporter.js'
+                    ],
+                    'clients/web/static/built/testing-no-cover.min.js': [
+                        'clients/web/test/lib/jasmine-1.3.1/jasmine.js',
+                        'clients/web/test/lib/jasmine-1.3.1/ConsoleReporter.js'
                     ]
                 }
             }
@@ -324,7 +328,6 @@ module.exports = function (grunt) {
         }
     };
 
-
     // Configure a given plugin for building
     var configurePlugin = function (pluginDir) {
         var pluginName = path.basename(pluginDir);
@@ -336,9 +339,10 @@ module.exports = function (grunt) {
             fs.mkdirSync(staticDir);
         }
 
+        var files;
         var jadeDir = pluginDir + '/web_client/templates';
         if (fs.existsSync(jadeDir)) {
-            var files = {};
+            files = {};
             files[staticDir + '/templates.js'] = [jadeDir + '/**/*.jade'];
             grunt.config.set('jade.plugin_' + pluginName, {
                 files: files
@@ -351,7 +355,7 @@ module.exports = function (grunt) {
 
         var cssDir = pluginDir + '/web_client/stylesheets';
         if (fs.existsSync(cssDir)) {
-            var files = {};
+            files = {};
             files[staticDir + '/plugin.min.css'] = [cssDir + '/**/*.styl'];
             grunt.config.set('stylus.plugin_' + pluginName, {
                 files: files
@@ -364,7 +368,7 @@ module.exports = function (grunt) {
 
         var jsDir = pluginDir + '/web_client/js';
         if (fs.existsSync(jsDir)) {
-            var files = {};
+            files = {};
             files[staticDir + '/plugin.min.js'] = [
                 staticDir + '/templates.js',
                 jsDir + '/**/*.js'

--- a/clients/web/static/girder-swagger.js
+++ b/clients/web/static/girder-swagger.js
@@ -5,7 +5,7 @@ $(function () {
         apiRoot = window.location.origin + window.location.pathname;
     }
     window.swaggerUi = new SwaggerUi({
-        url: apiRoot + '/describe',
+        url: 'describe',
         dom_id: 'swagger-ui-container',
         supportHeaderParams: false,
         supportedSubmitMethods: ['get', 'post', 'put', 'delete'],

--- a/clients/web/test/spec/swaggerSpec.js
+++ b/clients/web/test/spec/swaggerSpec.js
@@ -1,0 +1,46 @@
+function jasmineTests() {
+    var jasmineEnv = jasmine.getEnv();
+    var consoleReporter = new jasmine.ConsoleReporter();
+    window.jasmine_phantom_reporter = consoleReporter;
+    jasmineEnv.addReporter(consoleReporter);
+    function waitAndExecute() {
+        if (!jasmineEnv.currentRunner().suites_.length) {
+            window.setTimeout(waitAndExecute, 10);
+            return;
+        }
+        jasmineEnv.execute();
+    }
+
+    waitAndExecute();
+
+    describe('Test the swagger pages', function () {
+        it('Test swagger', function () {
+            waitsFor(function () {
+                return $('li#resource_system.resource').length > 0;
+            }, 'swagger docs to appear');
+            runs(function () {
+                $('li#resource_system.resource .heading h2 a').click();
+            });
+            waitsFor(function () {
+                return $('#system_getVersion:visible').length > 0;
+            }, 'end points to be visible');
+            runs(function () {
+                $('#system_getVersion h3 a').click();
+            });
+            waitsFor(function () {
+                return $('#system_getVersion .sandbox_header input.submit[name="commit"]:visible').length > 0;
+            }, 'version try out button to be visible');
+            runs(function () {
+                $('#system_getVersion .sandbox_header input.submit[name="commit"]').click();
+            });
+            waitsFor(function () {
+                return $('#system_getVersion .response_body.json').text().indexOf('apiVersion') >= 0;
+            }, 'version information was returned');
+        });
+    });
+
+}
+
+$(function () {
+    $.getScript('/static/built/testing-no-cover.min.js', jasmineTests);
+});

--- a/clients/web/test/specRunner.js
+++ b/clients/web/test/specRunner.js
@@ -37,16 +37,14 @@ var terminate = function () {
     var status = this.page.evaluate(function () {
         if (window.jasmine_phantom_reporter.status === "success") {
             return window.coverageHandler.handleCoverage(window._$blanket);
-        }
-        else {
+        } else {
             return false;
         }
     });
 
     if (status) {
         phantom.exit(0);
-    }
-    else {
+    } else {
         phantom.exit(1);
     }
 };
@@ -108,10 +106,10 @@ page.onCallback = function (data) {
             }
             break;
         case 'uploadFile':
-            var path = data.path
-            if (!path && data.size!==undefined) {
+            var path = data.path;
+            if (!path && data.size !== undefined) {
                 path = uploadTemp;
-                fs.write(path, new Array(data.size+1).join("-"), "wb");
+                fs.write(path, new Array(data.size + 1).join("-"), "wb");
             }
             page.uploadFile(data.selector, path);
             if (fs.size(path) >= 1024 * 64) {
@@ -157,8 +155,10 @@ page.onLoadFinished = function (status) {
         phantom.exit(1);
     }
     if (phantom.args[3]) {
-        page.evaluate(function(timeout) {
-            jasmine.getEnv().defaultTimeoutInterval = timeout;
+        page.evaluate(function (timeout) {
+            if (window.jasmine) {
+                jasmine.getEnv().defaultTimeoutInterval = timeout;
+            }
         }, phantom.args[3]);
     }
 };
@@ -172,11 +172,11 @@ page.settings.resourceTimeout = 15000;
 page.onResourceTimeout = function (request) {
     console.log('Resource timed out.  (#' + request.id + '): ' +
                 JSON.stringify(request));
-    console.log('PHANTOM_TIMEOUT')
+    console.log('PHANTOM_TIMEOUT');
     /* The exit code doesn't get sent back from here, so setting this to a
      * non-zero value doesn't seem to have any benefit. */
     phantom.exit(0);
-}
+};
 
 page.open(pageUrl, function (status) {
     if (status !== 'success') {

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -27,15 +27,21 @@ Girder to keep any customization separate. ::
 
 You should now see your Girder instance running on Heroku. Congratulations!
 
-Apache Reverse Proxy
---------------------
+Reverse Proxy
+-------------
 
-In many cases, it is useful to route multiple web services from a single server.
-You can configure Apache's `mod_proxy <http://httpd.apache.org/docs/current/mod/mod_proxy.html>`_
-to route traffic to these services using a reverse proxy.  For example, if you have an
-Apache server accepting requests at ``www.example.com``, and you want to forward requests
-to ``www.example.com/girder`` to a Girder instance listening on port ``9000``.  You can
-add the following section to your Apache config:
+In many cases, it is useful to route multiple web services from a single
+server.  For example, if you have a server accepting requests at
+``www.example.com``, you may want to forward requests to
+``www.example.com/girder`` to a Girder instance listening on port ``9000``.
+
+Apache
+++++++
+
+When using Apache, configure Apache's `mod_proxy
+<http://httpd.apache.org/docs/current/mod/mod_proxy.html>`_ to route traffic to
+these services using a reverse proxy.  Add the following section to your Apache
+config:
 
 .. code-block:: apacheconf
 
@@ -44,10 +50,28 @@ add the following section to your Apache config:
         ProxyPassReverse /girder http://localhost:9000
     </VirtualHost>
 
-In such a scenario, Girder must be configured properly in order to serve content
-correctly.  Fortunately, this can be accomplished by setting a few parameters in
-your local configuration file at ``girder/conf/girder.local.cfg``.  In this example,
-we have the following:
+Nginx
++++++
+
+Nginx can be used by adding a block such as:
+
+.. code-block:: nginx
+
+    location /girder/ {
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Server $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://localhost:9000/;
+    }
+
+Girder Settings
++++++++++++++++
+
+In such a scenario, Girder must be configured properly in order to serve
+content correctly.  This can be accomplished by setting a few parameters in
+your local configuration file at ``girder/conf/girder.local.cfg``.  In this
+example, we have the following:
 
 .. code-block:: ini
 
@@ -67,10 +91,11 @@ proxy service adds the appropriate X-Forwarded-Host header to proxied requests.
 For this purpose, the X-Forwarded-Host should be the host used in http
 requests, including any non-default port.
 
-After modifying the configuration, always remember to rebuild Girder by changing to
-the main Girder directory and issuing the following command: ::
+After modifying the configuration, always remember to rebuild Girder by
+changing to the main Girder directory and issuing the following command: ::
 
     $ grunt init && grunt
+
 
 Docker Container
 ----------------

--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -19,7 +19,6 @@
 
 import cherrypy
 import mako
-import os
 
 from girder.constants import VERSION
 from . import docs, access
@@ -251,7 +250,6 @@ class Describe(Resource):
         return {
             'apiVersion': API_VERSION,
             'swaggerVersion': SWAGGER_VERSION,
-            'basePath': cherrypy.url(),
             'apis': [{'path': '/{}'.format(resource)}
                      for resource in sorted(docs.discovery)]
         }
@@ -293,7 +291,7 @@ class Describe(Resource):
         return {
             'apiVersion': API_VERSION,
             'swaggerVersion': SWAGGER_VERSION,
-            'basePath': os.path.dirname(os.path.dirname(cherrypy.url())),
+            'basePath': '.',
             'models': docs.models,
             'apis': [{'path': route,
                       'operations': sorted(op, self._compareOperations)}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ add_web_client_test(routing "${PROJECT_SOURCE_DIR}/clients/web/test/spec/routing
 add_web_client_test(version "${PROJECT_SOURCE_DIR}/clients/web/test/spec/versionSpec.js")
 add_web_client_test(custom_widgets "${PROJECT_SOURCE_DIR}/clients/web/test/spec/customWidgetsSpec.js")
 add_web_client_test(widgets "${PROJECT_SOURCE_DIR}/clients/web/test/spec/widgetsSpec.js")
+add_web_client_test(swagger "${PROJECT_SOURCE_DIR}/clients/web/test/spec/swaggerSpec.js" BASEURL "/api/v1" NOCOVERAGE)
 
 add_subdirectory(clients)
 add_subdirectory(packaging)

--- a/tests/JavascriptTests.cmake
+++ b/tests/JavascriptTests.cmake
@@ -100,9 +100,11 @@ function(add_web_client_test case specFile)
   # RESOURCE_LOCKS (list of resources): A list of resources that this test
   #     needs exclusive access to.  Defaults to mongo and cherrypy.
   # TIMEOUT (seconds): An overall test timeout.
+  # BASEURL (url): The base url to load for the test.
   set(testname "web_client_${case}")
 
-  set(_args PLUGIN ASSETSTORE WEBSECURITY)
+  set(_options NOCOVERAGE)
+  set(_args PLUGIN ASSETSTORE WEBSECURITY BASEURL)
   set(_multival_args RESOURCE_LOCKS TIMEOUT ENABLEDPLUGINS)
   cmake_parse_arguments(fn "${_options}" "${_args}" "${_multival_args}" ${ARGN})
 
@@ -144,7 +146,6 @@ function(add_web_client_test case specFile)
     "ASSETSTORE_TYPE=${assetstoreType}"
     "WEB_SECURITY=${webSecurity}"
     "ENABLED_PLUGINS=${plugins}"
-    "COVERAGE_FILE=${PROJECT_BINARY_DIR}/js_coverage/${case}.cvg"
     "GIRDER_TEST_DB=mongodb://localhost:27017/girder_test_${testname}"
     "GIRDER_TEST_ASSETSTORE=webclient_${testname}"
     "GIRDER_PORT=${web_client_port}"
@@ -163,7 +164,17 @@ function(add_web_client_test case specFile)
   if(fn_TIMEOUT)
     set_property(TEST ${testname} PROPERTY TIMEOUT ${fn_TIMEOUT})
   endif()
+  if(fn_BASEURL)
+    set_property(TEST ${testname} APPEND PROPERTY ENVIRONMENT
+        "BASEURL=${fn_BASEURL}"
+    )
+  endif()
 
-  set_property(TEST ${testname} APPEND PROPERTY DEPENDS js_coverage_reset)
-  set_property(TEST js_coverage_combine_report APPEND PROPERTY DEPENDS ${testname})
+  if (NOT fn_NOCOVERAGE)
+    set_property(TEST ${testname} APPEND PROPERTY ENVIRONMENT
+        "COVERAGE_FILE=${PROJECT_BINARY_DIR}/js_coverage/${case}.cvg"
+    )
+    set_property(TEST ${testname} APPEND PROPERTY DEPENDS js_coverage_reset)
+    set_property(TEST js_coverage_combine_report APPEND PROPERTY DEPENDS ${testname})
+  endif()
 endfunction()

--- a/tests/base.py
+++ b/tests/base.py
@@ -54,13 +54,6 @@ def startServer(mock=True, mockS3=False):
     """
     server = setupServer(test=True, plugins=enabledPlugins)
 
-    # Log all requests if we asked to do so
-    if 'cherrypy' in os.environ.get('EXTRADEBUG', '').split():
-        cherrypy.config.update({'log.screen': True})
-        logHandler = logging.StreamHandler(sys.stdout)
-        logHandler.setLevel(logging.DEBUG)
-        cherrypy.log.error_log.addHandler(logHandler)
-
     if mock:
         cherrypy.server.unsubscribe()
 
@@ -68,6 +61,13 @@ def startServer(mock=True, mockS3=False):
 
     # Make server quiet (won't announce start/stop or requests)
     cherrypy.config.update({'environment': 'embedded'})
+
+    # Log all requests if we asked to do so
+    if 'cherrypy' in os.environ.get('EXTRADEBUG', '').split():
+        cherrypy.config.update({'log.screen': True})
+        logHandler = logging.StreamHandler(sys.stdout)
+        logHandler.setLevel(logging.DEBUG)
+        cherrypy.log.error_log.addHandler(logHandler)
 
     mockSmtp.start()
     if mockS3:

--- a/tests/cases/api_describe_test.py
+++ b/tests/cases/api_describe_test.py
@@ -85,7 +85,6 @@ class ApiDescribeTestCase(base.TestCase):
         # Test top level describe endpoint
         resp = self.request(path='/describe', method='GET')
         self.assertStatusOk(resp)
-        self.assertTrue('/api/v1/describe' in resp.json['basePath'])
         self.assertEqual(resp.json['swaggerVersion'], describe.SWAGGER_VERSION)
         self.assertEqual(resp.json['apiVersion'], describe.API_VERSION)
         self.assertTrue({'path': '/group'} in resp.json['apis'])

--- a/tests/web_client_test.py
+++ b/tests/web_client_test.py
@@ -90,7 +90,7 @@ class WebClientTestEndpoints(Resource):
 class WebClientTestCase(base.TestCase):
     def setUp(self):
         self.specFile = os.environ['SPEC_FILE']
-        self.coverageFile = os.environ['COVERAGE_FILE']
+        self.coverageFile = os.environ.get('COVERAGE_FILE', '')
         assetstoreType = os.environ['ASSETSTORE_TYPE']
         self.webSecurity = os.environ.get('WEB_SECURITY', 'true')
         if self.webSecurity != 'false':
@@ -104,13 +104,16 @@ class WebClientTestCase(base.TestCase):
         testServer.root.api.v1.webclienttest = WebClientTestEndpoints()
 
     def testWebClientSpec(self):
+        baseUrl = '/static/built/testEnv.html'
+        if os.environ.get('BASEURL', ''):
+            baseUrl = os.environ['BASEURL']
+
         cmd = (
             os.path.join(
                 ROOT_DIR, 'node_modules', 'phantomjs', 'bin', 'phantomjs'),
             '--web-security=%s' % self.webSecurity,
             os.path.join(ROOT_DIR, 'clients', 'web', 'test', 'specRunner.js'),
-            'http://localhost:%s/static/built/testEnv.html' % os.environ[
-                'GIRDER_PORT'],
+            'http://localhost:%s%s' % (os.environ['GIRDER_PORT'], baseUrl),
             self.specFile,
             self.coverageFile,
             os.environ.get('JASMINE_TIMEOUT', '')


### PR DESCRIPTION
Update proxy documentation.

Don't use the apiRoot within the swagger base.

Added a test for swagger docs.

Loading the actual swagger page doesn't play well with the blanket js coverage tests, so a testing-no-coverage.min.js library is built.

Cleaned up some style issues in various files.

The EXTRADEBUG=cherrypy option to show all cherrypy calls had been disabled when the startup log output was changed.

Swagger doesn't work with certain basePath values behind a proxy.