### PR TITLE
Editable girder install plugins

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -112,3 +112,11 @@ then restart the Girder server before it will be active.
 .. note:: The ``girder-install plugin`` command can also accept a list of plugins
    to be installed. You may need to run it as root if you installed Girder at the
    system level.
+
+For development purposes it is possible to symlink (rather than copy) the plugin
+directory. This is accomplished with the ``-s`` or ``--symlink`` flag: ::
+
+     girder-install -s plugin /path/to/your/plugin
+
+Enabled plugins installed with ``-s`` may be edited in place and those changes will
+be reflected after a server restart.

--- a/girder/utility/install.py
+++ b/girder/utility/install.py
@@ -113,10 +113,10 @@ def install_plugin(opts):
 
         if (os.path.isdir(targetPath) and
                 os.path.samefile(pluginPath, targetPath) and not
-                opts.editable ^ os.path.islink(targetPath)):
+                opts.symlink ^ os.path.islink(targetPath)):
             # If source and dest are the same, we are done for this plugin.
             # Note: ^ is a logical xor - not xor means only continue if
-            # editable and islink() are either both false, or both true
+            # symlink and islink() are either both false, or both true
             continue
 
         if os.path.exists(targetPath):
@@ -129,7 +129,7 @@ def install_plugin(opts):
             else:
                 raise Exception('Plugin already exists at %s, use "-f" to '
                                 'overwrite the existing directory.')
-        if opts.editable:
+        if opts.symlink:
             os.symlink(pluginPath, targetPath)
         else:
             shutil.copytree(pluginPath, targetPath)
@@ -155,7 +155,7 @@ def main():
     plugin.set_defaults(func=install_plugin)
     plugin.add_argument('-f', '--force', action='store_true',
                         help='Overwrite plugins if they already exist.')
-    plugin.add_argument('-e', '--editable', action='store_true',
+    plugin.add_argument('-s', '--symlink', action='store_true',
                         help='Install by symlinking to the plugin directory.')
 
     plugin.add_argument('plugin', nargs='+',

--- a/girder/utility/install.py
+++ b/girder/utility/install.py
@@ -124,8 +124,11 @@ def install_plugin(opts):
                 print(constants.TerminalColor.warning(
                     'Removing existing plugin at %s.' % targetPath))
 
-                shutil.rmtree(targetPath,
-                              onerror=lambda *args: os.unlink(targetPath))
+                if opts.symlink:
+                    os.symlink(pluginPath, targetPath)
+                else:
+                    shutil.copytree(pluginPath, targetPath)
+
             else:
                 raise Exception('Plugin already exists at %s, use "-f" to '
                                 'overwrite the existing directory.')

--- a/girder/utility/install.py
+++ b/girder/utility/install.py
@@ -124,10 +124,10 @@ def install_plugin(opts):
                 print(constants.TerminalColor.warning(
                     'Removing existing plugin at %s.' % targetPath))
 
-                if opts.symlink:
-                    os.symlink(pluginPath, targetPath)
+                if os.path.islink(targetPath):
+                    os.unlink(targetPath)
                 else:
-                    shutil.copytree(pluginPath, targetPath)
+                    shutil.rmtree(targetPath)
 
             else:
                 raise Exception('Plugin already exists at %s, use "-f" to '

--- a/tests/cases/install_test.py
+++ b/tests/cases/install_test.py
@@ -29,7 +29,8 @@ from girder.utility import install, config
 
 pluginRoot = os.path.join(os.path.dirname(os.path.dirname(__file__)),
                           'test_plugins')
-PluginOpts = collections.namedtuple('PluginOpts', ['plugin', 'force'])
+PluginOpts = collections.namedtuple('PluginOpts',
+                                    ['plugin', 'force', 'editable'])
 POPEN = 'subprocess.Popen'
 
 
@@ -75,7 +76,7 @@ class InstallTestCase(base.TestCase):
             install.install_plugin(PluginOpts(force=False, plugin=[
                 os.path.join(pluginRoot, 'has_deps'),
                 os.path.join(constants.ROOT_DIR, 'plugins', 'jobs')
-            ]))
+            ], editable=False))
 
             self.assertEqual(len(p.mock_calls), 1)
             self.assertEqual(p.mock_calls[0][1][0][:2], ('npm', 'install'))
