### PR TITLE
Add a cookieAuth decorator to make endpoints accept cookie authentication

### DIFF
--- a/docs/developer-cookbook.rst
+++ b/docs/developer-cookbook.rst
@@ -210,6 +210,8 @@ body would be ``0123456789``.
 
 .. code-block:: python
 
+    from girder.api import access
+
     @access.public
     def rawExample(self, params):
         def gen():
@@ -420,21 +422,27 @@ Supporting web browser operations where custom headers cannot be set
 Some aspects of the web browser make it infeasible to pass the usual
 ``Girder-Token`` authentication header when making a request. For example,
 if using an ``EventSource`` object for SSE, or when you must redirect the user's
-browser to a download endpoint that serves its content as an attachment. In such
-cases, you may allow specific REST API routes to authenticate using the Cookie.
-You should only do this if the endpoint is "read-only", that is, in cases where
-it does not make modifications to data on the server, to avoid vulnerabilities
-to Cross-Site Request Forgery attacks. If your endpoint is not read-only and
-you are unable to pass the ``Girder-Token`` header to it, you can pass a ``token``
-query parameter containing the token as a last resort, but in practice this will
-probably never be the case.
+browser to a download endpoint that serves its content as an attachment.
 
-In order to allow cookie authentication for your route, simply set the
-``cookieAuth`` property on your route handler function to ``True``. Example:
+In such cases, you may allow specific REST API routes to authenticate using the
+Cookie. To avoid vulnerabilities to Cross-Site Request Forgery attacks, you
+should only do this if the endpoint is "read-only" (that is, the endpoint does
+not make modifications to data on the server). Accordingly, only routes for
+``HEAD`` and ``GET`` requests allow cookie authentication to be enabled (without
+an additional override).
+
+In order to allow cookie authentication for your route, simply add the
+``cookie`` decorator to your route handler function. Example:
 
 .. code-block:: python
 
+    from girder.api import access
+
+    @access.cookie
     @access.public
     def download(self, params):
         ...
-    download.cookieAuth = True
+
+As a last resort, if your endpoint is not read-only and you are unable to pass
+the ``Girder-Token`` header to it, you can pass a ``token`` query parameter
+containing the token , but in practice this will probably never be the case.

--- a/girder/api/access.py
+++ b/girder/api/access.py
@@ -77,3 +77,38 @@ def token(fun):
         return fun(*args, **kwargs)
     accessDecorator.accessLevel = 'token'
     return accessDecorator
+
+
+def cookie(*args, **kwargs):
+    """
+    REST endpoints that allow the use of a cookie for authentication should be
+    wrapped in this decorator.
+
+    When used as a normal decorator, this is only effective on endpoints for
+    HEAD and GET routes (as these routes should be read-only in a RESTful API).
+
+    While allowing cookie authentication on other types of routes exposes an
+    application to Cross-Site Request Forgery (CSRF) attacks, an optional
+    ``force=True`` argument may be passed to the decorator to make it effective
+    on any type of route.
+    """
+    if len(args) == 1 and callable(args[0]):  # Used as a raw decorator
+        force = False
+        args[0].cookieAuth = (True, force)
+        return args[0]
+
+    else:  # Used with arguments
+        if len(args) == 1 and isinstance(args[0], bool):
+            force = args[0]
+        elif 'force' in kwargs:
+            force = kwargs['force']
+        elif (not args) and (not kwargs):
+            force = False
+        else:
+            raise TypeError('Unsupported extra decorator arguments.')
+
+        def decorator(fun):
+            fun.cookieAuth = (True, force)
+            return fun
+
+        return decorator

