### PR TITLE
Querying access on object with no ACL raised an exception

### DIFF
--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -671,8 +671,8 @@ class AccessControlledModel(Model):
         list.
         """
         acList = {
-            'users': doc['access'].get('users', []),
-            'groups': doc['access'].get('groups', [])
+            'users': doc.get('access', {}).get('users', []),
+            'groups': doc.get('access', {}).get('groups', [])
         }
 
         for user in acList['users']:


### PR DESCRIPTION
We should simply return an empty ACL in this case.