### PR TITLE
new route: /resource/stat

### DIFF
--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -224,8 +224,12 @@ class Resource(BaseResource):
         return self._lookupPath(params['path'], self.getCurrentUser())
 
     stat.description = (
-        Description('Get any resource by girder path.')
-        .param('path', 'The path of the resource.')
+        Description('Look up a resource in the data hierarchy by path.')
+        .param('path',
+               'The path of the resource.  The path must be an absolute Unix '
+               'path starting with either "/users/[user name]", for a user\'s'
+               'resources or "/collection/[collection name]", for resources '
+               'under a collection.')
         .errorResponse('Path is invalid.')
         .errorResponse('Path refers to a resource that does not exist.')
         .errorResponse('Read access was denied for the resource.', 403))

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -149,7 +149,7 @@ class Resource(BaseResource):
         :returns: the child resource.
         """
 
-        filterObject = { 'name': token }
+        filterObject = {'name': token}
         candidateParent = None
 
         # figure out the parentId's type
@@ -207,8 +207,8 @@ class Resource(BaseResource):
 
         pathArray = path[1:].split('/')
         model = pathArray[0]
-        isUserPath = ( model == 'user' )
-        isCollectionPath = ( model == 'collection' )
+        isUserPath = (model == 'user')
+        isCollectionPath = (model == 'collection')
 
         if user is None:
             user = self.getCurrentUser()
@@ -258,7 +258,6 @@ class Resource(BaseResource):
         .errorResponse('Path is invalid.')
         .errorResponse('Path refers to a resource that does not exist.')
         .errorResponse('Read access was denied for the resource.', 403))
-
 
     @access.public
     def download(self, params):

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -37,7 +37,7 @@ class Resource(BaseResource):
     def __init__(self):
         self.resourceName = 'resource'
         self.route('GET', ('search',), self.search)
-        self.route('GET', ('stat',), self.stat)
+        self.route('GET', ('lookup',), self.lookup)
         self.route('GET', (':id',), self.getResource)
         self.route('GET', ('download',), self.download)
         self.route('POST', ('download',), self.download)
@@ -219,11 +219,11 @@ class Resource(BaseResource):
         return result
 
     @access.public
-    def stat(self, params):
+    def lookup(self, params):
         self.requireParams('path', params)
         return self._lookupPath(params['path'], self.getCurrentUser())
 
-    stat.description = (
+    lookup.description = (
         Description('Look up a resource in the data hierarchy by path.')
         .param('path',
                'The path of the resource.  The path must be an absolute Unix '

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -176,14 +176,6 @@ class Resource(BaseResource):
             parentType, parent.get('name', parent.get('_id')), token))
 
     def _lookUpPath(self, path, user):
-        """
-        Find a particular resource by path or throw an exception.  The given
-        user must have read access to all resources featured in the path.
-        :param path: the path of the object to find
-        :param user: the user to search as
-        :returns: the resource.
-        """
-
         pathArray = [token for token in path.split('/') if token]
         model = pathArray[0]
 

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -141,7 +141,7 @@ class Resource(BaseResource):
             raise RestException('Invalid resources format.')
         return model
 
-    def _lookupToken(self, token, parentType, parent):
+    def _lookUpToken(self, token, parentType, parent):
         """
         Find a particular child resource by name or throw an exception.
         :param token: the name of the child resource to find
@@ -175,7 +175,7 @@ class Resource(BaseResource):
         raise RestException('Child resource not found: {}({})->{}'.format(
             parentType, parent.get('name', parent.get('_id')), token))
 
