### PR TITLE
Uglify was broken with the recent refactor, this fixes it

### DIFF
--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -90,7 +90,7 @@ module.exports = function (grunt) {
                         '<%= pluginDir %>/<%= grunt.task.current.args[0] %>/web_client/js/**/*.js',
                         '<%= grunt.config.getRaw("jade.plugin.files")[0].dest %>'
                     ],
-                    dest: '<%= staticDir %>/built/plugins/<%= grunt.task.current.args[0] %>/plugin.min.css'
+                    dest: '<%= staticDir %>/built/plugins/<%= grunt.task.current.args[0] %>/plugin.min.js'
                 }]
             }
         },


### PR DESCRIPTION
@jbeezley could you take a look at this, I just noticed on a fresh girder install that none of the plugin javascripts were being loaded, which was because they had the wrong name and were being overwritten by the stylus step. It wasn't affecting environments where the js had already been built.