### PR TITLE
Change all dictionary accesses to use view objects

### DIFF
--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -342,7 +342,7 @@ class Describe(Resource):
                 'operations': sorted(
                     op, key=functools.cmp_to_key(self._compareOperations))
                 } for route, op in sorted(
-                    six.iteritems(docs.routes[resource]),
+                    six.viewitems(docs.routes[resource]),
                     key=functools.cmp_to_key(self._compareRoutes))
             ]
         }

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -230,7 +230,7 @@ class loadmodel(object):
     def __call__(self, fun):
         @six.wraps(fun)
         def wrapped(*args, **kwargs):
-            for raw, converted in six.iteritems(self.map):
+            for raw, converted in six.viewitems(self.map):
                 id = self._getIdValue(kwargs, raw)
 
                 if self.force:

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -613,7 +613,7 @@ class Folder(AccessControlledModel):
             for (filepath, file) in self.model('item').fileList(
                     item, user, path, includeMetadata):
                 yield (filepath, file)
-        if includeMetadata and metadataFile and len(doc.get('meta', {})):
+        if includeMetadata and metadataFile and doc.get('meta', {}):
             def stream():
                 yield json.dumps(doc['meta'], default=str)
             yield (os.path.join(path, metadataFile), stream)

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -177,11 +177,11 @@ class Folder(AccessControlledModel):
             folder['meta'] = {}
 
         # Add new metadata to existing metadata
-        folder['meta'].update(six.iteritems(metadata))
+        folder['meta'].update(six.viewitems(metadata))
 
         # Remove metadata fields that were set to null (use items in py3)
         folder['meta'] = {k: v
-                          for k, v in six.iteritems(folder['meta'])
+                          for k, v in six.viewitems(folder['meta'])
                           if v is not None}
 
         folder['updated'] = datetime.datetime.utcnow()

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -418,7 +418,7 @@ class Item(acl_mixin.AccessControlMixin, Model):
         if subpath:
             files = list(self.childFiles(item=doc, limit=2))
             if (len(files) != 1 or files[0]['name'] != doc['name'] or
-                    (includeMetadata and len(doc.get('meta', {})))):
+                    (includeMetadata and doc.get('meta', {}))):
                 path = os.path.join(path, doc['name'])
         metadataFile = "girder-item-metadata.json"
         for file in self.childFiles(item=doc):

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -321,10 +321,10 @@ class Item(acl_mixin.AccessControlMixin, Model):
             item['meta'] = {}
 
         # Add new metadata to existing metadata
-        item['meta'].update(metadata.items())
+        item['meta'].update(six.viewitems(metadata))
 
         # Remove metadata fields that were set to null (use items in py3)
-        toDelete = [k for k, v in six.iteritems(item['meta']) if v is None]
+        toDelete = [k for k, v in six.viewitems(item['meta']) if v is None]
         for key in toDelete:
             del item['meta'][key]
 

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -416,7 +416,7 @@ class Item(acl_mixin.AccessControlMixin, Model):
                         then the returned paths include the item name.
         """
         if subpath:
-            files = [file for file in self.childFiles(item=doc, limit=2)]
+            files = list(self.childFiles(item=doc, limit=2))
             if (len(files) != 1 or files[0]['name'] != doc['name'] or
                     (includeMetadata and len(doc.get('meta', {})))):
                 path = os.path.join(path, doc['name'])

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -71,7 +71,7 @@ class Model(ModelImporter):
                 self.collection.ensure_index(index)
 
         if type(self._textIndex) is dict:
-            textIdx = [(k, 'text') for k in self._textIndex.keys()]
+            textIdx = [(k, 'text') for k in six.viewkeys(self._textIndex)]
             try:
                 self.collection.ensure_index(
                     textIdx, weights=self._textIndex,

--- a/girder/models/notification.py
+++ b/girder/models/notification.py
@@ -164,7 +164,7 @@ class Notification(Model):
         if 'increment' in kwargs:
             record['data']['current'] += kwargs['increment']
 
-        for field, value in six.iteritems(kwargs):
+        for field, value in six.viewitems(kwargs):
             if field in ('total', 'current', 'state', 'message'):
                 record['data'][field] = value
 

--- a/girder/utility/config.py
+++ b/girder/utility/config.py
@@ -32,7 +32,7 @@ def _mergeConfig(filename):
     cherrypy._cpconfig.merge(cherrypy.config, filename)
     global_config = cherrypy.config.pop('global', {})
 
-    for option, value in six.iteritems(global_config):
+    for option, value in six.viewitems(global_config):
         cherrypy.config[option] = value
 
 

--- a/girder/utility/model_importer.py
+++ b/girder/utility/model_importer.py
@@ -51,8 +51,8 @@ def reinitializeAll():
     """
     Force all models to reconnect/rebuild indices (needed for testing).
     """
-    for pluginModels in six.itervalues(_modelInstances):
-        for model in six.itervalues(pluginModels):
+    for pluginModels in six.viewvalues(_modelInstances):
+        for model in six.viewvalues(pluginModels):
             model.reconnect()
 
 

--- a/girder/utility/plugin_utilities.py
+++ b/girder/utility/plugin_utilities.py
@@ -69,7 +69,7 @@ def loadPlugins(plugins, root, appconf, apiRoot=None, curConfig=None):
 
     filteredDepGraph = {
         pluginName: info['dependencies']
-        for pluginName, info in six.iteritems(findAllPlugins(curConfig))
+        for pluginName, info in six.viewitems(findAllPlugins(curConfig))
         if pluginName in plugins
     }
 
@@ -242,27 +242,27 @@ def toposort(data):
         return
 
     # Ignore self dependencies.
-    for k, v in data.items():
+    for k, v in six.viewitems(data):
         v.discard(k)
 
     # Find all items that don't depend on anything.
     extra = functools.reduce(
-        set.union, six.itervalues(data)) - set(six.iterkeys(data))
+        set.union, six.viewvalues(data)) - set(six.viewkeys(data))
     # Add empty dependencies where needed
     data.update({item: set() for item in extra})
 
     # Perform the topological sort.
     while True:
-        ordered = set(item for item, dep in six.iteritems(data) if not dep)
+        ordered = set(item for item, dep in six.viewitems(data) if not dep)
         if not ordered:
             break
         yield ordered
         data = {item: (dep - ordered)
-                for item, dep in six.iteritems(data) if item not in ordered}
+                for item, dep in six.viewitems(data) if item not in ordered}
     # Detect any cycles in the dependency graph.
     if data:
         raise Exception('Cyclic dependencies detected:\n%s' % '\n'.join(
-                        repr(x) for x in six.iteritems(data)))
+                        repr(x) for x in six.viewitems(data)))
 
 
 def addChildNode(node, name, obj=None):

--- a/plugins/geospatial/server/geospatial.py
+++ b/plugins/geospatial/server/geospatial.py
@@ -461,7 +461,7 @@ class GeospatialItem(Resource):
         """
         geospatial = self.getBodyJson()
 
