### PR TITLE
Small utility for getting info from the current URL

### DIFF
--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -35,7 +35,12 @@ from girder.models.model_base import AccessException, GirderException, \
     ValidationException
 from girder.utility.model_importer import ModelImporter
 from girder.utility import config
-from six.moves import range
+from six.moves import range, urllib
+
+
+def getUrlParts(url=None):
+    url = url or cherrypy.url()
+    return urllib.parse.urlparse(url)
 
 
 def getApiUrl(url=None):

--- a/tests/cases/rest_util_test.py
+++ b/tests/cases/rest_util_test.py
@@ -56,5 +56,13 @@ class RestUtilTestCase(unittest.TestCase):
         url = 'https://localhost/thing/api/v1/hello/world?foo=bar#test'
         self.assertEqual(rest.getApiUrl(url), 'https://localhost/thing/api/v1')
 
+        parts = rest.getUrlParts(url)
+        self.assertEqual(parts.path, '/thing/api/v1/hello/world')
+        self.assertEqual(rest.getApiUrl(parts.path), '/thing/api/v1')
+        self.assertEqual(parts.port, None)
+        self.assertEqual(parts.hostname, 'localhost')
+        self.assertEqual(parts.query, 'foo=bar')
+        self.assertEqual(parts.fragment, 'test')
+
         url = 'https://localhost/girder#users'
         self.assertRaises(Exception, rest.getApiUrl, url=url)


### PR DESCRIPTION
This is useful for plugins that need to send jobs to romanesco that
use girder IO mode, since they have to specify the girder location
via multiple fields.