### PR TITLE
Fix KeyError on non-existent plugin dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
     - popd
     - cmake --version
 
-    - npm install -g npm@next
+    - npm install -g npm
     - npm --version
 install:
     - scripts/InstallPythonRequirements.py --mode=dev --ignore-plugins=${IGNORE_PLUGINS}

--- a/clients/web/src/stylesheets/body/plugins.styl
+++ b/clients/web/src/stylesheets/body/plugins.styl
@@ -31,6 +31,10 @@
       margin-top 7px
       color #999
 
+    .g-plugin-warning
+      margin-top 10px
+      color #d9534f
+
     &:last-child
       border-bottom none
 

--- a/clients/web/src/templates/body/plugins.jade
+++ b/clients/web/src/templates/body/plugins.jade
@@ -11,6 +11,7 @@ div.g-plugin-restart
   each plugin in allPlugins
     .g-plugin-list-item
       input.g-plugin-switch(type="checkbox", key="#{plugin.key}",
+                            disabled=!plugin.value.meetsDependencies,
                             checked=(plugin.value.enabled ? "checked" : undefined))
       .g-plugin-name
         | #{plugin.value.name}
@@ -22,3 +23,5 @@ div.g-plugin-restart
                                  title="Configure Plugin")
             i.icon-cog
       .g-plugin-description #{plugin.value.description}
+        if (!plugin.value.meetsDependencies)
+          .g-plugin-warning This plugin has unmet dependencies.

