### PR TITLE
Make api.docs.addModel require a resource type

### DIFF
--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -336,7 +336,7 @@ class Describe(Resource):
             'apiVersion': API_VERSION,
             'swaggerVersion': SWAGGER_VERSION,
             'basePath': getApiUrl(),
-            'models': docs.models,
+            'models': docs.models[resource],
             'apis': [{
                 'path': route,
                 'operations': sorted(

--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -336,7 +336,7 @@ class Describe(Resource):
             'apiVersion': API_VERSION,
             'swaggerVersion': SWAGGER_VERSION,
             'basePath': getApiUrl(),
-            'models': docs.models[resource],
+            'models': dict(docs.models[resource], **docs.models[None]),
             'apis': [{
                 'path': route,
                 'operations': sorted(

--- a/girder/api/docs.py
+++ b/girder/api/docs.py
@@ -19,6 +19,8 @@
 
 import collections
 import functools
+import six
+from girder.constants import TerminalColor
 
 models = collections.defaultdict(dict)
 # routes is dict of dicts of lists
@@ -112,18 +114,21 @@ def removeRouteDocs(resource, route, method, info, handler):
                 del routes[resource]
 
 
-def addModel(resources, name, model):
+def addModel(name, model, resources=None, silent=False):
     """
     Add a model to the Swagger documentation.
 
     :param resources: The type(s) of resource(s) to add the model to. New
         resource types may be implicitly defined, with the expectation that
-        routes will be added for them at some point.
-    :param resources: str or tuple[str]
-    :param name: The name of the model(s).
+        routes will be added for them at some point. If no resources are
+        passed, the model will be exposed for every resource type
+    :param resources: str or tuple/list[str]
+    :param name: The name of the model.
     :type name: str
     :param model: The model to add.
     :type model: dict
+    :param silent: Set this to True to suppress warnings.
+    :type silent: bool
 
     .. warning:: This is a low-level API which does not validate the format of
        ``model``. See the `Swagger Model documentation`_ for a complete
@@ -137,7 +142,14 @@ def addModel(resources, name, model):
        swagger-spec/blob/d79c205485d702302003d4de2f2c980d1caf10f9/
        versions/1.2.md#527-model-object
     """
-    if isinstance(resources, str):
-        resources = (resources,)
-    for resource in resources:
-        models[resource][name] = model
+    if resources:
+        if isinstance(resources, six.string_types):
+            resources = (resources,)
+        for resource in resources:
+            models[resource][name] = model
+    else:
+        if not silent:
+            print(TerminalColor.warning(
+                'WARNING: adding swagger models without specifying resources '
+                'to bind to is discouraged (%s).' % name))
+        models[None][name] = model

--- a/girder/api/docs.py
+++ b/girder/api/docs.py
@@ -20,8 +20,8 @@
 import collections
 import functools
 
-models = {}
-# A dict of dicts of lists
+models = collections.defaultdict(dict)
+# routes is dict of dicts of lists
 routes = collections.defaultdict(
     functools.partial(collections.defaultdict, list))
 
@@ -112,13 +112,25 @@ def removeRouteDocs(resource, route, method, info, handler):
                 del routes[resource]
 
 
-def addModel(name, model):
+def addModel(resource, name, model):
     """
-    This is called to add a model to the swagger documentation.
+    Add a model to the Swagger documentation.
 
+    :param resource: The type of existing resource to add the model to.
+    :param resource: str
     :param name: The name of the model.
     :type name: str
     :param model: The model to add.
     :type model: dict
+
+    .. warning:: This is a low-level API which does not validate the format of
+       ``model``. See the `Swagger Model documentation`_ for a complete
+       specification of the correct format for ``model``.
+
+    .. _Swagger Model documentation: https://github.com/swagger-api/
+       swagger-spec/blob/d79c205485d702302003d4de2f2c980d1caf10f9/
+       versions/1.2.md#527-model-object
     """
-    models[name] = model
+    if resource not in routes:
+        raise Exception('"%s" is not a known resource type' % resource)
+    models[resource][name] = model

--- a/girder/api/docs.py
+++ b/girder/api/docs.py
@@ -112,13 +112,13 @@ def removeRouteDocs(resource, route, method, info, handler):
                 del routes[resource]
 
 
-def addModel(resource, name, model):
+def addModel(resources, name, model):
     """
     Add a model to the Swagger documentation.
 
-    :param resource: The type of existing resource to add the model to.
-    :param resource: str
-    :param name: The name of the model.
+    :param resources: The type(s) of existing resource(s) to add the model to.
+    :param resources: str or tuple[str]
+    :param name: The name of the model(s).
     :type name: str
     :param model: The model to add.
     :type model: dict
@@ -127,10 +127,19 @@ def addModel(resource, name, model):
        ``model``. See the `Swagger Model documentation`_ for a complete
        specification of the correct format for ``model``.
 
+    .. versionchanged:: The syntax and behavior of this function was modified
+        after v1.3.2. The previous implementation did not include a resources
+        parameter.
+
     .. _Swagger Model documentation: https://github.com/swagger-api/
        swagger-spec/blob/d79c205485d702302003d4de2f2c980d1caf10f9/
        versions/1.2.md#527-model-object
     """
-    if resource not in routes:
-        raise Exception('"%s" is not a known resource type' % resource)
-    models[resource][name] = model
+    if isinstance(resources, str):
+        resources = (resources,)
+    for resource in resources:
+        if resource not in routes:
+            raise Exception('"%s" is not a known resource type' % resource)
+    # any errors should be detected ahead of time, to make the change atomic
+    for resource in resources:
+        models[resource][name] = model

--- a/girder/api/docs.py
+++ b/girder/api/docs.py
@@ -116,7 +116,9 @@ def addModel(resources, name, model):
     """
     Add a model to the Swagger documentation.
 
-    :param resources: The type(s) of existing resource(s) to add the model to.
+    :param resources: The type(s) of resource(s) to add the model to. New
+        resource types may be implicitly defined, with the expectation that
+        routes will be added for them at some point.
     :param resources: str or tuple[str]
     :param name: The name of the model(s).
     :type name: str
@@ -137,9 +139,5 @@ def addModel(resources, name, model):
     """
     if isinstance(resources, str):
         resources = (resources,)
-    for resource in resources:
-        if resource not in routes:
-            raise Exception('"%s" is not a known resource type' % resource)
-    # any errors should be detected ahead of time, to make the change atomic
     for resource in resources:
         models[resource][name] = model

--- a/tests/cases/api_describe_test.py
+++ b/tests/cases/api_describe_test.py
@@ -21,6 +21,7 @@ from .. import base
 
 from girder.api import access, describe
 from girder.api.rest import Resource
+from girder.api.docs import addModel
 
 OrderedRoutes = [
     ('GET', (), ''),
@@ -51,9 +52,37 @@ class DummyResource(Resource):
     handler.description = describe.Description('Does nothing')
 
 
+class ModelResource(Resource):
+    def __init__(self):
+        self.resourceName = 'model'
+        self.route('POST', (), self.hasModel)
+
+    @access.public
+    def hasModel(self, params):
+        pass
+
+    addModel('model', 'Body', {
+        'id': 'Body',
+        'require': 'bob',
+        'properties': {
+            'bob': {
+                'type': 'array',
+                'items': {
+                    'type': 'integer'
+                }
+            }
+        }
+    })
+
+    hasModel.description = describe.Description('What a model') \
+        .param('body', 'Where its at!', dataType='Body', required=True,
+               paramType='body')
+
+
 def setUpModule():
     server = base.startServer()
     server.root.api.v1.accesstest = DummyResource()
+    server.root.api.v1.modeltest = ModelResource()
 
 
 def tearDownModule():
@@ -112,3 +141,7 @@ class ApiDescribeTestCase(base.TestCase):
         expectedRoutes = [(method, '/foo'+testPath)
                           for method, pathElements, testPath in OrderedRoutes]
         self.assertEqual(listedRoutes, expectedRoutes)
+
+    def testAddModel(self):
+        resp = self.request(path='/describe/model', method='GET')
+        self.assertStatusOk(resp)

--- a/tests/cases/api_describe_test.py
+++ b/tests/cases/api_describe_test.py
@@ -86,7 +86,6 @@ class ModelResource(Resource):
                paramType='body')
 
 
-
 def setUpModule():
     server = base.startServer()
     server.root.api.v1.accesstest = DummyResource()

--- a/tests/cases/api_describe_test.py
+++ b/tests/cases/api_describe_test.py
@@ -52,6 +52,20 @@ class DummyResource(Resource):
     handler.description = describe.Description('Does nothing')
 
 
+test_model = {
+    'id': 'Body',
+    'require': 'bob',
+    'properties': {
+        'bob': {
+            'type': 'array',
+            'items': {
+                'type': 'integer'
+            }
+        }
+    }
+}
+
+
 class ModelResource(Resource):
     def __init__(self):
         self.resourceName = 'model'
@@ -61,18 +75,7 @@ class ModelResource(Resource):
     def hasModel(self, params):
         pass
 
-    addModel('model', 'Body', {
-        'id': 'Body',
-        'require': 'bob',
-        'properties': {
-            'bob': {
-                'type': 'array',
-                'items': {
-                    'type': 'integer'
-                }
-            }
-        }
-    })
+    addModel('model', 'Body', test_model)
 
     hasModel.description = describe.Description('What a model') \
         .param('body', 'Where its at!', dataType='Body', required=True,
@@ -145,3 +148,4 @@ class ApiDescribeTestCase(base.TestCase):
     def testAddModel(self):
         resp = self.request(path='/describe/model', method='GET')
         self.assertStatusOk(resp)
+        self.assertEqual(resp.json['models'], {'Body': test_model})


### PR DESCRIPTION
Per the Swagger specification, each model should be applied only to a specific resource or set of resources. More rationale is provided in issue #958

This commit changes the undocumented, but public, ``addModel`` function to require each new model to specify a resource type which it will be associated with. The same model may be added to multiple resources via repeated calls to the function. This also updates the API resource description endpoint to only return models which are associated with each given resource type.

Closes #958.