### PR TITLE
Don't use except: without specifying the exception.

### DIFF
--- a/docs/developer-cookbook.rst
+++ b/docs/developer-cookbook.rst
@@ -301,7 +301,7 @@ behaviors, use the following examples:
 
     try:
         ...
-    except:
+    except Exception:
         # Will log the most recent exception, including a traceback, request URL,
         # and remote IP address. Should only be called from within an exception handler.
         logger.exception('A descriptive message')

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -135,7 +135,7 @@ def getCurrentUser(returnToken=False):
     else:
         try:
             ensureTokenScopes(token, TokenScope.USER_AUTH)
-        except:
+        except Exception:
             return retVal(None, token)
         user = ModelImporter.model('user').load(token['userId'], force=True)
         return retVal(user, token)
@@ -314,7 +314,7 @@ def endpoint(fun):
                 val['field'] = e.field
         except cherrypy.HTTPRedirect:  # flake8: noqa
             raise
-        except:
+        except Exception:
             # These are unexpected failures; send a 500 status
             logger.exception('500 Error')
             cherrypy.response.status = 500

--- a/girder/events.py
+++ b/girder/events.py
@@ -132,7 +132,7 @@ class AsyncEventsThread(threading.Thread):
                 event = trigger(eventName, info)
                 if isinstance(callback, types.FunctionType):
                     callback(event)
-            except:
+            except Exception:
                 logger.exception('In handler for event "%s":' % eventName)
                 pass  # Must continue the event loop even if handler failed
 

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -383,7 +383,7 @@ class Model(ModelImporter):
         if objectId and type(id) is not ObjectId:
             try:
                 id = ObjectId(id)
-            except:
+            except Exception:
                 raise ValidationException('Invalid ObjectId: {}'.format(id),
                                           field='id')
         doc = self.collection.find_one({'_id': id}, fields=fields)
@@ -849,7 +849,7 @@ class AccessControlledModel(Model):
                    sort=None, fields=None):
         """
         Custom override of Model.textSearch to also force permission-based
-        filtering. The parameters are the same as Model.textSearch, except:
+        filtering. The parameters are the same as Model.textSearch.
 
         :param user: The user to apply permission filtering for.
         """

--- a/girder/utility/plugin_utilities.py
+++ b/girder/utility/plugin_utilities.py
@@ -86,7 +86,7 @@ def loadPlugins(plugins, root, appconf, apiRoot=None, curConfig=None):
                     plugin, root, appconf, apiRoot, curConfig=curConfig)
                 print TerminalColor.success('Loaded plugin "{}"'
                                             .format(plugin))
-            except:
+            except Exception:
                 print TerminalColor.error(
                     'ERROR: Failed to load plugin "{}":'.format(plugin))
                 traceback.print_exc()

--- a/plugins/hdfs_assetstore/server/assetstore.py
+++ b/plugins/hdfs_assetstore/server/assetstore.py
@@ -84,7 +84,7 @@ class HdfsAssetstoreAdapter(AbstractAssetstoreAdapter):
         try:
             client = HdfsAssetstoreAdapter._getClient(doc)
             client.serverdefaults()
-        except:
+        except Exception:
             raise ValidationException('Could not connect to HDFS at %s:%d.' %
                                       (info['host'], info['port']))
 
@@ -191,7 +191,7 @@ class HdfsAssetstoreAdapter(AbstractAssetstoreAdapter):
 
         try:
             resp.raise_for_status()
-        except:
+        except Exception:
             logger.exception('HDFS response: ' + resp.text)
             raise Exception('Error appending to HDFS, see log for details.')
 
@@ -203,7 +203,7 @@ class HdfsAssetstoreAdapter(AbstractAssetstoreAdapter):
         chunk.close()
         try:
             resp.raise_for_status()
-        except:
+        except Exception:
             logger.exception('HDFS response: ' + resp.text)
             raise Exception('Error appending to HDFS, see log for details.')
 
@@ -211,7 +211,7 @@ class HdfsAssetstoreAdapter(AbstractAssetstoreAdapter):
 
         try:
             resp.raise_for_status()
-        except:
+        except Exception:
             logger.exception('HDFS response: ' + resp.text)
             raise Exception('Error appending to HDFS, see log for details.')
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,5 +8,6 @@ six==1.8.0
 Sphinx==1.2.2
 virtualenv==1.11.6
 flake8-docstrings==0.2.1.post1
+flake8-blind-except==0.1.0
 mccabe==0.3
 mock==1.0.1

--- a/tests/base.py
+++ b/tests/base.py
@@ -389,7 +389,7 @@ class TestCase(unittest.TestCase, model_importer.ModelImporter):
         if isJson:
             try:
                 response.json = json.loads(response.collapse_body())
-            except:
+            except Exception:
                 print response.collapse_body()
                 raise AssertionError('Did not receive JSON response')
 
@@ -439,7 +439,7 @@ class TestCase(unittest.TestCase, model_importer.ModelImporter):
         if isJson:
             try:
                 response.json = json.loads(response.collapse_body())
-            except:
+            except Exception:
                 print response.collapse_body()
                 raise AssertionError('Did not receive JSON response')
 

--- a/tests/mock_smtp.py
+++ b/tests/mock_smtp.py
@@ -54,7 +54,7 @@ class MockSmtpReceiver(object):
                 self.address = ('localhost', port)
                 self.smtp = MockSmtpServer(self.address, None)
                 break
-            except:
+            except Exception:
                 pass
         else:
             raise Exception('Could not bind to any port for Mock SMTP server')


### PR DESCRIPTION
By itself, `except:` will catch all exceptions, even, for instance, SIGINT (Control-C).  This isn't usually desired, and if it is, a comment should be added to explain why.  Rather, the default exception that should be used when you want to catch nearly all exceptions is `except Exception:`.  This lets `BaseException`s through (which includes SIGINT) while stopping all subclassed `Exception`.