### PR TITLE
Bump cffi version to 1.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cffi==0.8.6
+cffi==1.3.0
 CherryPy==3.7.0
 pymongo==3.0.3
 bcrypt==1.1.1


### PR DESCRIPTION
Minerva now depends on ```cryptography==1.1.0``` which requires ```cffi>=1.1.0```