### PR TITLE
Add additional checks to packaging tests

### DIFF
--- a/tests/packaging/test_rest_api.sh
+++ b/tests/packaging/test_rest_api.sh
@@ -24,7 +24,7 @@ echo "Detected api version ${version}"
 
 timeout=0
 until [ $timeout -eq 5 ]; do
-    json=$("${CURL}" --max-time 5 --silent http://localhost:${GIRDER_PORT}/api/v1/system/version)
+    json=$("${CURL}" --connect-timeout 5 --max-time 5 --silent http://localhost:${GIRDER_PORT}/api/v1/system/version)
     if [ -n "$json" ] && [[ $json == *shortSHA* ]]; then
         break
     fi

--- a/tests/packaging/test_rest_api.sh
+++ b/tests/packaging/test_rest_api.sh
@@ -7,31 +7,42 @@ unset PYTHONPATH
 
 source "${virtualenv_activate}"
 
+# Start Girder server
 export GIRDER_PORT=31200
 python -m girder &> /dev/null &
+
+# Ensure the server started
+girder_pid=$!
+sleep 1
+if ! ps -p $girder_pid &> /dev/null ; then
+    echo "Error: Girder could not be started"
+    exit 1
+fi
 
 version="$(girder-install version)"
 echo "Detected api version ${version}"
 
-TIMEOUT=0
-until [ $TIMEOUT -eq 15 ]; do
+timeout=0
+until [ $timeout -eq 5 ]; do
     json=$("${CURL}" -s http://localhost:${GIRDER_PORT}/api/v1/system/version)
     if [ -n "$json" ] && [[ $json == *shortSHA* ]]; then
         break
     fi
-    TIMEOUT=$((TIMEOUT+1))
+    timeout=$((timeout+1))
     sleep 1
 done
 
-echo "Girder responded with ${json}"
-
-python <<EOF
+if [ -n "$json" ]; then
+    echo "Girder responded with ${json}"
+    python <<EOF
 import json
 assert json.loads("""${json}""")['apiVersion'].strip() == """${version}""".strip()
 EOF
-
-status=$?
+    status=$?
+else
+    echo "Error: Girder did not respond"
+    status=1
+fi
 
 kill -9 %+
-
 exit ${status}

--- a/tests/packaging/test_rest_api.sh
+++ b/tests/packaging/test_rest_api.sh
@@ -24,7 +24,7 @@ echo "Detected api version ${version}"
 
 timeout=0
 until [ $timeout -eq 5 ]; do
-    json=$("${CURL}" -s http://localhost:${GIRDER_PORT}/api/v1/system/version)
+    json=$("${CURL}" --max-time 5 --silent http://localhost:${GIRDER_PORT}/api/v1/system/version)
     if [ -n "$json" ] && [[ $json == *shortSHA* ]]; then
         break
     fi

--- a/tests/packaging/test_web_content.sh
+++ b/tests/packaging/test_web_content.sh
@@ -10,32 +10,41 @@ source "${virtualenv_activate}"
 
 girder-install -f web -s "${source_path}"/girder-web-*.tar.gz
 
+# Start Girder server
 export GIRDER_PORT=50202
 python -m girder &> /dev/null &
 
-# Loop until girder is giving answers
-TIMEOUT=0
-until [ $TIMEOUT -eq 15 ]; do
+# Ensure the server started
+girder_pid=$!
+sleep 1
+if ! ps -p $girder_pid &> /dev/null; then
+    echo "Error: Girder could not be started"
+    exit 1
+fi
+
+# Loop until Girder is giving answers
+timeout=0
+until [ $timeout -eq 15 ]; do
     json=$("${CURL}" -s http://localhost:${GIRDER_PORT}/api/v1/system/version)
     if [ -n "$json" ]; then
         break
     fi
-    TIMEOUT=$((TIMEOUT+1))
+    timeout=$((timeout+1))
     sleep 1
 done
 
+# Do the real tests
 "${CURL}" -s http://localhost:${GIRDER_PORT} | "${GREP}" "g-global-info-apiroot" > /dev/null
 if [ $? -ne 0 ] ; then
-    echo "Failed to load main page"
+    echo "Error: Failed to load main page"
     exit $?
 fi
 
 "${CURL}" -s http://localhost:${GIRDER_PORT}/api/v1 | "${GREP}" "swagger" > /dev/null
 if [ $? -ne 0 ] ; then
-    echo "Failed to load swagger docs"
+    echo "Error: Failed to load Swagger docs"
     exit $?
 fi
 
 kill -9 %+
-
 exit 0

--- a/tests/packaging/test_web_content.sh
+++ b/tests/packaging/test_web_content.sh
@@ -25,7 +25,7 @@ fi
 # Loop until Girder is giving answers
 timeout=0
 until [ $timeout -eq 15 ]; do
-    json=$("${CURL}" -s http://localhost:${GIRDER_PORT}/api/v1/system/version)
+    json=$("${CURL}" --max-time 5 --silent http://localhost:${GIRDER_PORT}/api/v1/system/version)
     if [ -n "$json" ]; then
         break
     fi
@@ -34,13 +34,13 @@ until [ $timeout -eq 15 ]; do
 done
 
 # Do the real tests
-"${CURL}" -s http://localhost:${GIRDER_PORT} | "${GREP}" "g-global-info-apiroot" > /dev/null
+"${CURL}" --max-time 5 --silent http://localhost:${GIRDER_PORT} | "${GREP}" "g-global-info-apiroot" > /dev/null
 if [ $? -ne 0 ] ; then
     echo "Error: Failed to load main page"
     exit $?
 fi
 
-"${CURL}" -s http://localhost:${GIRDER_PORT}/api/v1 | "${GREP}" "swagger" > /dev/null
+"${CURL}" --max-time 5 --silent http://localhost:${GIRDER_PORT}/api/v1 | "${GREP}" "swagger" > /dev/null
 if [ $? -ne 0 ] ; then
     echo "Error: Failed to load Swagger docs"
     exit $?

--- a/tests/packaging/test_web_content.sh
+++ b/tests/packaging/test_web_content.sh
@@ -25,7 +25,7 @@ fi
 # Loop until Girder is giving answers
 timeout=0
 until [ $timeout -eq 15 ]; do
-    json=$("${CURL}" --max-time 5 --silent http://localhost:${GIRDER_PORT}/api/v1/system/version)
+    json=$("${CURL}" --connect-timeout 5 --max-time 5 --silent http://localhost:${GIRDER_PORT}/api/v1/system/version)
     if [ -n "$json" ]; then
         break
     fi


### PR DESCRIPTION
These will explicitly detect and report when a Girder server failed to start, or when a the server did not return a response.

Also, ensure that packaging tests will timeout when a server doesn't respond. This makes each HTTP request timeout after 5 seconds. The test still won't fail if the very first request takes significantly longer (as it's retried in a loop).