### PR TITLE
Always use npm installed jscs and jshint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,8 @@ if(JAVASCRIPT_STYLE_TESTS)
     message(FATAL_ERROR "'nodejs' executable couldn't be found.\n"
                         "Consider reconfiguring passing -DNODEJS_EXECUTABLE:FILEPATH=/path/to/nodejs")
   endif()
-  find_program(JSHINT_EXECUTABLE jshint ${PROJECT_SOURCE_DIR}/node_modules/jshint/bin)
-  find_program(JSSTYLE_EXECUTABLE jscs ${PROJECT_SOURCE_DIR}/node_modules/jscs/bin)
+  find_program(JSHINT_EXECUTABLE jshint ${PROJECT_SOURCE_DIR}/node_modules/jshint/bin NO_DEFAULT_PATH)
+  find_program(JSSTYLE_EXECUTABLE jscs ${PROJECT_SOURCE_DIR}/node_modules/jscs/bin NO_DEFAULT_PATH)
 endif()
 
 if(BUILD_TESTING)


### PR DESCRIPTION
Without `NO_DEFAULT_PATH`, cmake will pick up globally installed* versions of jscs and jshint, which likely the wrong version.  This forces the local version.

<verb>*</verb> I use nvm, get off my lawn.