### PR TITLE
Lookup resource by name

### DIFF
--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -122,6 +122,29 @@ class Description(object):
         self._params.append(param)
         return self
 
+    def pagingParams(self, defaultSort, defaultSortDir=1, defaultLimit=50):
+        """
+        Adds the limit, offset, sort, and sortdir parameter documentation to
+        this route handler.
+
+        :param defaultSort: The default field used to sort the result set.
+        :type defaultSort: str
+        :param defaultSortDir: Sort order: -1 or 1 (desc or asc)
+        :type defaultSortDir: int
+        :param defaultLimit: The default page size.
+        :type defaultLimit: int
+        """
+        self.param('limit', 'Result set size limit.', default=defaultLimit,
+                   required=False, dataType='int')
+        self.param('offset', 'Offset into result set.', default=0,
+                   required=False, dataType='int')
+        self.param('sort', 'Field to sort the result set by.',
+                   default=defaultSort, required=False)
+        self.param('sortdir', 'Sort order: 1 for ascending, -1 for descending.',
+                   required=False, dataType='int', enum=(1, -1),
+                   default=defaultSortDir)
+        return self
+
     def consumes(self, value):
         self._consumes.append(value)
         return self

--- a/girder/api/v1/assetstore.py
+++ b/girder/api/v1/assetstore.py
@@ -65,14 +65,7 @@ class Assetstore(Resource):
             offset=offset, limit=limit, sort=sort))
     find.description = (
         Description('List assetstores.')
-        .param('limit', "Result set size limit.", required=False,
-               dataType='integer', default=50)
-        .param('offset', "Offset into result set.", required=False,
-               dataType='integer', default=0)
-        .param('sort', "Field to sort the assetstore list by.",
-               required=False, default='name')
-        .param('sortdir', "1 for ascending, -1 for descending.",
-               required=False, dataType='integer', default=1)
+        .pagingParams(defaultSort='name')
         .errorResponse()
         .errorResponse('You are not an administrator.', 403))
 

--- a/girder/api/v1/collection.py
+++ b/girder/api/v1/collection.py
@@ -60,14 +60,7 @@ class Collection(Resource):
         .responseClass('Collection')
         .param('text', "Pass this to perform a text search for collections.",
                required=False)
-        .param('limit', "Result set size limit.", required=False,
-               dataType='int', default=50)
-        .param('offset', "Offset into result set.", required=False,
-               dataType='int', default=0)
-        .param('sort', "Field to sort the result list by.",
-               required=False, default='name')
-        .param('sortdir', "1 for ascending, -1 for descending.",
-               required=False, dataType='int', default=1))
+        .pagingParams(defaultSort='name'))
 
     @access.user
     def createCollection(self, params):

--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -77,10 +77,12 @@ class Folder(Resource):
                 exc=True)
 
             filters = {}
-            if 'text' in params:
+            if params.get('text'):
                 filters['$text'] = {
                     '$search': params['text']
                 }
