### PR TITLE
Improvements to templated endpoints

### DIFF
--- a/girder/api/api_docs.mako
+++ b/girder/api/api_docs.mako
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>${title}</title>
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Droid+Sans:400,700">
+    <link rel="stylesheet" href="${staticRoot}/lib/fontello/css/fontello.css">
+    <link rel="stylesheet" href="${staticRoot}/built/swagger/css/reset.css">
+    <link rel="stylesheet" href="${staticRoot}/built/swagger/css/screen.css">
+    <link rel="stylesheet" href="${staticRoot}/built/swagger/docs.css">
+    <link rel="icon" type="image/png" href="${staticRoot}/img/Girder_Favicon.png">
+    <style type="text/css">
+      .response_throbber {
+        content: url("${staticRoot}/built/swagger/images/throbber.gif");
+      }
+    </style>
+  </head>
+  <body>
+    <div class="docs-header">
+      <span>Girder REST API Documentation</span>
+      <i class="icon-book-alt right"></i>
+      <div id="g-global-info-apiroot" style="display: none">${apiRoot}</div>
+    </div>
+    <div class="docs-body">
+      <p>Below you will find the list of all of the resource types exposed by
+      the Girder RESTful Web API. Click any of the resource links to open up a
+      list of all available endpoints related to each resource type.</p>
+      <p>Clicking any of those endpoints will display detailed documentation
+      about the purpose of each endpoint and the input parameters and output
+      values. You can also call API endpoints directly from this page by typing
+      in the parameters you wish to pass and then clicking the "Try it out!"
+      button.</p>
+      <p><b>Warning:</b> This is not a sandbox&mdash;calls that you make from
+      this page are the same as calling the API with any other client, so
+      update or delete calls that you make will affect the actual data on the
+      server.</p>
+    </div>
+    <div class="swagger-section">
+      <div id="swagger-ui-container"
+          class="swagger-ui-wrap docs-swagger-container">
+      </div>
+    </div>
+    <script src="${staticRoot}/built/swagger/lib/jquery-1.8.0.min.js"></script>
+    <script src="${staticRoot}/built/swagger/lib/jquery.slideto.min.js"></script>
+    <script src="${staticRoot}/built/swagger/lib/jquery.wiggle.min.js"></script>
+    <script src="${staticRoot}/built/swagger/lib/jquery.ba-bbq.min.js"></script>
+    <script src="${staticRoot}/built/swagger/lib/handlebars-1.0.0.js"></script>
+    <script src="${staticRoot}/built/swagger/lib/underscore-min.js"></script>
+    <script src="${staticRoot}/built/swagger/lib/backbone-min.js"></script>
+    <script src="${staticRoot}/built/swagger/lib/shred.bundle.js"></script>
+    <script src="${staticRoot}/built/swagger/lib/swagger.js"></script>
+    <script src="${staticRoot}/built/swagger/swagger-ui.min.js"></script>
+    <script src="${staticRoot}/built/swagger/lib/highlight.7.3.pack.js"></script>
+    <script src="${staticRoot}/girder-swagger.js"></script>
+  </body>
+</html>

--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -17,13 +17,12 @@
 #  limitations under the License.
 ###############################################################################
 
-import cherrypy
 import functools
-import mako
 import os
 import six
 
 from girder import constants
+from girder.utility.webroot import WebrootBase
 from . import docs, access
 from .rest import Resource, RestException, getApiUrl
 
@@ -167,50 +166,21 @@ class Description(object):
         return self
 
 
-class ApiDocs(object):
+class ApiDocs(WebrootBase):
     """
-    This serves up the swagger page.
+    This serves up the Swagger page.
     """
-    exposed = True
-
-    indexHtml = None
-
-    vars = {
-        'apiRoot': '',
-        'staticRoot': '',
-        'title': 'Girder - REST API Documentation'
-    }
-
     def __init__(self, templatePath=None):
         if not templatePath:
             templatePath = os.path.join(constants.PACKAGE_DIR,
                                         'api', 'api_docs.mako')
