### PR TITLE
Filesystem assetstore sync

### DIFF
--- a/clients/web/src/stylesheets/body/assetstores.styl
+++ b/clients/web/src/stylesheets/body/assetstores.styl
@@ -34,15 +34,13 @@
 .jqplot-data-label
   color black
 
-.g-s3-import-button-container
-  border-top 1px solid #d7d7d7
-  margin-top 2px
-  padding-top 10px
+.g-assetstore-import-button-container
+  display inline-block
 
-.g-s3-import-instructions
+.g-import-instructions
   margin-bottom 22px
   padding-top 8px
   border-top 1px solid #eee
 
-.g-submit-s3-import
+.g-submit-assetstore-import
   margin-top 7px

--- a/clients/web/src/templates/body/assetstores.jade
+++ b/clients/web/src/templates/body/assetstores.jade
@@ -60,10 +60,6 @@
             div
               b Service:
               span.g-service-key  #{assetstore.get('service')}
-            div.g-s3-import-button-container
-              a.g-s3-import-button.btn.btn-sm.btn-success(href="#assetstore/#{assetstore.id}/s3import")
-                i.icon-link-ext
-                |  Import files from S3
 
         if assetstore.capacityKnown()
           div
@@ -84,5 +80,10 @@
             button.g-set-current.btn.btn-sm.btn-primary(
               cid="#{assetstore.cid}") Set as current
 
+          if importableTypes.indexOf(assetstore.get('type')) !== -1
+            div.g-assetstore-import-button-container
+              a.g-import-button.btn.btn-sm.btn-success(href="#assetstore/#{assetstore.id}/import")
+                i.icon-link-ext
+                |  Import data
 
 #g-new-assetstore-container

--- a/clients/web/src/templates/body/filesystemImport.jade
+++ b/clients/web/src/templates/body/filesystemImport.jade
@@ -1,0 +1,32 @@
+.g-body-title Import existing data from the filesystem
+.g-body-subtitle #{assetstore.get('name')}
+
+.g-import-instructions.
+  Use this page to import existing data from this assetstore's filesystem.
+  Specify a root directory on the filesystem, and it will be imported recursively.
+  The directory does not need to be under the assetstore's root dir. You must also
+  specify a destination collection, user, or folder ID under which to place the
+  imported data. Files that are imported are not managed directly by the server.
+  They will not be copied, but will be served from their existing location. When
+  the referencing files in Girder are deleted, the underlying imported file will
+  not be removed.
+
+form.g-filesystem-import-form
+  .form-group
+    label(for="g-filesystem-import-path") Import path (absolute path to directory or file)
+    input.form-control.input-sm#g-filesystem-import-path(type="text")
+  .form-group
+    label(for="g-filesystem-import-dest-type") Destination type
+    select.form-control#g-filesystem-import-dest-type
+      option(value="folder") Folder
+      option(value="user") User
+      option(value="collection") Collection
+  .form-group
+    label(for="g-filesystem-import-dest-id") Destination ID
+    input.form-control.input-sm#g-filesystem-import-dest-id(
+      type="text"
+      placeholder="Existing folder, user, or collection ID to use as the destination")
+  .g-validation-failed-message
+  button.g-submit-assetstore-import.btn.btn-success(type="submit")
+    i.icon-link-ext
+    |  Begin import

--- a/clients/web/src/templates/body/s3Import.jade
+++ b/clients/web/src/templates/body/s3Import.jade
@@ -1,7 +1,7 @@
 .g-body-title Import existing data from S3
 .g-body-subtitle #{assetstore.get('name')}
 
-.g-s3-import-instructions.
+.g-import-instructions.g-s3import-instructions.
   Use this page to import existing data from this assetstore's S3 bucket
   (<b>#{assetstore.get('bucket')}</b>). You may import a specific directory of keys
   within the bucket, or a specific key by path. If you wish to import the entire
@@ -26,6 +26,6 @@ form.g-s3-import-form
       type="text"
       placeholder="Existing folder, user, or collection ID to use as the destination")
   .g-validation-failed-message
