### PR TITLE
Add support for S3 uploading to python client docs

### DIFF
--- a/docs/python-client.rst
+++ b/docs/python-client.rst
@@ -46,8 +46,8 @@ To specify a host using SSL (https) ::
 Upload a local file hierarchy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Currently, the girder_client does not support uploads to the S3 Assetstore type
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+The girder_client can upload to an S3 Assetstore when uploading to a Girder server
+that is version 1.3.0 or later.
 
 The upload command, ``-c upload``, is the default, so the following two forms
 are equivalent ::


### PR DESCRIPTION
Update of python client docs for release 1.3.0.

@zachmullen PTAL