@@ -90,32 +91,32 @@ class InstallTestCase(base.TestCase):
         with self.assertRaisesRegexp(Exception, 'Plugin already exists'):
             install.install_plugin(PluginOpts(force=False, plugin=[
                 os.path.join(pluginRoot, 'has_deps')
-            ]))
+            ], editable=False))
 
         # Should succeed if force=True
         with mock.patch(POPEN, return_value=ProcMock()):
             install.install_plugin(PluginOpts(force=True, plugin=[
                 os.path.join(pluginRoot, 'has_deps')
-            ]))
+            ], editable=False))
 
         # If npm install returns 1, should fail
         with mock.patch(POPEN, return_value=ProcMock(rc=1)), \
                 self.assertRaisesRegexp(Exception, 'npm install returned 1'):
             install.install_plugin(PluginOpts(force=True, plugin=[
                 os.path.join(pluginRoot, 'has_deps')
-            ]))
+            ], editable=False))
 
         # If bad path is given, should fail gracefuly
         with self.assertRaisesRegexp(Exception, 'Invalid plugin directory'):
             install.install_plugin(PluginOpts(force=True, plugin=[
                 '/bad/install/path'
-            ]))
+            ], editable=False))
 
         # If src == dest, we should still run npm and succeed.
         with mock.patch(POPEN, return_value=ProcMock()):
             install.install_plugin(PluginOpts(force=True, plugin=[
                 os.path.join(self.pluginDir, 'has_deps')
-            ]))
+            ], editable=False))
 
     def testWebInstall(self):
         with mock.patch(POPEN, return_value=ProcMock(rc=2)) as p,\

--- a/tests/cases/install_test.py
+++ b/tests/cases/install_test.py
@@ -118,6 +118,40 @@ class InstallTestCase(base.TestCase):
                 os.path.join(self.pluginDir, 'has_deps')
             ], editable=False))
 
+        # Should fail if exists as directory and editable is true
+        with self.assertRaisesRegexp(Exception, 'Plugin already exists'):
+            install.install_plugin(PluginOpts(force=False, plugin=[
+                os.path.join(pluginRoot, 'has_deps')
+            ], editable=True))
+
+        # Should be a link if force=True and editable=True
+        with mock.patch(POPEN, return_value=ProcMock()):
+            install.install_plugin(PluginOpts(force=True, plugin=[
+                os.path.join(pluginRoot, 'has_deps')
+            ], editable=True))
+
+            self.assertTrue(os.path.islink(os.path.join(
+                self.pluginDir, 'has_deps')))
+
+            # Should fail if exists as link and editable is false
+            with self.assertRaisesRegexp(Exception, 'Plugin already exists'):
+                install.install_plugin(PluginOpts(force=False, plugin=[
+                    os.path.join(pluginRoot, 'has_deps')
+                ], editable=False))
+
+        # Should not be a link if force=True and editable=False
+        with mock.patch(POPEN, return_value=ProcMock()):
+            install.install_plugin(PluginOpts(force=True, plugin=[
+                os.path.join(pluginRoot, 'has_deps')
+            ], editable=False))
+
+            self.assertFalse(os.path.islink(os.path.join(
+                self.pluginDir, 'has_deps')))
+
+
+
+
+
     def testWebInstall(self):
         with mock.patch(POPEN, return_value=ProcMock(rc=2)) as p,\
                 self.assertRaisesRegexp(Exception, 'npm install returned 2'):

--- a/tests/cases/install_test.py
+++ b/tests/cases/install_test.py
@@ -30,7 +30,7 @@ from girder.utility import install, config
 pluginRoot = os.path.join(os.path.dirname(os.path.dirname(__file__)),
                           'test_plugins')
 PluginOpts = collections.namedtuple('PluginOpts',
-                                    ['plugin', 'force', 'editable'])
+                                    ['plugin', 'force', 'symlink'])
 POPEN = 'subprocess.Popen'
 
 