-  button.g-submit-s3-import.btn.btn-success(type="submit")
+  button.g-submit-assetstore-import.g-submit-s3-import.btn.btn-success(type="submit")
     i.icon-link-ext
     |  Begin import

--- a/clients/web/src/views/body/FilesystemImportView.js
+++ b/clients/web/src/views/body/FilesystemImportView.js
@@ -1,0 +1,34 @@
+girder.views.FilesystemImportView = girder.View.extend({
+    events: {
+        'submit .g-filesystem-import-form': function (e) {
+            e.preventDefault();
+
+            var destId = this.$('#g-filesystem-import-dest-id').val().trim(),
+                destType = this.$('#g-filesystem-import-dest-type').val();
+
+            this.$('.g-validation-failed-message').empty();
+
+            this.assetstore.off('g:imported').on('g:imported', function () {
+                girder.router.navigate(destType + '/' + destId, {trigger: true});
+            }, this).on('g:error', function (resp) {
+                this.$('.g-validation-failed-message').text(resp.responseJSON.message);
+            }, this).import({
+                importPath: this.$('#g-filesystem-import-path').val().trim(),
+                destinationId: destId,
+                destinationType: destType,
+                progress: true
+            });
+        }
+    },
+
+    initialize: function (settings) {
+        this.assetstore = settings.assetstore;
+        this.render();
+    },
+
+    render: function () {
+        this.$el.html(girder.templates.filesystemImport({
+            assetstore: this.assetstore
+        }));
+    }
+});

--- a/clients/web/src/views/body/S3ImportView.js
+++ b/clients/web/src/views/body/S3ImportView.js
@@ -33,6 +33,8 @@ girder.views.S3ImportView = girder.View.extend({
     }
 });
 
