### PR TITLE
Fetch no longer ignores default error handler

### DIFF
--- a/clients/web/src/app.js
+++ b/clients/web/src/app.js
@@ -45,7 +45,6 @@ girder.App = girder.View.extend({
         girder.events.on('g:resetPasswordUi', this.resetPasswordDialog, this);
         girder.events.on('g:alert', this.alert, this);
         girder.events.on('g:login', this.login, this);
-        girder.events.on('g:logout', this.logout, this);
     },
 
     _defaultLayout: {
@@ -219,24 +218,19 @@ girder.App = girder.View.extend({
     },
 
     /**
-     * On login, we re-render the current body view.
+     * On login we re-render the current body view; whereas on
+     * logout, we redirect to the front page.
      */
     login: function () {
         var route = girder.dialogs.splitRoute(Backbone.history.fragment).base;
         Backbone.history.fragment = null;
-        girder.router.navigate(route, {trigger: true});
         girder.eventStream.close();
 
         if (girder.currentUser) {
             girder.eventStream.open();
+            girder.router.navigate(route, {trigger: true});
+        } else {
+            girder.router.navigate('/', {trigger: true});
         }
-    },
-
-    /**
-     * On logout, we redirect to the front page.
-     */
-    logout: function () {
-        girder.eventStream.close();
-        girder.router.navigate('/', {trigger: true});
     }
 });

--- a/clients/web/src/app.js
+++ b/clients/web/src/app.js
@@ -45,6 +45,7 @@ girder.App = girder.View.extend({
         girder.events.on('g:resetPasswordUi', this.resetPasswordDialog, this);
         girder.events.on('g:alert', this.alert, this);
         girder.events.on('g:login', this.login, this);
+        girder.events.on('g:logout', this.logout, this);
     },
 
     _defaultLayout: {
@@ -218,7 +219,7 @@ girder.App = girder.View.extend({
     },
 
     /**
-     * On login or logout, we re-render the current body view.
+     * On login, we re-render the current body view.
      */
     login: function () {
         var route = girder.dialogs.splitRoute(Backbone.history.fragment).base;
@@ -229,5 +230,13 @@ girder.App = girder.View.extend({
         if (girder.currentUser) {
             girder.eventStream.open();
         }
+    },
+
+    /**
+     * On logout, we redirect to the front page.
+     */
+    logout: function () {
+        girder.eventStream.close();
+        girder.router.navigate('/', {trigger: true});
     }
 });

--- a/clients/web/src/init.js
+++ b/clients/web/src/init.js
@@ -168,7 +168,7 @@ _.extend(girder, {
         }).then(function () {
             girder.currentUser = null;
 
-            girder.events.trigger('g:logout');
+            girder.events.trigger('g:login', null);
             girder.events.trigger('g:logout.success');
         }, function (jqxhr) {
             girder.events.trigger('g:logout.error', jqxhr.status, jqxhr);

--- a/clients/web/src/init.js
+++ b/clients/web/src/init.js
@@ -168,7 +168,7 @@ _.extend(girder, {
         }).then(function () {
             girder.currentUser = null;
 
-            girder.events.trigger('g:login', null);
+            girder.events.trigger('g:logout');
             girder.events.trigger('g:logout.success');
         }, function (jqxhr) {
             girder.events.trigger('g:logout.error', jqxhr.status, jqxhr);

--- a/clients/web/src/model.js
+++ b/clients/web/src/model.js
@@ -60,17 +60,24 @@ girder.Model = Backbone.Model.extend({
     /**
      * Fetch a single resource from the server. Triggers g:fetched on success,
      * or g:error on error.
+     * To ignore the default error handler, pass
+     *     ignoreError: true
+     * in your opts object.
      */
-    fetch: function () {
+    fetch: function (opts) {
         if (this.resourceName === null) {
             alert('Error: You must set a resourceName on your model.');
             return;
         }
 
-        girder.restRequest({
-            path: this.resourceName + '/' + this.get('_id'),
-            error: null
-        }).done(_.bind(function (resp) {
+        opts = opts || {};
+        var restOpts = {
+            path: this.resourceName + '/' + this.get('_id')
+        };
+        if (opts.ignoreError) {
+            restOpts.error = null;
+        }
+        girder.restRequest(restOpts).done(_.bind(function (resp) {
             this.set(resp);
             this.trigger('g:fetched');
         }, this)).error(_.bind(function (err) {

--- a/clients/web/src/views/body/AssetstoresView.js
+++ b/clients/web/src/views/body/AssetstoresView.js
@@ -17,14 +17,10 @@ girder.views.AssetstoresView = girder.View.extend({
         }).on('g:created', this.addAssetstore, this);
 
         // Fetch all of the current assetstores
-        if (girder.currentUser && girder.currentUser.get('admin')) {
-            this.collection = new girder.collections.AssetstoreCollection();
-            this.collection.on('g:changed', function () {
-                this.render();
-            }, this).fetch();
-        } else {
+        this.collection = new girder.collections.AssetstoreCollection();
+        this.collection.on('g:changed', function () {
             this.render();
-        }
+        }, this).fetch();
     },
 
     render: function () {

--- a/clients/web/src/views/body/CollectionView.js
+++ b/clients/web/src/views/body/CollectionView.js
@@ -153,8 +153,6 @@
             girder.events.trigger('g:navigateTo', girder.views.CollectionView, _.extend({
                 collection: collection
             }, params || {}));
-        }, this).on('g:error', function () {
-            girder.router.navigate('/collections', {trigger: true});
         }, this).fetch();
     };
 

--- a/clients/web/src/views/body/GroupView.js
+++ b/clients/web/src/views/body/GroupView.js
@@ -316,8 +316,6 @@
             girder.events.trigger('g:navigateTo', girder.views.GroupView, _.extend({
                 group: group
             }, params || {}));
-        }, this).on('g:error', function () {
-            girder.router.navigate('/groups', {trigger: true});
         }, this).fetch();
     };
 

--- a/clients/web/src/views/body/UserSettingsView.js
+++ b/clients/web/src/views/body/UserSettingsView.js
@@ -83,9 +83,6 @@ girder.views.UserAccountView = girder.View.extend({
 
         girder.cancelRestRequests('fetch');
         this.render();
-
-        // This page should be re-rendered if the user logs in or out
-        girder.events.on('g:login', this.userChanged, this);
     },
 
     render: function () {
@@ -115,18 +112,6 @@ girder.views.UserAccountView = girder.View.extend({
         }, this);
 
         return this;
-    },
-
-    userChanged: function () {
-        // When the user changes, we should refresh the model to update the
-        // _accessLevel attribute on the viewed user, then re-render the page.
-        this.model.off('g:fetched').on('g:fetched', function () {
-            this.render();
-        }, this).on('g:error', function () {
-            // Current user no longer has write access to this user, so we
-            // send them back to the user list page.
-            girder.router.navigate('users', {trigger: true});
-        }, this).fetch();
     }
 });
 

--- a/clients/web/src/views/layout/GlobalNavView.js
+++ b/clients/web/src/views/layout/GlobalNavView.js
@@ -18,6 +18,7 @@ girder.views.LayoutGlobalNavView = girder.View.extend({
     initialize: function (settings) {
         girder.events.on('g:highlightItem', this.selectForView, this);
         girder.events.on('g:login', this.render, this);
+        girder.events.on('g:logout', this.render, this);
         girder.events.on('g:login-changed', this.render, this);
 
         settings = settings || {};

--- a/clients/web/src/views/layout/HeaderUserView.js
+++ b/clients/web/src/views/layout/HeaderUserView.js
@@ -27,6 +27,7 @@ girder.views.LayoutHeaderUserView = girder.View.extend({
     initialize: function () {
         girder.events.on('g:login', this.render, this);
         girder.events.on('g:login-changed', this.render, this);
+        girder.events.on('g:logout', this.render, this);
     },
 
     render: function () {

--- a/clients/web/test/spec/adminSpec.js
+++ b/clients/web/test/spec/adminSpec.js
@@ -91,6 +91,13 @@ describe('Test the settings page', function () {
             return $('#g-settings-error-message').text() === '';
         }, 'error message to be cleared');
     });
+    it('logout and check for redirect to front page from settings page', function () {
+        girderTest.logout()();
+
+        waitsFor(function () {
+            return $('.g-frontpage-title:visible').length > 0;
+        }, 'front page to display');
+    });
 });
 
 describe('Test the assetstore page', function () {
@@ -233,6 +240,12 @@ describe('Test the assetstore page', function () {
     }
 
     it('Go to assetstore page', function () {
+        girderTest.login('admin', 'Admin', 'Admin', 'adminpassword!')();
+
+        runs(function () {
+            $("a.g-nav-link[g-target='admin']").click();
+        });
+
         runs(function () {
             $("a.g-nav-link[g-target='admin']").click();
         });
@@ -284,10 +297,10 @@ describe('Test the assetstore page', function () {
 
     /* Logout to make sure we don't see the assetstores any more */
     it('logout from admin account', girderTest.logout('logout to no longer view asset stores'));
-    it('check logged out state', function() {
-        runs(function () {
-            expect($('#g-app-body-container').text()).toEqual('Must be logged in as admin to view this page.');
-        });
+    it('logout and check for redirect to front page from assetstore page', function () {
+        waitsFor(function () {
+            return $('.g-frontpage-title:visible').length > 0;
+        }, 'front page to display');
     });
 });
 
@@ -372,7 +385,7 @@ describe('Test the plugins page', function () {
         });
     });
     /* Logout to make sure we don't see the plugins any more */
-    it('log out and check state', function() {
+    it('log out and check for redirect to front page from plugins page', function() {
         waitsFor(function () {
             return $('.g-logout').length > 0;
         }, 'logout link to render');
@@ -390,5 +403,9 @@ describe('Test the plugins page', function () {
             $('#g-dialog-container').click();
         });
         girderTest.waitForLoad();
+
+        waitsFor(function () {
+            return $('.g-frontpage-title:visible').length > 0;
+        }, 'front page to display');
     });
 });

--- a/clients/web/test/spec/adminSpec.js
+++ b/clients/web/test/spec/adminSpec.js
@@ -33,6 +33,10 @@ describe('Create an admin and non-admin user', function () {
         expect($('.g-global-nav-li span').text()).not.toContain('Admin console');
     });
 
+    waitsFor(function () {
+        return $('.g-frontpage-title:visible').length > 0;
+    }, 'front page to display');
+
     it('register a (normal user)',
         girderTest.createUser('johndoe',
                               'john.doe@email.com',
@@ -47,6 +51,11 @@ describe('Create an admin and non-admin user', function () {
 
 describe('Test the settings page', function () {
     it('Logout', girderTest.logout());
+
+    it('Test that anonymous loading settings page prompts login', function () {
+        girderTest.anonymousLoadPage(false, 'settings', true);
+    });
+
     it('Login as admin', girderTest.login('admin', 'Admin', 'Admin', 'adminpassword!'));
     it('Go to settings page', function () {
         runs(function () {
@@ -239,6 +248,10 @@ describe('Test the assetstore page', function () {
         });
     }
 
+    it('Test that anonymous loading assetstore page prompts login', function () {
+        girderTest.anonymousLoadPage(false, 'assetstores', true);
+    });
+
     it('Go to assetstore page', function () {
         girderTest.login('admin', 'Admin', 'Admin', 'adminpassword!')();
 
@@ -314,6 +327,11 @@ describe('Test the plugins page', function () {
         });
         spyOn(girder.restartServer, '_reloadWindow');
     });
+
+    it('Test that anonymous loading plugins page prompts login', function () {
+        girderTest.anonymousLoadPage(false, 'plugins', true);
+    });
+
     it('Login as admin', girderTest.login('admin', 'Admin', 'Admin', 'adminpassword!'));
     it('Go to plugins page', function () {
         runs(function () {

--- a/clients/web/test/spec/adminSpec.js
+++ b/clients/web/test/spec/adminSpec.js
@@ -386,23 +386,7 @@ describe('Test the plugins page', function () {
     });
     /* Logout to make sure we don't see the plugins any more */
     it('log out and check for redirect to front page from plugins page', function() {
-        waitsFor(function () {
-            return $('.g-logout').length > 0;
-        }, 'logout link to render');
-        runs(function () {
-            $('.g-logout').click();
-        });
-        waitsFor(function () {
-            return girder.currentUser === null;
-        }, 'user to be cleared');
-        girderTest.waitForDialog();
-        waitsFor(function () {
-            return $('input#g-login').length > 0;
-        }, 'register dialog to appear');
-        runs(function () {
-            $('#g-dialog-container').click();
-        });
-        girderTest.waitForLoad();
+        girderTest.logout('logout to no longer view plugins page')();
 
         waitsFor(function () {
             return $('.g-frontpage-title:visible').length > 0;

--- a/clients/web/test/spec/adminSpec.js
+++ b/clients/web/test/spec/adminSpec.js
@@ -401,6 +401,15 @@ describe('Test the plugins page', function () {
         runs(function () {
             expect($('.g-plugin-list-item input[type=checkbox]:checked').length).toBe(0);
         });
+        waitsFor(function () {
+            var resp = girder.restRequest({
+                path: 'system/plugins',
+                type: 'GET',
+                async: false
+            });
+            return (resp && resp.responseJSON && resp.responseJSON.enabled &&
+                resp.responseJSON.enabled.length === 0);
+        });
     });
     /* Logout to make sure we don't see the plugins any more */
     it('log out and check for redirect to front page from plugins page', function() {

--- a/clients/web/test/spec/collectionSpec.js
+++ b/clients/web/test/spec/collectionSpec.js
@@ -173,7 +173,17 @@ describe('Test collection actions', function () {
         }, 'access dialog to be hidden');
     });
 
+    it('logout and check for redirect to front page from collection page', function () {
+        girderTest.logout()();
+
+        waitsFor(function () {
+            return $('.g-frontpage-title:visible').length > 0;
+        }, 'front page to display');
+    });
+
     it('go back to collections page again', function () {
+        girderTest.login('admin', 'Admin', 'Admin', 'adminpassword!')();
+
         runs(function () {
             $("a.g-nav-link[g-target='collections']").click();
         });
@@ -188,9 +198,19 @@ describe('Test collection actions', function () {
 
     });
 
-    it('logout to become anonymous', girderTest.logout());
+    it('logout to become anonymous, and check for redirect to front page from collections list page', function () {
+        girderTest.logout()();
+
+        waitsFor(function () {
+            return $('.g-frontpage-title:visible').length > 0;
+        }, 'front page to display');
+    });
 
     it('check if public collection is viewable (and ensure private is not)', function () {
+
+        runs(function () {
+            $("a.g-nav-link[g-target='collections']").click();
+        });
 
         waitsFor(function () {
             return $('li.active .g-page-number').text() === 'Page 1' &&

--- a/clients/web/test/spec/collectionSpec.js
+++ b/clients/web/test/spec/collectionSpec.js
@@ -12,6 +12,8 @@ $(function () {
 
 describe('Test collection actions', function () {
 
+    var privateCollectionFragment, privateFolderFragment;
+
     it('register a user (first is admin)',
         girderTest.createUser('admin',
                               'admin@email.com',
@@ -73,6 +75,7 @@ describe('Test collection actions', function () {
         }, 'edit collection menu item to appear');
 
         runs(function () {
+            privateCollectionFragment = Backbone.history.fragment;
             $('.g-edit-collection').click();
         });
         girderTest.waitForDialog();
@@ -110,10 +113,30 @@ describe('Test collection actions', function () {
             return $(".g-edit-collection").is(':visible');
         }, 'ensure edit collection menu item continues to appear');
 
+        // save fragment of Private folder
+        runs(function () {
+            $('.g-folder-list-link:first').click();
+        });
+
+        waitsFor(function () {
+            return $(".g-folder-metadata").is(':visible');
+        }, 'ensure collection folder is displayed');
+
+        runs(function ()  {
+            privateFolderFragment = Backbone.history.fragment;
+        });
     });
 
+    it('test that login dialog appears when anonymous loads a private collection', function () {
+        girderTest.anonymousLoadPage(true, privateCollectionFragment, true);
+    });
+
+    it('test that login dialog appears when anonymous loads a private folder in a private collection', function () {
+        girderTest.anonymousLoadPage(false, privateFolderFragment, true);
+    });
 
     it('make new collection public', function () {
+        girderTest.login('admin', 'Admin', 'Admin', 'adminpassword!')();
 
         runs(function () {
             $("a.g-nav-link[g-target='collections']").click();
@@ -179,6 +202,15 @@ describe('Test collection actions', function () {
         waitsFor(function () {
             return $('.g-frontpage-title:visible').length > 0;
         }, 'front page to display');
+    });
+
+    it('test that login dialog does not appear when anonymous loads a public collection', function () {
+        // despite its name, privateCollectionFragment now points to a public collection
+        girderTest.anonymousLoadPage(false, privateCollectionFragment, false);
+    });
+
+    it('test that login dialog appears when anonymous loads a private folder in a public collection', function () {
+        girderTest.anonymousLoadPage(false, privateFolderFragment, true);
     });
 
     it('go back to collections page again', function () {

--- a/clients/web/test/spec/dataSpec.js
+++ b/clients/web/test/spec/dataSpec.js
@@ -574,14 +574,38 @@ describe('Create a data hierarchy', function () {
                               'Doe',
                               'password!'));
     it('test copy permissions', function () {
+        // navigate back to John Doe's Public folder
+        girderTest.goToUsersPage()();
+        runs(function () {
+            $('.g-quick-search-container input.g-search-field')
+                .val('john').trigger('input');
+        });
+        waitsFor(function () {
+            return $('.g-quick-search-container .g-search-results')
+                .hasClass('open');
+        }, 'search to return');
+
+        runs(function () {
+            var results = $('.g-quick-search-container li.g-search-result');
+            expect(results.length).toBe(2);
+
+            expect(results.find('a[resourcetype="folder"]').length).toBe(1);
+            expect(results.find('a[resourcetype="user"]').length).toBe(1);
+
+            results.find('a[resourcetype="user"]').click();
+        });
+
         var oldPicked;
+        waitsFor(function () {
+            return $('.g-list-checkbox').length == 1;
+        }, 'User folders to be shown');
         runs(function () {
             $('a.g-folder-list-link:first').click();
         });
         girderTest.waitForLoad();
         waitsFor(function () {
             return $('.g-list-checkbox').length == 3;
-        }, 'public folder to be shown');
+        }, 'Public folder to be shown');
         /* Select one item and make sure we can't copy or move */
         runs(function () {
             $('.g-list-checkbox:last').click();
@@ -681,7 +705,7 @@ describe('Create a data hierarchy', function () {
             return $('.g-checked-actions-menu:visible').length == 0;
         }, 'checked actions menu to hide');
         runs(function () {
-            /* Skip a bunch of UI actiosn to more quickly get back to have one
+            /* Skip a bunch of UI actions to more quickly get back to have one
              * item selected. */
             girder.pickedResources = oldPicked;
             $('a.g-folder-list-link:first').click();

--- a/clients/web/test/spec/folderSpec.js
+++ b/clients/web/test/spec/folderSpec.js
@@ -97,6 +97,45 @@ describe('Test folder creation, editing, and deletion', function () {
         });
     });
 
+    it('test that anonymous loading the private folder of the user prompts a login dialog', function () {
+        waitsFor(function () {
+            return $('a.g-folder-list-link:contains(Private):visible').length === 1;
+        }, 'the private folder to be clickable');
+
+        runs(function () {
+            $('a.g-folder-list-link:contains(Private)').click();
+        });
+
+        waitsFor(function () {
+            return Backbone.history.fragment.search('folder') > -1;
+        }, 'the url state to change');
+
+        runs(function () {
+            var privateFolderFragment = Backbone.history.fragment;
+            girderTest.anonymousLoadPage(true, privateFolderFragment, true, girderTest.login('admin', 'Admin', 'Admin', 'adminpassword!'));
+        });
+
+        // get back to where you once belonged, the User page, so that testing may continue
+        girderTest.goToUsersPage()();
+
+        runs(function () {
+            expect($('.g-user-list-entry').length).toBe(1);
+        });
+
+        runs(function () {
+            $("a.g-user-link:contains('Admin')").click();
+        });
+
+        waitsFor(function () {
+            return $('.g-user-name').text() === 'Admin Admin';
+        }, 'user page to appear');
+
+        // check for actions menu
+        runs(function () {
+            expect($("button:contains('Actions')").length).toBe(1);
+        });
+    });
+
     it('create a subfolder in the public folder of the user', function () {
 
         waitsFor(function () {

--- a/clients/web/test/spec/groupSpec.js
+++ b/clients/web/test/spec/groupSpec.js
@@ -173,6 +173,11 @@ describe('Test group actions', function () {
     it('Create a private group',
        girderTest.createGroup('privGroup', 'private group', false));
 
+    it('Test that anonymous loading private group prompts login', function () {
+        var privateGroupFragment = Backbone.history.fragment;
+        girderTest.anonymousLoadPage(true, privateGroupFragment, true, girderTest.login('admin', 'Admin', 'Admin', 'adminpassword!'));
+    });
+
     it('go back to groups page', girderTest.goToGroupsPage());
 
     it('Create a public group',

--- a/clients/web/test/spec/groupSpec.js
+++ b/clients/web/test/spec/groupSpec.js
@@ -125,7 +125,22 @@ function _testDirectAdd(policy, curUser, curSetting) {
                 'password!')();
         }
         curUser = policy.user;
-    }
+        // go back to the groups page since we've logged out
+        girderTest.goToGroupsPage()();
+        waitsFor(function () {
+            return $('.g-group-list-entry').length >= 1 &&
+                   $('.g-group-list-entry:contains("pubGroup") .g-group-link').length === 1;
+        }, 'the public groups to show up');
+        runs(function () {
+            $('.g-group-list-entry:contains("pubGroup") .g-group-link').click();
+        });
+        waitsFor(function () {
+            return $('.g-group-name').text() === 'pubGroup' &&
+                   $('.g-group-members>li').length === 1 &&
+                   $('.g-group-mods>li').length === 1 &&
+                   $('.g-group-admins>li').length === 2;
+        }, 'the group page to load');
+     }
     /* If the invite search field exists or we think it should,
      * test that the add button exists as we expect */
     if (policy.mayAdd === null) {
@@ -223,7 +238,24 @@ describe('Test group actions', function () {
         }, 'admin user to appear in the member list');
     });
 
+    it('check that logging out of a group redirects to the front page', function () {
+        girderTest.logout()();
+        waitsFor(function () {
+            return $('.g-frontpage-title:visible').length > 0;
+        }, 'front page to display');
+    });
+
+    it('check that logging out of the groups list page redirects to the front page', function () {
+        girderTest.login('admin', 'Admin', 'Admin', 'adminpassword!')();
+        girderTest.goToGroupsPage()();
+        girderTest.logout()();
+        waitsFor(function () {
+            return $('.g-frontpage-title:visible').length > 0;
+        }, 'front page to display');
+    });
+
     it('check that the groups page has both groups for admin', function () {
+        girderTest.login('admin', 'Admin', 'Admin', 'adminpassword!')();
         girderTest.goToGroupsPage()();
         waitsFor(function () {
             return $('.g-group-list-entry').length === 2;
@@ -239,6 +271,7 @@ describe('Test group actions', function () {
 
     it('check that the groups page has only the public groups for anon', function () {
         girderTest.logout()();
+        girderTest.goToGroupsPage()();
         waitsFor(function () {
             return $('.g-group-list-entry').length === 1;
         }, 'the two groups to show up');

--- a/clients/web/test/spec/userSpec.js
+++ b/clients/web/test/spec/userSpec.js
@@ -58,14 +58,20 @@ describe('Create an admin and non-admin user', function () {
         });
     });
 
-    it('check redirect to users page', function () {
+    it('check redirect to front page after logout from user page', function () {
         girderTest.logout()();
         waitsFor(function () {
-            return Backbone.history.fragment === 'users';
-        }, 'redirect to users');
+            return $('.g-frontpage-title:visible').length > 0;
+        }, 'front page to display');
+    });
+
+    it('check redirect to front page after logout from users list page', function () {
+        girderTest.login('admin', 'Admin', 'Admin', 'adminpassword!')();
+        girderTest.goToUsersPage()();
+        girderTest.logout()();
         waitsFor(function () {
-            return $('.g-user-list-entry:visible').length > 0;
-        }, 'user list to be present');
+            return $('.g-frontpage-title:visible').length > 0;
+        }, 'front page to display');
     });
 
     it('check for admin checkbox on admin user settings page', function () {

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -775,3 +775,34 @@ girderTest.confirmDialog = function () {
     });
     girderTest.waitForLoad();
 };
+
+/*
+ * Loads a particular fragment as anonymous and checks whether the login dialog
+ * appears.  Assumes you are logged out, or else you should pass logoutFirst=true.
+ * If you would like the system to log back in at the end of this function,
+ * pass a loginFunction to be called.
+ */
+girderTest.anonymousLoadPage = function (logoutFirst, fragment, hasLoginDialog, loginFunction) {
+    /*
+     * :param logoutFirst: boolean, whether this function should log out the current user
+     *                     before loading the fragment.
+     * :param fragment: URL fragment to load.
+     * :param hasLoginDialog: boolean, whether the page loaded at the fragment's route should
+     *                        display a login dialog.
+     * :param loginFunction: function, if passed, the loginFunction will be called at the end of
+     *                       this function to log the user back in.
+     */
+    if (logoutFirst) {
+        girderTest.logout()();
+    }
+    girderTest.testRoute(fragment, hasLoginDialog);
+    if (hasLoginDialog) {
+        waitsFor(function () {
+            return $('input#g-login').length > 0;
+        }, 'login dialog to appear');
+    }
+    girderTest.testRoute('', false);
+    if (loginFunction) {
+        loginFunction();
+    }
+};

--- a/plugins/user_quota/plugin_tests/userQuotaSpec.js
+++ b/plugins/user_quota/plugin_tests/userQuotaSpec.js
@@ -119,7 +119,7 @@ function _testQuotaDialogAsUser(hasChart) {
 
 describe('test the user quota plugin', function () {
     var collectionDialogRoute, userDialogRoute, userRoute;
-    it('create reources', function () {
+    it('create resources', function () {
         girderTest.createUser(
             'admin', 'admin@email.com', 'Quota', 'Admin', 'testpassword')();
         _goToCollection();


### PR DESCRIPTION
Now fetch will call the default error handler.  This will report the error in the error console and send a notification through girder.

In some cases where the user isn't authenticated and attempts to read access controlled resources, the default error handler will open the login dialog.  Sometimes the login dialog won't actually appear, e.g. the [CollectionView will send the user back to the Collections List](https://github.com/girder/girder/blob/master/clients/web/src/views/body/CollectionView.js#L157).