### PR TITLE
Simplify API description registry

### DIFF
--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -336,7 +336,6 @@ class Describe(Resource):
             'apiVersion': API_VERSION,
             'swaggerVersion': SWAGGER_VERSION,
             'basePath': '.',
-            'models': docs.models,
             'apis': [{
                 'path': route,
                 'operations': sorted(

--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -294,7 +294,7 @@ class Describe(Resource):
             'apiVersion': API_VERSION,
             'swaggerVersion': SWAGGER_VERSION,
             'apis': [{'path': '/{}'.format(resource)}
-                     for resource in sorted(docs.discovery)]
+                     for resource in sorted(six.viewkeys(docs.routes))]
         }
 
     def _compareRoutes(self, routeOp1, routeOp2):

--- a/girder/api/docs.py
+++ b/girder/api/docs.py
@@ -20,7 +20,6 @@
 import collections
 
 
-discovery = set()
 routes = collections.defaultdict(dict)
 
 
@@ -62,7 +61,6 @@ def addRouteDocs(resource, route, method, info, handler):
     if info not in routes[resource][path]:
         routes[resource][path].append(info)
 
-    discovery.add(resource)
 
 
 def removeRouteDocs(resource, route, method, info, handler):
@@ -101,4 +99,4 @@ def removeRouteDocs(resource, route, method, info, handler):
         if not len(routes[resource][path]):
             del routes[resource][path]
             if not len(routes[resource]):
-                discovery.remove(resource)
+                del routes[resource]

--- a/girder/api/docs.py
+++ b/girder/api/docs.py
@@ -33,7 +33,7 @@ def _toRoutePath(resource, route):
     """
     # Convert wildcard tokens from :foo form to {foo} form
     convRoute = [
-        '{{{}}}'.format(token[1:]) if token[0] == ':' else token
+        '{%s}' % token[1:] if token[0] == ':' else token
         for token in route
     ]
     path = '/'.join(['', resource] + convRoute)

--- a/girder/api/docs.py
+++ b/girder/api/docs.py
@@ -18,9 +18,37 @@
 ###############################################################################
 
 import collections
+import functools
 
 
-routes = collections.defaultdict(dict)
+# A dict of dicts of lists
+routes = collections.defaultdict(
+    functools.partial(collections.defaultdict, list))
+
+
+def _toRoutePath(resource, route):
+    """
+    Convert a base resource type and list of route components into a
+    Swagger-compatible route path.
+    """
+    # Convert wildcard tokens from :foo form to {foo} form
+    convRoute = [
+        '{{{}}}'.format(token[1:]) if token[0] == ':' else token
+        for token in route
+    ]
+    path = '/'.join(['', resource] + convRoute)
+    return path
+
+
+def _toOperation(info, method, handler):
+    """
+    Augment route info, returning a Swagger-compatible operation description.
+    """
+    operation = dict(info)
+    operation['httpMethod'] = method.upper()
+    if 'nickname' not in operation:
+        operation['nickname'] = handler.__name__
+    return operation
 
 
 def addRouteDocs(resource, route, method, info, handler):
@@ -32,35 +60,22 @@ def addRouteDocs(resource, route, method, info, handler):
     :param resource: The name of the resource, e.g. "item"
     :type resource: str
     :param route: The route to describe.
-    :type route: list
+    :type route: list[str]
     :param method: The HTTP method for this route, e.g. "POST"
     :type method: str
-    :param info: The information representing the API documentation.
+    :param info: The information representing the API documentation, typically
+    from ``girder.api.describe.Description.asDict``.
     :type info: dict
+    :param handler: The actual handler method for this route.
+    :type handler: function
     """
-    # Convert wildcard tokens from :foo form to {foo} form.
-    convRoute = []
-    for token in route:
-        if token[0] == ':':
-            convRoute.append('{{{}}}'.format(token[1:]))
-        else:
-            convRoute.append(token)
+    path = _toRoutePath(resource, route)
 
-    path = '/'.join(['', resource] + convRoute)
-
-    info = info.copy()
-    info['httpMethod'] = method.upper()
-
-    if 'nickname' not in info:
-        info['nickname'] = handler.__name__
+    operation = _toOperation(info, method, handler)
 
     # Add the operation to the given route
-    if path not in routes[resource]:
-        routes[resource][path] = []
-
-    if info not in routes[resource][path]:
-        routes[resource][path].append(info)
-
+    if operation not in routes[resource][path]:
+        routes[resource][path].append(operation)
 
 
 def removeRouteDocs(resource, route, method, info, handler):
@@ -75,28 +90,23 @@ def removeRouteDocs(resource, route, method, info, handler):
     :type method: str
     :param info: The information representing the API documentation.
     :type info: dict
+    :param handler: The actual handler method for this route.
+    :type handler: function
     """
-    # Convert wildcard tokens from :foo form to {foo} form.
-    convRoute = []
-    for token in route:
-        if token[0] == ':':
-            convRoute.append('{{{}}}'.format(token[1:]))
-        else:
-            convRoute.append(token)
+    if resource not in routes:
+        return
 
-    path = '/'.join(['', resource] + convRoute)
+    path = _toRoutePath(resource, route)
 
     if path not in routes[resource]:
         return
 
-    info = info.copy()
-    info['httpMethod'] = method.upper()
+    operation = _toOperation(info, method, handler)
 
-    if 'nickname' not in info:
-        info['nickname'] = handler.__name__
     if info in routes[resource][path]:
-        routes[resource][path].remove(info)
-        if not len(routes[resource][path]):
+        routes[resource][path].remove(operation)
+        # Clean up any empty route paths
+        if not routes[resource][path]:
             del routes[resource][path]
-            if not len(routes[resource]):
+            if not routes[resource]:
                 del routes[resource]

--- a/girder/api/docs.py
+++ b/girder/api/docs.py
@@ -22,7 +22,6 @@ import collections
 
 discovery = set()
 routes = collections.defaultdict(dict)
-models = {}
 
 
 def addRouteDocs(resource, route, method, info, handler):
@@ -103,15 +102,3 @@ def removeRouteDocs(resource, route, method, info, handler):
             del routes[resource][path]
             if not len(routes[resource]):
                 discovery.remove(resource)
-
-
-def addModel(name, model):
-    """
-    This is called to add a model to the swagger documentation.
-
-    :param name: The name of the model.
-    :type name: str
-    :param model: The model to add.
-    :type model: dict
-    """
-    models[name] = model


### PR DESCRIPTION
This significantly simplifies the registry of API descriptions.

There are 3 commits:

* **Remove useless "models" property from Swagger resource descriptions**
The "models" field in a Swagger resource description should contain a detailed listing of the properties in a model. At the moment, Girder has no mechanism to expose this information (though it might come via the Model._filterKeys attribute). Without this information, there is no reason to include a "models" field in resource descriptions. For more information, see:
https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md#52-api-declaration
https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md#527-model-object

 The empty "models" variable was first added by commit a54c433 , but with no mechanism to ever
set or use it.

 Later, commit cef7f4e finally started returning the "models" property with the resource description endpoint, but even assuming that the variable was set correctly, the code returns the same thing for each seperate resource type. The "addModel" function isn't tested or used anywhere, and only serves to set values in an already-misused variable.

 It's probably best at this point to consider this to be cruft, and remove it all. Future work could attempt to define Model descriptions via Swagger's specification, but this is nowhere close.

* **Remove unnecessary global variable from route doc setup**
The "discovery" variable holds the resource types that have route documentation. The exact same data can be obtained from the keys in the "routes" variable.

* **Refactor "girder.api.docs", to fix documentation and improve maintainability**
This also makes the code more maintainable, by avoiding repetition of code which must always be exactly the same for "removeRouteDocs" to work properly.