### PR TITLE
Avoid duplicate route documentation

### DIFF
--- a/girder/api/docs.py
+++ b/girder/api/docs.py
@@ -60,7 +60,9 @@ def addRouteDocs(resource, route, method, info, handler):
     if path not in routes[resource]:
         routes[resource][path] = []
 
-    routes[resource][path].append(info)
+    if info not in routes[resource][path]:
+        routes[resource][path].append(info)
+
     discovery.add(resource)
 
 


### PR DESCRIPTION
If plugins extended existing rest resource classes to add new
routes, they would end up duplicating all of the existing routes
in the docs. This prevents that from happening, and therefore
allows normal class extension for rest resources.