### PR TITLE
Add a constructor to the Resource class

### DIFF
--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -190,6 +190,7 @@ def _cmp(a, b):
 
 class Describe(Resource):
     def __init__(self):
+        super(Describe, self).__init__()
         self.route('GET', (), self.listResources, nodoc=True)
         self.route('GET', (':resource',), self.describeResource, nodoc=True)
 

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -438,6 +438,25 @@ class Resource(ModelImporter):
     """
     exposed = True
 
+    def __init__(self):
+        self._routes = collections.defaultdict(
+            lambda: collections.defaultdict(list))
+
+    def _ensureInit(self):
+        """
+        Calls ``Resource.__init__`` if the subclass constructor did not already
+        do so.
+
+        In the past, Resource subclasses were not expected to call their
+        superclass constructor.
+        """
+        if not hasattr(self, '_routes'):
+            Resource.__init__(self)
+            print(TerminalColor.warning(
+                'WARNING: Resource subclass "%s" did not call '
+                '"Resource__init__()" from its constructor.' %
+                self.__class__.__name__))
+
     def route(self, method, route, handler, nodoc=False, resource=None):
         """
         Define a route for your REST resource.
@@ -458,10 +477,7 @@ class Resource(ModelImporter):
         :type nodoc: bool
         :param resource: The name of the resource at the root of this route.
         """
-        if not hasattr(self, '_routes'):
-            self._routes = collections.defaultdict(
-                lambda: collections.defaultdict(list))
-
+        self._ensureInit()
         # Insertion sort to maintain routes in required order.
         nLengthRoutes = self._routes[method.lower()][len(route)]
         for i in range(len(nLengthRoutes)):
@@ -510,8 +526,7 @@ class Resource(ModelImporter):
         :type handler: function
         :param resource: the name of the resource at the root of this route.
         """
-        if not hasattr(self, '_routes'):
-            return
+        self._ensureInit()
         nLengthRoutes = self._routes[method.lower()][len(route)]
         for i in range(len(nLengthRoutes)):
             if nLengthRoutes[i][0] == route:

--- a/girder/api/v1/assetstore.py
+++ b/girder/api/v1/assetstore.py
@@ -30,6 +30,7 @@ class Assetstore(Resource):
     API Endpoint for managing assetstores. Requires admin privileges.
     """
     def __init__(self):
+        super(Assetstore, self).__init__()
         self.resourceName = 'assetstore'
         self.route('GET', (), self.find)
         self.route('GET', (':id',), self.getAssetstore)

--- a/girder/api/v1/collection.py
+++ b/girder/api/v1/collection.py
@@ -32,6 +32,7 @@ from girder.utility.progress import ProgressContext
 class Collection(Resource):
     """API Endpoint for collections."""
     def __init__(self):
+        super(Collection, self).__init__()
         self.resourceName = 'collection'
         self.route('DELETE', (':id',), self.deleteCollection)
         self.route('GET', (), self.find)

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -34,6 +34,7 @@ class File(Resource):
     them.
     """
     def __init__(self):
+        super(File, self).__init__()
         self.resourceName = 'file'
         self.route('DELETE', (':id',), self.deleteFile)
         self.route('DELETE', ('upload', ':id'), self.cancelUpload)

--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -32,6 +32,7 @@ class Folder(Resource):
     """API Endpoint for folders."""
 
     def __init__(self):
+        super(Folder, self).__init__()
         self.resourceName = 'folder'
         self.route('DELETE', (':id',), self.deleteFolder)
         self.route('DELETE', (':id', 'contents'), self.deleteContents)

--- a/girder/api/v1/group.py
+++ b/girder/api/v1/group.py
@@ -28,6 +28,7 @@ from girder.api import access
 class Group(Resource):
     """API Endpoint for groups."""
     def __init__(self):
+        super(Group, self).__init__()
         self.resourceName = 'group'
         self.route('DELETE', (':id',), self.deleteGroup)
         self.route('DELETE', (':id', 'member'), self.removeFromGroup)

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -29,6 +29,7 @@ from girder.api import access
 class Item(Resource):
     """API endpoint for items"""
     def __init__(self):
+        super(Item, self).__init__()
         self.resourceName = 'item'
         self.route('DELETE', (':id',), self.deleteItem)
         self.route('GET', (), self.find)

--- a/girder/api/v1/notification.py
+++ b/girder/api/v1/notification.py
@@ -42,6 +42,7 @@ def sseMessage(event):
 
 class Notification(Resource):
     def __init__(self):
+        super(Notification, self).__init__()
         self.resourceName = 'notification'
         self.route('GET', ('stream',), self.stream)
 

