### PR TITLE
Support range downloading

### DIFF
--- a/clients/web/src/views/body/AssetstoresView.js
+++ b/clients/web/src/views/body/AssetstoresView.js
@@ -104,7 +104,13 @@ girder.views.AssetstoresView = girder.View.extend({
                 timeout: 4000
             });
             this.collection.fetch({}, true);
-        }, this).save();
+        }, this).off('g:error').on('g:error', function (err) {
+            girder.events.trigger('g:alert', {
+                icon: 'cancel',
+                text: err.responseJSON.message,
+                type: 'danger'
+            });
+        }).save();
     },
 
     deleteAssetstore: function (evt) {

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -294,11 +294,16 @@ def endpoint(fun):
         try:
             val = fun(self, args, kwargs)
 
+            # If this is a partial response, we set the status appropriately
+            if 'Content-Range' in cherrypy.response.headers:
+                cherrypy.response.status = 206
+
             if isinstance(val, types.FunctionType):
                 # If the endpoint returned a function, we assume it's a
                 # generator function for a streaming response.
                 cherrypy.response.stream = True
                 return val()
+
             if isinstance(val, cherrypy.lib.file_generator):
                 # Don't do any post-processing of static files
                 return val

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -212,14 +212,32 @@ class File(Resource):
         Defers to the underlying assetstore adapter to stream a file out.
         Requires read permission on the folder that contains the file's item.
         """
-        offset = int(params.get('offset', 0))
-        return self.model('file').download(file, offset)
+        rangeHeader = cherrypy.lib.httputil.get_ranges(
+            cherrypy.request.headers.get('Range'), file.get('size', 0))
+
+        # The HTTP Range header takes precedence over query params
+        if rangeHeader and len(rangeHeader):
+            # Currently we only support a single range.
+            offset, endByte = rangeHeader[0]
+        else:
+            offset = int(params.get('offset', 0))
+            endByte = params.get('endByte')
+
+            if endByte is not None:
+                endByte = int(endByte)
+
+        return self.model('file').download(file, offset, endByte=endByte)
     download.cookieAuth = True
     download.description = (
         Description('Download a file.')
+        .notes('This endpoint also accepts the HTTP "Range" header for partial '
+               'file downloads.')
         .param('id', 'The ID of the file.', paramType='path')
         .param('offset', 'Start downloading at this offset in bytes within '
                'the file.', dataType='integer', required=False)
+        .param('endByte', 'If you only wish to download part of the file, '
+               'pass this as the index of the last byte to download.',
+               dataType='integer', required=False)
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied on the parent folder.', 403))
 

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -236,8 +236,11 @@ class File(Resource):
         .param('offset', 'Start downloading at this offset in bytes within '
                'the file.', dataType='integer', required=False)
         .param('endByte', 'If you only wish to download part of the file, '
-               'pass this as the index of the last byte to download.',
-               dataType='integer', required=False)
+               'pass this as the index of the last byte to download. Unlike '
+               'the HTTP Range header, the endByte parameter is non-inclusive, '
+               'so you should set it to the index of the byte one past the '
+               'final byte you wish to recieve.', dataType='integer',
+               required=False)
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied on the parent folder.', 403))
 

--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -61,16 +61,24 @@ class File(acl_mixin.AccessControlMixin, Model):
 
         Model.remove(self, file)
 
-    def download(self, file, offset=0, headers=True):
+    def download(self, file, offset=0, headers=True, endByte=None):
         """
         Use the appropriate assetstore adapter for whatever assetstore the
         file is stored in, and call downloadFile on it. If the file is a link
         file rather than a file in an assetstore, we redirect to it.
+
+        :param file: The file to download.
+        :param offset: The start byte within the file.
+        :type offset: int
+        :param headers: Whether to set headers (i.e. is this an HTTP request
+            for a single file, or something else).
+        :type headers: bool
         """
         if file.get('assetstoreId'):
             assetstore = self.model('assetstore').load(file['assetstoreId'])
             adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
-            return adapter.downloadFile(file, offset=offset, headers=headers)
+            return adapter.downloadFile(
+                file, offset=offset, headers=headers, endByte=endByte)
         elif file.get('linkUrl'):
             if headers:
                 raise cherrypy.HTTPRedirect(file['linkUrl'])

--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -14,6 +14,7 @@
 #  limitations under the License.
 ###############################################################################
 
+import cherrypy
 import os
 import six
 
@@ -123,7 +124,7 @@ class AbstractAssetstoreAdapter(ModelImporter):
         raise Exception('Must override deleteFile in %s.'
                         % self.__class__.__name__)  # pragma: no cover
 
-    def downloadFile(self, file, offset=0, headers=True):
+    def downloadFile(self, file, offset=0, headers=True, endByte=None):
         """
         This method is in charge of returning a value to the RESTful endpoint
         that can be used to download the file. This can return a generator
@@ -136,6 +137,9 @@ class AbstractAssetstoreAdapter(ModelImporter):
         :type offset: int
         :param headers: Flag for whether headers should be sent on the response.
         :type headers: bool
+        :param endByte: Final byte to download. If ``None``, downloads to the
+            end of the file.
+        :type endByte: int or None
         """
         raise Exception('Must override downloadFile in %s.'
                         % self.__class__.__name__)  # pragma: no cover
@@ -171,6 +175,27 @@ class AbstractAssetstoreAdapter(ModelImporter):
             return len(chunk.encode('utf8'))
         else:
             return len(chunk)
+
+    def setContentHeaders(self, file, offset, endByte):
+        """
+        Sets the Content-Length, Content-Disposition, Content-Type, and also
+        the Content-Range header if this is a partial download.
+
+        :param file: The file being downloaded.
+        :param offset: The start byte of the download.
+        :type offset: int
+        :param endByte: The end byte of the download (non-inclusive).
+        :type endByte: int
+        """
+        cherrypy.response.headers['Content-Type'] = \
+            file.get('mimeType') or 'application/octet-stream'
+        cherrypy.response.headers['Content-Disposition'] = \
+            'attachment; filename="%s"' % file['name']
+        cherrypy.response.headers['Content-Length'] = endByte - offset
+
+        if offset or endByte < file['size']:
+            cherrypy.response.headers['Content-Range'] = 'bytes %d-%d/%d' % (
+                offset, endByte - 1, file['size'])
 
     def checkUploadSize(self, upload, chunkSize):
         """Check if the upload is valid based on the chunk size.  If this

--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -191,9 +191,9 @@ class AbstractAssetstoreAdapter(ModelImporter):
             file.get('mimeType') or 'application/octet-stream'
         cherrypy.response.headers['Content-Disposition'] = \
             'attachment; filename="%s"' % file['name']
-        cherrypy.response.headers['Content-Length'] = endByte - offset
+        cherrypy.response.headers['Content-Length'] = max(endByte - offset, 0)
 
-        if offset or endByte < file['size']:
+        if (offset or endByte < file['size']) and file['size']:
             cherrypy.response.headers['Content-Range'] = 'bytes %d-%d/%d' % (
                 offset, endByte - 1, file['size'])
 

--- a/girder/utility/filesystem_assetstore_adapter.py
+++ b/girder/utility/filesystem_assetstore_adapter.py
@@ -232,6 +232,9 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
 
                 while True:
                     readLen = min(BUF_SIZE, endByte - bytesRead)
+                    if readLen <= 0:
+                        break
+
                     data = f.read(readLen)
                     bytesRead += readLen
 

--- a/girder/utility/gridfs_assetstore_adapter.py
+++ b/girder/utility/gridfs_assetstore_adapter.py
@@ -232,7 +232,6 @@ class GridFsAssetstoreAdapter(AbstractAssetstoreAdapter):
             'n': {'$gte': n}
         }, fields=['data']).sort('n', pymongo.ASCENDING)
 
