### PR TITLE
Update install docs to clarify install steps for developers vs. users

### DIFF
--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -104,10 +104,9 @@ example, we have the following:
        tools.proxy.local: ""
 
 After modifying the configuration, always remember to rebuild Girder by
-changing to the main Girder directory and issuing the following command: ::
+changing to the Girder directory and issuing the following command: ::
 
-    $ grunt init && grunt
-
+    $ npm install
 
 Docker Container
 ----------------

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -10,10 +10,31 @@ the tools used to develop Girder.
 Configuring Your Development Environment
 ----------------------------------------
 
-In order to develop Girder, you can refer to the :doc:`prerequisites` and
-:doc:`installation` sections to setup a local development environment. Once
-Girder is started via ``python -m girder``, the server will reload itself
-whenever a Python file is modified.
+In order to develop Girder, you should first refer to the :doc:`prerequisites`
+and :doc:`installation` sections to setup a basic local environment.
+
+Next, you should install the `Grunt <http://gruntjs.com>`_ build tool globally,
+to allow it to be run directly from the command line: ::
+
+    npm install -g grunt
+    npm install -g grunt-cli
+
+Finally, you should also install the Python development dependencies, to
+provide helpful development tools and to allow the test suite to run: ::
+
+    pip install -r requirements-dev.txt
+
+.. note:: One of the development requirements, `httpretty`, can fail to install
+   if under certain system locales (see the `error report
+   <https://github.com/gabrielfalcao/HTTPretty/issues/108>`_).  Changing to any
+   UTF8 locale works around this problem.  For instance, on Ubuntu, you can
+   change your system locale using the commands: ::
+
+        locale-gen en_US.UTF-8
+        export LANG=en_US.utf8
+
+During development, once Girder is started via ``python -m girder``, the server
+will reload itself whenever a Python file is modified.
 
 To get the same auto-building behavior for JavaScript, we use ``grunt-watch``.
 Thus, running ``grunt watch`` in the root of the repository will watch for

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -47,20 +47,6 @@ dependencies: ::
 
     pip install -r requirements.txt
 
-.. note:: If you intend to develop Girder or want to run the test suite, you should also
-   install the development dependencies: ::
-
-        pip install -r requirements-dev.txt
-
-   One of the development requirements, `httpretty`, can fail to install if
-   under certain system locales (see the `error report
-   <https://github.com/gabrielfalcao/HTTPretty/issues/108>`_).  Changing to any
-   UTF8 locale works around this problem.  For instance, on Ubuntu, you can
-   change your system locale using the commands: ::
-
-        locale-gen en_US.UTF-8
-        export LANG=en_US.utf8
-
 To build the client-side code project, cd into the root of the repository
 and run: ::
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -61,17 +61,13 @@ dependencies: ::
         locale-gen en_US.UTF-8
         export LANG=en_US.utf8
 
-Before you can build the client-side code project, you must install the
-`Grunt <http://gruntjs.com>`_ command line utilities: ::
-
-    npm install -g grunt-cli
-
-Then cd into the root of the repository and run: ::
+To build the client-side code project, cd into the root of the repository
+and run: ::
 
     npm install
 
-This should run ``grunt init`` and ``grunt`` to build all of the javascript and
-CSS files needed to run the web client application.
+This will run multiple `Grunt <http://gruntjs.com>`_ tasks, to build all of
+the Javascript and CSS files needed to run the web client application.
 
 .. _run-girder:
 


### PR DESCRIPTION
The Grunt CLI does not directly depend on the Grunt task runner.

See http://gruntjs.com/getting-started#installing-the-cli