+// This route is only preserved for backward compatibility. The generic route
+// "assetstore/:id/import" is preferred, and is defined in AssetstoresView.js.
 girder.router.route('assetstore/:id/s3import', 's3Import', function (assetstoreId) {
     var assetstore = new girder.models.AssetstoreModel({
         _id: assetstoreId

--- a/clients/web/test/spec/adminSpec.js
+++ b/clients/web/test/spec/adminSpec.js
@@ -279,12 +279,102 @@ describe('Test the assetstore page', function () {
         });
     };
 
+    var _testFilesystemImport = function (params) {
+        var privateFolder = null;
+
+        runs(function () {
+            var container = _getAssetstoreContainer(params.name);
+            var el = $('a.g-import-button', container);
+            window.location = el[0].href;
+        });
+
+        waitsFor(function () {
+            return $('input#g-filesystem-import-path').length > 0;
+        }, 'import page to load');
+
+        runs(function () {
+            var coll = new girder.collections.FolderCollection();
+            coll.on('g:changed', function () {
+                privateFolder = coll.models[0];
+            }).fetch({
+                parentType: 'user',
+                parentId: girder.currentUser.id
+            });
+        });
+
+        waitsFor(function () {
+            return privateFolder !== null;
+        }, 'admin user folders to be fetched');
+
+        runs(function () {
+            $('#g-filesystem-import-dest-id').val(privateFolder.id);
+            $('#g-filesystem-import-dest-type').val('folder');
+            $('#g-filesystem-import-path').val('/invalid/path');
+
+            $('.g-submit-assetstore-import').click();
+        });
+
+        waitsFor(function () {
+            return $('.g-validation-failed-message').text() ===
+                'No such directory: /invalid/path.';
+        });
+
+        runs(function () {
+            $('#g-filesystem-import-path').val('./tests/cases/py_client');
+
+            $('.g-submit-assetstore-import').click();
+        });
+
+        waitsFor(function () {
+            return $('.g-folder-list-entry').text().indexOf('testdata') !== -1;
+        }, 'user folders to show');
+
+        runs(function () {
+            _.each($('.g-folder-list-link'), function (link) {
+                if ($(link).text() === 'testdata') {
+                    $(link).click();
+                }
+            });
+        });
+
+        waitsFor(function () {
+            return $('.g-item-list-link').text().indexOf('hello.txt') !== -1;
+        }, 'item to appear in the hierarchy widget');
+
+        runs(function () {
+            $('.g-item-list-link').click();
+        });
+
+        waitsFor(function () {
+            return $('.g-file-list-link').length === 1;
+        }, 'item page to render');
+
+        // Delete the containing folder so we can delete the assetstore
+        runs(function () {
+            privateFolder.on('g:deleted', function () {
+                privateFolder = null;
+            }).destroy();
+        });
+
+        waitsFor(function () {
+            return privateFolder === null;
+        }, 'private folder to be deleted');
+
+        runs(function () {
+            window.location = '#assetstores';
+        });
+
+        waitsFor(function () {
+            return $('.g-assetstore-container').length > 0;
+        }, 'assetstore page to load');
+    };
+
     var _testS3Import = function (params) {
         var privateFolder = null;
 
         runs(function () {
             var container = _getAssetstoreContainer(params.name);
-            var el = $('a.g-s3-import-button', container);
+            var el = $('a.g-import-button', container);
             window.location = el[0].href;
         });
 
@@ -392,9 +482,10 @@ describe('Test the assetstore page', function () {
         });
     });
 
-    _testAssetstore('filesystem', 'g-create-fs-tab',
-                    {'g-new-fs-name': 'name',
-                     'g-new-fs-root': '/tmp/assetstore'});
+    _testAssetstore('filesystem', 'g-create-fs-tab', {
+        'g-new-fs-name': 'name',
+        'g-new-fs-root': '/tmp/assetstore'
+    }, _testFilesystemImport);
 
     _testAssetstore('gridfs', 'g-create-gridfs-tab',
                     {'g-new-gridfs-name': 'name',

--- a/docs/api-docs.rst
+++ b/docs/api-docs.rst
@@ -188,6 +188,9 @@ Utility
 .. automodule:: girder.utility.mail_utils
    :members:
 
+.. automodule:: girder.utility.progress
+   :members:
+
 Constants
 ---------
 .. automodule:: girder.constants

--- a/girder/models/assetstore.py
+++ b/girder/models/assetstore.py
@@ -167,11 +167,11 @@ class Assetstore(Model):
         return current
 
     def importData(self, assetstore, parent, parentType, params, progress,
-                   user):
+                   user, **kwargs):
         """
         Calls the importData method of the underlying assetstore adapter.
         """
         adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
         return adapter.importData(
             parent=parent, parentType=parentType, params=params,
-            progress=progress, user=user)
+            progress=progress, user=user, **kwargs)

--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -188,7 +188,7 @@ class File(acl_mixin.AccessControlMixin, Model):
             '_id': item['baseParentId']
         }, field='size', amount=sizeIncrement, multi=False)
 