--- a/clients/web/src/views/body/PluginsView.js
+++ b/clients/web/src/views/body/PluginsView.js
@@ -43,6 +43,8 @@ girder.views.PluginsView = girder.View.extend({
                 info.enabled = true;
                 info.configRoute = girder.getPluginConfigRoute(name);
             }
+
+            info.meetsDependencies = this._meetsDependencies(info);
         }, this);
 
         this.$el.html(girder.templates.plugins({
@@ -77,6 +79,17 @@ girder.views.PluginsView = girder.View.extend({
         }
 
         return this;
+    },
+
+    /**
+     * Takes a plugin object and recursively determines if it fulfills
+     * dependencies. Meaning, it's dependencies exist in this.allPlugins.
+     **/
+    _meetsDependencies: function (plugin) {
+        return _.every(plugin.dependencies, function (pluginName) {
+            return _.has(this.allPlugins, pluginName) &&
+                this._meetsDependencies(this.allPlugins[pluginName]);
+        }, this);
     },
 
     _sortPlugins: function (plugins) {

--- a/clients/web/test/spec/adminSpec.js
+++ b/clients/web/test/spec/adminSpec.js
@@ -461,6 +461,18 @@ describe('Test the plugins page', function () {
         }, 'plugins page to load');
         girderTest.waitForLoad();
     });
+    it('Enable a plugin with non-existent dependencies', function () {
+        runs(function () {
+            var target = $('.g-plugin-list-item:contains(has_nonexistent_deps)');
+
+            expect(target.find('.bootstrap-switch-disabled').length > 0).toBe(true);
+            expect(target.find('.g-plugin-warning').length > 0).toBe(true);
+
+            target.find('.bootstrap-switch-label').click();
+
+            expect($('.g-plugin-restart').css('visibility')).toBe('hidden');
+        });
+    });
     it('Enable a plugin', function () {
         runs(function () {
             expect($('.g-plugin-list-item .bootstrap-switch').length > 0).toBe(true);

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -32,7 +32,7 @@ from girder.constants import SettingKey, TerminalColor, TokenScope
 from girder.models.model_base import AccessException, GirderException, \
     ValidationException
 from girder.utility.model_importer import ModelImporter
-from girder.utility import config
+from girder.utility import config, JsonEncoder
 from six.moves import range, urllib
 
 
@@ -279,7 +279,7 @@ def _createResponse(val):
             # Pretty-print and HTML-ify the response for the browser
             cherrypy.response.headers['Content-Type'] = 'text/html'
             resp = json.dumps(val, indent=4, sort_keys=True,
-                              separators=(',', ': '), default=str)
+                              separators=(',', ': '), cls=JsonEncoder)
             resp = resp.replace(' ', '&nbsp;').replace('\n', '<br />')
             resp = '<div style="font-family:monospace;">%s</div>' % resp
             return resp.encode('utf8')
@@ -287,7 +287,7 @@ def _createResponse(val):
     # Default behavior will just be normal JSON output. Keep this
     # outside of the loop body in case no Accept header is passed.
     cherrypy.response.headers['Content-Type'] = 'application/json'
-    return json.dumps(val, sort_keys=True, default=str).encode('utf8')
+    return json.dumps(val, sort_keys=True, cls=JsonEncoder).encode('utf8')
 
 
 def endpoint(fun):

--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -149,8 +149,13 @@ class System(Resource):
         Return the plugin information for the system. This includes a list of
         all of the currently enabled plugins, as well as
         """
+        allPlugins = plugin_utilities.findAllPlugins()
+        for plugin in allPlugins.values():
+            if 'dependencies' in plugin:
+                plugin['dependencies'] = list(plugin['dependencies'])
+
         return {
-            'all': plugin_utilities.findAllPlugins(),
+            'all': allPlugins,
             'enabled': self.model('setting').get(SettingKey.PLUGINS_ENABLED)
         }
     getPlugins.description = (

--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -104,7 +104,8 @@ class System(Resource):
         .param('value', 'The value for this setting.', required=False)
         .param('list', 'A JSON list of objects with key and value representing '
                'a list of settings to set.', required=False)
-        .errorResponse('You are not a system administrator.', 403))
+        .errorResponse('You are not a system administrator.', 403)
+        .errorResponse('Failed to set system setting.', 500))
 
     @access.admin
     def getSetting(self, params):

--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -181,6 +181,7 @@ class System(Resource):
         .responseClass('Setting')
         .notes('Must be a system administrator to call this.')
         .param('plugins', 'JSON array of plugins to enable.')
+        .errorResponse('Required dependencies do not exist.', 500)
         .errorResponse('You are not a system administrator.', 403))
 
     @access.admin

--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -150,13 +150,8 @@ class System(Resource):
         Return the plugin information for the system. This includes a list of
         all of the currently enabled plugins, as well as
         """
-        allPlugins = plugin_utilities.findAllPlugins()
-        for plugin in allPlugins.values():
-            if 'dependencies' in plugin:
-                plugin['dependencies'] = list(plugin['dependencies'])
-
         return {
-            'all': allPlugins,
+            'all': plugin_utilities.findAllPlugins(),
             'enabled': self.model('setting').get(SettingKey.PLUGINS_ENABLED)
         }
     getPlugins.description = (

--- a/girder/models/setting.py
+++ b/girder/models/setting.py
@@ -73,7 +73,7 @@ class Setting(Model):
 
                 if dep not in allPlugins:
                     raise GirderException(
-                        'Required dependency %s does not exist.' % plugin)
+                        'Required dependency %s does not exist.' % dep)
                 else:
                     addDeps(dep)
 

--- a/girder/models/setting.py
+++ b/girder/models/setting.py
@@ -22,7 +22,7 @@ import cherrypy
 import six
 
 from ..constants import SettingDefault
-from .model_base import Model, ValidationException
+from .model_base import Model, ValidationException, GirderException
 from girder.utility import camelcase, plugin_utilities
 from bson.objectid import ObjectId
 
@@ -70,7 +70,12 @@ class Setting(Model):
             for dep in allPlugins[plugin]['dependencies']:
                 if dep not in doc['value']:
                     doc['value'].add(dep)
-                addDeps(dep)
+
+                if dep not in allPlugins:
+                    raise GirderException(
+                        'Required dependency %s does not exist.' % plugin)
+                else:
+                    addDeps(dep)
 
         for enabled in list(doc['value']):
             if enabled in allPlugins:

--- a/girder/utility/__init__.py
+++ b/girder/utility/__init__.py
@@ -1,3 +1,23 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+import json
 import re
 
 
@@ -10,3 +30,15 @@ def camelcase(value):
     """
     return ''.join(x.capitalize() if x else '_' for x in
                    re.split("[._]+", value))
+
+
+class JsonEncoder(json.JSONEncoder):
+    """
+    This extends the standard json.JSONEncoder to allow for more types to be
+    sensibly serialized. This is used in Girder's REST layer to serialize
+    route return values when JSON is requested.
+    """
+    def default(self, obj):
+        if isinstance(obj, set):
+            return tuple(obj)
+        return str(obj)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,7 +44,8 @@ add_web_client_test(data_filesystem "${PROJECT_SOURCE_DIR}/clients/web/test/spec
 add_web_client_test(data_gridfs "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE gridfs)
 add_web_client_test(data_gridfsrs "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE gridfsrs RESOURCE_LOCKS replicaset)
 add_web_client_test(data_s3 "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE s3 WEBSECURITY false)
-add_web_client_test(admin "${PROJECT_SOURCE_DIR}/clients/web/test/spec/adminSpec.js" ASSETSTORE s3 WEBSECURITY false PLUGIN_DIRS "${PROJECT_SOURCE_DIR}/plugins:${PROJECT_SOURCE_DIR}/tests/test_plugins")
+add_web_client_test(admin "${PROJECT_SOURCE_DIR}/clients/web/test/spec/adminSpec.js" ASSETSTORE s3 WEBSECURITY false
+  PLUGIN_DIRS "${PROJECT_SOURCE_DIR}/plugins:${PROJECT_SOURCE_DIR}/tests/test_plugins")
 add_web_client_test(collection "${PROJECT_SOURCE_DIR}/clients/web/test/spec/collectionSpec.js")
 add_web_client_test(group "${PROJECT_SOURCE_DIR}/clients/web/test/spec/groupSpec.js")
 add_web_client_test(user "${PROJECT_SOURCE_DIR}/clients/web/test/spec/userSpec.js")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,7 +44,7 @@ add_web_client_test(data_filesystem "${PROJECT_SOURCE_DIR}/clients/web/test/spec
 add_web_client_test(data_gridfs "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE gridfs)
 add_web_client_test(data_gridfsrs "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE gridfsrs RESOURCE_LOCKS replicaset)
 add_web_client_test(data_s3 "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE s3 WEBSECURITY false)
-add_web_client_test(admin "${PROJECT_SOURCE_DIR}/clients/web/test/spec/adminSpec.js" ASSETSTORE s3 WEBSECURITY false)
+add_web_client_test(admin "${PROJECT_SOURCE_DIR}/clients/web/test/spec/adminSpec.js" ASSETSTORE s3 WEBSECURITY false PLUGIN_DIRS "${PROJECT_SOURCE_DIR}/plugins:${PROJECT_SOURCE_DIR}/tests/test_plugins")
 add_web_client_test(collection "${PROJECT_SOURCE_DIR}/clients/web/test/spec/collectionSpec.js")
 add_web_client_test(group "${PROJECT_SOURCE_DIR}/clients/web/test/spec/groupSpec.js")
 add_web_client_test(user "${PROJECT_SOURCE_DIR}/clients/web/test/spec/userSpec.js")

--- a/tests/JavascriptTests.cmake
+++ b/tests/JavascriptTests.cmake
@@ -98,6 +98,8 @@ function(add_web_client_test case specFile)
   # Optional parameters:
   # PLUGIN (name of plugin) : this plugin is loaded (unless overridden with
   #     ENABLEDPLUGINS) and the test name includes the plugin name
+  # PLUGIN_DIRS (list of plugin dirs) : A list of directories plugins
+  # should live in.
   # ASSETSTORE (assetstore type) : use the specified assetstore type when
   #     running the test.  Defaults to 'filesystem'
   # WEBSECURITY (boolean) : if false, don't use CORS validatation.  Defaults to
@@ -116,7 +118,7 @@ function(add_web_client_test case specFile)
   set(testname "web_client_${case}")
 
   set(_options NOCOVERAGE)
-  set(_args PLUGIN ASSETSTORE WEBSECURITY BASEURL)
+  set(_args PLUGIN ASSETSTORE WEBSECURITY BASEURL PLUGIN_DIRS)
   set(_multival_args RESOURCE_LOCKS TIMEOUT ENABLEDPLUGINS)
   cmake_parse_arguments(fn "${_options}" "${_args}" "${_multival_args}" ${ARGN})
 
@@ -125,6 +127,12 @@ function(add_web_client_test case specFile)
     set(plugins ${fn_PLUGIN})
   else()
     set(plugins "")
+  endif()
+
+  if(fn_PLUGIN_DIRS)
+    set(pluginDirs ${fn_PLUGIN_DIRS})
+  else()
+    set(pluginDirs "")
   endif()
 
   if(fn_ASSETSTORE)
@@ -158,6 +166,7 @@ function(add_web_client_test case specFile)
     "ASSETSTORE_TYPE=${assetstoreType}"
     "WEB_SECURITY=${webSecurity}"
     "ENABLED_PLUGINS=${plugins}"
+    "PLUGIN_DIRS=${pluginDirs}"
     "GIRDER_TEST_DB=mongodb://localhost:27017/girder_test_${testname}"
     "GIRDER_TEST_ASSETSTORE=webclient_${testname}"
     "GIRDER_PORT=${web_client_port}"

--- a/tests/cases/rest_util_test.py
+++ b/tests/cases/rest_util_test.py
@@ -84,8 +84,8 @@ class RestUtilTestCase(unittest.TestCase):
 
     def testCustomJsonEncoder(self):
         resource = TestResource()
-        resp = resource.returnsSet()
+        resp = resource.returnsSet().decode('utf8')
         self.assertEqual(json.loads(resp), {'key': [1, 2, 3]})
 
-        resp = resource.returnsDate()
+        resp = resource.returnsDate().decode('utf8')
         self.assertEqual(json.loads(resp), {'key': str(date)})

--- a/tests/cases/rest_util_test.py
+++ b/tests/cases/rest_util_test.py
@@ -17,10 +17,24 @@
 #  limitations under the License.
 ###############################################################################
 
-import unittest
+import datetime
+import json
 import six
+import unittest
 
 from girder.api import rest
+
+date = datetime.datetime.now()
+
+
+class TestResource(object):
+    @rest.endpoint
+    def returnsSet(self, *args, **kwargs):
+        return {'key': {1, 2, 3}}
+
+    @rest.endpoint
+    def returnsDate(self, *args, **kwargs):
+        return {'key': date}
 
 
 class RestUtilTestCase(unittest.TestCase):
@@ -67,3 +81,11 @@ class RestUtilTestCase(unittest.TestCase):
 
         url = 'https://localhost/girder#users'
         self.assertRaises(Exception, rest.getApiUrl, url=url)
+
+    def testCustomJsonEncoder(self):
+        resource = TestResource()
+        resp = resource.returnsSet()
+        self.assertEqual(json.loads(resp), {'key': [1, 2, 3]})
+
+        resp = resource.returnsDate()
+        self.assertEqual(json.loads(resp), {'key': str(date)})

--- a/tests/cases/system_test.py
+++ b/tests/cases/system_test.py
@@ -237,6 +237,14 @@ class SystemTestCase(base.TestCase):
         self.assertEqual(len(enabled), 3)
         self.assertTrue('test_plugin' in enabled)
         self.assertTrue('does_nothing' in enabled)
+        resp = self.request(
+            path='/system/plugins', method='PUT', user=self.users[0],
+            params={'plugins': '["has_nonexistent_deps"]'},
+            exception=True)
+        self.assertStatus(resp, 500)
+        self.assertEqual(resp.json['message'],
+                         ("Required dependency a_plugin_that_does_not_exist"
+                          " does not exist."))
 
     def testBadPlugin(self):
         pluginRoot = os.path.join(os.path.dirname(os.path.dirname(__file__)),

--- a/tests/test_plugins/has_nonexistent_deps/plugin.json
+++ b/tests/test_plugins/has_nonexistent_deps/plugin.json
@@ -1,0 +1,3 @@
+{
+    "dependencies": ["a_plugin_that_does_not_exist"]
+}

--- a/tests/web_client_test.py
+++ b/tests/web_client_test.py
@@ -28,7 +28,6 @@ from girder.api import access
 from girder.api.describe import Description
 from girder.api.rest import Resource, RestException
 from girder.constants import ROOT_DIR
-from girder.utility import config
 from girder.utility.progress import ProgressContext
 from . import base
 from six.moves import range

--- a/tests/web_client_test.py
+++ b/tests/web_client_test.py
@@ -30,6 +30,7 @@ from girder.api import access
 from girder.api.describe import Description
 from girder.api.rest import Resource, RestException
 from girder.constants import ROOT_DIR
+from girder.utility import config
 from girder.utility.progress import ProgressContext
 from . import base
 from six.moves import range
@@ -42,6 +43,13 @@ def setUpModule():
     mockS3 = False
     if 's3' in os.environ['ASSETSTORE_TYPE']:
         mockS3 = True
+
+    pluginDirs = os.environ.get('PLUGIN_DIRS', '')
+
+    if pluginDirs:
+        curConfig = config.getConfig()
+        curConfig['plugins'] = {'plugin_directory': pluginDirs}
+
     plugins = os.environ.get('ENABLED_PLUGINS', '')
     if plugins:
         base.enabledPlugins.extend(plugins.split())


### PR DESCRIPTION
See #980 for details of the error.

This addresses the issue by returning a 500 on the ```/system/plugins``` API call if a plugin can't be enabled. It addresses the UI issue by disabling the switch with a message if it can't enable all of the dependencies as well.

In the future, the PluginsView may need to be changed a bit - because it currently assumes that PUT calls to ```/system/plugins``` will succeed, leaving switches in an inconsistent state, restart buttons around when it doesn't need to be restarted, etc.