### PR TITLE
Upgrade the oauth plugin to a new major release

### DIFF
--- a/plugins/oauth/plugin.json
+++ b/plugins/oauth/plugin.json
@@ -1,5 +1,5 @@
 {
     "name": "OAuth2 login",
     "description": "Allow users to login via supported OAuth2 providers.",
-    "version": "1.1.0"
+    "version": "2.0.0"
 }


### PR DESCRIPTION
The recent refactoring of the oauth plugin changed the response structure of the HTTP API. This should have resulted in a major release bump (2.0), not just a minor one (1.1). This corrects that oversight.
