### PR TITLE
Make models always expose the '_id' field

### DIFF
--- a/girder/models/collection.py
+++ b/girder/models/collection.py
@@ -41,7 +41,7 @@ class Collection(AccessControlledModel):
         })
 
         self.exposeFields(level=AccessType.READ, fields=(
-            '_id', 'name', 'description', 'public', 'created', 'updated',
+            'name', 'description', 'public', 'created', 'updated',
             'size'))
 
     def filter(self, collection, user=None):

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -50,7 +50,7 @@ class Folder(AccessControlledModel):
         })
 
         self.exposeFields(level=AccessType.READ, fields=(
-            '_id', 'name', 'public', 'description', 'created', 'updated',
+            'name', 'public', 'description', 'created', 'updated',
             'size', 'meta', 'parentId', 'parentCollection', 'creatorId',
             'baseParentType', 'baseParentId'))
 

--- a/girder/models/group.py
+++ b/girder/models/group.py
@@ -62,7 +62,7 @@ class Group(AccessControlledModel):
         })
 
         self.exposeFields(level=AccessType.READ, fields=(
-            '_id', 'name', 'public', 'description', 'created', 'updated',
+            'name', 'public', 'description', 'created', 'updated',
             'addAllowed'))
 
     def filter(self, group, user, accessList=False, requests=False):

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -50,7 +50,7 @@ class Item(acl_mixin.AccessControlMixin, Model):
         self.resourceParent = 'folderId'
 
         self.exposeFields(level=AccessType.READ, fields=(
-            '_id', 'size', 'updated', 'description', 'created', 'meta',
+            'size', 'updated', 'description', 'created', 'meta',
             'creatorId', 'folderId', 'name', 'baseParentType', 'baseParentId'))
 
     def filter(self, item, user=None):

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -46,7 +46,7 @@ class Model(ModelImporter):
         self._textLanguage = None
 
         self._filterKeys = {
-            AccessType.READ: set(),
+            AccessType.READ: set('_id'),
             AccessType.WRITE: set(),
             AccessType.ADMIN: set(),
             AccessType.SITE_ADMIN: set()

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -41,8 +41,7 @@ class User(AccessControlledModel):
         }, language='none')
 
         self.exposeFields(level=AccessType.READ, fields=(
-            '_id', 'login', 'public', 'firstName', 'lastName', 'admin',
-            'created'))
+            'login', 'public', 'firstName', 'lastName', 'admin', 'created'))
         self.exposeFields(level=AccessType.ADMIN, fields=(
             'size', 'email', 'groups', 'groupInvites'))
 


### PR DESCRIPTION
All current models that use the filter capability add the '_id' field to their list of exposed fields for all accesses. To ensure that the important '_id' field is easily availble in new models, it is now part of the default set of exposed keys.

It is still possible to call "Model.hideFields" if necessary.