### PR TITLE
Update phantomjs version for compatability with iojs

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "argv" : "0.0.2",
     "jshint": "2.5.5",
     "comment-json" : "0.1.11",
-    "phantomjs": "1.9.9",
+    "phantomjs": "1.9.18",
     "phantomjs-polyfill": "0.0.1",
     "blanket": "1.1.6",
     "jscs": "1.6.1"


### PR DESCRIPTION
I was hitting a bug in phantomjs locally using iojs.  It looks like official iojs support wasn't add unit 1.9.15.  There doesn't appear to be any issues updating this to the latest in the 1.9 series.