### PR TITLE
Make model creation an atomic database operation

### DIFF
--- a/clients/web/src/templates/body/systemConfiguration.jade
+++ b/clients/web/src/templates/body/systemConfiguration.jade
@@ -28,23 +28,37 @@ form.g-settings-form(role="form")
   .form-group
     label(for="g-core-registration-policy") Registration policy
     select#g-core-registration-policy.form-control.input-sm
-      option(value="open", selected=(settings['core.registration_policy'] ===
-             "open")) Open registration
-      option(value="closed", selected=(settings['core.registration_policy'] ===
-             "closed")) Closed registration
+      option(value="open",
+             selected=((settings['core.registration_policy'] ||
+                        defaults['core.registration_policy']) === "open")
+            ) Open registration
+      option(value="closed",
+             selected=((settings['core.registration_policy'] ||
+                        defaults['core.registration_policy']) === "closed")
+            ) Closed registration
   .form-group
     label(for="g-core-add-to-group-policy") Allow members to be directly added to groups
     select#g-core-add-to-group-policy.form-control.input-sm
-      option(value="never", selected=(settings['core.add_to_group_policy'] ===
-             "never")) No, members must be invited and accept invitations
-      option(value="noadmin", selected=(settings['core.add_to_group_policy'] ===
-             "noadmin")) No, except for group administrators when enabled per group
-      option(value="nomod", selected=(settings['core.add_to_group_policy'] ===
-             "nomod")) No, except for group administrators and moderators when enabled per group
-      option(value="yesadmin", selected=(settings['core.add_to_group_policy'] ===
-             "yesadmin")) Yes, by group administrators unless disabled per group
-      option(value="yesmod", selected=(settings['core.add_to_group_policy'] ===
-             "yesmod")) Yes, by group administrators and moderators unless disabled per group
+      option(value="never",
+             selected=((settings['core.add_to_group_policy'] ||
+                        defaults['core.add_to_group_policy']) === "never")
+            ) No, members must be invited and accept invitations
+      option(value="noadmin",
+             selected=((settings['core.add_to_group_policy'] ||
+                        defaults['core.add_to_group_policy']) === "noadmin")
+            ) No, except for group administrators when enabled per group
+      option(value="nomod",
+             selected=((settings['core.add_to_group_policy'] ||
+                        defaults['core.add_to_group_policy']) === "nomod")
+            ) No, except for group administrators and moderators when enabled per group
+      option(value="yesadmin",
+             selected=((settings['core.add_to_group_policy'] ||
+                        defaults['core.add_to_group_policy']) === "yesadmin")
+            ) Yes, by group administrators unless disabled per group
+      option(value="yesmod",
+             selected=((settings['core.add_to_group_policy'] ||
+                        defaults['core.add_to_group_policy']) === "yesmod")
+            ) Yes, by group administrators and moderators unless disabled per group
 
   .g-collection-create-policy-container.g-settings-form-container
     label(for="g-collection-create-policy") Collection creation policy
@@ -54,10 +68,14 @@ form.g-settings-form(role="form")
   .form-group
     label(for="g-core-user-default-folders") Create default folders for new users
     select#g-core-user-default-folders.form-control.input-sm
-      option(value="none", selected=(settings['core.user_default_folders'] ===
-             "none")) No
-      option(value="public_private", selected=(settings['core.user_default_folders'] ===
-             "public_private")) Yes, "Public" and "Private"
+      option(value="none",
+             selected=((settings['core.user_default_folders'] ||
+                        defaults['core.user_default_folders']) === "none")
+            ) No
+      option(value="public_private",
+             selected=((settings['core.user_default_folders'] ||
+                        defaults['core.user_default_folders']) === "public_private")
+            ) Yes, "Public" and "Private"
 
   .panel-group#g-configuration-accordion
     .panel.panel-default

--- a/clients/web/src/templates/body/systemConfiguration.jade
+++ b/clients/web/src/templates/body/systemConfiguration.jade
@@ -51,6 +51,13 @@ form.g-settings-form(role="form")
     textarea#g-core-collection-create-policy.form-control
       = JSON.stringify(settings['core.collection_create_policy'] || defaults['core.collection_create_policy'], null, 4)
     .g-search-container