@@ -76,7 +76,7 @@ class InstallTestCase(base.TestCase):
             install.install_plugin(PluginOpts(force=False, plugin=[
                 os.path.join(pluginRoot, 'has_deps'),
                 os.path.join(constants.ROOT_DIR, 'plugins', 'jobs')
-            ], editable=False))
+            ], symlink=False))
 
             self.assertEqual(len(p.mock_calls), 1)
             self.assertEqual(p.mock_calls[0][1][0][:2], ('npm', 'install'))
@@ -91,59 +91,59 @@ class InstallTestCase(base.TestCase):
         with self.assertRaisesRegexp(Exception, 'Plugin already exists'):
             install.install_plugin(PluginOpts(force=False, plugin=[
                 os.path.join(pluginRoot, 'has_deps')
-            ], editable=False))
+            ], symlink=False))
 
         # Should succeed if force=True
         with mock.patch(POPEN, return_value=ProcMock()):
             install.install_plugin(PluginOpts(force=True, plugin=[
                 os.path.join(pluginRoot, 'has_deps')
-            ], editable=False))
+            ], symlink=False))
 
         # If npm install returns 1, should fail
         with mock.patch(POPEN, return_value=ProcMock(rc=1)), \
                 self.assertRaisesRegexp(Exception, 'npm install returned 1'):
             install.install_plugin(PluginOpts(force=True, plugin=[
                 os.path.join(pluginRoot, 'has_deps')
-            ], editable=False))
+            ], symlink=False))
 
         # If bad path is given, should fail gracefuly
         with self.assertRaisesRegexp(Exception, 'Invalid plugin directory'):
             install.install_plugin(PluginOpts(force=True, plugin=[
                 '/bad/install/path'
-            ], editable=False))
+            ], symlink=False))
 
         # If src == dest, we should still run npm and succeed.
         with mock.patch(POPEN, return_value=ProcMock()):
             install.install_plugin(PluginOpts(force=True, plugin=[
                 os.path.join(self.pluginDir, 'has_deps')
-            ], editable=False))
+            ], symlink=False))
 
-        # Should fail if exists as directory and editable is true
+        # Should fail if exists as directory and symlink is true
         with self.assertRaisesRegexp(Exception, 'Plugin already exists'):
             install.install_plugin(PluginOpts(force=False, plugin=[
                 os.path.join(pluginRoot, 'has_deps')
-            ], editable=True))
+            ], symlink=True))
 
-        # Should be a link if force=True and editable=True
+        # Should be a link if force=True and symlink=True
         with mock.patch(POPEN, return_value=ProcMock()):
             install.install_plugin(PluginOpts(force=True, plugin=[
                 os.path.join(pluginRoot, 'has_deps')
-            ], editable=True))
+            ], symlink=True))
 
             self.assertTrue(os.path.islink(os.path.join(
                 self.pluginDir, 'has_deps')))
 
-            # Should fail if exists as link and editable is false
+            # Should fail if exists as link and symlink is false
             with self.assertRaisesRegexp(Exception, 'Plugin already exists'):
                 install.install_plugin(PluginOpts(force=False, plugin=[
                     os.path.join(pluginRoot, 'has_deps')
-                ], editable=False))
+                ], symlink=False))
 
-        # Should not be a link if force=True and editable=False
+        # Should not be a link if force=True and symlink=False
         with mock.patch(POPEN, return_value=ProcMock()):
             install.install_plugin(PluginOpts(force=True, plugin=[
                 os.path.join(pluginRoot, 'has_deps')
-            ], editable=False))
+            ], symlink=False))
 
             self.assertFalse(os.path.islink(os.path.join(
                 self.pluginDir, 'has_deps')))

--- a/tests/cases/install_test.py
+++ b/tests/cases/install_test.py
@@ -148,10 +148,6 @@ class InstallTestCase(base.TestCase):
             self.assertFalse(os.path.islink(os.path.join(
                 self.pluginDir, 'has_deps')))
 
-
-
-
-
     def testWebInstall(self):
         with mock.patch(POPEN, return_value=ProcMock(rc=2)) as p,\
                 self.assertRaisesRegexp(Exception, 'npm install returned 2'):


### PR DESCRIPTION
Adds an ```--editable``` or ```-e``` flag to ```girder-install plugin``` that will symlink rather than copy the directory tree into girder/plugins/

@zachmullen PTAL  @jbeezley thanks!