### PR TITLE
Make debug-js beautiful.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,7 +36,10 @@ module.exports = function (grunt) {
 
     if (debugJs) {
         console.log('Building JS in debug mode'.yellow);
-        uglifyOptions.beautify = false;
+        uglifyOptions.beautify = {
+            beautify: true,
+            ascii_only: true
+        };
         uglifyOptions.mangle = false;
         uglifyOptions.compress = false;
     } else {


### PR DESCRIPTION
When the --debug-js option is specified with Grunt, beautify the results, but keep them ASCII.