-        for k, v in geospatial.items():
+        for k, v in six.viewitems(geospatial):
             if '.' in k or k[0] == '$':
                 raise RestException('Geospatial key name {} must not contain a'
                                     ' period or begin with a dollar sign.'
@@ -477,8 +477,8 @@ class GeospatialItem(Resource):
         if GEOSPATIAL_FIELD not in item:
             item[GEOSPATIAL_FIELD] = dict()
 
-        item[GEOSPATIAL_FIELD].update(geospatial.items())
-        keys = [k for k, v in six.iteritems(item[GEOSPATIAL_FIELD])
+        item[GEOSPATIAL_FIELD].update(six.viewitems(geospatial))
+        keys = [k for k, v in six.viewitems(item[GEOSPATIAL_FIELD])
                 if v is None]
 
         for key in keys:

--- a/plugins/oauth/plugin_tests/oauth_test.py
+++ b/plugins/oauth/plugin_tests/oauth_test.py
@@ -19,6 +19,7 @@
 
 import httmock
 import json
+import six
 
 from girder.constants import SettingKey
 from server.constants import PluginSettings
@@ -61,7 +62,7 @@ class OauthTest(base.TestCase):
             'first-last@mail.com': 'first-last'
         }
 
-        for input, expected in expect.items():
+        for input, expected in six.viewitems(expect):
             output = _deriveLogin(input, self.model('user'))
             self.assertEqual(output, expected)
 
@@ -121,7 +122,7 @@ class OauthTest(base.TestCase):
         self.assertEqual(queryParams['redirect_uri'],
                          ['http://127.0.0.1/api/v1/oauth/google/callback'])
         self.assertEqual(queryParams['state'][0], 'http://localhost/#foo/bar')
-        self.assertEqual(len(resp.cookie.values()), 1)
+        self.assertEqual(len(resp.cookie), 1)
 
         cookie = resp.cookie
 
@@ -145,7 +146,7 @@ class OauthTest(base.TestCase):
         }, cookie=self._createCsrfCookie(cookie))
         self.assertStatus(resp, 303)
         self.assertEqual(resp.headers['Location'], 'http://localhost/#foo/bar')
-        self.assertEqual(len(resp.cookie.values()), 1)
+        self.assertEqual(len(resp.cookie), 1)
         self.assertEqual(resp.cookie['oauthLogin'].value, '')
 
         # Test logging in with an existing user
@@ -189,7 +190,7 @@ class OauthTest(base.TestCase):
         self.assertStatus(resp, 303)
         self.assertEqual(resp.headers['Location'],
                          'http://localhost/#foo/bar')
-        self.assertEqual(len(resp.cookie.values()), 2)
+        self.assertEqual(len(resp.cookie), 2)
         self.assertTrue('oauthLogin' in resp.cookie)
         self.assertTrue('girderToken' in resp.cookie)
         self.assertEqual(resp.cookie['oauthLogin'].value, '')

--- a/plugins/provenance/server/resource.py
+++ b/plugins/provenance/server/resource.py
@@ -92,8 +92,8 @@ class ResourceExt(Resource):
     def unbindModels(self, resources={}):
         """Unbind any models that were bound and aren't listed as needed.
         :param resources: resources that shouldn't be unbound."""