-
         def stream():
             co = chunkOffset  # Can't assign to outer scope without "nonlocal"
             position = offset

--- a/plugins/hdfs_assetstore/plugin_tests/assetstore_test.py
+++ b/plugins/hdfs_assetstore/plugin_tests/assetstore_test.py
@@ -302,7 +302,7 @@ class HdfsAssetstoreTest(base.TestCase):
         resp = self.request(path='/file/{}/download'.format(file['_id']),
                             user=self.admin, isJson=False,
                             additionalHeaders=[('Range', 'bytes=1-3')])
-        self.assertStatusOk(resp)
+        self.assertStatus(resp, 206)
         self.assertEqual('ell', self.getBody(resp))
         self.assertEqual(resp.headers['Accept-Ranges'], 'bytes')
         self.assertEqual(resp.headers['Content-Length'], 3)

--- a/plugins/hdfs_assetstore/plugin_tests/assetstore_test.py
+++ b/plugins/hdfs_assetstore/plugin_tests/assetstore_test.py
@@ -298,6 +298,16 @@ class HdfsAssetstoreTest(base.TestCase):
         self.assertStatusOk(resp)
         self.assertEqual(resp.collapse_body().strip(), 'hello')
 
+        # Test download with range header
+        resp = self.request(path='/file/{}/download'.format(file['_id']),
+                            user=self.admin, isJson=False,
+                            additionalHeaders=[('Range', 'bytes=1-3')])
+        self.assertStatusOk(resp)
+        self.assertEqual('ell', self.getBody(resp))
+        self.assertEqual(resp.headers['Accept-Ranges'], 'bytes')
+        self.assertEqual(resp.headers['Content-Length'], 3)
+        self.assertEqual(resp.headers['Content-Range'], 'bytes 1-3/6')
+
         helloTxtPath = os.path.join(_mockRoot, 'to_import', 'hello.txt')
 
         # Deleting an imported file should not delete the backing HDFS file