+            if params.get('name'):
+                filters['name'] = params['name']
 
             return [self.model('folder').filter(folder, user) for folder in
                     self.model('folder').childFolders(
@@ -100,6 +102,9 @@ class Folder(Resource):
                enum=['folder', 'user', 'collection'])
         .param('parentId', "The ID of the folder's parent.", required=False)
         .param('text', 'Pass to perform a text search.', required=False)
+        .param('name', 'Pass to lookup a folder by exact name match. Must '
+               'pass parentType and parentId as well when using this.',
+               required=False)
         .param('limit', "Result set size limit.", required=False,
                dataType='int', default=50)
         .param('offset', "Offset into result set.", required=False,

--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -50,18 +50,12 @@ class Folder(Resource):
         Get a list of folders with given search parameters. Currently accepted
         search modes are:
 
-        1. Searching by parentId and parentType.
-        2. Searching with full text search.
-
-        To search with full text search, pass the "text" parameter. To search
-        by parent, (i.e. list child folders) pass parentId and parentType,
-        which must be one of ('folder' | 'collection' | 'user'). You can also
-        pass limit, offset, sort, and sortdir parameters.
-
-        :param limit: The result set size limit, default=50.
-        :param offset: Offset into the results, default=0.
-        :param sort: The field to sort by, default=lowerName.
-        :param sortdir: 1 for ascending, -1 for descending, default=1.
+        1. Searching by parentId and parentType, with optional additional
+           filtering by the name field (exact match) or using full text search
+           within a single parent folder. Pass a "name" parameter or "text"
+           parameter to invoke these additional filters.
+        2. Searching with full text search across all folders in the system.
+           Simply pass a "text" parameter for this mode.
         """
         limit, offset, sort = self.getPagingParameters(params, 'lowerName')
         user = self.getCurrentUser()

--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -105,14 +105,7 @@ class Folder(Resource):
         .param('name', 'Pass to lookup a folder by exact name match. Must '
                'pass parentType and parentId as well when using this.',
                required=False)
-        .param('limit', "Result set size limit.", required=False,
-               dataType='int', default=50)
-        .param('offset', "Offset into result set.", required=False,
-               dataType='int', default=0)
-        .param('sort', "Field to sort the folder list by.",
-               required=False, default='name')
-        .param('sortdir', "1 for ascending, -1 for descending.",
-               required=False, dataType='int', default=1)
+        .pagingParams(defaultSort='name')
         .errorResponse()
         .errorResponse('Read access was denied on the parent resource.', 403))
 

--- a/girder/api/v1/group.py
+++ b/girder/api/v1/group.py
@@ -74,14 +74,7 @@ class Group(Resource):
         Description('Search for groups or list all groups.')
         .param('text', "Pass this to perform a full-text search for groups.",
                required=False)
-        .param('limit', "Result set size limit.", required=False,
-               dataType='int', default=50)
-        .param('offset', "Offset into result set.", required=False,
-               dataType='int', default=0)
-        .param('sort', "Field to sort the group list by.",
-               required=False, default='name')
-        .param('sortdir', "1 for ascending, -1 for descending.",
-               required=False, dataType='int', default=1)
+        .pagingParams(defaultSort='name')
         .param('exact', 'If true, only return exact name matches. This is '
                'case sensitive.', required=False, dataType='boolean',
                default=False)
@@ -157,14 +150,7 @@ class Group(Resource):
         Description('Show outstanding invitations for a group.')
         .responseClass('Group')
         .param('id', 'The ID of the group.', paramType='path')
-        .param('limit', "Result set size limit.", required=False,
-               dataType='int', default=50)
-        .param('offset', "Offset into result set.", required=False,
-               dataType='int', default=0)
-        .param('sort', "Field to sort the invitee list by.",
-               required=False, default='lastName')
-        .param('sortdir', "1 for ascending, -1 for descending.",
-               required=False, dataType='int', default=1)
+        .pagingParams(defaultSort='lastName')
         .errorResponse()
         .errorResponse('Read access was denied for the group.', 403))
 
@@ -240,14 +226,7 @@ class Group(Resource):
     listMembers.description = (
         Description('List members of a group.')
         .param('id', 'The ID of the group.', paramType='path')
-        .param('limit', "Result set size limit.", required=False, default=50,
-               dataType='int')
-        .param('offset', "Offset into result set.", required=False, default=0,
-               dataType='int')
-        .param('sort', "Field to sort the member list by.", default='lastName',
-               required=False)
-        .param('sortdir', "1 for ascending, -1 for descending.", default=1,
-               required=False, dataType='int')
+        .pagingParams(defaultSort='lastName')
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the group.', 403))
 

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -95,14 +95,7 @@ class Item(Resource):
                required=False)
         .param('name', 'Pass to lookup an item by exact name match. Must '
                'pass folderId as well when using this.', required=False)
-        .param('limit', "Result set size limit.", default=50,
-               required=False, dataType='int')
-        .param('offset', "Offset into result set.", default=0, required=False,
-               dataType='int')
-        .param('sort', "Field to sort the item list by.", default='lowerName',
-               required=False)
-        .param('sortdir', "1 for ascending, -1 for descending", default=1,
-               required=False, dataType='int')
+        .pagingParams(defaultSort='lowerName')
         .errorResponse()
         .errorResponse('Read access was denied on the parent folder.', 403))
 
@@ -230,14 +223,7 @@ class Item(Resource):
         Description('Get the files within an item.')
         .responseClass('File')
         .param('id', 'The ID of the item.', paramType='path')
-        .param('limit', "Result set size limit.", required=False, default=50,
-               dataType='int')
-        .param('offset', "Offset into result set.", required=False, default=0,
-               dataType='int')
-        .param('sort', "Field to sort the result list by.", default='name',
-               required=False)
-        .param('sortdir', "1 for ascending, -1 for descending", default=1,
-               required=False, dataType='int')
+        .pagingParams(defaultSort='name')
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403))
 

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -68,10 +68,13 @@ class Item(Resource):
             folder = self.model('folder').load(id=params['folderId'], user=user,
                                                level=AccessType.READ, exc=True)
             filters = {}
-            if 'text' in params:
+            if params.get('text'):
                 filters['$text'] = {
                     '$search': params['text']
                 }
+            if params.get('name'):
+                filters['name'] = params['name']
+
             return [self.model('item').filter(item, user) for item in
                     self.model('folder').childItems(
                         folder=folder, limit=limit, offset=offset, sort=sort,
@@ -90,6 +93,8 @@ class Item(Resource):
                required=False)
         .param('text', "Pass this to perform a full text search for items.",
                required=False)
+        .param('name', 'Pass to lookup an item by exact name match. Must '
+               'pass folderId as well when using this.', required=False)
         .param('limit', "Result set size limit.", default=50,
                required=False, dataType='int')
         .param('offset', "Offset into result set.", default=0, required=False,

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -47,19 +47,12 @@ class Item(Resource):
         Get a list of items with given search parameters. Currently accepted
         search modes are:
 
-        1. Searching by folderId.
-        2. Searching with full text search.
-
-        To search with full text search, pass the "text" parameter. To search
-        by parent, (i.e. list child items in a folder) pass folderId. You can
-        also pass limit, offset, sort, and sortdir parameters.
-
-        :param text: Pass this to perform a full-text search of items.
-        :param folderId: Get child items of a particular folder.
-        :param limit: The result set size limit, default=50.
-        :param offset: Offset into the results, default=0.
-        :param sort: The field to sort by, default=lowerName.
-        :param sortdir: 1 for ascending, -1 for descending, default=1.
+        1. Searching by folderId, with optional additional filtering by the name
+           field (exact match) or using full text search within a single parent
+           folder. Pass a "name" parameter or "text" parameter to invoke these
+           additional filters.
+        2. Searching with full text search across all items in the system.
+           Simply pass a "text" parameter for this mode.
         """
         limit, offset, sort = self.getPagingParameters(params, 'lowerName')
         user = self.getCurrentUser()

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -65,14 +65,7 @@ class User(Resource):
         .responseClass('User')
         .param('text', "Pass this to perform a full text search for items.",
                required=False)
-        .param('limit', "Result set size limit.", required=False, default=50,
-               dataType='int')
-        .param('offset', "Offset into result set.", required=False, default=0,
-               dataType='int')
-        .param('sort', "Field to sort the user list by.", default='lastName',
-               required=False)
-        .param('sortdir', "1 for ascending, -1 for descending.", default=1,
-               required=False, dataType='int'))
+        .pagingParams(defaultSort='lastName'))
 
     @access.public
     @loadmodel(map={'id': 'userToGet'}, model='user', level=AccessType.READ)

