### PR TITLE
Changing default auth header to Girder-Authentication

### DIFF
--- a/clients/web/src/init.js
+++ b/clients/web/src/init.js
@@ -144,7 +144,7 @@ _.extend(girder, {
             method: 'GET',
             path: '/user/authentication',
             headers: {
-                Authorization: auth
+                'Girder-Authorization': auth
             }
         }).then(function (response) {
             response.user.token = response.authToken;

--- a/docs/developer-cookbook.rst
+++ b/docs/developer-cookbook.rst
@@ -19,9 +19,10 @@ login process requires the client to make an HTTP ``GET`` request to the
 ``api/v1/user/authentication`` route, using HTTP Basic Auth to pass the user
 credentials. For example, for a user with login "john" and password "hello",
 first base-64 encode the string ``"john:hello"`` which yields ``"am9objpoZWxsbw=="``.
-Then take the base-64 encoded value and pass it via the ``Authorization`` header: ::
+Then take the base-64 encoded value and pass it via the ``Girder-Authorization``
+header (The ``Authorization`` header will also work): ::
 
-    Authorization: Basic am9objpoZWxsbw==
+    Girder-Authorization: Basic am9objpoZWxsbw==
 
 If the username and password are correct, you will receive a 200 status code and
 a JSON document from which you can extract the authentication token, e.g.:

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -105,7 +105,10 @@ class User(Resource):
         # Only create and send new cookie if user isn't already sending
         # a valid one.
         if not user:
-            authHeader = cherrypy.request.headers.get('Authorization')
+            authHeader = cherrypy.request.headers.get('Girder-Authorization')
+
+            if not authHeader:
+                authHeader = cherrypy.request.headers.get('Authorization')
 
             if not authHeader or not authHeader[0:6] == 'Basic ':
                 raise RestException('Use HTTP Basic Authentication', 401)

--- a/girder/constants.py
+++ b/girder/constants.py
@@ -151,7 +151,7 @@ class SettingDefault:
         # changes to the CORS origin
         SettingKey.CORS_ALLOW_HEADERS:
             'Accept-Encoding, Authorization, Content-Disposition, '
-            'Content-Type, Cookie, Girder-Token',
+            'Content-Type, Cookie, Girder-Authorization, Girder-Token',
             # An apache server using reverse proxy would also need
             #  X-Requested-With, X-Forwarded-Server, X-Forwarded-For,
             #  X-Forwarded-Host, Remote-Addr

--- a/tests/base.py
+++ b/tests/base.py
@@ -307,7 +307,8 @@ class TestCase(unittest.TestCase, model_importer.ModelImporter):
         token = self.model('token').createToken(user)
         return str(token['_id'])
 
-    def _buildHeaders(self, headers, cookie, user, token, basicAuth, authHeader):
+    def _buildHeaders(self, headers, cookie, user, token, basicAuth,
+                      authHeader):
         if cookie is not None:
             headers.append(('Cookie', cookie))
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -307,7 +307,7 @@ class TestCase(unittest.TestCase, model_importer.ModelImporter):
         token = self.model('token').createToken(user)
         return str(token['_id'])
 
-    def _buildHeaders(self, headers, cookie, user, token, basicAuth):
+    def _buildHeaders(self, headers, cookie, user, token, basicAuth, authHeader):
         if cookie is not None:
             headers.append(('Cookie', cookie))
 
@@ -321,12 +321,13 @@ class TestCase(unittest.TestCase, model_importer.ModelImporter):
 
         if basicAuth is not None:
             auth = base64.b64encode(basicAuth.encode('utf8'))
-            headers.append(('Authorization', 'Basic {}'.format(auth.decode())))
+            headers.append((authHeader, 'Basic {}'.format(auth.decode())))
 
     def request(self, path='/', method='GET', params=None, user=None,
                 prefix='/api/v1', isJson=True, basicAuth=None, body=None,
                 type=None, exception=False, cookie=None, token=None,
-                additionalHeaders=None, useHttps=False):
+                additionalHeaders=None, useHttps=False,
+                authHeader='Girder-Authorization'):
         """
         Make an HTTP request.
 
@@ -349,6 +350,8 @@ class TestCase(unittest.TestCase, model_importer.ModelImporter):
                                   request.  Each item is a tuple of the form
                                   (header-name, header-value).
         :param useHttps: if True, pretend to use https
+        :param authHeader: The HTTP request header to use for authentication.
+        :type authHeader: str
         :returns: The cherrypy response object from the request.
         """
         if not params:
@@ -380,7 +383,7 @@ class TestCase(unittest.TestCase, model_importer.ModelImporter):
             local, remote, 'http' if not useHttps else 'https', 'HTTP/1.1')
         request.show_tracebacks = True
 
-        self._buildHeaders(headers, cookie, user, token, basicAuth)
+        self._buildHeaders(headers, cookie, user, token, basicAuth, authHeader)
 
         try:
             response = request.run(method, prefix + path, qs, 'HTTP/1.1',

--- a/tests/cases/user_test.py
+++ b/tests/cases/user_test.py
@@ -118,13 +118,13 @@ class UserTestCase(base.TestCase):
         # Bad authentication header
         resp = self.request(
             path='/user/authentication', method='GET',
-            additionalHeaders=[('Authorization', 'Basic Not-Valid-64')])
+            additionalHeaders=[('Girder-Authorization', 'Basic Not-Valid-64')])
         self.assertStatus(resp, 401)
         self.assertEqual('Invalid HTTP Authorization header',
                          resp.json['message'])
         resp = self.request(
             path='/user/authentication', method='GET',
-            additionalHeaders=[('Authorization', 'Basic NotValid')])
+            additionalHeaders=[('Girder-Authorization', 'Basic NotValid')])
         self.assertStatus(resp, 401)
         self.assertEqual('Invalid HTTP Authorization header',
                          resp.json['message'])
@@ -155,6 +155,12 @@ class UserTestCase(base.TestCase):
                             basicAuth='badlogin:good:password')
         self.assertStatus(resp, 403)
         self.assertEqual('Login failed.', resp.json['message'])
+
+        # Login successfully with fallback Authorization header
+        resp = self.request(path='/user/authentication', method='GET',
+                            basicAuth='goodlogin:good:password',
+                            authHeader='Authorization')
+        self.assertStatusOk(resp)
 
         # Login successfully with login
         resp = self.request(path='/user/authentication', method='GET',


### PR DESCRIPTION
The Authentication header conflicts with htaccess authentication in Apache, so changing the default to Girder-Authentication with a fallback to Authentication.