+  .form-group
+    label(for="g-core-user-default-folders") Create default folders for new users
+    select#g-core-user-default-folders.form-control.input-sm
+      option(value="none", selected=(settings['core.user_default_folders'] ===
+             "none")) No
+      option(value="public_private", selected=(settings['core.user_default_folders'] ===
+             "public_private")) Yes, "Public" and "Private"
 
   .panel-group#g-configuration-accordion
     .panel.panel-default

--- a/clients/web/src/templates/body/systemConfiguration.jade
+++ b/clients/web/src/templates/body/systemConfiguration.jade
@@ -36,7 +36,7 @@ form.g-settings-form(role="form")
     label(for="g-core-add-to-group-policy") Allow members to be directly added to groups
     select#g-core-add-to-group-policy.form-control.input-sm
       option(value="never", selected=(settings['core.add_to_group_policy'] ===
-             "never")) No - members must be invited and accept invitations
+             "never")) No, members must be invited and accept invitations
       option(value="noadmin", selected=(settings['core.add_to_group_policy'] ===
              "noadmin")) No, except for group administrators when enabled per group
       option(value="nomod", selected=(settings['core.add_to_group_policy'] ===
@@ -44,7 +44,7 @@ form.g-settings-form(role="form")
       option(value="yesadmin", selected=(settings['core.add_to_group_policy'] ===
              "yesadmin")) Yes, by group administrators unless disabled per group
       option(value="yesmod", selected=(settings['core.add_to_group_policy'] ===
-             "yesmod")) Yes by group administrators and moderators unless disabled per group
+             "yesmod")) Yes, by group administrators and moderators unless disabled per group
 
   .g-collection-create-policy-container.g-settings-form-container
     label(for="g-collection-create-policy") Collection creation policy

--- a/clients/web/src/views/body/SystemConfigurationView.js
+++ b/clients/web/src/views/body/SystemConfigurationView.js
@@ -54,7 +54,8 @@ girder.views.SystemConfigurationView = girder.View.extend({
             'core.cors.allow_methods',
             'core.cors.allow_headers',
             'core.add_to_group_policy',
-            'core.collection_create_policy'
+            'core.collection_create_policy',
+            'core.user_default_folders'
         ];
         this.settingsKeys = keys;
         girder.restRequest({

--- a/girder/constants.py
+++ b/girder/constants.py
@@ -134,6 +134,7 @@ class SettingKey:
     CORS_ALLOW_HEADERS = 'core.cors.allow_headers'
     ADD_TO_GROUP_POLICY = 'core.add_to_group_policy'
     COLLECTION_CREATE_POLICY = 'core.collection_create_policy'
+    USER_DEFAULT_FOLDERS = 'core.user_default_folders'
 
 
 class SettingDefault:
@@ -161,7 +162,8 @@ class SettingDefault:
             'open': False,
             'groups': [],
             'users': []
-        }
+        },
+        SettingKey.USER_DEFAULT_FOLDERS: 'public_private'
     }
 
 

--- a/girder/constants.py
+++ b/girder/constants.py
@@ -179,3 +179,20 @@ class TokenScope:
     ANONYMOUS_SESSION = 'core.anonymous_session'
     USER_AUTH = 'core.user_auth'
     TEMPORARY_USER_AUTH = 'core.user_auth.temporary'
+
+
+class CoreEventHandler(object):
+    """
+    This enum represents handler identifier strings for core event handlers.
+    If you wish to unbind a core event handler, use one of these as the
+    ``handlerName`` argument. Unbinding core event handlers can be used to
+    disable certain default functionalities.
+    """
+    # For adding a group's creator into its ACL at creation time.
+    GROUP_CREATOR_ACCESS = 'core.grantCreatorAccess'
+
+    # For creating the default Public and Private folders at user creation time.
+    USER_DEFAULT_FOLDERS = 'core.addDefaultFolders'
+
+    # For adding a user into his or her own ACL.
+    USER_SELF_ACCESS = 'core.grantSelfAccess'