--- a/plugins/jobs/server/job_rest.py
+++ b/plugins/jobs/server/job_rest.py
@@ -59,14 +59,7 @@ class Job(Resource):
                'not passed or empty, will use the currently logged in user. If '
                'set to "None", will list all jobs that do not have an owning '
                'user.', required=False)
-        .param('limit', "Result set size limit (default=50).", required=False,
-               dataType='int')
-        .param('offset', "Offset into result set (default=0).", required=False,
-               dataType='int')
-        .param('sort', "Field to sort the result list by (default=created)",
-               required=False)
-        .param('sortdir', "1 for ascending, -1 for descending (default=-1)",
-               required=False, dataType='int'))
+        .pagingParams(defaultSort='created', defaultSortDir=pymongo.DESCENDING))
 
     @access.public
     @loadmodel(model='job', plugin='jobs', level=AccessType.READ)

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -195,3 +195,18 @@ class PythonClientTestCase(base.TestCase):
         self.assertEqual(item_count, callback_counts['item'])
         self.assertTrue(all(items.values()))
         self.assertTrue(all(folders.values()))
+
+        # Upload again with reuse_existing on
+        existingList = list(self.model('folder').childFolders(
+            parentType='folder', parent=callbackPublicFolder,
+            user=callbackUser, limit=0))
+        client.upload(self.libTestDir, callbackPublicFolder['_id'],
+                      reuse_existing=True)
+        newList = list(self.model('folder').childFolders(
+            parentType='folder', parent=callbackPublicFolder,
+            user=callbackUser, limit=0))
+        self.assertEqual(existingList, newList)
+        self.assertEqual(len(newList), 1)
+        self.assertEqual([f['name'] for f in self.model('folder').childFolders(
+            parentType='folder', parent=newList[0],
+            user=callbackUser, limit=0)], ['sub0', 'sub1', 'sub2'])


### PR DESCRIPTION
For once, I actually managed to keep my commits logically isolated.

* **1st commit**: adds new search modes for items and folders allowing them to be looked up directly by name and parent ID, which makes it much easier to externally query for the existence of a resource at a given path when the parent ID is known.

* **2nd commit**: some refactoring to reduce code duplication in our swagger descriptions.

* **3rd commit**: move some private methods in girder client into the public API and tweak them a little for consistency. These use the new lookup mode. Also added tests that exercise all this new functionality.