### PR TITLE
Fix quota issues.

### DIFF
--- a/plugins/user_quota/plugin_tests/userQuotaSpec.js
+++ b/plugins/user_quota/plugin_tests/userQuotaSpec.js
@@ -1,4 +1,7 @@
+/* globals girderTest, runs, waitsFor, expect, describe, it */
+
 $(function () {
+    var app;
     /* Include the built version of the our templates.  This means that grunt
      * must be run to generate these before the test. */
     girderTest.addCoveredScripts([
@@ -11,7 +14,7 @@ $(function () {
     );
 
     girder.events.trigger('g:appload.before');
-    var app = new girder.App({
+    app = new girder.App({
         el: 'body',
         parentView: null
     });
@@ -20,11 +23,12 @@ $(function () {
 
 /* Go to the collections page.  If a collection is specified, go to that
  * collection's page.
+ *
  * @param collection: the name of the collection to go to.
  */
 function _goToCollection(collection) {
     runs(function () {
-        $("a.g-nav-link[g-target='collections']").click();
+        $('a.g-nav-link[g-target=\'collections\']').click();
     });
     waitsFor(function () {
         return $('.g-collections-search-container:visible').length > 0;
@@ -43,19 +47,70 @@ function _goToCollection(collection) {
 }
 
 /* Go to the users page.  If a user is specified, go to that user's page.
+ *
  * @param user: the full name of the user to go to.
  */
 function _goToUser(user) {
     girderTest.goToUsersPage()();
     if (user) {
         runs(function () {
-            $("a.g-user-link:contains('" + user + "')").click();
+            $('a.g-user-link:contains("' + user + '")').click();
         });
         waitsFor(function () {
             return $('.g-user-name').text() === user;
         }, 'user page to appear');
         girderTest.waitForLoad();
     }
+}
+
+/* Go to a collection, make it public, and give user1 access to it.
+ *
+ * @param collection: the name of the collection to go to.
+ */
+function _makeCollectionPublic(collection) {
+    _goToCollection(collection);
+    runs(function () {
+        $('.g-collection-actions-button').click();
+    });
+    waitsFor(function () {
+        return $('.g-collection-access-control[role="menuitem"]:visible').length === 1;
+    }, 'access control menu item to appear');
+    runs(function () {
+        $('.g-collection-access-control').click();
+    });
+    girderTest.waitForDialog();
+    waitsFor(function () {
+        return $('#g-dialog-container').hasClass('in') &&
+               $('#g-access-public:visible').is(':enabled');
+    }, 'dialog and public access radio button to appear');
+    runs(function () {
+        $('#g-access-public').click();
+        $('#g-dialog-container .g-search-field').val('user1');
+        $('#g-dialog-container input.g-search-field').trigger('input');
+    });
+    waitsFor(function () {
+        return $('.g-search-result').length === 1;
+    }, 'user1 to be listed');
+    runs(function () {
+        $('.g-search-result a').click();
+    });
+    waitsFor(function () {
+        return $('.g-user-access-entry').length === 2;
+    }, 'user1 to be in the access list');
+    runs(function () {
+        $('.g-access-col-right select').eq(1).val(2);
+    });
+    waitsFor(function () {
+        return $('.g-save-access-list:visible').is(':enabled') &&
+               $('.radio.g-selected').text().match('Public').length > 0;
+    }, 'access save button to appear');
+    runs(function () {
+        $('.g-save-access-list').click();
+    });
+    girderTest.waitForLoad();
+    waitsFor(function () {
+        return !$('#g-dialog-container').hasClass('in');
+    }, 'access dialog to be hidden');
 }
 
 /* Test the quota dialog, expecting that this is an admin and can set the
@@ -66,7 +121,7 @@ function _goToUser(user) {
 function _testQuotaDialogAsAdmin(hasChart, capacity) {
     girderTest.waitForDialog('quota dialog to appear');
     waitsFor(function () {
-        return $(".g-quota-capacity").length === 1;
+        return $('.g-quota-capacity').length === 1;
     }, 'capacity to appear');
     waitsFor(function () {
         return $('a.btn-default').length === 1;
@@ -75,17 +130,17 @@ function _testQuotaDialogAsAdmin(hasChart, capacity) {
         return $(hasChart ? '.g-has-chart' : '.g-no-chart').length === 1;
     }, 'the chart to be determined (' + hasChart + ' ' + capacity + ')');
     runs(function () {
-        expect($("#g-sizeValue").length).toBe(1);
+        expect($('#g-sizeValue').length).toBe(1);
         /* The change() call should automatically set the custom quota radio
          * button. */
-        $("#g-sizeValue").val('abc').trigger('input');
+        $('#g-sizeValue').val('abc').trigger('input');
         $('.g-save-policies').click();
     });
     waitsFor(function () {
         return $('.g-validation-failed-message').text().indexOf('Invalid quota') >= 0;
     }, 'an error message to appear');
     runs(function () {
-        $("#g-sizeValue").val(capacity ? capacity : '');
+        $('#g-sizeValue').val(capacity ? capacity : '');
     });
     runs(function () {
         $('.g-save-policies').click();
@@ -100,7 +155,7 @@ function _testQuotaDialogAsAdmin(hasChart, capacity) {
 function _testQuotaDialogAsUser(hasChart) {
     girderTest.waitForDialog();
     waitsFor(function () {
-        return $(".g-quota-capacity").length === 1;
+        return $('.g-quota-capacity').length === 1;
     }, 'capacity to appear');
     waitsFor(function () {
         return $('a.btn-default').length === 1;
@@ -109,7 +164,7 @@ function _testQuotaDialogAsUser(hasChart) {
         return $(hasChart ? '.g-has-chart' : '.g-no-chart').length === 1;
     }, 'the chart to be determined');
     runs(function () {
-        expect($("#g-sizeValue").length).toBe(0);
+        expect($('#g-sizeValue').length).toBe(0);
     });
     runs(function () {
         $('a.btn-default').click();
@@ -124,59 +179,23 @@ describe('test the user quota plugin', function () {
             'admin', 'admin@email.com', 'Quota', 'Admin', 'testpassword')();
         _goToCollection();
         girderTest.createCollection('Collection A', 'ColDescription')();
+        _goToCollection();
+        girderTest.createCollection('Collection B', 'ColDescription')();
         girderTest.logout('logout from admin')();
         girderTest.createUser(
             'user1', 'user@email.com', 'Quota', 'User', 'testpassword')();
         girderTest.logout('logout from user1')();
         girderTest.createUser(
             'user2', 'user2@email.com', 'Another', 'User', 'testpassword')();
-    });
-    it('make the collection public', function () {
         girderTest.logout('logout from user2')();
+        girderTest.createUser(
+            'user3', 'user3@email.com', 'Third', 'User', 'testpassword')();
+    });
+    it('make the collections public', function () {
+        girderTest.logout('logout from user3')();
         girderTest.login('admin', 'Quota', 'Admin', 'testpassword')();
-        _goToCollection('Collection A');
-        runs(function () {
-            $('.g-collection-actions-button').click();
-        });
-        waitsFor(function () {
-            return $(".g-collection-access-control[role='menuitem']:visible").length === 1;
-        }, 'access control menu item to appear');
-        runs(function () {
-            $('.g-collection-access-control').click();
-        });
-        girderTest.waitForDialog();
-        waitsFor(function () {
-            return $('#g-dialog-container').hasClass('in') &&
-                   $('#g-access-public:visible').is(':enabled');
-        }, 'dialog and public access radio button to appear');
-        runs(function () {
-            $('#g-access-public').click();
-            $('#g-dialog-container .g-search-field').val('user1');
-            $('#g-dialog-container input.g-search-field').trigger('input');
-        });
-        waitsFor(function () {
-            return $('.g-search-result').length === 1;
-        }, 'user1 to be listed');
-        runs(function () {
-            $('.g-search-result a').click();
-        });
-        waitsFor(function () {
-            return $('.g-user-access-entry').length === 2;
-        }, 'user1 to be in the access list');
-        runs(function () {
-            $('.g-access-col-right select').eq(1).val(2);
-        });
-        waitsFor(function () {
-            return $('.g-save-access-list:visible').is(':enabled') &&
-                   $('.radio.g-selected').text().match("Public").length > 0;
-        }, 'access save button to appear');
-        runs(function () {
-            $('.g-save-access-list').click();
-        });
-        girderTest.waitForLoad();
-        waitsFor(function () {
-            return !$('#g-dialog-container').hasClass('in');
-        }, 'access dialog to be hidden');
+        _makeCollectionPublic('Collection A');
+        _makeCollectionPublic('Collection B');
     });
     it('check that admin can set the default quotas', function () {
         waitsFor(function () {
@@ -231,7 +250,7 @@ describe('test the user quota plugin', function () {
             $('.g-collection-actions-button').click();
         });
         waitsFor(function () {
-            return $(".g-collection-policies[role='menuitem']:visible").length === 1;
+            return $('.g-collection-policies[role="menuitem"]:visible').length === 1;
         }, 'collection actions menu to appear');
         runs(function () {
             $('.g-collection-policies').click();
@@ -252,7 +271,7 @@ describe('test the user quota plugin', function () {
             $('.g-user-actions-button').click();
         });
         waitsFor(function () {
-            return $(".g-user-policies[role='menuitem']:visible").length === 1;
+            return $('.g-user-policies[role="menuitem"]:visible').length === 1;
         }, 'user actions menu to appear');
         runs(function () {
             $('.g-user-policies').click();
@@ -265,13 +284,13 @@ describe('test the user quota plugin', function () {
     });
     it('test routes', function () {
         girderTest.testRoute(collectionDialogRoute, true, function () {
-            return $(".g-quota-capacity").length === 1;
+            return $('.g-quota-capacity').length === 1;
         });
         girderTest.testRoute(userRoute, false, function () {
             return $('.g-user-name').text() === 'Quota User';
         });
         girderTest.testRoute(userDialogRoute, true, function () {
-            return $(".g-quota-capacity").length === 1;
+            return $('.g-quota-capacity').length === 1;
         });
         runs(function () {
             $('a[data-dismiss="modal"]').click();
@@ -295,7 +314,7 @@ describe('test the user quota plugin', function () {
             });
         });
     });
-    it('check that user2 can view but not set quota', function () {
+    it('check that user1 can view but not set quota', function () {
         girderTest.logout('logout from admin')();
         girderTest.login('user1', 'Quota', 'User', 'testpassword')();
         _goToCollection('Collection A');
@@ -303,7 +322,7 @@ describe('test the user quota plugin', function () {
             $('.g-collection-actions-button').click();
         });
         waitsFor(function () {
-            return $(".g-collection-policies[role='menuitem']:visible").length === 1;
+            return $('.g-collection-policies[role="menuitem"]:visible').length === 1;
         }, 'collection actions menu to appear');
         runs(function () {
             $('.g-collection-policies').click();
@@ -314,7 +333,7 @@ describe('test the user quota plugin', function () {
             $('.g-user-actions-button').click();
         });
         waitsFor(function () {
-            return $(".g-user-policies[role='menuitem']:visible").length === 1;
+            return $('.g-user-policies[role="menuitem"]:visible').length === 1;
         }, 'user actions menu to appear');
         runs(function () {
             $('.g-user-policies').click();
@@ -332,14 +351,86 @@ describe('test the user quota plugin', function () {
             $('.g-collection-actions-button').click();
         });
         waitsFor(function () {
-            return $(".g-download-collection[role='menuitem']:visible").length === 1;
+            return $('.g-download-collection[role="menuitem"]:visible').length === 1;
         }, 'collection actions menu to appear');
         runs(function () {
             expect($('.g-collection-policies').length).toBe(0);
         });
         _goToUser('Quota User');
         runs(function () {
-            expect($("button:contains('Actions')").length).toBe(0);
+            expect($('button:contains("Actions")').length).toBe(0);
         });
+    });
+    it('check that admin can set the default collection quota', function () {
+        girderTest.logout('logout from user2')();
+        girderTest.login('admin', 'Quota', 'Admin', 'testpassword')();
+        waitsFor(function () {
+            return $('a.g-nav-link[g-target="admin"]').length > 0;
+        }, 'admin console link to load');
+        runs(function () {
+            $('a.g-nav-link[g-target="admin"]').click();
+        });
+        waitsFor(function () {
+            return $('.g-plugins-config').length > 0;
+        }, 'the admin console to load');
+        runs(function () {
+            $('.g-plugins-config').click();
+        });
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('input.g-plugin-switch[key="user_quota"]').length > 0;
+        }, 'the plugins page to load');
+        runs(function () {
+            expect($('.g-plugin-config-link[g-route="plugins/user_quota/config"]').length > 0);
+            $('.g-plugin-config-link[g-route="plugins/user_quota/config"]').click();
+        });
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('input.g-sizeValue').length > 0;
+        }, 'quota default settings to be shown');
+        runs(function () {
+            $('input.g-sizeValue[model=collection]').val('256000');
+            $('#g-user-quota-form input.btn-primary').click();
+        });
+        waitsFor(function () {
+            var resp = girder.restRequest({
+                path: 'system/setting',
+                type: 'GET',
+                data: {key: 'user_quota.default_collection_quota'},
+                async: false
+            });
+            return resp.responseText === '256000';
+        }, 'default collection quota settings to change');
+        girderTest.waitForLoad();
+    });
+    it('check that a user that has never had their quota altered sees the default', function () {
+        girderTest.logout('logout from admin')();
+        girderTest.login('user3', 'Third', 'User', 'testpassword')();
+        _goToUser('Third User');
+        runs(function () {
+            $('.g-user-actions-button').click();
+        });
+        waitsFor(function () {
+            return $('.g-user-policies[role="menuitem"]:visible').length === 1;
+        }, 'user actions menu to appear');
+        runs(function () {
+            $('.g-user-policies').click();
+        });
+        _testQuotaDialogAsUser(true);
+    });
+    it('check that a collection that has never had their quota altered sees the default', function () {
+        girderTest.logout('logout from user3')();
+        girderTest.login('user1', 'Quota', 'User', 'testpassword')();
+        _goToCollection('Collection B');
+        runs(function () {
+            $('.g-collection-actions-button').click();
+        });
+        waitsFor(function () {
+            return $('.g-collection-policies[role="menuitem"]:visible').length === 1;
+        }, 'collection actions menu to appear');
+        runs(function () {
+            $('.g-collection-policies').click();
+        });
+        _testQuotaDialogAsUser(true);
     });
 });

--- a/plugins/user_quota/server/quota.py
+++ b/plugins/user_quota/server/quota.py
@@ -180,7 +180,7 @@ class QuotaPolicy(Resource):
         for key in dir(self):
             if key.startswith('_validate_'):
                 validKeys.append(key.split('_validate_', 1)[1])
-        for key in policy.keys():
+        for key in list(policy):
             if key.startswith('_'):
                 del policy[key]
         for key in policy:

--- a/plugins/user_quota/server/quota.py
+++ b/plugins/user_quota/server/quota.py
@@ -180,6 +180,9 @@ class QuotaPolicy(Resource):
         for key in dir(self):
             if key.startswith('_validate_'):
                 validKeys.append(key.split('_validate_', 1)[1])
+        for key in policy.keys():
+            if key.startswith('_'):
+                del policy[key]
         for key in policy:
             if key not in validKeys:
                 raise RestException(
@@ -192,6 +195,11 @@ class QuotaPolicy(Resource):
     @access.public
     @loadmodel(model='collection', level=AccessType.READ)
     def getCollectionQuota(self, collection, params):
+        if QUOTA_FIELD not in collection:
+            collection[QUOTA_FIELD] = {}
+        collection[QUOTA_FIELD][
+            '_currentFileSizeQuota'] = self._getFileSizeQuota(
+            'collection', collection)
         return self._filter('collection', collection)
     getCollectionQuota.description = (
         Description('Get quota and assetstore policies for the collection.')
@@ -215,6 +223,10 @@ class QuotaPolicy(Resource):
     @access.public
     @loadmodel(model='user', level=AccessType.READ)
     def getUserQuota(self, user, params):
+        if QUOTA_FIELD not in user:
+            user[QUOTA_FIELD] = {}
+        user[QUOTA_FIELD]['_currentFileSizeQuota'] = self._getFileSizeQuota(
+            'user', user)
         return self._filter('user', user)
     getUserQuota.description = (
         Description('Get quota and assetstore policies for the user.')
@@ -288,6 +300,11 @@ class QuotaPolicy(Resource):
             model = resource['baseParentType']
             resourceId = resource['baseParentId']
             resource = self.model(model).load(id=resourceId, force=True)
+        if model in ('user', 'collection') and resource:
+            # Ensure the base resource has a quota field so we can use the
+            # default quota if apropriate
+            if QUOTA_FIELD not in resource:
+                resource[QUOTA_FIELD] = {}
         if not resource or QUOTA_FIELD not in resource:
             return None, None
         return model, resource

--- a/plugins/user_quota/web_client/js/userQuota.js
+++ b/plugins/user_quota/web_client/js/userQuota.js
@@ -206,7 +206,7 @@ girder.views.QuotaPolicies = girder.View.extend({
         }
         $(el).addClass('g-has-chart');
         used = view.model.get('size');
-        free = used < quota ? quota - used : 0;
+        free = Math.max(quota - used, 0);
         data = [
             ['Used (' + girder.formatSize(used) + ')', used],
             ['Free (' + girder.formatSize(free) + ')', free]

--- a/plugins/user_quota/web_client/js/userQuota.js
+++ b/plugins/user_quota/web_client/js/userQuota.js
@@ -3,6 +3,7 @@
 (function () {
     _.each({user: 'User', collection: 'Collection'}, function (
             modelName, modelType) {
+        var fullModelName;
         var viewName = modelName + 'View';
         girder.views[viewName] = girder.views[viewName].extend({
             events: function () {
@@ -18,11 +19,12 @@
                                                                   arguments);
             },
             render: function () {
+                var el, settings;
                 /* Add the quota menu item to the resource menu as needed */
                 girder.views[viewName].__super__.render.call(this);
-                var el = $('.g-' + modelType + '-header a.g-delete-' +
-                           modelType).closest('li');
-                var settings = {girder: girder};
+                el = $('.g-' + modelType + '-header a.g-delete-' +
+                       modelType).closest('li');
+                settings = {girder: girder};
                 settings[modelType] = this.model;
                 el.before(girder.templates[modelType + 'PoliciesMenu'](
                     settings));
@@ -42,7 +44,7 @@
                 }, this);
             }
         });
-        var fullModelName = modelName + 'Model';
+        fullModelName = modelName + 'Model';
         girder.models[fullModelName] = girder.models[fullModelName].extend({
             /* Saves the quota policy on this model to the server.  Saves the
              * state of whatever this model's "quotaPolicy" parameter is set
@@ -157,8 +159,9 @@
 girder.views.QuotaPolicies = girder.View.extend({
     events: {
         'submit #g-policies-edit-form': function (e) {
+            var fields;
             e.preventDefault();
-            var fields = {
+            fields = {
                 fileSizeQuota: this.$('#g-fileSizeQuota').val(),
                 useQuotaDefault: $('input:radio[name=defaultQuota]:checked')
                     .val() === 'True',
@@ -189,18 +192,22 @@ girder.views.QuotaPolicies = girder.View.extend({
     },
 
     capacityChart: function (view, el) {
+        var used, free, data;
         var quota = view.model.get('quotaPolicy').fileSizeQuota;
         if (view.model.get('quotaPolicy').useQuotaDefault !== false) {
             quota = view.model.get('defaultQuota');
+            if (!quota) {
+                quota = this.model.get('quotaPolicy')._currentFileSizeQuota;
+            }
         }
         if (!quota) {
             $(el).addClass('g-no-chart');
             return;
         }
         $(el).addClass('g-has-chart');
-        var used = view.model.get('size');
-        var free = used < quota ? quota - used : 0;
-        var data = [
+        used = view.model.get('size');
+        free = used < quota ? quota - used : 0;
+        data = [
             ['Used (' + girder.formatSize(used) + ')', used],
             ['Free (' + girder.formatSize(free) + ')', free]
         ];
@@ -233,15 +240,19 @@ girder.views.QuotaPolicies = girder.View.extend({
     },
 
     capacityString: function () {
+        var used, free;
         var quota = this.model.get('quotaPolicy').fileSizeQuota;
         if (this.model.get('quotaPolicy').useQuotaDefault !== false) {
             quota = this.model.get('defaultQuota');
+            if (!quota) {
+                quota = this.model.get('quotaPolicy')._currentFileSizeQuota;
+            }
         }
         if (!quota) {
             return 'Unlimited';
         }
-        var used = this.model.get('size');
-        var free = quota - used;
+        used = this.model.get('size');
+        free = quota - used;
         if (free > 0) {
             return girder.formatSize(free) + ' free of ' +
                 girder.formatSize(quota);
@@ -251,20 +262,21 @@ girder.views.QuotaPolicies = girder.View.extend({
 
     render: function () {
         var view = this;
+        var sizeInfo, defaultQuota, defaultQuotaString, modal;
         var name = view.model.attributes.name;
         if (view.modelType === 'user') {
             name = view.model.attributes.firstName + ' ' +
                    view.model.attributes.lastName;
         }
-        var sizeInfo = girder.userQuota.sizeToValueAndUnits(
+        sizeInfo = girder.userQuota.sizeToValueAndUnits(
             view.model.get('quotaPolicy').fileSizeQuota);
-        var defaultQuota = this.model.get('defaultQuota'), defaultQuotaString;
+        defaultQuota = this.model.get('defaultQuota');
         if (!defaultQuota) {
             defaultQuotaString = 'Unlimited';
         } else {
             defaultQuotaString = girder.formatSize(defaultQuota);
         }
-        var modal = this.$el.html(girder.templates.quotaPolicies({
+        modal = this.$el.html(girder.templates.quotaPolicies({
             girder: girder,
             model: view.model,
             modelType: view.modelType,
@@ -334,11 +346,11 @@ girder.userQuota = {
      *                    for none. */
     valueAndUnitsToSize: function (sizeValue, sizeUnits) {
         var sizeBytes = sizeValue;
+        var match, i, suffixes = 'bkMGT';
         if (parseFloat(sizeValue) > 0) {
             sizeBytes = parseFloat(sizeValue);
             /* parse suffix */
-            var suffixes = 'bkMGT';
-            var match = sizeValue.match(
+            match = sizeValue.match(
                 new RegExp('^\\s*[0-9.]+\\s*([' + suffixes + '])', 'i'));
             if (match && match.length > 1) {
                 for (sizeUnits = 0; sizeUnits < suffixes.length;
@@ -349,7 +361,7 @@ girder.userQuota = {
                     }
                 }
             }
-            for (var i = 0; i < parseInt(sizeUnits); i += 1) {
+            for (i = 0; i < parseInt(sizeUnits); i += 1) {
                 sizeBytes *= 1024;
             }
             sizeBytes = parseInt(sizeBytes);

--- a/tests/jsstyle.cfg
+++ b/tests/jsstyle.cfg
@@ -2,5 +2,6 @@
     "preset": "crockford",
     "disallowDanglingUnderscores": null,
     "requireMultipleVarDecl": null,
-    "requireCamelCaseOrUpperCaseIdentifiers": null
+    "requireCamelCaseOrUpperCaseIdentifiers": null,
+    "requireVarDeclFirst": null
 }

--- a/tests/jsstyle.cfg
+++ b/tests/jsstyle.cfg
@@ -2,6 +2,5 @@
     "preset": "crockford",
     "disallowDanglingUnderscores": null,
     "requireMultipleVarDecl": null,
-    "requireCamelCaseOrUpperCaseIdentifiers": null,
-    "requireVarDeclFirst": null
+    "requireCamelCaseOrUpperCaseIdentifiers": null
 }


### PR DESCRIPTION
There were two issues.  If a user or collection never had a quota set on it, default quotas were not enforced.

In the web client, if logged in as a non-admin user and viewing the quota for a user or collection that used a default quota, it would show 'Unlimited' instead of the appropriate quota.

Add tests that would have failed before and now work.

This fixes issue #1003 .