-    def createFile(self, creator, item, name, size, assetstore, mimeType,
+    def createFile(self, creator, item, name, size, assetstore, mimeType=None,
                    saveFile=True, reuseExisting=False):
         """
         Create a new file record in the database.

--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -18,6 +18,7 @@ import cherrypy
 import os
 import six
 
+from girder.utility import progress
 from ..constants import SettingKey
 from .model_importer import ModelImporter
 from ..models.model_base import ValidationException
@@ -143,6 +144,24 @@ class AbstractAssetstoreAdapter(ModelImporter):
         """
         raise Exception('Must override downloadFile in %s.'
                         % self.__class__.__name__)  # pragma: no cover
+
+    def findInvalidFiles(self, progress=progress.noProgress, filters=None,
+                         checkSize=True, **kwargs):
+        """
+        Finds and yields any invalid files in the assetstore. It is left to
+        the caller to decide what to do with them.
+
+        :param progress: Pass a progress context to record progress.
+        :type progress: :py:class:`girder.utility.progress.ProgressContext`
+        :param filters: Additional query dictionary to restrict the search for
+            files. There is no need to set the ``assetstoreId`` in the filters,
+            since that is done automatically.
+        :type filters: dict or None
+        :param checkSize: Whether to make sure the size of the underlying
+            data matches the size of the file.
+        :type checkSize: bool
+        """
+        return ()
 
     def copyFile(self, srcFile, destFile):
         """

--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -85,8 +85,8 @@ class AbstractAssetstoreAdapter(ModelImporter):
         :type chunk: file
         :returns: Must return the upload document with any optional changes.
         """
-        raise Exception('Must override processChunk in %s.'
-                        % self.__class__.__name__)  # pragma: no cover
+        raise NotImplementedError('Must override processChunk in %s.' %
+                                  self.__class__.__name__)  # pragma: no cover
 
     def finalizeUpload(self, upload, file):
         """
@@ -122,8 +122,8 @@ class AbstractAssetstoreAdapter(ModelImporter):
         :param file: The File document about to be deleted.
         :type file: dict
         """
-        raise Exception('Must override deleteFile in %s.'
-                        % self.__class__.__name__)  # pragma: no cover
+        raise NotImplementedError('Must override deleteFile in %s.' %
+                                  self.__class__.__name__)  # pragma: no cover
 
     def downloadFile(self, file, offset=0, headers=True, endByte=None):
         """
@@ -142,8 +142,8 @@ class AbstractAssetstoreAdapter(ModelImporter):
             end of the file.
         :type endByte: int or None
         """
-        raise Exception('Must override downloadFile in %s.'
-                        % self.__class__.__name__)  # pragma: no cover
+        raise NotImplementedError('Must override downloadFile in %s.' %
+                                  self.__class__.__name__)  # pragma: no cover
 
     def findInvalidFiles(self, progress=progress.noProgress, filters=None,
                          checkSize=True, **kwargs):
@@ -161,7 +161,8 @@ class AbstractAssetstoreAdapter(ModelImporter):
             data matches the size of the file.
         :type checkSize: bool
         """
-        return ()
+        raise NotImplementedError('Must override findInvalidFiles in %s.' %
+                                  self.__class__.__name__)  # pragma: no cover
 
     def copyFile(self, srcFile, destFile):
         """
@@ -242,8 +243,8 @@ class AbstractAssetstoreAdapter(ModelImporter):
         abandoned.  It must clean up temporary files, chunks, or whatever other
         information the assest store contains.
         """
-        raise Exception('Must override cancelUpload in %s.'
-                        % self.__class__.__name__)  # pragma: no cover
+        raise NotImplementedError('Must override cancelUpload in %s.' %
+                                  self.__class__.__name__)  # pragma: no cover
 
     def untrackedUploads(self, knownUploads=(), delete=False):
         """
@@ -277,5 +278,6 @@ class AbstractAssetstoreAdapter(ModelImporter):
         :param user: The girder user performing the import.
         :type user: dict or None
         """
-        raise ValidationException(
-            'This assetstore type does not support importing existing data.')
+        raise NotImplementedError(
+            'The %s assetstore type does not support importing existing data.'
+            % self.__class__.__name__)  # pragma: no cover)

--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -240,7 +240,7 @@ class AbstractAssetstoreAdapter(ModelImporter):
         """
         return ()
 
-    def importData(self, parent, parentType, params, progress, user):
+    def importData(self, parent, parentType, params, progress, user, **kwargs):
         """
         Assetstores that are capable of importing pre-existing data from the
         underlying storage medium can implement this method.

--- a/girder/utility/filesystem_assetstore_adapter.py
+++ b/girder/utility/filesystem_assetstore_adapter.py
@@ -41,6 +41,9 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
     This assetstore type stores files on the filesystem underneath a root
     directory. Files are named by their SHA-512 hash, which avoids duplication
     of file content.
+
+    :param assetstore: The assetstore to act on.
+    :type assetstore: dict
     """
 
     @staticmethod
@@ -69,14 +72,12 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
     @staticmethod
     def fileIndexFields():
         """
-        File documents should have an index on their sha512 field.
+        File documents should have an index on their sha512 field, as well as
+        whether or not they are imported.
         """
         return ['sha512', 'imported']
 
     def __init__(self, assetstore):
-        """
-        :param assetstore: The assetstore to act on.
-        """
         self.assetstore = assetstore
         # If we can't create the temp directory, the assetstore still needs to
         # be initialized so that it can be deleted or modified.  The validation

--- a/girder/utility/filesystem_assetstore_adapter.py
+++ b/girder/utility/filesystem_assetstore_adapter.py
@@ -218,7 +218,11 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
         if endByte is None or endByte > file['size']:
             endByte = file['size']
 
-        path = os.path.join(self.assetstore['root'], file['path'])
+        if file.get('imported'):
+            path = file['fullPath']
+        else:
+            path = os.path.join(self.assetstore['root'], file['path'])
+
         if not os.path.isfile(path):
             raise GirderException(
                 'File %s does not exist.' % path,
@@ -252,8 +256,11 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
     def deleteFile(self, file):
         """
         Deletes the file from disk if it is the only File in this assetstore
-        with the given sha512.
+        with the given sha512. Imported files are not actually deleted.
         """
+        if file.get('imported'):
+            return
+
         q = {
             'sha512': file['sha512'],
             'assetstoreId': self.assetstore['_id']
@@ -270,3 +277,61 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
         """
         if os.path.exists(upload['tempFile']):
             os.unlink(upload['tempFile'])
+
+    def importFile(self, item, path, user, name=None, mimeType=None, size=None):
+        """
+        Import a single file from the filesystem into the assetstore.
+
+        :param item: The parent item for the file.
+        :type item: dict
+        :param path: The path on the local filesystem.
+        :type path: str
+        :param user: The user to list as the creator of the file.
+        :type user: dict
+        :param name: Name for the file. Defaults to the basename of ``path``.
+        :type name: str
+        :param mimeType: MIME type of the file if known.
+        :type mimeType: str
+        :param size: Size of the file in bytes. Will stat the file if not
+            passed.
+        :type size: int
+        :returns: The file document that was created.
+        """
+        if size is None:
+            size = os.path.getsize(path)
+
+        name = name or os.path.basename(path)
+
+        file = self.model('file').createFile(
+            name=name, creator=user, item=item, reuseExisting=True,
+            assetstore=self.assetstore, mimeType=mimeType, size=size)
+        file['fullPath'] = os.path.abspath(os.path.expanduser(path))
+        file['imported'] = True
+        return self.model('file').save(file)
+
+    def importData(self, parent, parentType, params, progress, user):
+        importPath = params['importPath']
+
+        if not os.path.isdir(importPath):
+            raise ValidationException('No such directory: %s.' % importPath)
+
+        for name in os.listdir(importPath):
+            progress.update(message=name)
+            path = os.path.join(importPath, name)
+
+            if os.path.isdir(path):
+                folder = self.model('folder').createFolder(
+                    parent=parent, name=name, parentType=parentType,
+                    creator=user, reuseExisting=True)
+                self.importData(folder, 'folder', params={
+                    'importPath': os.path.join(importPath, name)
+                }, progress=progress, user=user)
+            else:
+                if parentType != 'folder':
+                    raise ValidationException(
+                        'Files cannot be imported directly underneath a %s.' %
+                        parentType)
+
+                item = self.model('item').createItem(
+                    name=name, creator=user, folder=parent, reuseExisting=True)
+                self.importFile(item, path, user, name=name)

--- a/girder/utility/filesystem_assetstore_adapter.py
+++ b/girder/utility/filesystem_assetstore_adapter.py
@@ -217,7 +217,7 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
         file.
         """
         if file.get('imported'):
-            return file['fullPath']
+            return file['path']
         else:
             return os.path.join(self.assetstore['root'], file['path'])
 
@@ -314,7 +314,7 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
         file = self.model('file').createFile(
             name=name, creator=user, item=item, reuseExisting=True,
             assetstore=self.assetstore, mimeType=mimeType, size=size)
-        file['fullPath'] = os.path.abspath(os.path.expanduser(path))
+        file['path'] = os.path.abspath(os.path.expanduser(path))
         file['imported'] = True
         return self.model('file').save(file)
 

--- a/girder/utility/progress.py
+++ b/girder/utility/progress.py
@@ -31,19 +31,23 @@ class ProgressContext(ModelImporter):
     """
     This class is a context manager that can be used to update progress in a way
     that rate-limits writes to the database and guarantees a flush when the
-    context is exited.
-    """
-    def __init__(self, on, interval=0.5, **kwargs):
-        """
-        Create a new progress manager. This is a no-op if "on" is set to false,
-        which is convenient for the caller's semantics.
+    context is exited. This is a no-op if "on" is set to False, which is
+    meant as a convenience for callers. Any additional kwargs passed to this
+    constructor are passed through to the ``initProgress`` method of the
+    notification model.
 
-        :param on: Whether to record progress.
-        :type on: bool
-        :param interval: Minimum time interval at which to write updates
-        to the database, in seconds.
-        :type interval: int or float
-        """
+    :param on: Whether to record progress.
+    :type on: bool
+    :param interval: Minimum time interval at which to write updates to the
+        database, in seconds.
+    :type interval: int or float
+    :param user: The user creating this progress.
+    :type user: dict
+    :param title: The title for the task being tracked.
+    :type title: str
+    """
+
+    def __init__(self, on, interval=0.5, **kwargs):
         self.on = on
         self.interval = interval
 
@@ -84,8 +88,8 @@ class ProgressContext(ModelImporter):
         the last time the record was written to the database. Accepts the
         same kwargs as Notification.updateProgress.
 
-        :param force: Whether we should force the write to the database.
-        Use only in cases where progress may be indeterminate for a long time.
+        :param force: Whether we should force the write to the database. Use
+            only in cases where progress may be indeterminate for a long time.
         :type force: bool
         """
         # Extend the response timeout, even if we aren't reporting the progress
@@ -110,8 +114,8 @@ def setResponseTimeLimit(duration=600, onlyExtend=True):
     which can take longer should call this function.
 
     Note that for cherrypy responses that include streaming generator
-    functions,such as downloads, the timeout is only relevant until the first
-    `yield` is reached.  As such, long running generator responses do not
+    functions, such as downloads, the timeout is only relevant until the first
+    ``yield`` is reached.  As such, long running generator responses do not
     generally need to call this function.
 
     :param duration: additional duration in seconds to allow for the response.

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -336,7 +336,7 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
             return stream
 
     def importData(self, parent, parentType, params, progress, user,
-                   bucket=None):
+                   bucket=None, **kwargs):
         importPath = params.get('importPath', '').strip().lstrip('/')
 
         if importPath and not importPath.endswith('/'):
@@ -356,7 +356,7 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
                     creator=user, reuseExisting=True)
                 self.importData(parent=folder, parentType='folder', params={
                     'importPath': obj.name
-                }, progress=progress, user=user, bucket=bucket)
+                }, progress=progress, user=user, bucket=bucket, **kwargs)
             elif isinstance(obj, boto.s3.key.Key):
                 name = obj.name.rsplit('/', 1)[-1]
                 if not name:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+import mock