-        with open(templatePath) as templateFile:
-            # This may raise an IOError, but there's no way to recover
-            self.template = templateFile.read()
+        super(ApiDocs, self).__init__(templatePath)
 
-    def updateHtmlVars(self, vars):
-        self.vars.update(vars)
-        self.indexHtml = None
-
-    def GET(self, **params):
-        if self.indexHtml is None:
-            self.indexHtml = mako.template.Template(self.template).render(
-                **self.vars)
-
-        return self.indexHtml
-
-    def DELETE(self, **params):
-        raise cherrypy.HTTPError(405)
-
-    def PATCH(self, **params):
-        raise cherrypy.HTTPError(405)
-
-    def POST(self, **params):
-        raise cherrypy.HTTPError(405)
-
-    def PUT(self, **params):
-        raise cherrypy.HTTPError(405)
+        self.vars = {
+            'apiRoot': '',
+            'staticRoot': '',
+            'title': 'Girder - REST API Documentation'
+        }
 
 
 def _cmp(a, b):

--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -20,9 +20,10 @@
 import cherrypy
 import functools
 import mako
+import os
 import six
 
-from girder.constants import VERSION
+from girder import constants
 from . import docs, access
 from .rest import Resource, RestException, getApiUrl
 
@@ -33,7 +34,7 @@ version. If we break backward compatibility in any way, we should increment the
 major version.  This value is derived from the version number given in
 the top level package.json.
 """
-API_VERSION = VERSION['apiVersion']
+API_VERSION = constants.VERSION['apiVersion']
 
 SWAGGER_VERSION = '1.2'
 
@@ -180,79 +181,13 @@ class ApiDocs(object):
         'title': 'Girder - REST API Documentation'
     }
 
-    template = r"""
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>${title}</title>
-    <link rel="stylesheet"
-        href="//fonts.googleapis.com/css?family=Droid+Sans:400,700">
-    <link rel="stylesheet"
-        href="${staticRoot}/lib/fontello/css/fontello.css">
-    <link rel="stylesheet"
-        href="${staticRoot}/built/swagger/css/reset.css">
-    <link rel="stylesheet"
-        href="${staticRoot}/built/swagger/css/screen.css">
-    <link rel="stylesheet"
-        href="${staticRoot}/built/swagger/docs.css">
-    <link rel="icon"
-        type="image/png"
-        href="${staticRoot}/img/Girder_Favicon.png">
-    <style type="text/css">
-.response_throbber {
-  content:url("${staticRoot}/built/swagger/images/throbber.gif");
-}
-    </style>
-  </head>
-  <body>
-    <div class="docs-header">
-      <span>Girder REST API Documentation</span>
-      <i class="icon-book-alt right"></i>
-      <div id="g-global-info-apiroot" style="display: none">${apiRoot}</div>
-    </div>
-    <div class="docs-body">
-      <p>Below you will find the list of all of the resource types exposed
-      by the Girder RESTful Web API. Click any of the resource links to open
-      up a list of all available endpoints related to each resource type.
-      </p>
-      <p>Clicking any of those endpoints will display detailed documentation
-      about the purpose of each endpoint and the input parameters and output
-      values. You can also call API endpoints directly from this page by
-      typing in the parameters you wish to pass and then clicking the "Try
-      it out!" button.</p>
-      <p><b>Warning:</b> This is not a sandbox&mdash;calls that you make
-      from this page are the same as calling the API with any other client,
-      so update or delete calls that you make will affect the actual data on
-      the server.</p>
-    </div>
-    <div class="swagger-section">
-      <div id="swagger-ui-container"
-          class="swagger-ui-wrap docs-swagger-container">
-      </div>
-    </div>
-    <script src="${staticRoot}/built/swagger/lib/jquery-1.8.0.min.js">
-    </script>
-    <script src="${staticRoot}/built/swagger/lib/jquery.slideto.min.js">
-    </script>
-    <script src="${staticRoot}/built/swagger/lib/jquery.wiggle.min.js">
-    </script>
-    <script src="${staticRoot}/built/swagger/lib/jquery.ba-bbq.min.js">
-    </script>
-    <script src="${staticRoot}/built/swagger/lib/handlebars-1.0.0.js">
-    </script>
-    <script src="${staticRoot}/built/swagger/lib/underscore-min.js">
-    </script>
-    <script src="${staticRoot}/built/swagger/lib/backbone-min.js"></script>
-    <script src="${staticRoot}/built/swagger/lib/shred.bundle.js"></script>
-    <script src="${staticRoot}/built/swagger/lib/swagger.js"></script>
-    <script src="${staticRoot}/built/swagger/swagger-ui.min.js"></script>
-    <script src="${staticRoot}/built/swagger/lib/highlight.7.3.pack.js">
-    </script>
-    <script src="${staticRoot}/girder-swagger.js"></script>
-  </body>
-</html>
-"""
+    def __init__(self, templatePath=None):
+        if not templatePath:
+            templatePath = os.path.join(constants.PACKAGE_DIR,
+                                        'api', 'api_docs.mako')
+        with open(templatePath) as templateFile:
+            # This may raise an IOError, but there's no way to recover
+            self.template = templateFile.read()
 
     def updateHtmlVars(self, vars):
         self.vars.update(vars)

--- a/girder/utility/config.py
+++ b/girder/utility/config.py
@@ -21,7 +21,7 @@ import cherrypy
 import os
 import six
 
-from girder.constants import ROOT_DIR
+from girder.constants import PACKAGE_DIR
 
 
 def _mergeConfig(filename):
@@ -42,9 +42,9 @@ def _loadConfigsByPrecedent():
     """
     configPaths = []
     configPaths.append(
-        os.path.join(ROOT_DIR, 'girder', 'conf', 'girder.dist.cfg'))
+        os.path.join(PACKAGE_DIR, 'conf', 'girder.dist.cfg'))
     configPaths.append(
-        os.path.join(ROOT_DIR, 'girder', 'conf', 'girder.local.cfg'))
+        os.path.join(PACKAGE_DIR, 'conf', 'girder.local.cfg'))
     configPaths.append(
         os.path.join('/etc', 'girder.cfg'))
     configPaths.append(

--- a/girder/utility/mail_utils.py
+++ b/girder/utility/mail_utils.py
@@ -26,7 +26,7 @@ from email.mime.text import MIMEText
 from mako.lookup import TemplateLookup
 from girder import events
 from girder import logger
-from girder.constants import SettingKey, ROOT_DIR
+from girder.constants import SettingKey, PACKAGE_DIR
 from .model_importer import ModelImporter
 
 
@@ -130,6 +130,6 @@ def _sendmail(event):
     logger.info('Sent email to %s', msg['To'])
 
 
-_templateDir = os.path.join(ROOT_DIR, 'girder', 'mail_templates')
+_templateDir = os.path.join(PACKAGE_DIR, 'mail_templates')
 _templateLookup = TemplateLookup(directories=[_templateDir], collection_size=50)
 events.bind('_sendmail', 'core.email', _sendmail)

--- a/girder/utility/webroot.mako
+++ b/girder/utility/webroot.mako
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>${title}</title>
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Droid+Sans:400,700">
+    <link rel="stylesheet" href="${staticRoot}/lib/bootstrap/css/bootstrap.min.css">
+    <link rel="stylesheet" href="${staticRoot}/lib/bootstrap/css/bootstrap-switch.min.css">
+    <link rel="stylesheet" href="${staticRoot}/lib/fontello/css/fontello.css">
+    <link rel="stylesheet" href="${staticRoot}/lib/fontello/css/animation.css">
+    <link rel="stylesheet" href="${staticRoot}/built/jsoneditor/jsoneditor.min.css">
+    <link rel="stylesheet" href="${staticRoot}/lib/jqplot/css/jquery.jqplot.min.css">
+    <link rel="stylesheet" href="${staticRoot}/built/app.min.css">
+    <link rel="icon" type="image/png" href="${staticRoot}/img/Girder_Favicon.png">
+    % for plugin in pluginCss:
+    <link rel="stylesheet" href="${staticRoot}/built/plugins/${plugin}/plugin.min.css">
+    % endfor
+  </head>
+  <body>
+    <div id="g-global-info-apiroot" class="hide">${apiRoot}</div>
+    <div id="g-global-info-staticroot" class="hide">${staticRoot}</div>
+    <script src="${staticRoot}/built/libs.min.js"></script>
+    <script src="${staticRoot}/built/app.min.js"></script>
+    <script src="${staticRoot}/built/main.min.js"></script>
+    % for plugin in pluginJs:
+    <script src="${staticRoot}/built/plugins/${plugin}/plugin.min.js"></script>
+    % endfor
+  </body>
+</html>

--- a/girder/utility/webroot.py
+++ b/girder/utility/webroot.py
@@ -38,51 +38,13 @@ class Webroot(object):
         'title': 'Girder'
     }
 
