### PR TITLE
Filter out node_modules from packaged plugins

### DIFF
--- a/grunt_tasks/package.js
+++ b/grunt_tasks/package.js
@@ -87,7 +87,8 @@ module.exports = function (grunt) {
                 filter: function (fname) {
                     return !fname.match(/\/plugin_tests/) &&
                            !fname.match(/cmake$/) &&
-                           !fname.match(/py[co]$/);
+                           !fname.match(/py[co]$/) &&
+                           !fname.match(/\/node_modules/);
                 }
             }
         }


### PR DESCRIPTION
The new `npm install` step that occurs in plugin directories can generate a large `node_modules` directory that is only needed at build time.  These are now filtered out in the packaging step.