--- a/girder/events.py
+++ b/girder/events.py
@@ -41,6 +41,7 @@ function to be called when the task is finished. That callback function will
 receive the Event object as its only argument.
 """
 
+import contextlib
 import threading
 import types
 
@@ -206,10 +207,28 @@ def unbind(eventName, handlerName):
 
 def unbindAll():
     """
-    Clears the entire event map. Any bound listeners will be unbound.
+    Clears the entire event map. All bound listeners will be unbound.
+
+     .. warning:: This will also disable internal event listeners, which are
+       necessary for normal Girder functionality. This function should generally
+       never be called outside of testing.
     """
     global _mapping
     _mapping = {}
+
+
+@contextlib.contextmanager
+def bound(eventName, handlerName, handler):
+    """
+    A context manager to temporarily bind an event handler within its scope.
+
+    Parameters are the same as those to :py:func:`girder.events.bind`.
+    """
+    bind(eventName, handlerName, handler)
+    try:
+        yield
+    finally:
+        unbind(eventName, handlerName)
 
 
 def trigger(eventName, info=None, pre=None, async=False):

--- a/girder/models/collection.py
+++ b/girder/models/collection.py
@@ -126,8 +126,9 @@ class Collection(AccessControlledModel):
             'size': 0
         }
 
-        self.setPublic(collection, public=public)
-        self.setUserAccess(collection, user=creator, level=AccessType.ADMIN)
+        self.setPublic(collection, public, save=False)
+        self.setUserAccess(collection, user=creator, level=AccessType.ADMIN,
+                           save=False)
 
         return self.save(collection)
 

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -482,14 +482,15 @@ class Folder(AccessControlledModel):
         }
 
         if parentType in ('folder', 'collection'):
-            self.copyAccessPolicies(src=parent, dest=folder)
+            self.copyAccessPolicies(src=parent, dest=folder, save=False)
 
         if creator is not None:
-            self.setUserAccess(folder, user=creator, level=AccessType.ADMIN)
+            self.setUserAccess(folder, user=creator, level=AccessType.ADMIN,
+                               save=False)
 
         # Allow explicit public flag override if it's set.
         if public is not None and type(public) is bool:
-            self.setPublic(folder, public=public)
+            self.setPublic(folder, public, save=False)
 
         if allowRename:
             self.validate(folder, allowRename=True)

--- a/girder/models/group.py
+++ b/girder/models/group.py
@@ -21,7 +21,7 @@ import datetime
 
 from .model_base import AccessControlledModel, ValidationException
 from girder import events
-from girder.constants import AccessType
+from girder.constants import AccessType, CoreEventHandler
 
 
 class Group(AccessControlledModel):
@@ -66,7 +66,8 @@ class Group(AccessControlledModel):
             '_id', 'name', 'public', 'description', 'created', 'updated',
             'addAllowed'))
 
-        events.bind('model.group.save.created', 'grantCreatorAccess',
+        events.bind('model.group.save.created',
+                    CoreEventHandler.GROUP_CREATOR_ACCESS,
                     self._grantCreatorAccess)
 
     def filter(self, group, user, accessList=False, requests=False):

--- a/girder/models/group.py
+++ b/girder/models/group.py
@@ -343,7 +343,7 @@ class Group(AccessControlledModel):
             'requests': []
         }
 
-        self.setPublic(group, public=public)
+        self.setPublic(group, public, save=False)
 
         return self.save(group)
 

--- a/girder/models/setting.py
+++ b/girder/models/setting.py
@@ -198,6 +198,12 @@ class Setting(Model):
             'Upload minimum chunk size must be an integer >= 0.',
             'value')
 
+    def validateCoreUserDefaultFolders(self, doc):
+        if doc['value'] not in ('public_private', 'none'):
+            raise ValidationException(
+                'User default folders must be either "public_private" or '
+                '"none".', 'value')
+
     def get(self, key, default='__default__'):
         """
         Retrieve a setting by its key.