+from girder import constants, logger
+
+# Mock the logging methods so that we don't actually write logs to disk,
+# and so tests can potentially inspect calls to logging methods.
+print(constants.TerminalColor.warning('Mocking girder log methods.'))
+for method in ('info', 'error', 'exception'):
+    setattr(logger, method, mock.MagicMock())

--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -174,7 +174,7 @@ class AssetstoreTestCase(base.TestCase):
         self.assertEqual(resp.json['_modelType'], 'file')
         file = self.model('file').load(resp.json['_id'], force=True, exc=True)
 
-        self.assertTrue(os.path.isfile(file['fullPath']))
+        self.assertTrue(os.path.isfile(file['path']))
 
         # Make sure downloading the file works
         resp = self.request('/file/%s/download' % str(file['_id']),
@@ -188,7 +188,7 @@ class AssetstoreTestCase(base.TestCase):
         self.assertStatusOk(resp)
 
         self.assertIsNone(self.model('file').load(file['_id'], force=True))
-        self.assertTrue(os.path.isfile(file['fullPath']))
+        self.assertTrue(os.path.isfile(file['path']))
 
     def testFilesystemAssetstoreRemoveMissing(self):
         # Create several files in the assetstore, some of which point to real
@@ -203,7 +203,7 @@ class AssetstoreTestCase(base.TestCase):
             name='hello.txt', creator=self.admin, item=item,
             assetstore=self.assetstore, size=os.path.getsize(path))
         real['imported'] = True
