### PR TITLE
Fixes #925. Read-only s3 assetstores shouldn't query untracked uploads

### DIFF
--- a/girder/models/assetstore.py
+++ b/girder/models/assetstore.py
@@ -79,7 +79,7 @@ class Assetstore(Model):
         # delete partial uploads before we delete the store.
         adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
         try:
-            adapter.untrackedUploads([], 'delete')
+            adapter.untrackedUploads([], delete=True)
         except ValidationException:
             # this assetstore is currently unreachable, so skip this step
             pass

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -435,7 +435,7 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
                     getParams['upload_id_marker'] = \
                         multipartUploads.next_upload_id_marker
 
-    def untrackedUploads(self, knownUploads=[], delete=False):
+    def untrackedUploads(self, knownUploads=None, delete=False):
         """
         List and optionally discard uploads that are in the assetstore but not
         in the known list.
@@ -446,10 +446,16 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
         :type delete: bool
         :returns: a list of unknown uploads.
         """
+        if self.assetstore.get('readOnly'):
+            return []
+
         untrackedList = []
         prefix = self.assetstore.get('prefix', '')
         if prefix:
             prefix += '/'
+
+        if knownUploads is None:
+            knownUploads = []
 
         bucket = self._getBucket()
         if not bucket:


### PR DESCRIPTION
@kotfic PTAL. I reproduced what you were seeing with the nasanex bucket in readonly mode, and with this change was able to delete it.