### PR TITLE
Add leading slash to apiRoot if necessary

### DIFF
--- a/plugins/oauth/web_client/js/ConfigView.js
+++ b/plugins/oauth/web_client/js/ConfigView.js
@@ -37,11 +37,17 @@ girder.views.oauth_ConfigView = girder.View.extend({
     },
 
     render: function () {
-        var origin = window.location.protocol + '//' + window.location.host;
+        var origin = window.location.protocol + '//' + window.location.host,
+            apiRoot = girder.apiRoot;
+
+        if (apiRoot.substring(0, 1) !== '/') {
+            apiRoot = '/' + apiRoot;
+        }
+
         this.$el.html(girder.templates.oauth_config({
             google: {
                 jsOrigin: origin,
-                redirectUri: origin + girder.apiRoot + '/oauth/google/callback'
+                redirectUri: origin + apiRoot + '/oauth/google/callback'
             }
         }));
 


### PR DESCRIPTION
@zachmullen Not sure this is the right fix. However, when I use the OAuth plugin Authorized redirect URI is missing a slash before the API root part. So I track it down this config file. Obviously, I could check for a slash in the client and fix it up there, thoughts?