### PR TITLE
Make imported files trigger events with their extra attributes present

### DIFF
--- a/girder/utility/filesystem_assetstore_adapter.py
+++ b/girder/utility/filesystem_assetstore_adapter.py
@@ -313,7 +313,8 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
 
         file = self.model('file').createFile(
             name=name, creator=user, item=item, reuseExisting=True,
-            assetstore=self.assetstore, mimeType=mimeType, size=stat.st_size)
+            assetstore=self.assetstore, mimeType=mimeType, size=stat.st_size,
+            saveFile=False)
         file['path'] = os.path.abspath(os.path.expanduser(path))
         file['mtime'] = stat.st_mtime
         file['imported'] = True


### PR DESCRIPTION
This will make extra attributes ("path", "mtime", "imported") on imported files be present at the time of the "model.file.save.created" event, so event handlers can more intelligently handle imported files.

This will also remove an unnecessary extra call to the database.