### PR TITLE
Make sure static/built/plugins dir always exists

### DIFF
--- a/clients/web/static/built/plugins/.gitignore
+++ b/clients/web/static/built/plugins/.gitignore
@@ -1,3 +1,2 @@
 *
 !.gitignore
-!plugins/


### PR DESCRIPTION
Some plugins with custom Gruntfiles (including COVALIC) expected
this directory to exist at the time their Gruntfile is first executed,
but prior to actual task execution. If users had installed such a
plugin without running grunt beforehand, they would encounter errors.
The easiest fix is just to ensure that the directory is present.