### PR TITLE
Update to latest version of grunt watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "grunt-contrib-jade": "0.11.0",
     "grunt-contrib-stylus": "~0.22.0",
     "grunt-contrib-uglify": "~0.4.0",
-    "grunt-contrib-watch": "~0.3.1",
+    "grunt-contrib-watch": "~0.6.1",
     "grunt-contrib-copy": "~0.5.0",
     "grunt-shell": ">=0.2.1",
     "grunt-gitinfo": "~0.1.0",


### PR DESCRIPTION
This fixes an issue causing `grunt watch` to fail when the configured task matches no files.