--- a/plugins/hdfs_assetstore/server/assetstore.py
+++ b/plugins/hdfs_assetstore/server/assetstore.py
@@ -142,7 +142,7 @@ class HdfsAssetstoreAdapter(AbstractAssetstoreAdapter):
                             chunkLen = endByte - position
                             shouldBreak = True
                         yield chunk[offset - position:chunkLen]
-                        position = offset
+                        position = offset + chunkLen - 1
                 else:
                     if position + chunkLen > endByte:
                         chunkLen = endByte - position

--- a/plugins/hdfs_assetstore/server/assetstore.py
+++ b/plugins/hdfs_assetstore/server/assetstore.py
@@ -133,6 +133,7 @@ class HdfsAssetstoreAdapter(AbstractAssetstoreAdapter):
             shouldBreak = False
             for chunk in fileStream:
                 chunkLen = len(chunk)
+
                 if position < offset:
                     if position + chunkLen <= offset:
                         position += chunkLen
@@ -147,6 +148,7 @@ class HdfsAssetstoreAdapter(AbstractAssetstoreAdapter):
                         chunkLen = endByte - position
                         shouldBreak = True
                     yield chunk[:chunkLen]
+                    position += chunkLen
 
                 if shouldBreak:
                     break

--- a/plugins/hdfs_assetstore/server/assetstore.py
+++ b/plugins/hdfs_assetstore/server/assetstore.py
@@ -135,20 +135,18 @@ class HdfsAssetstoreAdapter(AbstractAssetstoreAdapter):
                 chunkLen = len(chunk)
 
                 if position < offset:
-                    if position + chunkLen <= offset:
-                        position += chunkLen
-                    else:
+                    if position + chunkLen > offset:
                         if position + chunkLen > endByte:
                             chunkLen = endByte - position
                             shouldBreak = True
                         yield chunk[offset - position:chunkLen]
-                        position = offset + chunkLen - 1
                 else:
                     if position + chunkLen > endByte:
                         chunkLen = endByte - position
                         shouldBreak = True
                     yield chunk[:chunkLen]
-                    position += chunkLen
+
+                position += chunkLen
 
                 if shouldBreak:
                     break

--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -450,7 +450,7 @@ class AssetstoreTestCase(base.TestCase):
                             user=self.admin, method='GET', isJson=False)
         self.assertStatusOk(resp)
         self.assertEqual(self.getBody(resp), '')
-        self.assertEqual(resp.headers['Content-Length'], '0')
+        self.assertEqual(resp.headers['Content-Length'], 0)
         self.assertEqual(resp.headers['Content-Disposition'],
                          'attachment; filename="My File.txt"')
 

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -228,6 +228,21 @@ class FileTestCase(base.TestCase):
 
         self.assertEqual(contents[1:], self.getBody(resp))
 