-    def _lookupPath(self, path, user):
+    def _lookUpPath(self, path, user):
         """
         Find a particular resource by path or throw an exception.  The given
         user must have read access to all resources featured in the path.
@@ -210,7 +210,7 @@ class Resource(BaseResource):
             document = parent
             self.model(model).requireAccess(document, user)
             for token in pathArray[2:]:
-                document, model = self._lookupToken(token, model, document)
+                document, model = self._lookUpToken(token, model, document)
                 self.model(model).requireAccess(document, user)
         except RestException:
             raise RestException('Path not found: {}'.format(path))
@@ -221,7 +221,7 @@ class Resource(BaseResource):
     @access.public
     def lookup(self, params):
         self.requireParams('path', params)
-        return self._lookupPath(params['path'], self.getCurrentUser())
+        return self._lookUpPath(params['path'], self.getCurrentUser())
 
     lookup.description = (
         Description('Look up a resource in the data hierarchy by path.')

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -37,6 +37,7 @@ class Resource(BaseResource):
     def __init__(self):
         self.resourceName = 'resource'
         self.route('GET', ('search',), self.search)
+        self.route('GET', ('stat',), self.stat)
         self.route('GET', (':id',), self.getResource)
         self.route('GET', ('download',), self.download)
         self.route('POST', ('download',), self.download)
@@ -243,6 +244,21 @@ class Resource(BaseResource):
 
         result = self.model(model).filter(document, user)
         return result
+
+    @access.public
+    def stat(self, params):
+        path = params.get('path')
+        currentUser = self.getCurrentUser()
+        result = self._lookupPath(path, currentUser)
+        return result
+
+    stat.description = (
+        Description('Get any resource by girder path.')
+        .param('path', 'The path of the resource.')
+        .errorResponse('Path is invalid.')
+        .errorResponse('Path refers to a resource that does not exist.')
+        .errorResponse('Read access was denied for the resource.', 403))
+
 
     @access.public
     def download(self, params):

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -227,7 +227,7 @@ class Resource(BaseResource):
         Description('Look up a resource in the data hierarchy by path.')
         .param('path',
                'The path of the resource.  The path must be an absolute Unix '
-               'path starting with either "/users/[user name]", for a user\'s'
+               'path starting with either "/user/[user name]", for a user\'s'
                'resources or "/collection/[collection name]", for resources '
                'under a collection.')
         .errorResponse('Path is invalid.')

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -175,7 +175,7 @@ class Resource(BaseResource):
         raise RestException('Child resource not found: {}({})->{}'.format(
             parentType, parent.get('name', parent.get('_id')), token))
 
-    def _lookupPath(self, path, user=None):
+    def _lookupPath(self, path, user):
         """
         Find a particular resource by path or throw an exception.  The given
         user must have read access to all resources featured in the path.
@@ -186,9 +186,6 @@ class Resource(BaseResource):
 
         pathArray = [token for token in path.split('/') if token]
         model = pathArray[0]
-
-        if user is None:
-            user = self.getCurrentUser()
 
         parent = None
         if model == 'user':

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -150,17 +150,7 @@ class Resource(BaseResource):
         :returns: the child resource
         """
 
-        filterObject = {
-            'name': token,
-            'parentId': parent['_id'],
-            'baseParentId': parent.get('baseParentId'),
-            'baseParentType': parent.get('baseParentType'),
-        }
-
-        if parentType in ('collection', 'user'):
-            filterObject.update(
-                baseParentId=parent['_id'],
-                baseParentType=parentType)
+        filterObject = {'name': token, 'parentId': parent['_id']}
 
         # look for a folder
         candidateChild = self.model('folder').findOne(filterObject)
@@ -169,8 +159,6 @@ class Resource(BaseResource):
 
         # if folder not found, look for an item
         filterObject['folderId'] = filterObject.pop('parentId')
-        del filterObject['baseParentId']
-        del filterObject['baseParentType']
         candidateChild = self.model('item').findOne(filterObject)
         if candidateChild is not None:
             return candidateChild, 'item'

--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -37,6 +37,10 @@ class File(acl_mixin.AccessControlMixin, Model):
         self.resourceColl = 'item'
         self.resourceParent = 'itemId'
 
+        self.exposeFields(level=AccessType.READ, fields=(
+            "_id", "mimeType", "itemId", "exts", "name", "created",
+            "assetstoreId", "creatorId", "size"))
+
     def remove(self, file, updateItemSize=True, **kwargs):
         """
         Use the appropriate assetstore adapter for whatever assetstore the