--- a/girder/api/access.py
+++ b/girder/api/access.py
@@ -57,11 +57,8 @@ def public(fun):
     Functions that allow any client access, including those that haven't logged
     in should be wrapped in this decorator.
     """
-    @functools.wraps(fun)
-    def accessDecorator(*args, **kwargs):
-        return fun(*args, **kwargs)
-    accessDecorator.accessLevel = 'public'
-    return accessDecorator
+    fun.accessLevel = 'public'
+    return fun
 
 
 def token(fun):

--- a/girder/api/docs.py
+++ b/girder/api/docs.py
@@ -62,7 +62,7 @@ def addRouteDocs(resource, route, method, info, handler):
     :param resource: The name of the resource, e.g. "item"
     :type resource: str
     :param route: The route to describe.
-    :type route: list[str]
+    :type route: tuple[str]
     :param method: The HTTP method for this route, e.g. "POST"
     :type method: str
     :param info: The information representing the API documentation, typically
@@ -87,7 +87,7 @@ def removeRouteDocs(resource, route, method, info, handler):
     :param resource: The name of the resource, e.g. "item"
     :type resource: str
     :param route: The route to describe.
-    :type route: list
+    :type route: tuple[str]
     :param method: The HTTP method for this route, e.g. "POST"
     :type method: str
     :param info: The information representing the API documentation.

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -447,7 +447,7 @@ class Resource(ModelImporter):
         :param route: The route, as a list of path params relative to the
             resource root. Elements of this list starting with ':' are assumed
             to be wildcards.
-        :type route: tuple
+        :type route: tuple[str]
         :param handler: The method to be called if the route and method are
             matched by a request. Wildcards in the route will be expanded and
             passed as kwargs with the same name as the wildcard identifier.
@@ -504,7 +504,7 @@ class Resource(ModelImporter):
         :param route: The route, as a list of path params relative to the
                       resource root. Elements of this list starting with ':'
                       are assumed to be wildcards.
-        :type route: list
+        :type route: tuple[str]
         :param handler: The method called for the route; this is necessary to
                         remove the documentation.
         :type handler: function

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -495,6 +495,16 @@ class Resource(ModelImporter):
                 'WARNING: No access level specified for route {} {}'
                 .format(method, routePath)))
 
+        if method.lower() not in ('head', 'get') \
+            and hasattr(handler, 'cookieAuth') \
+            and not (isinstance(handler.cookieAuth, tuple) and
+                     handler.cookieAuth[1]):
+            routePath = '/'.join([resource] + list(route))
+            print(TerminalColor.warning(
+                  'WARNING: Cannot allow cookie authentication for '
+                  'route {} {} without specifying "force=True"'
+                  .format(method, routePath)))
+
     def removeRoute(self, method, route, handler=None, resource=None):
         """
         Remove a route from the handler and documentation.
@@ -597,11 +607,6 @@ class Resource(ModelImporter):
                         # once with allowCookie will make the parameter
                         # effectively permanent (for the request)
                         getCurrentToken(allowCookie=True)
-                    else:
-                        print(TerminalColor.warning(
-                            'WARNING: Cannot allow cookie authentication for '
-                            'route "%s %s" without specifying "force=True"' %
-                            (method, '/'.join(path))))
 
             kwargs['params'] = params
             # Add before call for the API method. Listeners can return

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -161,7 +161,7 @@ def getCurrentUser(returnToken=False):
 
     def retVal(user, token):
         if returnToken:
-            return (user, token)
+            return user, token
         else:
             return user
 

--- a/girder/api/v1/collection.py
+++ b/girder/api/v1/collection.py
@@ -101,6 +101,7 @@ class Collection(Resource):
         .errorResponse('ID was invalid.')
         .errorResponse('Read permission denied on the collection.', 403))
 
+    @access.cookie
     @access.public
     @loadmodel(model='collection', level=AccessType.READ)
     def downloadCollection(self, collection, params):
@@ -118,7 +119,6 @@ class Collection(Resource):
                     yield data
             yield zip.footer()
         return stream
-    downloadCollection.cookieAuth = True
     downloadCollection.description = (
         Description('Download an entire collection as a zip archive.')
         .param('id', 'The ID of the collection.', paramType='path')

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -207,6 +207,7 @@ class File(Resource):
         .errorResponse('You are not the user who initiated the upload.', 403)
         .errorResponse('Failed to store upload.', 500))
 
+    @access.cookie
     @access.public
     @loadmodel(model='file', level=AccessType.READ)
     def download(self, file, params):
@@ -229,7 +230,6 @@ class File(Resource):
                 endByte = int(endByte)
 
         return self.model('file').download(file, offset, endByte=endByte)
