### PR TITLE
development.rst: Tweak env configuration instruction

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -30,20 +30,24 @@ provide helpful development tools and to allow the test suite to run: ::
 During development, once Girder is started via ``python -m girder``, the server
 will reload itself whenever a Python file is modified.
 
-To get the same auto-building behavior for JavaScript, we use ``grunt-watch``.
-Since ``grunt`` is installed in the ``./node_modules/.bin/`` directory, you could
-conveniently update the ``PATH`` running ``export PATH=$(pwd)/node_modules/.bin:$PATH``.
+Girder's web-based client application is built using the `Grunt <http://gruntjs.com/>`_
+task running tool. When you run the ``npm install`` command during Girder's
+installation, it will run all of the grunt tasks required to build the web client.
+Grunt tasks are run with the ``grunt`` executable, which is installed under your Girder source
+directory in the ``./node_modules/.bin/`` directory. You could conveniently update the
+``PATH`` by running ``export PATH=$(pwd)/node_modules/.bin:$PATH`` -- once you do that,
+you can just type ``grunt`` in your shell to run tasks.
 
-Alternatively, you could install the grunt command line interface globally so
-that the ``grunt`` command is automatically added to your ``PATH``.
-If you want to do that, run ``npm install -g grunt-cli``. Note that this
-command requires ``sudo`` on many systems.
+.. note :: Alternatively, you could install the grunt command line interface globally so
+   that the ``grunt`` command is automatically added to your ``PATH``. If you want to do
+   that, run ``npm install -g grunt-cli``. Note that this command requires ``sudo`` on many
+   systems.
 
-Thus, running ``grunt watch`` in the root of the repository will watch for
-JavaScript, Stylus, and Jade changes in order to rebuild them on-the-fly. If you
-do not run ``grunt watch`` while making code changes, you will need to run the
-``grunt`` command to manually rebuild the web client in order to see your changes
-reflected.
+It is recommended during development to make use of the ``grunt-watch`` tool. Running
+``grunt watch`` in the root of the repository will watch for JavaScript, Stylus, and
+Jade changes in order to rebuild them on-the-fly. If you do not run ``grunt watch``
+while making code changes, you will need to run the ``grunt`` command to manually
+rebuild the web client in order to see your changes reflected.
 
 Note that some browser debugging tools do not play well with local variable
 mangling in JavaScript. If you want to use such a debugger and need to work around this,

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -13,13 +13,7 @@ Configuring Your Development Environment
 In order to develop Girder, you should first refer to the :doc:`prerequisites`
 and :doc:`installation` sections to setup a basic local environment.
 
-Next, you should install the `Grunt <http://gruntjs.com>`_ build tool globally,
-to allow it to be run directly from the command line: ::
-
-    npm install -g grunt
-    npm install -g grunt-cli
-
-Finally, you should also install the Python development dependencies, to
+Next, you should install the Python development dependencies, to
 provide helpful development tools and to allow the test suite to run: ::
 
     pip install -r requirements-dev.txt
@@ -37,6 +31,14 @@ During development, once Girder is started via ``python -m girder``, the server
 will reload itself whenever a Python file is modified.
 
 To get the same auto-building behavior for JavaScript, we use ``grunt-watch``.
+Since ``grunt`` is installed in the ``./node_modules/.bin/`` directory, you could
+conveniently update the ``PATH`` running ``export PATH=$(pwd)/node_modules/.bin:$PATH``.
+
+Alternatively, you could install the grunt command line interface globally so
+that the ``grunt`` command is automatically added to your ``PATH``.
+If you want to do that, run ``npm install -g grunt-cli``. Note that this
+command requires ``sudo`` on many systems.
+
 Thus, running ``grunt watch`` in the root of the repository will watch for
 JavaScript, Stylus, and Jade changes in order to rebuild them on-the-fly. If you
 do not run ``grunt watch`` while making code changes, you will need to run the


### PR DESCRIPTION
This commit removes the instructions asking the developer to install `grunt` and `grunt-cli` globally. These instructions were (1) redundant with `npm install` command  and (2) broken on the system were it was needed to apply some fix (See [1])

[1] https://docs.npmjs.com/getting-started/fixing-npm-permissions