### PR TITLE
Build documentation for Assetstore, File, and Notification models

### DIFF
--- a/docs/api-docs.rst
+++ b/docs/api-docs.rst
@@ -67,14 +67,6 @@ Model Base
 .. automodule:: girder.models.model_base
    :members:
 
-.. _events:
-
-Events
-^^^^^^
-
-.. automodule:: girder.events
-    :members:
-
 User
 ^^^^
 .. automodule:: girder.models.user
@@ -117,11 +109,37 @@ Setting
 .. automodule:: girder.models.setting
    :members:
 
+Assetstore
+^^^^^^^^^^
+
+.. automodule:: girder.models.assetstore
+   :members:
+
+File
+^^^^
+
+.. automodule:: girder.models.file
+   :members:
+
 Upload
 ^^^^^^
 
 .. automodule:: girder.models.upload
    :members:
+
+.. _events:
+
+Events
+^^^^^^
+
+.. automodule:: girder.events
+    :members:
+
+Notification
+^^^^^^^^^^^^
+
+.. automodule:: girder.models.notification
+    :members:
 
 Python API for RESTful web API
 ------------------------------

--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -51,8 +51,8 @@ class File(acl_mixin.AccessControlMixin, Model):
 
         :param file: The file document to remove.
         :param updateItemSize: Whether to update the item size. Only set this
-        to False if you plan to delete the item and do not care about updating
-        its size.
+            to False if you plan to delete the item and do not care about
+            updating its size.
         """
         if file.get('assetstoreId'):
             assetstore = self.model('assetstore').load(file['assetstoreId'])
@@ -118,6 +118,7 @@ class File(acl_mixin.AccessControlMixin, Model):
         """
         Create a file that is a link to a URL rather than something we maintain
         in an assetstore.
+
         :param name: The local name for the file.
         :type name: str
         :param parent: The parent object for this file.
@@ -126,7 +127,7 @@ class File(acl_mixin.AccessControlMixin, Model):
         :type parentType: str
         :param url: The URL that this file points to
         :param creator: The user creating the file.
-        :type user: user
+        :type creator: dict
         """
         if parentType == 'folder':
             # Create a new item with the name of the file.
@@ -165,8 +166,8 @@ class File(acl_mixin.AccessControlMixin, Model):
         :param sizeIncrement: The change in size to propagate.
         :type sizeIncrement: int
         :param updateItemSize: Whether the item size should be updated. Set to
-        False if you plan to delete the item immediately and don't care to
-        update its size.
+            False if you plan to delete the item immediately and don't care to
+            update its size.
         """
         if updateItemSize:
             # Propagate size up to item
@@ -234,6 +235,7 @@ class File(acl_mixin.AccessControlMixin, Model):
     def copyFile(self, srcFile, creator, item=None):
         """
         Copy a file so that we don't need to duplicate stored data.
+
         :param srcFile: The file to copy.
         :type srcFile: dict
         :param creator: The user copying the file.

--- a/girder/models/notification.py
+++ b/girder/models/notification.py
@@ -66,7 +66,7 @@ class Notification(Model):
         :param user: User to send the notification to.
         :type user: dict
         :param expires: Expiration date (for transient notifications).
-        :type expires: datetime
+        :type expires: datetime.datetime
         :param token: Set this if the notification should correspond to a token
             instead of a user.
         :type token: dict
@@ -141,22 +141,23 @@ class Notification(Model):
         :param record: The existing progress record to update.
         :type record: dict
         :param total: Some numeric value representing the total task length. By
-        convention, setting this <= 0 means progress on this task is
-        indeterminate. Generally this shouldn't change except in cases where
-        progress on a task switches between indeterminate and determinate state.
+            convention, setting this <= 0 means progress on this task is
+            indeterminate. Generally this shouldn't change except in cases where
+            progress on a task switches between indeterminate and determinate
+            state.
         :type total: int, long, or float
         :param state: Represents the state of the underlying task execution.
         :type state: ProgressState enum value.
         :param current: Some numeric value representing the current progress
-        of the task (relative to total).
+            of the task (relative to total).
         :type current: int, long, or float
         :param increment: Amount to increment the progress by. Don't pass both
-        current and increment together, as that behavior is undefined.
+            current and increment together, as that behavior is undefined.
         :type increment: int, long, or float
         :param message: Message corresponding to the current state of the task.
         :type message: str
         :param expires: Set a custom (UTC) expiration time on the record.
-        Default is one hour from the current time.
+            Default is one hour from the current time.
         :type expires: datetime
         :param save: Whether to save the record to the database.
         :type save: bool


### PR DESCRIPTION
The documentation for these models was previously not being built.

Also, move the documentation on Events to a more logical ordering on the page.

Finally, fix major syntax errors in File and Notification documentation. These were probably never noticed because because File and Notification documentation were not being built, but these errors caused entire docstrings for several methods to not build properly.