### PR TITLE
Create User documents with an empty "groups" property

### DIFF
--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -240,6 +240,7 @@ class User(AccessControlledModel):
             'emailVerified': False,
             'admin': admin,
             'size': 0,
+            'groups': [],
             'groupInvites': []
         }
 


### PR DESCRIPTION
This makes User documents more consistent and can simplify a number of operations in the Group model.

For now, the Group model still can't assume that a User has a "groups" property, since existing databases aren't migrated.