### PR TITLE
Remove some redundant code in the folder creation HTTP API

### DIFF
--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -257,10 +257,6 @@ class Folder(Resource):
             parent=parent, name=name, parentType=parentType, creator=user,
             description=description, public=public)
 
-        if parentType in ('user', 'collection'):
-            folder = self.model('folder').setUserAccess(
-                folder, user=user, level=AccessType.ADMIN, save=True)
-
         return self.model('folder').filter(folder, user)
     createFolder.description = (
         Description('Create a new folder.')


### PR DESCRIPTION
The "createFolder" function in the model API already grants admin access to the folder creator. There's no need for the HTTP API to do it too.

The duplicate functionality in the HTTP API also may override plugin customizations that expect only one call to "setUserAccess" within the model layer.