--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -38,8 +38,10 @@ class File(acl_mixin.AccessControlMixin, Model):
         self.resourceParent = 'itemId'
 
         self.exposeFields(level=AccessType.READ, fields=(
-            "_id", "mimeType", "itemId", "exts", "name", "created",
-            "assetstoreId", "creatorId", "size"))
+            "_id", "mimeType", "itemId", "exts", "name", "created", "creatorId",
+            "size"))
+
+        self.exposeFields(level=AccessType.SITE_ADMIN, fields=("assetstoreId",))
 
     def remove(self, file, updateItemSize=True, **kwargs):
         """

--- a/tests/cases/resource_test.py
+++ b/tests/cases/resource_test.py
@@ -433,7 +433,6 @@ class ResourceTestCase(base.TestCase):
                             params={'path': '/bogus/path'})
         self.assertStatus(resp, 400)
 
-
     def testMove(self):
         self._createFiles()
         # Move item1 from the public to the private folder

--- a/tests/cases/resource_test.py
+++ b/tests/cases/resource_test.py
@@ -350,6 +350,84 @@ class ResourceTestCase(base.TestCase):
         self.assertStatusOk(resp)
         self.assertEqual(str(resp.json['_id']), str(self.file1['_id']))
 
+    def testGetResourceByPath(self):
+        self._createFiles()
+
+        # test users
+        resp = self.request(path='/resource/stat',
+                            method='GET', user=self.admin,
+                            params={'path': '/user/goodlogin'})
+
+        self.assertStatusOk(resp)
+        self.assertEqual(str(resp.json['_id']), str(self.admin['_id']))
+
+        resp = self.request(path='/resource/stat',
+                            method='GET', user=self.user,
+                            params={'path': '/user/userlogin'})
+        self.assertStatusOk(resp)
+        self.assertEqual(str(resp.json['_id']), str(self.user['_id']))
+
+        # test collections
+        resp = self.request(path='/resource/stat',
+                            method='GET', user=self.user,
+                            params={'path': '/collection/Test Collection'})
+        self.assertStatusOk(resp)
+        self.assertEqual(str(resp.json['_id']), str(self.collection['_id']))
+
+        resp = self.request(path='/resource/stat',
+                            method='GET', user=self.admin,
+                            params={'path':
+                                '/collection/Test Collection/' +
+                                self.collectionPrivateFolder['name']})
+        self.assertStatusOk(resp)
+        self.assertEqual(str(resp.json['_id']),
+                         str(self.collectionPrivateFolder['_id']))
+
+        # test folders
+        resp = self.request(path='/resource/stat',
+                            method='GET', user=self.user,
+                            params={'path': '/user/goodlogin/Public'})
+        self.assertStatusOk(resp)
+        self.assertEqual(
+            str(resp.json['_id']), str(self.adminPublicFolder['_id']))
+
+        resp = self.request(path='/resource/stat',
+                            method='GET', user=self.user,
+                            params={'path': '/user/goodlogin/Private'})
+        self.assertStatus(resp, 403)
+
+        # test subfolders
+        resp = self.request(path='/resource/stat',
+                            method='GET', user=self.admin,
+                            params={'path': '/user/goodlogin/Public/Folder 1'})
+        self.assertStatusOk(resp)
+        self.assertEqual(
+            str(resp.json['_id']), str(self.adminSubFolder['_id']))
+
+        # test items
+        paths = ('/user/goodlogin/Public/Item 1',
+                 '/user/goodlogin/Public/Item 2',
+                 '/user/goodlogin/Public/Folder 1/Item 3',
+                 '/collection/Test Collection/%s/Item 4' %
+                     self.collectionPrivateFolder['name'],
+                 '/collection/Test Collection/%s/Item 5' %
+                     self.collectionPrivateFolder['name'])
+
+        users = (self.user,
+                 self.user,
+                 self.user,
+                 self.admin,
+                 self.admin)
+
+        for path, item, user in zip(paths, self.items, users):
+            resp = self.request(path='/resource/stat',
+                                method='GET', user=user,
+                                params={'path': path})
+
+            self.assertStatusOk(resp)
+            self.assertEqual(
+                str(resp.json['_id']), str(item['_id']))
+
     def testMove(self):
         self._createFiles()
         # Move item1 from the public to the private folder

--- a/tests/cases/resource_test.py
+++ b/tests/cases/resource_test.py
@@ -354,27 +354,27 @@ class ResourceTestCase(base.TestCase):
         self._createFiles()
 
         # test users
-        resp = self.request(path='/resource/stat',
+        resp = self.request(path='/resource/lookup',
                             method='GET', user=self.admin,
                             params={'path': '/user/goodlogin'})
 
         self.assertStatusOk(resp)
         self.assertEqual(str(resp.json['_id']), str(self.admin['_id']))
 
-        resp = self.request(path='/resource/stat',
+        resp = self.request(path='/resource/lookup',
                             method='GET', user=self.user,
                             params={'path': '/user/userlogin'})
         self.assertStatusOk(resp)
         self.assertEqual(str(resp.json['_id']), str(self.user['_id']))
 
         # test collections
-        resp = self.request(path='/resource/stat',
+        resp = self.request(path='/resource/lookup',
                             method='GET', user=self.user,
                             params={'path': '/collection/Test Collection'})
         self.assertStatusOk(resp)
         self.assertEqual(str(resp.json['_id']), str(self.collection['_id']))
 
-        resp = self.request(path='/resource/stat',
+        resp = self.request(path='/resource/lookup',
                             method='GET', user=self.admin,
                             params={'path':
                                     '/collection/Test Collection/' +
@@ -384,20 +384,20 @@ class ResourceTestCase(base.TestCase):
                          str(self.collectionPrivateFolder['_id']))
 
         # test folders
-        resp = self.request(path='/resource/stat',
+        resp = self.request(path='/resource/lookup',
                             method='GET', user=self.user,
                             params={'path': '/user/goodlogin/Public'})
         self.assertStatusOk(resp)
         self.assertEqual(
             str(resp.json['_id']), str(self.adminPublicFolder['_id']))
 
-        resp = self.request(path='/resource/stat',
+        resp = self.request(path='/resource/lookup',
                             method='GET', user=self.user,
                             params={'path': '/user/goodlogin/Private'})
         self.assertStatus(resp, 403)
 
         # test subfolders
-        resp = self.request(path='/resource/stat',
+        resp = self.request(path='/resource/lookup',
                             method='GET', user=self.admin,
                             params={'path': '/user/goodlogin/Public/Folder 1'})
         self.assertStatusOk(resp)
@@ -419,7 +419,7 @@ class ResourceTestCase(base.TestCase):
                  self.admin)
 
         for path, item, user in zip(paths, self.items, users):
-            resp = self.request(path='/resource/stat',
+            resp = self.request(path='/resource/lookup',
                                 method='GET', user=user,
                                 params={'path': path})
 

--- a/tests/cases/resource_test.py
+++ b/tests/cases/resource_test.py
@@ -427,6 +427,13 @@ class ResourceTestCase(base.TestCase):
             self.assertEqual(
                 str(resp.json['_id']), str(item['_id']))
 
+        # test bogus path
+        resp = self.request(path='/resource/lookup',
+                            method='GET', user=self.user,
+                            params={'path': '/bogus/path'})
+        self.assertStatus(resp, 400)
+
+
     def testMove(self):
         self._createFiles()
         # Move item1 from the public to the private folder

--- a/tests/cases/resource_test.py
+++ b/tests/cases/resource_test.py
@@ -377,8 +377,8 @@ class ResourceTestCase(base.TestCase):
         resp = self.request(path='/resource/stat',
                             method='GET', user=self.admin,
                             params={'path':
-                                '/collection/Test Collection/' +
-                                self.collectionPrivateFolder['name']})
+                                    '/collection/Test Collection/' +
+                                    self.collectionPrivateFolder['name']})
         self.assertStatusOk(resp)
         self.assertEqual(str(resp.json['_id']),
                          str(self.collectionPrivateFolder['_id']))
@@ -405,13 +405,12 @@ class ResourceTestCase(base.TestCase):
             str(resp.json['_id']), str(self.adminSubFolder['_id']))
 
         # test items
+        privateFolder = self.collectionPrivateFolder['name']
         paths = ('/user/goodlogin/Public/Item 1',
                  '/user/goodlogin/Public/Item 2',
                  '/user/goodlogin/Public/Folder 1/Item 3',
-                 '/collection/Test Collection/%s/Item 4' %
-                     self.collectionPrivateFolder['name'],
-                 '/collection/Test Collection/%s/Item 5' %
-                     self.collectionPrivateFolder['name'])
+                 '/collection/Test Collection/%s/Item 4' % privateFolder,
+                 '/collection/Test Collection/%s/Item 5' % privateFolder)
 
         users = (self.user,
                  self.user,


### PR DESCRIPTION
Adds a new stat route under `/resource`.

Accepts a `path` query parameter that is a "girder path" and responds with the `user`, `collection`, `folder`, `item`, or `file` resource identified by `path`.