### PR TITLE
Upgrade npm to the latest version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ before_install:
     - cd cmake-*/bin && export PATH="${PWD}:${PATH}"
     - popd
     - cmake --version
+
+    - npm install -g npm@next
+    - npm --version
 install:
     - mkdir -p "${HOME}/.local/bin"
     - export PATH="${HOME}/.local/bin:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN pip install \
     -r plugins/geospatial/requirements.txt \
     -r plugins/metadata_extractor/requirements.txt
 RUN pip install -U six
+RUN npm install -g npm@next 
 RUN npm install -g grunt-cli
 RUN npm install
 RUN grunt init && grunt


### PR DESCRIPTION
Occasionally npm install would fail with an EEXIST error message.  This was caused by a race condition in npm (see https://github.com/npm/npm/issues/6309).  Upgrading to the latest npm version avoids this problem.

I've occasionally seen this failure in a travis build, but it is fairly rare.