-    template = r"""
-    <!DOCTYPE html>
-    <html lang="en">
-      <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>${title}</title>
-        <link rel="stylesheet"
-              href="//fonts.googleapis.com/css?family=Droid+Sans:400,700">
-        <link rel="stylesheet"
-              href="${staticRoot}/lib/bootstrap/css/bootstrap.min.css">
-        <link rel="stylesheet"
-              href="${staticRoot}/lib/bootstrap/css/bootstrap-switch.min.css">
-        <link rel="stylesheet"
-              href="${staticRoot}/lib/fontello/css/fontello.css">
-        <link rel="stylesheet"
-              href="${staticRoot}/lib/fontello/css/animation.css">
-        <link rel="stylesheet"
-              href="${staticRoot}/built/jsoneditor/jsoneditor.min.css">
-        <link rel="stylesheet"
-              href="${staticRoot}/lib/jqplot/css/jquery.jqplot.min.css">
-        <link rel="stylesheet"
-              href="${staticRoot}/built/app.min.css">
-        <link rel="icon"
-              type="image/png"
-              href="${staticRoot}/img/Girder_Favicon.png">
-
-        % for plugin in pluginCss:
-            <link rel="stylesheet"
-                  href="${staticRoot}/built/plugins/${plugin}/plugin.min.css">
-        % endfor
-      </head>
-      <body>
-        <div id="g-global-info-apiroot" class="hide">${apiRoot}</div>
-        <div id="g-global-info-staticroot" class="hide">${staticRoot}</div>
-        <script src="${staticRoot}/built/libs.min.js"></script>
-        <script src="${staticRoot}/built/app.min.js"></script>
-        <script src="${staticRoot}/built/main.min.js"></script>
-
-        % for plugin in pluginJs:
-          <script src="${staticRoot}/built/plugins/${plugin}/plugin.min.js">
-          </script>
-        % endfor
-      </body>
-    </html>
-    """
+    def __init__(self, templatePath=None):
+        if not templatePath:
+            templatePath = os.path.join(constants.PACKAGE_DIR,
+                                        'utility', 'webroot.mako')
+        with open(templatePath) as templateFile:
+            # This may raise an IOError, but there's no way to recover
+            self.template = templateFile.read()
 
     def GET(self):
         if self.indexHtml is None:

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,9 @@ setup(
             'girder-version.json',
             'conf/girder.dist.cfg',
             'mail_templates/*.mako',
-            'mail_templates/**/*.mako'
+            'mail_templates/**/*.mako',
+            'utility/webroot.mako',
+            'api/api_docs.mako'
         ]
     },
     install_requires=reqs,


### PR DESCRIPTION
* Use the more appropriate PACKAGE_DIR constant in some places 
*  Move Webroot and Description (Swagger root) templates to separate files
 * This will make future maintenance of these files easier, as they are no longer string literals constrained by Python style restrictions.
 * Since the new implementation stores the HTML string as an instance variable, instead of a class variable, it is possible to instantiate multiple Webroots with different templates in the same Girder instance.
 * This also slightly changes whitespace in the HTML template files, to improve their style once they are actually sent to a client.
* Move template serving endpoint code to a common class
 * This reduces code duplication and makes it easier to add additional templated endpoints in the future.