### PR TITLE
Add an option to disable JavaScript tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ option(PYTHON_STATIC_ANALYSIS "Run Python static analysis tests with flake8" ON)
 option(PYTHON_COVERAGE "Run tests with coverage.py" ON)
 option(PYTHON_BRANCH_COVERAGE "Use branch-level coverage instead of line-level" OFF)
 option(JAVASCRIPT_STYLE_TESTS "Run Javascript style tests with jslint" ON)
+option(BUILD_JAVASCRIPT_TESTS "Build Javascript tests" ON)
 
 if(PYTHON_COVERAGE)
   find_program(PYTHON_COVERAGE_EXECUTABLE coverage)

--- a/tests/JavascriptTests.cmake
+++ b/tests/JavascriptTests.cmake
@@ -1,6 +1,10 @@
 set(web_client_port 30001)
 
 function(javascript_tests_init)
+  if (NOT BUILD_JAVASCRIPT_TESTS)
+    return()
+  endif()
+
   add_test(
     NAME js_coverage_reset
     COMMAND "${PYTHON_EXECUTABLE}"
@@ -24,6 +28,10 @@ include(${PROJECT_SOURCE_DIR}/scripts/JsonConfigExpandRelpaths.cmake)
 include(${PROJECT_SOURCE_DIR}/scripts/JsonConfigMerge.cmake)
 
 function(add_javascript_style_test name input)
+  if (NOT BUILD_JAVASCRIPT_TESTS)
+    return()
+  endif()
+
   set(_args JSHINT_EXTRA_CONFIGS JSSTYLE_EXTRA_CONFIGS)
   cmake_parse_arguments(fn "${_options}" "${_args}" "${_multival_args}" ${ARGN})
 
@@ -101,6 +109,10 @@ function(add_web_client_test case specFile)
   #     needs exclusive access to.  Defaults to mongo and cherrypy.
   # TIMEOUT (seconds): An overall test timeout.
   # BASEURL (url): The base url to load for the test.
+  if (NOT BUILD_JAVASCRIPT_TESTS)
+    return()
+  endif()
+
   set(testname "web_client_${case}")
 
   set(_options NOCOVERAGE)


### PR DESCRIPTION
This adds the ability to disable JavaScript tests. I have a Girder ( server side only ) plugin and would like to run unit tests without having worry about npm javascript etc.