-        # iterate on keys() so that we can change the dictionary as we use it
-        for oldresource in list(self.boundResources.keys()):
+        # iterate over a list so that we can change the dictionary as we use it
+        for oldresource in list(six.viewkeys(self.boundResources)):
             if oldresource not in resources:
                 # Unbind this and remove it from the api
                 events.unbind('model.{}.save'.format(oldresource), 'provenance')

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -173,12 +173,12 @@ class PythonClientTestCase(base.TestCase):
                 folder_count += 1
 
         def folder_callback(folder, filepath):
-            self.assertIn(filepath, folders.keys())
+            self.assertIn(filepath, six.viewkeys(folders))
             folders[filepath] = True
             callback_counts['folder'] += 1
 
         def item_callback(item, filepath):
-            self.assertIn(filepath, items.keys())
+            self.assertIn(filepath, six.viewkeys(items))
             items[filepath] = True
             callback_counts['item'] += 1
 
@@ -193,8 +193,8 @@ class PythonClientTestCase(base.TestCase):
         # and that all folders and files have callbacks called on them
         self.assertEqual(folder_count, callback_counts['folder'])
         self.assertEqual(item_count, callback_counts['item'])
-        self.assertTrue(all(items.values()))
-        self.assertTrue(all(folders.values()))
+        self.assertTrue(all(six.viewvalues(items)))
+        self.assertTrue(all(six.viewvalues(folders)))
 
         # Upload again with reuse_existing on
         existingList = list(self.model('folder').childFolders(

--- a/tests/cases/rest_util_test.py
+++ b/tests/cases/rest_util_test.py
@@ -18,6 +18,7 @@
 ###############################################################################
 
 import unittest
+import six
 
 from girder.api import rest
 
@@ -44,7 +45,7 @@ class RestUtilTestCase(unittest.TestCase):
             True: True
         }
 
-        for input, output in expect.items():
+        for input, output in six.viewitems(expect):
             params = {
                 'some_key': input
             }

--- a/tests/cases/system_test.py
+++ b/tests/cases/system_test.py
@@ -20,6 +20,7 @@
 import json
 import os
 import time
+import six
 
 from subprocess import check_output, CalledProcessError
 
@@ -190,7 +191,7 @@ class SystemTestCase(base.TestCase):
             SettingKey.CORS_ALLOW_METHODS: {},
             SettingKey.CORS_ALLOW_HEADERS: {},
         }
-        allKeys = dict.fromkeys(SettingDefault.defaults.keys())
+        allKeys = dict.fromkeys(six.viewkeys(SettingDefault.defaults))
         allKeys.update(badValues)
         for key in allKeys:
             resp = self.request(path='/system/setting', method='PUT', params={

--- a/tests/cases/user_test.py
+++ b/tests/cases/user_test.py
@@ -79,7 +79,7 @@ class UserTestCase(base.TestCase):
         }
         # First test all of the required parameters.
         self.ensureRequiredParams(
-            path='/user', method='POST', required=params.keys())
+            path='/user', method='POST', required=six.viewkeys(params))
 
         # Now test parameter validation
         resp = self.request(path='/user', method='POST', params=params)

--- a/tests/js_coverage_tool.py
+++ b/tests/js_coverage_tool.py
@@ -72,9 +72,9 @@ def combine_report(args):
         'totalHits': 0,
         'files': {}
     }
-    for file, lines in six.iteritems(combined):
+    for file, lines in six.viewitems(combined):
         hits, sloc = 0, 0
-        for lineNum, hit in six.iteritems(lines):
+        for lineNum, hit in six.viewitems(lines):
             sloc += 1
             hits += hit
 
@@ -113,7 +113,7 @@ def report(args, combined, stats):
     })
     classesEl = ET.SubElement(packageEl, 'classes')
 
-    for file, data in six.iteritems(combined):
+    for file, data in six.viewitems(combined):
         lineRate = (float(stats['files'][file]['hits']) /
                     float(stats['files'][file]['sloc']))
         classEl = ET.SubElement(classesEl, 'class', {
@@ -125,7 +125,7 @@ def report(args, combined, stats):
         })
         linesEl = ET.SubElement(classEl, 'lines')
         ET.SubElement(classEl, 'methods')
-        for lineNum, hit in six.iteritems(data):
+        for lineNum, hit in six.viewitems(data):
             ET.SubElement(linesEl, 'line', {
                 'number': str(lineNum),
                 'hits': str(hit)


### PR DESCRIPTION
View objects are the only way to access dictionary objects in Python 3, so calling six.iterkeys/itervalues/iteritems on code run in Python 3 will wrap the result in an unnecessary iterator. Calling dict.keys/values/items on code run in Python 2 will create lists, which is inefficent for large dicts.

six.viewkeys/viewvalues/viewitems will be elided away completely for Python 3 and use an efficent data structure in Python 2.

Also includes some minor style cleanup in 2 subsequent commits.