--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -43,6 +43,7 @@ class System(Resource):
     The system endpoints are for querying and managing system-wide properties.
     """
     def __init__(self):
+        super(System, self).__init__()
         self.resourceName = 'system'
         self.route('DELETE', ('setting',), self.unsetSetting)
         self.route('GET', ('version',), self.getVersion)

--- a/girder/api/v1/token.py
+++ b/girder/api/v1/token.py
@@ -27,6 +27,7 @@ class Token(Resource):
     """API Endpoint for non-user tokens in the system."""
 
     def __init__(self):
+        super(Token, self).__init__()
         self.resourceName = 'token'
 
         self.route('DELETE', ('session',), self.deleteSession)

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -33,6 +33,7 @@ class User(Resource):
     """API Endpoint for users in the system."""
 
     def __init__(self):
+        super(User, self).__init__()
         self.resourceName = 'user'
 
         self.route('DELETE', ('authentication',), self.logout)

--- a/plugins/google_analytics/server/rest.py
+++ b/plugins/google_analytics/server/rest.py
@@ -25,6 +25,7 @@ from girder.api.rest import Resource
 
 class GoogleAnalytics(Resource):
     def __init__(self):
+        super(GoogleAnalytics, self).__init__()
         self.resourceName = 'google_analytics'
         self.route('GET', ('id',), self.getId)
 

--- a/plugins/hdfs_assetstore/server/rest.py
+++ b/plugins/hdfs_assetstore/server/rest.py
@@ -29,6 +29,7 @@ from snakebite.errors import FileNotFoundException
 
 class HdfsAssetstoreResource(Resource):
     def __init__(self):
+        super(HdfsAssetstoreResource, self).__init__()
         self.resourceName = 'hdfs_assetstore'
         self.route('PUT', (':id', 'import'), self.importData)
 

--- a/plugins/jobs/server/job_rest.py
+++ b/plugins/jobs/server/job_rest.py
@@ -26,6 +26,7 @@ from girder.constants import AccessType, SortDir
 
 class Job(Resource):
     def __init__(self):
+        super(Job, self).__init__()
         self.resourceName = 'job'
 
         self.route('GET', (), self.listJobs)

--- a/plugins/oauth/server/rest.py
+++ b/plugins/oauth/server/rest.py
@@ -30,6 +30,7 @@ from . import constants, providers
 
 class OAuth(Resource):
     def __init__(self):
+        super(OAuth, self).__init__()
         self.resourceName = 'oauth'
 
         self.route('GET', ('provider',), self.listProviders)

--- a/plugins/provenance/server/resource.py
+++ b/plugins/provenance/server/resource.py
@@ -40,6 +40,7 @@ class ResourceExt(Resource):
         use changes.
         :param info: the info class passed to the load function.
         """
+        super(ResourceExt, self).__init__()
         self.loadInfo = info
         self.boundResources = {}
 

--- a/plugins/thumbnails/server/rest.py
+++ b/plugins/thumbnails/server/rest.py
@@ -25,6 +25,7 @@ from girder.constants import AccessType
 
 class Thumbnail(Resource):
     def __init__(self):
+        super(Thumbnail, self).__init__()
         self.resourceName = 'thumbnail'
         self.route('POST', (), self.createThumbnail)
 

--- a/tests/cases/access_test.py
+++ b/tests/cases/access_test.py
@@ -52,6 +52,7 @@ def plainFn(user, params):
 
 class AccessTestResource(Resource):
     def __init__(self):
+        super(AccessTestResource, self).__init__()
         self.resourceName = 'accesstest'
         self.route('GET', ('default_access', ), self.defaultHandler)
         self.route('GET', ('admin_access', ), self.adminHandler)

--- a/tests/cases/api_describe_test.py
+++ b/tests/cases/api_describe_test.py
@@ -41,6 +41,7 @@ OrderedRoutes = [
 
 class DummyResource(Resource):
     def __init__(self):
+        super(DummyResource, self).__init__()
         self.resourceName = 'foo'
         for method, pathElements, testPath in OrderedRoutes:
             self.route(method, pathElements, self.handler)
@@ -74,6 +75,7 @@ docs.addModel('Global', globalModel)
 
 class ModelResource(Resource):
     def __init__(self):
+        super(ModelResource, self).__init__()
         self.resourceName = 'model'
         self.route('POST', (), self.hasModel)
 

--- a/tests/cases/routes_test.py
+++ b/tests/cases/routes_test.py
@@ -37,6 +37,7 @@ def tearDownModule():
 
 class DummyResource(Resource):
     def __init__(self):
+        super(DummyResource, self).__init__()
         self.route('GET', (':wc1', 'literal1'), self.handler)
         self.route('GET', (':wc1', 'literal2'), self.handler)
         self.route('GET', (':wc1', ':wc2'), self.handler)

--- a/tests/test_plugins/test_plugin/server.py
+++ b/tests/test_plugins/test_plugin/server.py
@@ -55,6 +55,7 @@ class CustomAppRoot(object):
 
 class Other(Resource):
     def __init__(self):
+        super(Other, self).__init__()
         self.resourceName = 'other'
 
         self.route('GET', (), self.getResource)

--- a/tests/web_client_test.py
+++ b/tests/web_client_test.py
@@ -61,6 +61,7 @@ def tearDownModule():
 
 class WebClientTestEndpoints(Resource):
     def __init__(self):
+        super(WebClientTestEndpoints, self).__init__()
         self.route('GET', ('progress', ), self.testProgress)
         self.route('PUT', ('progress', 'stop'), self.testProgressStop)
         self.route('POST', ('file', ), self.uploadFile)


### PR DESCRIPTION
All built-in Resource subclasses are updated to call the superclass constructor. However, non-migrated subclasses will continue to operate as before.