-        real['fullPath'] = path
+        real['path'] = path
         self.model('file').save(real)
 
         fake = self.model('file').createFile(
@@ -217,7 +217,7 @@ class AssetstoreTestCase(base.TestCase):
             name='fakeImport', creator=self.admin, item=item, size=1,
             assetstore=self.assetstore)
         fakeImport['imported'] = True
-        fakeImport['fullPath'] = '/nonexistent/path/to/file'
+        fakeImport['path'] = '/nonexistent/path/to/file'
         self.model('file').save(fakeImport)
 
         adapter = assetstore_utilities.getAssetstoreAdapter(self.assetstore)

--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -18,6 +18,7 @@
 ###############################################################################
 
 import httmock
+import inspect
 import io
 import json
 import mock
@@ -190,7 +191,7 @@ class AssetstoreTestCase(base.TestCase):
         self.assertIsNone(self.model('file').load(file['_id'], force=True))
         self.assertTrue(os.path.isfile(file['path']))
 
-    def testFilesystemAssetstoreRemoveMissing(self):
+    def testFilesystemAssetstoreFindInvalidFiles(self):
         # Create several files in the assetstore, some of which point to real
         # files on disk and some that don't
         folder = six.next(self.model('folder').childFolders(
@@ -221,6 +222,7 @@ class AssetstoreTestCase(base.TestCase):
         self.model('file').save(fakeImport)
 
         adapter = assetstore_utilities.getAssetstoreAdapter(self.assetstore)
+        self.assertTrue(inspect.isgeneratorfunction(adapter.findInvalidFiles))
 
         with ProgressContext(True, user=self.admin, title='test') as p:
             for i, info in enumerate(

--- a/tests/cases/py_client/cli_test.py
+++ b/tests/cases/py_client/cli_test.py
@@ -25,11 +25,12 @@ import shutil
 import sys
 import six
 
-# Need to set the environment variable before importing girder
-os.environ['GIRDER_PORT'] = os.environ.get('GIRDER_TEST_PORT', '20200')  # noqa
-
+from girder import config
 from tests import base
 from six import StringIO
+
+os.environ['GIRDER_PORT'] = os.environ.get('GIRDER_TEST_PORT', '20200')
+config.loadConfig()  # Must reload config to pickup correct port
 
 
 @contextlib.contextmanager

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -24,10 +24,11 @@ import os
 import shutil
 import six
 
-# Need to set the environment variable before importing girder
-os.environ['GIRDER_PORT'] = os.environ.get('GIRDER_TEST_PORT', '20200')  # noqa
-
+from girder import config
 from tests import base
+
+os.environ['GIRDER_PORT'] = os.environ.get('GIRDER_TEST_PORT', '20200')
+config.loadConfig()  # Must reload config to pickup correct port
 
 
 def setUpModule():

--- a/tests/web_client_test.py
+++ b/tests/web_client_test.py
@@ -23,9 +23,7 @@ import subprocess
 import sys
 import time
 
-# Need to set the environment variable before importing girder
-os.environ['GIRDER_PORT'] = os.environ.get('GIRDER_PORT', '30001')  # noqa
-
+from girder import config
 from girder.api import access
 from girder.api.describe import Description
 from girder.api.rest import Resource, RestException
@@ -34,6 +32,8 @@ from girder.utility.progress import ProgressContext
 from . import base
 from six.moves import range
 
+os.environ['GIRDER_PORT'] = os.environ.get('GIRDER_PORT', '30001')
+config.loadConfig()  # Reload config to pick up correct port
 testServer = None
 
 


### PR DESCRIPTION
Depends on #999 

Question for @girder/developers is whether we want to make this new method, which goes through and hunts down files whose underlying data is missing, should be part of the abstract assetstore API, or if it's OK to leave as a one-off method within the filesystem assetstore adapter for now.

Another question would be whether we want to expose this via the REST API. For now I chose not to since my need of this method does not require it.