### PR TITLE
geospatial plugin client test does not import the plugin client code

### DIFF
--- a/plugins/geospatial/plugin.cmake
+++ b/plugins/geospatial/plugin.cmake
@@ -18,4 +18,4 @@ add_python_test(geospatial PLUGIN geospatial)
 add_python_style_test(python_static_analysis_geospatial
                       "${PROJECT_SOURCE_DIR}/plugins/geospatial/server")
 
-add_web_client_test(geospatial "${PROJECT_SOURCE_DIR}/plugins/geospatial/plugin_tests/geospatialSpec.js")
+add_web_client_test(geospatial "${PROJECT_SOURCE_DIR}/plugins/geospatial/plugin_tests/geospatialSpec.js" PLUGIN geospatial)

--- a/plugins/geospatial/plugin_tests/geospatialSpec.js
+++ b/plugins/geospatial/plugin_tests/geospatialSpec.js
@@ -1,4 +1,14 @@
 $(function () {
+    /* Include the built version of the our templates.  This means that grunt
+    * must be run to generate these before the test. */
+    girderTest.addCoveredScripts([
+        '/static/built/plugins/geospatial/templates.js',
+        '/plugins/geospatial/web_client/js/ItemWidget.js'
+    ]);
+    girderTest.importStylesheet(
+        '/static/built/plugins/geospatial/plugin.min.css'
+    );
+
     girder.events.trigger('g:appload.before');
     var app = new girder.App({
         el: 'body',
@@ -12,31 +22,6 @@ describe('a test for the geospatial plugin', function () {
                                                        'geospatial@girder.org',
                                                        'Geospatial', 'Plugin',
                                                        'fuprEsuxAth2S7ac'));
-
-    waits(1000);
-    it('enables the geospatial plugin', function () {
-        waitsFor(function () {
-            return $('a.g-nav-link[g-target="admin"]').length > 0;
-        }, 'admin console link to load');
-        runs(function () {
-            $('a.g-nav-link[g-target="admin"]').click();
-        });
-        waitsFor(function () {
-            return $('.g-plugins-config').length > 0;
-        }, 'the admin console to load');
-        runs(function () {
-            $('.g-plugins-config').click();
-        });
-        waitsFor(function () {
-            return $('input.g-plugin-switch[key="geospatial"]').length > 0;
-        }, 'the plugins page to load');
-        runs(function () {
-            $('input.g-plugin-switch[key="geospatial"]').click();
-        });
-        runs(function () {
-            expect($('input.g-plugin-switch[key="geospatial"]').bootstrapSwitch('state')).toBe(true);
-        });
-    });
 
     it('creates an item and displays the geospatial info widget', function () {
         waitsFor(function () {

--- a/plugins/geospatial/plugin_tests/geospatialSpec.js
+++ b/plugins/geospatial/plugin_tests/geospatialSpec.js
@@ -83,7 +83,7 @@ describe('a test for the geospatial plugin', function () {
             return $('.g-item-name:contains(Geospatial Item)').length === 1;
         }, 'the item page to load');
         runs(function () {
-            expect($('.g-item-geospatial').length > 0);
+            expect($('.g-item-geospatial').length > 0).toBe(true);
         });
     });
 });

--- a/tests/JavascriptTests.cmake
+++ b/tests/JavascriptTests.cmake
@@ -93,7 +93,7 @@ endfunction()
 
 function(add_web_client_test case specFile)
   # test a web client using a spec file and the specRunner
-  # :param case: the nane of this test case
+  # :param case: the name of this test case
   # :param specFile: the path of the spec file to run
   # Optional parameters:
   # PLUGIN (name of plugin) : this plugin is loaded (unless overridden with


### PR DESCRIPTION
The current geospatialSpec does not actually test that the plugin client code is loaded.  This PR first adds a test which now correctly fails.  A fix will follow.