### PR TITLE
Add a "name" field to the oauth provider list API

### DIFF
--- a/plugins/oauth/plugin.json
+++ b/plugins/oauth/plugin.json
@@ -1,5 +1,5 @@
 {
     "name": "OAuth2 login",
     "description": "Allow users to login via supported OAuth2 providers.",
-    "version": "2.0.0"
+    "version": "2.1.0"
 }

--- a/plugins/oauth/plugin_tests/oauth_test.py
+++ b/plugins/oauth/plugin_tests/oauth_test.py
@@ -128,8 +128,9 @@ class OauthTest(base.TestCase):
         self.assertStatusOk(resp)
         self.assertIsInstance(resp.json, list)
         for provider in resp.json:
-            self.assertHasKeys(provider, ('id', 'url'))
+            self.assertHasKeys(provider, ('id', 'name', 'url'))
             if provider['id'] == 'google':
+                self.assertEqual(provider['name'], 'Google')
                 providerUrl = provider['url']
                 break
         else:
@@ -344,8 +345,9 @@ class OauthTest(base.TestCase):
 
         self.assertStatusOk(resp)
         for provider in resp.json:
-            self.assertHasKeys(provider, ('id', 'url'))
+            self.assertHasKeys(provider, ('id', 'name', 'url'))
             if provider['id'] == 'github':
+                self.assertEqual(provider['name'], 'GitHub')
                 providerUrl = provider['url']
                 break
         else:

--- a/plugins/oauth/server/rest.py
+++ b/plugins/oauth/server/rest.py
@@ -87,7 +87,8 @@ class OAuth(Resource):
             # Store as a list, so a consistent ordering can be maintained
             info = [
                 {
-                    'id': provider.getProviderName(),
+                    'id': provider.getProviderName(external=False),
+                    'name': provider.getProviderName(external=True),
                     'url': provider.getUrl(state)
                 }
                 for provider in enabledProviders

--- a/plugins/oauth/web_client/js/LoginView.js
+++ b/plugins/oauth/web_client/js/LoginView.js
@@ -30,10 +30,11 @@ girder.views.oauth_LoginView = girder.View.extend({
 
             if (btn) {
                 btn.providerId = provider.id;
+                btn.text = provider.name;
                 buttons.push(btn);
             }
             else {
-                console.warn('Unsupported OAuth2 provider: ' + provider);
+                console.warn('Unsupported OAuth2 provider: ' + provider.id);
             }
         }, this);
 
@@ -48,12 +49,10 @@ girder.views.oauth_LoginView = girder.View.extend({
     _buttons: {
         google: {
             icon: 'gplus',
-            text: 'Google',
             class: 'g-oauth-button-google'
         },
         github: {
             icon: 'github-circled',
-            text: 'GitHub',
             class: 'g-oauth-button-github'
         }
     }


### PR DESCRIPTION
Having a human-readable display name for the oauth provider is useful information for most clients to have.

This only adds an extra field to the objects returned by the HTTP API, so it requires only a minor version bump.