+        # Test downloading with a range header
+        resp = self.request(path='/file/%s/download' % str(file['_id']),
+                            method='GET', user=self.user, isJson=False,
+                            additionalHeaders=[('Range', 'bytes=2-7')])
+        self.assertStatusOk(resp)
+        self.assertEqual(contents[2:8], self.getBody(resp))
+        self.assertEqual(resp.headers['Accept-Ranges'], 'bytes')
+        length = len(contents)
+        begin, end = min(length, 2), min(length, 8)
+        self.assertEqual(resp.headers['Content-Length'], end - begin)
+
+        if length:
+            rangeVal = 'bytes %d-%d/%d' % (begin, end - 1, len(contents))
+            self.assertEqual(resp.headers['Content-Range'], rangeVal)
+
         # Test downloading with a name
         resp = self.request(
             path='/file/%s/download/%s' % (

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -224,7 +224,7 @@ class FileTestCase(base.TestCase):
         resp = self.request(path='/file/%s/download' % str(file['_id']),
                             method='GET', user=self.user, isJson=False,
                             params={'offset': 1})
-        self.assertStatusOk(resp)
+        self.assertStatus(resp, 206)
 
         self.assertEqual(contents[1:], self.getBody(resp))
 
@@ -232,7 +232,6 @@ class FileTestCase(base.TestCase):
         resp = self.request(path='/file/%s/download' % str(file['_id']),
                             method='GET', user=self.user, isJson=False,
                             additionalHeaders=[('Range', 'bytes=2-7')])
-        self.assertStatusOk(resp)
         self.assertEqual(contents[2:8], self.getBody(resp))
         self.assertEqual(resp.headers['Accept-Ranges'], 'bytes')
         length = len(contents)
@@ -240,8 +239,12 @@ class FileTestCase(base.TestCase):
         self.assertEqual(resp.headers['Content-Length'], end - begin)
 
         if length:
+            self.assertStatus(resp, 206)
+
             rangeVal = 'bytes %d-%d/%d' % (begin, end - 1, len(contents))
             self.assertEqual(resp.headers['Content-Range'], rangeVal)
+        else:
+            self.assertStatusOk(resp)
 
         # Test downloading with a name
         resp = self.request(

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -224,7 +224,10 @@ class FileTestCase(base.TestCase):
         resp = self.request(path='/file/%s/download' % str(file['_id']),
                             method='GET', user=self.user, isJson=False,
                             params={'offset': 1})
-        self.assertStatus(resp, 206)
+        if file['size']:
+            self.assertStatus(resp, 206)
+        else:
+            self.assertStatusOk(resp)
 
         self.assertEqual(contents[1:], self.getBody(resp))
 
@@ -232,6 +235,27 @@ class FileTestCase(base.TestCase):
         resp = self.request(path='/file/%s/download' % str(file['_id']),
                             method='GET', user=self.user, isJson=False,
                             additionalHeaders=[('Range', 'bytes=2-7')])
+        self.assertEqual(contents[2:8], self.getBody(resp))
+        self.assertEqual(resp.headers['Accept-Ranges'], 'bytes')
+        length = len(contents)
+        begin, end = min(length, 2), min(length, 8)
+        self.assertEqual(resp.headers['Content-Length'], end - begin)
+
+        if length:
+            self.assertStatus(resp, 206)
+
+            rangeVal = 'bytes %d-%d/%d' % (begin, end - 1, len(contents))
+            self.assertEqual(resp.headers['Content-Range'], rangeVal)
+        else:
+            self.assertStatusOk(resp)
+
+        # Test downloading with query range params
+        resp = self.request(path='/file/%s/download' % str(file['_id']),
+                            method='GET', user=self.user, isJson=False,
+                            params={
+                                'offset': 2,
+                                'endByte': 8
+                            })
         self.assertEqual(contents[2:8], self.getBody(resp))
         self.assertEqual(resp.headers['Accept-Ranges'], 'bytes')
         length = len(contents)

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -250,12 +250,12 @@ class FileTestCase(base.TestCase):
             self.assertStatusOk(resp)
 
         # Test downloading with query range params
-        resp = self.request(path='/file/%s/download' % str(file['_id']),
-                            method='GET', user=self.user, isJson=False,
-                            params={
-                                'offset': 2,
-                                'endByte': 8
-                            })
+        resp = self.request(
+            path='/file/%s/download' % str(file['_id']), isJson=False,
+            method='GET', user=self.user, params={
+                'offset': 2,
+                'endByte': 8
+            })
         self.assertEqual(contents[2:8], self.getBody(resp))
         self.assertEqual(resp.headers['Accept-Ranges'], 'bytes')
         length = len(contents)

--- a/tests/cases/item_test.py
+++ b/tests/cases/item_test.py
@@ -121,7 +121,7 @@ class ItemTestCase(base.TestCase):
         resp = self.request(path='/item/{}/download'.format(item['_id']),
                             method='GET', user=user, isJson=False,
                             params={'offset': 1})
-        self.assertStatusOk(resp)
+        self.assertStatus(resp, 206)
 
         self.assertEqual(contents[1:], self.getBody(resp))
 


### PR DESCRIPTION
Downloading will now also support the HTTP Range header as an
alternate means of specifying byte ranges when downloading files.
This functionality is now implemented in both the filesystem and
gridfs assetstores. The others will follow shortly.