-    download.cookieAuth = True
     download.description = (
         Description('Download a file.')
         .notes('This endpoint also accepts the HTTP "Range" header for partial '
@@ -246,10 +246,10 @@ class File(Resource):
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied on the parent folder.', 403))
 
+    @access.cookie
     @access.public
     def downloadWithName(self, id, name, params):
         return self.download(id=id, params=params)
-    downloadWithName.cookieAuth = True
     downloadWithName.description = (
         Description('Download a file.')
         .param('id', 'The ID of the file.', paramType='path')

--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -119,6 +119,7 @@ class Folder(Resource):
         .errorResponse()
         .errorResponse('Read access was denied on the folder.', 403))
 
+    @access.cookie
     @access.public
     @loadmodel(model='folder', level=AccessType.READ)
     def downloadFolder(self, folder, params):
@@ -140,7 +141,6 @@ class Folder(Resource):
                     yield data
             yield zip.footer()
         return stream
-    downloadFolder.cookieAuth = True
     downloadFolder.description = (
         Description('Download an entire folder as a zip archive.')
         .param('id', 'The ID of the folder.', paramType='path')

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -220,6 +220,7 @@ class Item(Resource):
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403))
 
+    @access.cookie
     @access.public
     @loadmodel(model='item', level=AccessType.READ)
     def download(self, item, params):
@@ -236,7 +237,6 @@ class Item(Resource):
             return self.model('file').download(files[0], offset)
         else:
             return self._downloadMultifileItem(item, user)
-    download.cookieAuth = True
     download.description = (
         Description('Download the contents of an item.')
         .param('id', 'The ID of the item.', paramType='path')

--- a/girder/api/v1/notification.py
+++ b/girder/api/v1/notification.py
@@ -45,6 +45,7 @@ class Notification(Resource):
         self.resourceName = 'notification'
         self.route('GET', ('stream',), self.stream)
 
+    @access.cookie
     @access.token
     def stream(self, params):
         """
@@ -82,7 +83,6 @@ class Notification(Resource):
 
                 time.sleep(wait)
         return streamGen
-    stream.cookieAuth = True
     stream.description = (
         Description('Stream notifications for a given user via the SSE '
                     'protocol.')

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -226,6 +226,7 @@ class Resource(BaseResource):
         .errorResponse('Path refers to a resource that does not exist.')
         .errorResponse('Read access was denied for the resource.', 403))
 
+    @access.cookie
     @access.public
     def download(self, params):
         """
@@ -261,7 +262,6 @@ class Resource(BaseResource):
                             yield data
             yield zip.footer()
         return stream
-    download.cookieAuth = True
     download.description = (
         Description('Download a set of items, folders, collections, and users '
                     'as a zip archive.')

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -226,7 +226,7 @@ class Resource(BaseResource):
         .errorResponse('Path refers to a resource that does not exist.')
         .errorResponse('Read access was denied for the resource.', 403))
 
-    @access.cookie
+    @access.cookie(force=True)
     @access.public
     def download(self, params):
         """

--- a/girder/utility/acl_mixin.py
+++ b/girder/utility/acl_mixin.py
@@ -53,7 +53,7 @@ class AccessControlMixin(object):
         doc = Model.load(self, id=id, objectId=objectId, fields=fields, exc=exc)
 
         if doc is not None:
-            if self.resourceParent in doc and doc[self.resourceParent]:
+            if doc.get(self.resourceParent):
                 loadType = self.resourceColl
                 loadId = doc[self.resourceParent]
             else:

--- a/tests/base.py
+++ b/tests/base.py
@@ -241,7 +241,7 @@ class TestCase(unittest.TestCase, model_importer.ModelImporter):
 
         :param obj: The dictionary object.
         :param keys: The keys it must not contain.
-        :type keys: list
+        :type keys: list or tuple
         """
         for k in keys:
             self.assertFalse(k in obj, 'Object contains key "%s"' % k)

--- a/tests/cases/access_test.py
+++ b/tests/cases/access_test.py
@@ -57,6 +57,10 @@ class AccessTestResource(Resource):
         self.route('GET', ('admin_access', ), self.adminHandler)
         self.route('GET', ('user_access', ), self.userHandler)
         self.route('GET', ('public_access', ), self.publicHandler)
+        self.route('GET', ('cookie_auth', ), self.cookieHandler)
+        self.route('POST', ('cookie_auth', ), self.cookieHandler)
+        self.route('GET', ('cookie_force_auth', ), self.cookieForceHandler)
+        self.route('POST', ('cookie_force_auth', ), self.cookieForceHandler)
 
     # We deliberately don't have an access decorator
     def defaultHandler(self, **kwargs):
@@ -72,6 +76,16 @@ class AccessTestResource(Resource):
 
     @access.public
     def publicHandler(self, **kwargs):
+        return
+
+    @access.cookie
+    @access.user
+    def cookieHandler(self, **kwargs):
+        return
+
+    @access.cookie(force=True)
+    @access.user
+    def cookieForceHandler(self, **kwargs):
         return
 
 
@@ -145,6 +159,32 @@ class AccessTestCase(base.TestCase):
                 self.assertStatusOk(resp)
             else:
                 self.assertStatus(resp, 403)
+
+    def testCookieAuth(self):
+        # No auth should always be rejected
+        for decorator in ['cookie_auth', 'cookie_force_auth']:
+            for method in ['GET', 'POST']:
+                resp = self.request(path='/accesstest/%s' % decorator,
+                                    method=method)
+                self.assertStatus(resp, 401)
+
+        # Token auth should always still succeed
+        for decorator in ['cookie_auth', 'cookie_force_auth']:
+            for method in ['GET', 'POST']:
+                resp = self.request(path='/accesstest/%s' % decorator,
+                                    method=method, user=self.user)
+                self.assertStatusOk(resp)
+
+        # Cookie auth should succeed unless POSTing to non-force endpoint
+        cookie = 'girderToken=%s' % self._genToken(self.user)
+        for decorator in ['cookie_auth', 'cookie_force_auth']:
+            for method in ['GET', 'POST']:
+                resp = self.request(path='/accesstest/%s' % decorator,
+                                    method=method, cookie=cookie)
+                if decorator == 'cookie_auth' and method != 'GET':
+                    self.assertStatus(resp, 401)
+                else:
+                    self.assertStatusOk(resp)
 
     def testLoadModelPlainFn(self):
         resp = self.request(path='/accesstest/test_loadmodel_plain/{}'.format(


### PR DESCRIPTION
This is cleaner and more Pythonic than the old ``endpoint.cookieAuth = True`` way. The old way will continue to work, but is now undocumented and should be considered deprecated.