### PR TITLE
Fix a quota issue with large quotas.

### DIFF
--- a/plugins/user_quota/plugin_tests/user_quota_test.py
+++ b/plugins/user_quota/plugin_tests/user_quota_test.py
@@ -82,27 +82,30 @@ class QuotaTestCase(base.TestCase):
                         finishe the upload later.
         :returns: file: the created file object
         """
-        contents = os.urandom(size)
         if parentType != 'file':
             resp = self.request(
                 path='/file', method='POST', user=self.admin, params={
                     'parentType': parentType,
                     'parentId': parent['_id'],
                     'name': name,
-                    'size': len(contents),
+                    'size': size,
                     'mimeType': 'application/octet-stream'
                 }, exception=error is not None)
         else:
             resp = self.request(
                 path='/file/%s/contents' % str(parent['_id']), method='PUT',
                 user=self.admin, params={
-                    'size': len(contents),
+                    'size': size,
                 }, exception=error is not None)
         if error:
             self.assertStatus(resp, 500)
             self.assertEqual(resp.json['type'], 'girder')
             self.assertEqual(resp.json['message'][:len(error)], error)
             return None
+        # We don't create the contents until after we check for the first
+        # error.  This means that we can try to upload huge files without
+        # allocating the space for them
+        contents = os.urandom(size)
         self.assertStatusOk(resp)
         upload = resp.json
         fields = [('offset', 0), ('uploadId', upload['_id'])]
@@ -296,6 +299,14 @@ class QuotaTestCase(base.TestCase):
         file = self._uploadFile('Fifth upload', folder, size=2048)
         # And a second 2 kb file will fail
         self._uploadFile('File too large', folder, size=2048,
+                         error='Upload would exceed file storage quota')
+        # Set a policy with a large quota to test using NumberLong in the
+        # mongo settings.
+        self._setQuotaDefault(model, 5*1024**3)
+        # A small file should now upload
+        file = self._uploadFile('Six upload', folder, size=2048)
+        # But a huge one will fail
+        self._uploadFile('File too large', folder, size=6*1024**3,
                          error='Upload would exceed file storage quota')
 
     def testAssetstorePolicy(self):

--- a/plugins/user_quota/server/quota.py
+++ b/plugins/user_quota/server/quota.py
@@ -358,7 +358,7 @@ class QuotaPolicy(Resource):
                 key = None
             if key:
                 quota = self.model('setting').get(key, None)
-        if not quota or quota < 0 or not isinstance(quota, int):
+        if not quota or quota < 0 or not isinstance(quota, six.integer_types):
             return None
         return quota
 


### PR DESCRIPTION
A comparison was being made to ensure that the quota was an integer.  In python 2, isinstance(quota, int) will fail if quota is a long, which happens when mongo stores the value as a NumberLong.  Python 3 was working properly.