### PR TITLE
Fixing heroku buildpacks.

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
 https://github.com/heroku/heroku-buildpack-nodejs.git
-https://github.com/girder/heroku-buildpack-python-libffi.git
+https://github.com/heroku/heroku-buildpack-python.git


### PR DESCRIPTION
Turns out the default python buildpack supports libffi now.