### PR TITLE
Use local install of grunt for npm install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ before_install:
     - npm --version
 install:
     - scripts/InstallPythonRequirements.py --mode=dev --ignore-plugins=${IGNORE_PLUGINS}
-    - npm install grunt grunt-cli
     - npm install
 script:
     - mkdir _build

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "jscs": "1.6.1"
   },
   "scripts": {
-    "postinstall": "grunt init && grunt"
+    "postinstall": "./node_modules/.bin/grunt init && ./node_modules/.bin/grunt"
   }
 }


### PR DESCRIPTION
Following the conversion on the girder mailing list.  Grunt was already being installed locally, so we might as well not enforce a global grunt install in the npm install step.