### PR TITLE
Simplify CherryPy tools configuration

### DIFF
--- a/girder/utility/server.py
+++ b/girder/utility/server.py
@@ -52,26 +52,26 @@ def configureServer(test=False, plugins=None, curConfig=None):
             'request.methods_with_bodies': ('POST', 'PUT', 'PATCH')
         },
         '/static': {
-            'tools.staticdir.on': 'True',
+            'tools.staticdir.on': True,
             'tools.staticdir.dir': 'clients/web/static'
         }
     }
 
     if test:
         appconf['/src'] = {
-            'tools.staticdir.on': 'True',
+            'tools.staticdir.on': True,
             'tools.staticdir.dir': 'clients/web/src',
         }
         appconf['/test'] = {
-            'tools.staticdir.on': 'True',
+            'tools.staticdir.on': True,
             'tools.staticdir.dir': 'clients/web/test',
         }
         appconf['/clients'] = {
-            'tools.staticdir.on': 'True',
+            'tools.staticdir.on': True,
             'tools.staticdir.dir': 'clients'
         }
         appconf['/plugins'] = {
-            'tools.staticdir.on': 'True',
+            'tools.staticdir.on': True,
             'tools.staticdir.dir': 'plugins',
         }
 

--- a/plugins/jquery_widgets/server.py
+++ b/plugins/jquery_widgets/server.py
@@ -1,5 +1,5 @@
 def load(info):
     info['config']['/jquery'] = {
-        'tools.staticdir.on': 'True',
+        'tools.staticdir.on': True,
         'tools.staticdir.dir': 'clients/jquery'
     }


### PR DESCRIPTION
CherryPy tools can be enabled by passing any truthy value to a config parameter of "<toolName>.on". Using a Python bool instead of a string is simpler.

See: https://github.com/cherrypy/cherrypy/blob/3.3.0/cherrypy/_cptools.py#L459