### PR TITLE
add several new style rules to the flake8 config file ignored set

### DIFF
--- a/tests/cases/rest_decorator_test.py
+++ b/tests/cases/rest_decorator_test.py
@@ -39,7 +39,7 @@ def tearDownModule():
     base.stopServer()
 
 
-class testEndpointDecoratorException(base.TestCase):
+class TestEndpointDecoratorException(base.TestCase):
     'Tests the endpoint decorator exception handling'
 
     @endpoint

--- a/tests/flake8.cfg
+++ b/tests/flake8.cfg
@@ -9,25 +9,49 @@ max-complexity: 14
 format: pylint
 exclude: girder/external/*
 # Ignore certain errors.
+#
 #   If an ignore line is not specified, the pep8 module defaults to
-# E123,E133,E226,E241,E242.  We didn't have any E133 or E242 errors, so don't
-# ignore those.  The errors we suppress are:
-#  E123 - closing bracket does not match indentation of opening bracket's line
-#  E226 - missing whitespace around arithmetic operator
-#  E241 - multiple spaces after ,
+#     E123,E133,E226,E241,E242.
+#   We didn't have any E133 or E242 errors, so don't ignore those.
+#
+# The errors we suppress are:
+#   Whitespace errors
+#   ~~~~~~~~~~~~~~~~~
+#     E123 - closing bracket does not match indentation of opening bracket's
+#            line
+#     E226 - missing whitespace around arithmetic operator
+#     E241 - multiple spaces after ","
+#
+#   Docstring errors
+#   ~~~~~~~~~~~~~~~~
 #   By including the flake8-docstrings module, we also will fail on PEP257
-# errors (D...).  For the moment, supress all of the D... errors that would
-# cause us to fail.  We may want to revisit this to make out code more PEP257
-# conformant.
-#  D10{0,1,2,3} - Public {module,class,method,function} docstring missing.
-#  D200 - One-line docstrings should fit on one line with quotes.
-#  D20{1,2} - No blank lines allowed {before,after} docstring.
-#  D20{3,4} - 1 blank required {before,after} class docstring.
-#  D205 - Blank line required between one-line summary and description.
-#  D208 - Docstring over-indented.
-#  D209 - Put multi-line docstring closing quotes on separate line.
-#  D300 - Use """triple double quotes""".
-#  D400 - First line should end with a period.
-#  D401 - First line should be in imperative mood.
-#  D402 - First line should not be the function's "signature".
+#   errors (D...).  For the moment, supress all of the D... errors that would
+#   cause us to fail.  We may want to revisit this to make out code more PEP257
+#   conformant.
+#     D100 - Public module   (100) docstring missing.
+#     D101 - Public class    (101) docstring missing.
+#     D102 - Public method   (102) docstring missing.
+#     D103 - Public function (103) docstring missing.
+#     D200 - One-line docstrings should fit on one line with quotes.
+#     D201 - No blank lines allowed before (201) docstring.
+#     D202 - No blank lines allowed after  (202) docstring.
+#     D203 - 1 blank required before (203) class docstring.
+#     D204 - 1 blank required after  (204) class docstring.
+#     D205 - Blank line required between one-line summary and description.
+#     D208 - Docstring over-indented.
+#     D209 - Put multi-line docstring closing quotes on separate line.
+#     D300 - Use """triple double quotes""".
+#     D400 - First line should end with a period.
+#     D401 - First line should be in imperative mood.
+#     D402 - First line should not be the function's "signature".
+#
+#   Identifier errors
+#   ~~~~~~~~~~~~~~~~~
+#   TODO(opadron) we should have an explanation of why we break away from normal
+#   Python naming conventions.  Is this a case of the prevailing style argument
+#   made in pep8?  If so, exactly who's style is prevailing?
+#     N802 - Function name should be lowercase.
+#     N803 - Argument name should be lowercase.
+#     N806 - Variable in function should be lowercase.
+#     N812 - Lowercase imported as non lowercase.
 ignore: D100,D101,D102,D103,D200,D201,D202,D203,D204,D205,D208,D209,D300,D400,D401,D402,E123,E226,E241,N802,N803,N806,N812

--- a/tests/flake8.cfg
+++ b/tests/flake8.cfg
@@ -30,4 +30,4 @@ exclude: girder/external/*
 #  D400 - First line should end with a period.
 #  D401 - First line should be in imperative mood.
 #  D402 - First line should not be the function's "signature".
-ignore: D100,D101,D102,D103,D200,D201,D202,D203,D204,D205,D208,D209,D300,D400,D401,D402,E123,E226,E241
+ignore: D100,D101,D102,D103,D200,D201,D202,D203,D204,D205,D208,D209,D300,D400,D401,D402,E123,E226,E241,N802,N803,N806,N812


### PR DESCRIPTION
Adds new rules from the [pep8-naming](https://github.com/flintwork/pep8-naming) plugin to the flake8 config file ignored set.

New rules to be ignored:
 - N802 function name should be lowercase
 - N803 argument name should be lowercase
 - N806 variable in function should be lowercase
 - N812 lowercase imported as non lowercase