### PR TITLE
Prevent item size from being updated if a file is created but not saved

### DIFF
--- a/girder/constants.py
+++ b/girder/constants.py
@@ -196,5 +196,8 @@ class CoreEventHandler(object):
     # For creating the default Public and Private folders at user creation time.
     USER_DEFAULT_FOLDERS = 'core.addDefaultFolders'
 
-    # For adding a user into his or her own ACL.
+    # For adding a user into its own ACL.
     USER_SELF_ACCESS = 'core.grantSelfAccess'
+
+    # For updating an item's size to include a new file.
+    FILE_PROPAGATE_SIZE = 'core.propagateSizeToItem'

--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -253,7 +253,7 @@ class File(acl_mixin.AccessControlMixin, Model):
 
         fileDoc = event.info
         itemId = fileDoc.get('itemId')
-        if itemId:
+        if itemId and fileDoc.get('size'):
             item = self.model('item').load(itemId, force=True)
             self.propagateSizeChange(item, fileDoc['size'])
 

--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -21,7 +21,8 @@ import cherrypy
 import datetime
 
 from .model_base import Model, ValidationException
-from ..constants import AccessType
+from girder import events
+from girder.constants import AccessType, CoreEventHandler
 from girder.utility import assetstore_utilities, acl_mixin
 
 
@@ -42,6 +43,11 @@ class File(acl_mixin.AccessControlMixin, Model):
             "size"))
 
         self.exposeFields(level=AccessType.SITE_ADMIN, fields=("assetstoreId",))
+
+        events.bind('model.file.save.created',
+                    CoreEventHandler.FILE_PROPAGATE_SIZE,
+                    self._propagateSizeToItem)
+
 
     def remove(self, file, updateItemSize=True, **kwargs):
         """
@@ -222,18 +228,34 @@ class File(acl_mixin.AccessControlMixin, Model):
             'assetstoreId': assetstore['_id'],
             'name': name,
             'mimeType': mimeType,
-            'size': size
+            'size': size,
+            'itemId': item['_id'] if item else None
         }
-
-        if item:
-            file['itemId'] = item['_id']
-            self.propagateSizeChange(item, size)
-        else:
-            file['itemId'] = None
 
         if saveFile:
             return self.save(file)
         return file
+
+    def _propagateSizeToItem(self, event):
+        """
+        This callback updates an item's size to include that of a newly-created
+        file.
+
+        This generally should not be called or overridden directly. This should
+        not be unregistered, as that would cause item, folder, and collection
+        sizes to be inaccurate.
+        """
+        # This task is not performed in "createFile", in case
+        # "saveFile==False". The item size should be updated only when it's
+        # certain that the file will actually be saved. It is also possible for
+        # "model.file.save" to set "defaultPrevented", which would prevent the
+        # item from being saved initially.
+
+        fileDoc = event.info
+        itemId = fileDoc.get('itemId')
+        if itemId:
+            item = self.model('item').load(itemId, force=True)
+            self.propagateSizeChange(item, fileDoc['size'])
 
     def copyFile(self, srcFile, creator, item=None):
         """

--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -48,7 +48,6 @@ class File(acl_mixin.AccessControlMixin, Model):
                     CoreEventHandler.FILE_PROPAGATE_SIZE,
                     self._propagateSizeToItem)
 
-
     def remove(self, file, updateItemSize=True, **kwargs):
         """
         Use the appropriate assetstore adapter for whatever assetstore the


### PR DESCRIPTION
See comments in the code for rationale on when this may happen.