### PR TITLE
Docker update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,37 @@ EXPOSE 8080
 RUN mkdir /girder
 RUN mkdir /girder/logs
 
+RUN apt-get update && apt-get install -qy software-properties-common python-software-properties && \
+  apt-get update && apt-get install -qy \
+    build-essential \
+    curl \
+    git \
+    libffi-dev \
+    libpython-dev \
+    python-pip && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Get node
+RUN set -ex \
+   && for key in \
+      7937DFD2AB06298B2293C3187D33FF9D0246406D \
+      114F43EE0176B71C7BC219DD50A3051F888C628D \
+   ; do \
+      gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+   done
+
+ENV NODE_VERSION 0.10.40
+ENV NPM_VERSION next
+
+RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
+   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+   && gpg --verify SHASUMS256.txt.asc \
+   && grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - \
+   && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
+   && rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc \
+   && npm install -g npm@"$NPM_VERSION" \
+   && npm cache clear
+
 WORKDIR /girder
 COPY girder /girder/girder
 COPY clients /girder/clients
@@ -18,24 +49,13 @@ COPY config_parse.py /girder/config_parse.py
 COPY package.json /girder/package.json
 COPY README.rst /girder/README.rst
 
-RUN apt-get update && apt-get install -y software-properties-common python-software-properties
-
-RUN add-apt-repository ppa:chris-lea/node.js
-
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    libffi-dev \
-    libpython-dev \
-    python-pip \
-    nodejs
 RUN pip install \
     -r requirements.txt \
     -r requirements-dev.txt \
     -r plugins/geospatial/requirements.txt \
     -r plugins/metadata_extractor/requirements.txt
-RUN pip install -U six
-RUN npm install -g npm@next 
-RUN npm install -g grunt-cli
-RUN npm install
+
+RUN npm install -g grunt-cli && npm cache clear
+RUN npm install && npm cache clear
 RUN grunt init && grunt
 ENTRYPOINT ["python", "-m", "girder"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM node:0.10.40
 MAINTAINER Patrick Reynolds <patrick.reynolds@kitware.com>
 
 EXPOSE 8080
@@ -9,33 +9,11 @@ RUN mkdir /girder/logs
 RUN apt-get update && apt-get install -qy software-properties-common python-software-properties && \
   apt-get update && apt-get install -qy \
     build-essential \
-    curl \
     git \
     libffi-dev \
     libpython-dev \
     python-pip && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# Get node
-RUN set -ex \
-   && for key in \
-      7937DFD2AB06298B2293C3187D33FF9D0246406D \
-      114F43EE0176B71C7BC219DD50A3051F888C628D \
-   ; do \
-      gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
-   done
-
-ENV NODE_VERSION 0.10.40
-ENV NPM_VERSION next
-
-RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
-   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
-   && gpg --verify SHASUMS256.txt.asc \
-   && grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - \
-   && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
-   && rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc \
-   && npm install -g npm@"$NPM_VERSION" \
-   && npm cache clear
 
 WORKDIR /girder
 COPY girder /girder/girder

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+mongodb:
+    image: mongo:3.0
+    ports:
+        - "27017"
+    volumes:
+        - "data/db"
+
+girder:
+    build: .
+    dockerfile: Dockerfile
+    ports:
+        - "8080:8080"
+    links:
+        - "mongodb:mongodb"
+    command: -d mongodb://mongodb:27017/girder


### PR DESCRIPTION
This PR should fix build failure on docker hub, which was caused by `pip install -U six`. Additionally, node pulled from `ppa:chris-lea/node.js` was outdated, which resulted in multiple warnings during `npm install` of girder. Now, both node and npm can be regulated via changing ENV vars in Dockerbuild.

As a bonus I've added simple fig file allowing for a quick local deployment:
```
docker-compose build
docker-compose up -d
```
