### PR TITLE
Fixes #809. Safer checkbox menu behavior

### DIFF
--- a/clients/web/src/views/widgets/HierarchyWidget.js
+++ b/clients/web/src/views/widgets/HierarchyWidget.js
@@ -470,6 +470,14 @@ girder.views.HierarchyWidget = girder.View.extend({
                 minItemLevel = Math.min(minItemLevel, this.parentModel.getAccessLevel());
             }
         }
+
+        if (folders.length + items.length) {
+            // Disable folder actions if checkboxes are checked
+            this.$('.g-folder-actions-button').attr('disabled', 'disabled');
+        } else {
+            this.$('.g-folder-actions-button').removeAttr('disabled');
+        }
+
         this.checkedMenuWidget.update({
             minFolderLevel: minFolderLevel,
             minItemLevel: minItemLevel,


### PR DESCRIPTION
When a user checks resources in the hierarchy widget, we now disable
the folder actions widget to make it hard to accidentally apply
actions to the parent folder rather than the checked resources.