### PR TITLE
Delete pending group invites when users are deleted

### DIFF
--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -147,6 +147,12 @@ class User(AccessControlledModel):
         # Delete all authentication tokens owned by this user
         self.model('token').removeWithQuery({'userId': user['_id']})
 
+        # Delete all pending group invites for this user
+        self.model('group').update(
+            {'requests': user['_id']},
+            {'$pull': {'requests': user['_id']}}
+        )
+
         # Delete all of the folders under this user
         folders = self.model('folder').find({
             'parentId': user['_id'],


### PR DESCRIPTION
The invalid database references left behind by this bug were causing large parts of the groups API to break. Some manual cleanup may be necessary on instances affected by this issue.