### PR TITLE
Removing non-responsive badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|logo| Girder |build-status| |docs-status| |gitter-badge|
+|logo| Girder |build-status| |docs-status| |license-badge| |gitter-badge|
 =========================================================================
 
 **Data Management Platform**
@@ -20,6 +20,10 @@ We'd love for you to `contribute to Girder <CONTRIBUTING.md>`_.
 .. |docs-status| image:: https://readthedocs.org/projects/girder/badge?version=latest
     :target: https://girder.readthedocs.org
     :alt: Documentation Status
+
+.. |license-badge| image:: https://img.shields.io/pypi/l/girder.svg 
+    :target: https://pypi.python.org/pypi/girder
+    :alt: License
 
 .. |gitter-badge| image:: https://badges.gitter.im/Join Chat.svg
     :target: https://gitter.im/girder/girder?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ We'd love for you to `contribute to Girder <CONTRIBUTING.md>`_.
     :target: https://girder.readthedocs.org
     :alt: Documentation Status
 
-.. |license-badge| image:: https://img.shields.io/pypi/l/girder.svg 
+.. |license-badge| image:: https://img.shields.io/pypi/l/girder.svg
     :target: https://pypi.python.org/pypi/girder
     :alt: License
 

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|logo| Girder |build-status| |docs-status| |license-badge| |gitter-badge|
+|logo| Girder |build-status| |docs-status| |gitter-badge|
 =========================================================================
 
 **Data Management Platform**
@@ -20,10 +20,6 @@ We'd love for you to `contribute to Girder <CONTRIBUTING.md>`_.
 .. |docs-status| image:: https://readthedocs.org/projects/girder/badge?version=latest
     :target: https://girder.readthedocs.org
     :alt: Documentation Status
-
-.. |license-badge| image:: https://pypip.in/license/girder/badge.png
-    :target: https://pypi.python.org/pypi/girder
-    :alt: License
 
 .. |gitter-badge| image:: https://badges.gitter.im/Join Chat.svg
     :target: https://gitter.im/girder/girder?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge


### PR DESCRIPTION
 Looks like pypin.in is down, [for good](https://github.com/badges/pypipins/issues/37#issuecomment-127772864)?

Do we care to look for a replacement, or can this be removed altogether?