--- a/girder/models/token.py
+++ b/girder/models/token.py
@@ -88,10 +88,11 @@ class Token(AccessControlledModel):
             # force=True, so we set it to public access. This is OK since tokens
             # are not exposed externally for listing, and the _id is the secure
             # token value.
-            self.setPublic(token, True)
+            self.setPublic(token, True, save=False)
         else:
             token['userId'] = user['_id']
-            self.setUserAccess(token, user=user, level=AccessType.ADMIN)
+            self.setUserAccess(token, user=user, level=AccessType.ADMIN,
+                               save=False)
 
         return self.save(token)
 

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -23,7 +23,7 @@ import re
 
 from .model_base import AccessControlledModel, ValidationException
 from girder import events
-from girder.constants import AccessType
+from girder.constants import AccessType, CoreEventHandler
 from girder.utility import config
 
 
@@ -47,9 +47,10 @@ class User(AccessControlledModel):
         self.exposeFields(level=AccessType.ADMIN, fields=(
             'size', 'email', 'groups', 'groupInvites'))
 
-        events.bind('model.user.save.created', 'grantSelfAccess',
-                    self._grantSelfAccess)
-        events.bind('model.user.save.created', 'addDefaultFolders',
+        events.bind('model.user.save.created',
+                    CoreEventHandler.USER_SELF_ACCESS, self._grantSelfAccess)
+        events.bind('model.user.save.created',
+                    CoreEventHandler.USER_DEFAULT_FOLDERS,
                     self._addDefaultFolders)
 
     def filter(self, user, currentUser):

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -275,9 +275,9 @@ class User(AccessControlledModel):
         This generally should not be called or overridden directly, but it may
         be unregistered from the `model.user.save.created` event.
         """
-        default_folder_setting = self.model('setting').get(
-            SettingKey.USER_DEFAULT_FOLDERS, 'public_private')
-        if default_folder_setting == 'public_private':
+        if self.model('setting').get(
+                SettingKey.USER_DEFAULT_FOLDERS, 'public_private') \
+                == 'public_private':
             user = event.info
 
             publicFolder = self.model('folder').createFolder(

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -250,9 +250,8 @@ class User(AccessControlledModel):
             'groupInvites': []
         }
 
-        self.setPassword(user, password)
-
-        self.setPublic(user, public=public)
+        self.setPassword(user, password, save=False)
+        self.setPublic(user, public, save=False)
 
         return self.save(user)
 

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -23,7 +23,7 @@ import re
 
 from .model_base import AccessControlledModel, ValidationException
 from girder import events
-from girder.constants import AccessType, CoreEventHandler
+from girder.constants import AccessType, CoreEventHandler, SettingKey
 from girder.utility import config
 
 
@@ -275,17 +275,20 @@ class User(AccessControlledModel):
         This generally should not be called or overridden directly, but it may
         be unregistered from the `model.user.save.created` event.
         """
-        user = event.info
+        default_folder_setting = self.model('setting').get(
+            SettingKey.USER_DEFAULT_FOLDERS, 'public_private')
+        if default_folder_setting == 'public_private':
+            user = event.info
 
-        publicFolder = self.model('folder').createFolder(
-            user, 'Public', parentType='user', public=True, creator=user)
-        privateFolder = self.model('folder').createFolder(
-            user, 'Private', parentType='user', public=False, creator=user)
-        # Give the user admin access to their own folders
-        self.model('folder').setUserAccess(
-            publicFolder, user, AccessType.ADMIN, save=True)
-        self.model('folder').setUserAccess(
-            privateFolder, user, AccessType.ADMIN, save=True)
+            publicFolder = self.model('folder').createFolder(
+                user, 'Public', parentType='user', public=True, creator=user)
+            privateFolder = self.model('folder').createFolder(
+                user, 'Private', parentType='user', public=False, creator=user)
+            # Give the user admin access to their own folders
+            self.model('folder').setUserAccess(
+                publicFolder, user, AccessType.ADMIN, save=True)
+            self.model('folder').setUserAccess(
+                privateFolder, user, AccessType.ADMIN, save=True)
 
     def fileList(self, doc, user=None, path='', includeMetadata=False,
                  subpath=True):

--- a/tests/base.py
+++ b/tests/base.py
@@ -213,7 +213,7 @@ class TestCase(unittest.TestCase, model_importer.ModelImporter):
 
         :param obj: The dictionary object.
         :param keys: The keys it must contain.
-        :type keys: list
+        :type keys: list or tuple
         """
         for k in keys:
             self.assertTrue(k in obj, 'Object does not contain key "%s"' % k)

--- a/tests/cases/user_test.py
+++ b/tests/cases/user_test.py
@@ -650,24 +650,21 @@ class UserTestCase(base.TestCase):
         def postSave(event):
             self.ctr += 2
 
-        events.bind('model.user.save', 'test', preSave)
+        with events.bound('model.user.save', 'test', preSave):
 
-        user = self.model('user').createUser(
-            login='myuser', password='passwd', firstName='A', lastName='A',
-            email='email@email.com')
-        self.assertEqual(self.ctr, 1)
+            user = self.model('user').createUser(
+                login='myuser', password='passwd', firstName='A', lastName='A',
+                email='email@email.com')
+            self.assertEqual(self.ctr, 1)
 
-        events.bind('model.user.save.after', 'test', postSave)
-        self.ctr = 0
+            with events.bound('model.user.save.after', 'test', postSave):
+                self.ctr = 0
 
-        user = self.model('user').save(user, triggerEvents=False)
-        self.assertEqual(self.ctr, 0)
+                user = self.model('user').save(user, triggerEvents=False)
+                self.assertEqual(self.ctr, 0)
 
-        self.model('user').save(user)
-        self.assertEqual(self.ctr, 2)
-
-        events.unbind('model.user.save', 'test')
-        events.unbind('model.user.save.after', 'test')
+                self.model('user').save(user)
+                self.assertEqual(self.ctr, 3)
 
     def testPrivateUser(self):
         """

--- a/tests/cases/user_test.py
+++ b/tests/cases/user_test.py
@@ -618,6 +618,31 @@ class UserTestCase(base.TestCase):
         self.assertStatusOk(resp)
         self.assertTrue(resp.json['admin'])
 
+    def testDefaultUserFolders(self):
+        self.model('setting').set(SettingKey.USER_DEFAULT_FOLDERS,
+                                  'public_private')
+        user1 = self.model('user').createUser(
+            'folderuser1', 'passwd', 'tst', 'usr', 'folderuser1@user.com')
+        user1_folders = self.model('folder').find({
+            'parentId': user1['_id'],
+            'parentCollection': 'user'})
+        self.assertSetEqual(
+            set(folder['name'] for folder in user1_folders),
+            {'Public', 'Private'}
+        )
+
+        self.model('setting').set(SettingKey.USER_DEFAULT_FOLDERS,
+                                  'none')
+        user2 = self.model('user').createUser(
+            'folderuser2', 'mypass', 'First', 'Last', 'folderuser2@user.com')
+        user2_folders = self.model('folder').find({
+            'parentId': user2['_id'],
+            'parentCollection': 'user'})
+        self.assertSetEqual(
+            set(folder['name'] for folder in user2_folders),
+            set()
+        )
+
     def testAdminFlag(self):
         admin = self.model('user').createUser(
             'user1', 'passwd', 'tst', 'usr', 'user@user.com')


### PR DESCRIPTION
In several places, a partially-created model is implicitly saved before the end of the "create..." function. This creates several problems.

First, if the code terminates at a later part of the "create..." function, the new database document will be left in an incomplete state.

Second, the premature save operation causes the "model.{}.save.created" event to be fired before the "create..." function has finished. This causes callbacks to receive an incomplete model.

Most significantly, since the remainder of the "create..." code is still executed unconditionally after the "model.{}.save.created" callback completes, it may undo some of the intentional functionality of the callback. In particular, a callback that sets a new user's "public" attribute to False would have this change undone.

This also moves the creation of default user folders into an event callback. This gives developers the option of unregistering this callback if they don't want users to have default folders. A user-facing option to specify this behavior could be added in the future.