### PR TITLE
Initialize the girder namespace in init.js

### DIFF
--- a/clients/web/src/init.js
+++ b/clients/web/src/init.js
@@ -4,6 +4,11 @@
 'use strict';
 
 /*
+ * Initialize global girder object
+ */
+var girder = girder || {};
+
+/*
  * Some cross-browser globals
  */
 if (!window.console) {


### PR DESCRIPTION
Currently, the girder object is initialized by the jade template.  This makes the initialization explicit locally and protects against possible problems related to the order the javascript files are loaded.