### PR TITLE
Allow description property to be set via decorator

### DIFF
--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -125,23 +125,25 @@ will default to being restricted to administrators.
 
 When you start the server, you may notice a warning message appears:
 ``WARNING: No description docs present for route GET item/:id/cat``. You
-can add self-describing API documentation to your route as in the following
+can add self-describing API documentation to your route using the
+``describeRoute`` decorator and ``Description`` class as in the following
 example: ::
 
-    from girder.api.describe import Description
+    from girder.api.describe import Description, describeRoute
     from girder.api import access
 
     @access.public
+    @describeRoute(
+        Description('Retrieve the cat for a given item.')
+        .param('id', 'The item ID', paramType='path')
+        .param('cat', 'The cat value.', required=False)
+        .errorResponse())
     def myHandler(id, params):
         return {
            'itemId': id,
            'cat': params.get('cat', 'No cat param passed')
         }
-    myHandler.description = (
-        Description('Retrieve the cat for a given item.')
-        .param('id', 'The item ID', paramType='path')
-        .param('cat', 'The cat value.', required=False)
-        .errorResponse())
+
 
 That will make your route automatically appear in the Swagger documentation
 and will allow users to interact with it via that UI. See the

--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -251,3 +251,26 @@ class Describe(Resource):
                     key=functools.cmp_to_key(self._compareRoutes))
             ]
         }
+
+
+class describeRoute(object):
+    def __init__(self, description):
+        """
+        This returns a decorator that can be used in lieu of setting the
+        description property on a route handler. Pass the Description object
+        (or None) that you want to use to describe this route. It should be
+        used like the following example:
+
+            @describeRoute(Description('Do something')
+                           .param('foo', 'Some parameter', ...)
+            )
+            def routeHandler(...)
+
+        :param description: The description for the route.
+        :type description: :py:class:`girder.api.describe.Description` or None
+        """
+        self.description = description
+
+    def __call__(self, fun):
+        fun.description = self.description
+        return fun

--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -20,7 +20,7 @@
 import cherrypy
 import json
 
-from ..describe import Description
+from ..describe import Description, describeRoute
 from ..rest import Resource, RestException, loadmodel
 from ...constants import AccessType
 from girder.utility import ziputil
@@ -47,6 +47,20 @@ class Folder(Resource):
         self.route('PUT', (':id', 'metadata'), self.setMetadata)
 
     @access.public
+    @describeRoute(
+        Description('Search for folders by certain properties.')
+        .responseClass('Folder')
+        .param('parentType', "Type of the folder's parent", required=False,
+               enum=['folder', 'user', 'collection'])
+        .param('parentId', "The ID of the folder's parent.", required=False)
+        .param('text', 'Pass to perform a text search.', required=False)
+        .param('name', 'Pass to lookup a folder by exact name match. Must '
+               'pass parentType and parentId as well when using this.',
+               required=False)
+        .pagingParams(defaultSort='name')
+        .errorResponse()
+        .errorResponse('Read access was denied on the parent resource.', 403)
+    )
     def find(self, params):
         """
         Get a list of folders with given search parameters. Currently accepted
@@ -91,19 +105,6 @@ class Folder(Resource):
                         sort=sort)]
         else:
             raise RestException('Invalid search mode.')
-    find.description = (
-        Description('Search for folders by certain properties.')
-        .responseClass('Folder')
-        .param('parentType', "Type of the folder's parent", required=False,
-               enum=['folder', 'user', 'collection'])
-        .param('parentId', "The ID of the folder's parent.", required=False)
-        .param('text', 'Pass to perform a text search.', required=False)
-        .param('name', 'Pass to lookup a folder by exact name match. Must '
-               'pass parentType and parentId as well when using this.',
-               required=False)
-        .pagingParams(defaultSort='name')
-        .errorResponse()
-        .errorResponse('Read access was denied on the parent resource.', 403))
 
     @access.public
     @loadmodel(model='folder', level=AccessType.READ)


### PR DESCRIPTION
The description property of route handlers can now be set
via a decorator rather than just being set as a property of the
function. This has a couple of minor benefits:

1. Users won't have to type the name of the function twice in
   order to describe it.
2. Descriptions can go above the function, rather than below it,
   which is a more familiar place to see documentation of a
   function.

@brianhelba this is obviously inspired by your recent similar change
regarding cookieAuth, PTAL.