### PR TITLE
Include a human-readable name in the default email sender setting

### DIFF
--- a/girder/constants.py
+++ b/girder/constants.py
@@ -145,7 +145,7 @@ class SettingDefault:
     defaults = {
         SettingKey.PLUGINS_ENABLED: [],
         SettingKey.COOKIE_LIFETIME: 180,
-        SettingKey.EMAIL_FROM_ADDRESS: 'no-reply@girder.org',
+        SettingKey.EMAIL_FROM_ADDRESS: 'Girder <no-reply@girder.org>',
         SettingKey.REGISTRATION_POLICY: 'open',
         SettingKey.SMTP_HOST: 'localhost:25',
         SettingKey.UPLOAD_MINIMUM_CHUNK_SIZE: 1024 * 1024 * 5,

--- a/girder/utility/mail_utils.py
+++ b/girder/utility/mail_utils.py
@@ -93,7 +93,7 @@ def sendEmail(to=None, subject=None, text=None, toAdmins=False):
     msg['Subject'] = subject or '[no subject]'
     msg['To'] = ', '.join(to)
     msg['From'] = ModelImporter.model('setting').get(
-        SettingKey.EMAIL_FROM_ADDRESS, 'no-reply@girder.org')
+        SettingKey.EMAIL_FROM_ADDRESS, 'Girder <no-reply@girder.org>')
 
     events.daemon.trigger('_sendmail', info={
         'message': msg,


### PR DESCRIPTION
This provides a cue to administrators that they can use a human-readable display name in this field, per RFC2822-3.4.