### PR TITLE
Fix large zip files

### DIFF
--- a/girder/utility/ziputil.py
+++ b/girder/utility/ziputil.py
@@ -77,8 +77,9 @@ class ZipInfo(object):
             filename = filename[0:nullByte]
         if os.sep != '/' and os.sep in filename:
             filename = filename.replace(os.sep, '/')
-
-        self.filename = filename.encode('utf8')
+        if isinstance(filename, six.text_type):
+            filename = filename.encode('utf8')
+        self.filename = filename
         self.timestamp = timestamp
         self.compressType = STORE
         if sys.platform == 'win32':
@@ -149,8 +150,10 @@ class ZipGenerator(object):
         :param path: The path within the archive for this entry.
         :type path: str
         """
-        header = ZipInfo(os.path.join(self.rootPath, str(path)),
-                         time.localtime()[0:6])
+        fullpath = os.path.join(self.rootPath, path)
+        if isinstance(fullpath, six.text_type):
+            fullpath = fullpath.encode('utf8')
+        header = ZipInfo(fullpath, time.localtime()[0:6])
         header.externalAttr = (0o100644 & 0xFFFF) << 16
         header.compressType = self.compression
         header.headerOffset = self.offset
@@ -214,7 +217,7 @@ class ZipGenerator(object):
 
             if header.headerOffset > Z64_LIMIT:
                 extra.append(header.headerOffset)
-                headerOffset = -1
+                headerOffset = 0xffffffff
             else:
                 headerOffset = header.headerOffset
 

--- a/tests/cases/resource_test.py
+++ b/tests/cases/resource_test.py
@@ -624,7 +624,10 @@ class ResourceTestCase(base.TestCase):
 
             def genEmptyData():
                 for val in range(0, fileLength, chunkSize):
-                    yield chunk
+                    if fileLength - val < chunkSize:
+                        yield chunk[:fileLength - val]
+                    else:
+                        yield chunk
 
             return genEmptyData
 
@@ -635,6 +638,17 @@ class ResourceTestCase(base.TestCase):
         zip.useCRC = False
         for data in zip.addFile(
                 genEmptyFile(6 * 1024 * 1024 * 1024), 'bigfile'):
+            pass
+        # Add a second small file at the end to test some of the other Zip64
+        # code
+        for data in zip.addFile(genEmptyFile(100), 'smallfile'):
+            pass
+        # Test that we don't crash on Unicode file names
+        for data in zip.addFile(
+                genEmptyFile(100), u'\u0421\u0443\u043f\u0435\u0440-\u0440'
+                '\u0443\u0441\u0441\u043a\u0438, \u0627\u0633\u0645 \u0627'
+                '\u0644\u0645\u0644\u0641 \u0628\u0627\u0644\u0644\u063a'
+                '\u0629 \u0627\u0644\u0639\u0631\u0628\u064a\u0629'):
             pass
         footer = zip.footer()
         self.assertEqual(footer[-6:], b'\xFF\xFF\xFF\xFF\x00\x00')

--- a/tests/cases/resource_test.py
+++ b/tests/cases/resource_test.py
@@ -650,5 +650,8 @@ class ResourceTestCase(base.TestCase):
                 '\u0644\u0645\u0644\u0641 \u0628\u0627\u0644\u0644\u063a'
                 '\u0629 \u0627\u0644\u0639\u0631\u0628\u064a\u0629'):
             pass
+        # Test filename with a null
+        for data in zip.addFile(genEmptyFile(100), 'with\x00null'):
+            pass
         footer = zip.footer()
         self.assertEqual(footer[-6:], b'\xFF\xFF\xFF\xFF\x00\x00')


### PR DESCRIPTION
If a zip file contained multiple files and one of them started at an offset >= 2Gb from the start of the file, the zip footer would fail to be created.

Also, zip filenames with non-ASCII characters could fail to be created due to string conversions.

The test has been updated to detect both of these conditions.