### PR TITLE
Give the "limit" parameter of "filterResultsByPermission" a default value

### DIFF
--- a/girder/models/collection.py
+++ b/girder/models/collection.py
@@ -190,7 +190,7 @@ class Collection(AccessControlledModel):
 
         if level is not None:
             folders = self.filterResultsByPermission(
-                cursor=folders, user=user, level=level, limit=None)
+                cursor=folders, user=user, level=level)
         count += sum(self.model('folder').subtreeCount(
             folder, includeItems=includeItems, user=user, level=level)
             for folder in folders)
@@ -233,7 +233,7 @@ class Collection(AccessControlledModel):
             })
 
             folders = self.filterResultsByPermission(
-                cursor=cursor, user=user, level=AccessType.ADMIN, limit=None)
+                cursor=cursor, user=user, level=AccessType.ADMIN)
 
             for folder in folders:
                 self.model('folder').setAccessList(

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -568,7 +568,7 @@ class Folder(AccessControlledModel):
             return folders.count()
         else:
             return sum(1 for _ in self.filterResultsByPermission(
-                cursor=folders, user=user, level=level, limit=None))
+                cursor=folders, user=user, level=level))
 
     def subtreeCount(self, folder, includeItems=True, user=None, level=None):
         """
@@ -596,7 +596,7 @@ class Folder(AccessControlledModel):
 
         if level is not None:
             folders = self.filterResultsByPermission(
-                cursor=folders, user=user, level=level, limit=None)
+                cursor=folders, user=user, level=level)
 
         count += sum(self.subtreeCount(subfolder, includeItems=includeItems,
                                        user=user, level=level)
@@ -790,7 +790,7 @@ class Folder(AccessControlledModel):
             })
 
             subfolders = self.filterResultsByPermission(
-                cursor=cursor, user=user, level=AccessType.ADMIN, limit=None)
+                cursor=cursor, user=user, level=AccessType.ADMIN)
 
             for folder in subfolders:
                 self.setAccessList(

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -839,7 +839,7 @@ class AccessControlledModel(Model):
             dest = self.save(dest, validate=False)
         return dest
 
-    def filterResultsByPermission(self, cursor, user, level, limit, offset=0,
+    def filterResultsByPermission(self, cursor, user, level, limit=0, offset=0,
                                   removeKeys=()):
         """
         Given a database result cursor, this generator will yield only the

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -310,7 +310,7 @@ class User(AccessControlledModel):
 
         if level is not None:
             folders = self.filterResultsByPermission(
-                cursor=folders, user=user, level=level, limit=None)
+                cursor=folders, user=user, level=level)
 
         count += sum(self.model('folder').subtreeCount(
             folder, includeItems=includeItems, user=user, level=level)


### PR DESCRIPTION
The other methods in the model API also have default values for "limit".

Note, the model API has defaults of "limit=0" for all of its functions. The HTTP API uses use a default of "limit=50".