### PR TITLE
Update file metadata in S3 if it changes

### DIFF
--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -253,7 +253,7 @@ class Describe(Resource):
         }
 
 
-class describeRoute(object):
+class describeRoute(object):  # noqa: class name
     def __init__(self, description):
         """
         This returns a decorator that can be used in lieu of setting the

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -203,7 +203,7 @@ def getBodyJson():
         raise RestException('Invalid JSON passed in request body.')
 
 
-class loadmodel(ModelImporter):
+class loadmodel(ModelImporter):  # noqa: class name
     """
     This is a decorator that can be used to load a model based on an ID param.
     For access controlled models, it will check authorization for the current
@@ -292,6 +292,44 @@ def _createResponse(val):
     return json.dumps(val, sort_keys=True, cls=JsonEncoder).encode('utf8')
 
 
+def _handleRestException(e):
+    # Handle all user-error exceptions from the REST layer
+    cherrypy.response.status = e.code
+    val = {'message': e.message, 'type': 'rest'}
+    if e.extra is not None:
+        val['extra'] = e.extra
+    return val
+
+
+def _handleAccessException(e):
+    # Permission exceptions should throw a 401 or 403, depending
+    # on whether the user is logged in or not
+    if getCurrentUser() is None:
+        cherrypy.response.status = 401
+    else:
+        cherrypy.response.status = 403
+        logger.exception('403 Error')
+    return {'message': e.message, 'type': 'access'}
+
+
+def _handleGirderException(e):
+    # Handle general Girder exceptions
+    logger.exception('500 Error')
+    cherrypy.response.status = 500
+    val = {'message': e.message, 'type': 'girder'}
+    if e.identifier is not None:
+        val['identifier'] = e.identifier
+    return val
+
+
+def _handleValidationException(e):
+    cherrypy.response.status = 400
+    val = {'message': e.message, 'type': 'validation'}
+    if e.field is not None:
+        val['field'] = e.field
+    return val
+
+
 def endpoint(fun):
     """
     REST HTTP method endpoints should use this decorator. It converts the return
@@ -333,33 +371,14 @@ def endpoint(fun):
                 return val
 
         except RestException as e:
-            # Handle all user-error exceptions from the REST layer
-            cherrypy.response.status = e.code
-            val = {'message': e.message, 'type': 'rest'}
-            if e.extra is not None:
-                val['extra'] = e.extra
+            val = _handleRestException(e)
         except AccessException as e:
-            # Permission exceptions should throw a 401 or 403, depending
-            # on whether the user is logged in or not
-            if self.getCurrentUser() is None:
-                cherrypy.response.status = 401
-            else:
-                cherrypy.response.status = 403
-                logger.exception('403 Error')
-            val = {'message': e.message, 'type': 'access'}
+            val = _handleAccessException(e)
         except GirderException as e:
-            # Handle general Girder exceptions
-            logger.exception('500 Error')
-            cherrypy.response.status = 500
-            val = {'message': e.message, 'type': 'girder'}
-            if e.identifier is not None:
-                val['identifier'] = e.identifier
+            val = _handleGirderException(e)
         except ValidationException as e:
-            cherrypy.response.status = 400
-            val = {'message': e.message, 'type': 'validation'}
-            if e.field is not None:
-                val['field'] = e.field
-        except cherrypy.HTTPRedirect:  # flake8: noqa
+            val = _handleValidationException(e)
+        except cherrypy.HTTPRedirect:
             raise
         except Exception:
             # These are unexpected failures; send a 500 status
@@ -786,7 +805,9 @@ class Resource(ModelImporter):
         return getCurrentUser(returnToken)
 
     def sendAuthTokenCookie(self, user, scope=None):
-        """ Helper method to send the authentication cookie """
+        """
+        Helper method to send the authentication cookie
+        """
         days = int(self.model('setting').get(SettingKey.COOKIE_LIFETIME))
         token = self.model('token').createToken(user, days=days, scope=scope)
 
@@ -798,7 +819,9 @@ class Resource(ModelImporter):
         return token
 
     def deleteAuthTokenCookie(self):
-        """ Helper method to kill the authentication cookie """
+        """
+        Helper method to kill the authentication cookie
+        """
         cookie = cherrypy.response.cookie
         cookie['girderToken'] = ''
         cookie['girderToken']['path'] = '/'
@@ -811,7 +834,7 @@ class Resource(ModelImporter):
 
         allowHeaders = self.model('setting').get(SettingKey.CORS_ALLOW_HEADERS)
         allowMethods = self.model('setting').get(SettingKey.CORS_ALLOW_METHODS)\
-                       or 'GET, POST, PUT, HEAD, DELETE'
+            or 'GET, POST, PUT, HEAD, DELETE'
 
         cherrypy.response.headers['Access-Control-Allow-Methods'] = allowMethods
         cherrypy.response.headers['Access-Control-Allow-Headers'] = allowHeaders
@@ -871,7 +894,7 @@ class Resource(ModelImporter):
 _sharedContext = Resource()
 
 
-class boundHandler(object):
+class boundHandler(object):  # noqa: class name
     """
     This decorator allows unbound functions to be conveniently added as route
     handlers to existing :py:class:`girder.api.rest.Resource` instances.

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -325,7 +325,7 @@ class File(Resource):
     def updateFile(self, file, params):
         file['name'] = params.get('name', file['name']).strip()
         file['mimeType'] = params.get('mimeType',
-                                      file.get('mimeType', '')).strip()
+                                      (file.get('mimeType') or '').strip())
         fileModel = self.model('file')
         return fileModel.filter(
             fileModel.updateFile(file), self.getCurrentUser())

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -21,7 +21,7 @@ import cherrypy
 import errno
 import six
 
-from ..describe import Description
+from ..describe import Description, describeRoute
 from ..rest import Resource, RestException, loadmodel
 from ...constants import AccessType
 from girder.models.model_base import AccessException, GirderException
@@ -50,10 +50,31 @@ class File(Resource):
 
     @access.public
     @loadmodel(model='file', level=AccessType.READ)
+    @describeRoute(
+        Description('Get a file\'s information.')
+        .param('id', 'The ID of the file.', paramType='path')
+        .errorResponse()
+        .errorResponse('Read access was denied on the file.', 403)
+    )
     def getFile(self, file, params):
         return self.model('file').filter(file, self.getCurrentUser())
 
     @access.user
+    @describeRoute(
+        Description('Start a new upload or create an empty or link file.')
+        .responseClass('Upload')
+        .param('parentType', 'Type being uploaded into (folder or item).')
+        .param('parentId', 'The ID of the parent.')
+        .param('name', 'Name of the file being created.')
+        .param('size', 'Size in bytes of the file.',
+               dataType='integer', required=False)
+        .param('mimeType', 'The MIME type of the file.', required=False)
+        .param('linkUrl', 'If this is a link file, pass its URL instead '
+               'of size and mimeType using this parameter.', required=False)
+        .errorResponse()
+        .errorResponse('Write access was denied on the parent folder.', 403)
+        .errorResponse('Failed to create upload.', 500)
+    )
     def initUpload(self, params):
         """
         Before any bytes of the actual file are sent, a request should be made
@@ -96,22 +117,19 @@ class File(Resource):
             else:
                 return self.model('file').filter(
                     self.model('upload').finalizeUpload(upload), user)
-    initUpload.description = (
-        Description('Start a new upload or create an empty or link file.')
-        .responseClass('Upload')
-        .param('parentType', 'Type being uploaded into (folder or item).')
-        .param('parentId', 'The ID of the parent.')
-        .param('name', 'Name of the file being created.')
-        .param('size', 'Size in bytes of the file.',
-               dataType='integer', required=False)
-        .param('mimeType', 'The MIME type of the file.', required=False)
-        .param('linkUrl', 'If this is a link file, pass its URL instead '
-               'of size and mimeType using this parameter.', required=False)
-        .errorResponse()
-        .errorResponse('Write access was denied on the parent folder.', 403)
-        .errorResponse('Failed to create upload.', 500))
 
     @access.user
+    @describeRoute(
+        Description('Finalize an upload explicitly if necessary.')
+        .notes('This is only required in certain non-standard upload '
+               'behaviors. Clients should know which behavior models require '
+               'the finalize step to be called in their behavior handlers.')
+        .param('uploadId', 'The ID of the upload record.', paramType='form')
+        .errorResponse('ID was invalid.')
+        .errorResponse('The upload does not require finalization.')
+        .errorResponse('Not enough bytes have been uploaded.')
+        .errorResponse('You are not the user who initiated the upload.', 403)
+    )
     def finalizeUpload(self, params):
         self.requireParams('uploadId', params)
         user = self.getCurrentUser()
@@ -132,18 +150,14 @@ class File(Resource):
         file = self.model('upload').finalizeUpload(upload)
         extraKeys = file.get('additionalFinalizeKeys', ())
         return self.model('file').filter(file, user, additionalKeys=extraKeys)
-    finalizeUpload.description = (
-        Description('Finalize an upload explicitly if necessary.')
-        .notes('This is only required in certain non-standard upload '
-               'behaviors. Clients should know which behavior models require '
-               'the finalize step to be called in their behavior handlers.')
-        .param('uploadId', 'The ID of the upload record.', paramType='form')
-        .errorResponse('ID was invalid.')
-        .errorResponse('The upload does not require finalization.')
-        .errorResponse('Not enough bytes have been uploaded.')
-        .errorResponse('You are not the user who initiated the upload.', 403))
 
     @access.user
+    @describeRoute(
+        Description('Request required offset before resuming an upload.')
+        .param('uploadId', 'The ID of the upload record.')
+        .errorResponse("The ID was invalid, or the offset did not match the "
+                       "server's record.")
+    )
     def requestOffset(self, params):
         """
         This should be called when resuming an interrupted upload. It will
@@ -162,13 +176,23 @@ class File(Resource):
         else:
             return offset
 
-    requestOffset.description = (
-        Description('Request required offset before resuming an upload.')
-        .param('uploadId', 'The ID of the upload record.')
-        .errorResponse("The ID was invalid, or the offset did not match the "
-                       "server's record."))
-
     @access.user
+    @describeRoute(
+        Description('Upload a chunk of a file with multipart/form-data.')
+        .consumes('multipart/form-data')
+        .param('uploadId', 'The ID of the upload record.', paramType='form')
+        .param('offset', 'Offset of the chunk in the file.', dataType='integer',
+               paramType='form')
+        .param('chunk', 'The actual bytes of the chunk. For external upload '
+               'behaviors, this may be set to an opaque string that will be '
+               'handled by the assetstore adapter.',
+               dataType='File', paramType='body')
+        .errorResponse('ID was invalid.')
+        .errorResponse('Received too many bytes.')
+        .errorResponse('Chunk is smaller than the minimum size.')
+        .errorResponse('You are not the user who initiated the upload.', 403)
+        .errorResponse('Failed to store upload.', 500)
+    )
     def readChunk(self, params):
         """
         After the temporary upload record has been created (see initUpload),
@@ -201,25 +225,26 @@ class File(Resource):
             if exc.errno == errno.EACCES:
                 raise Exception('Failed to store upload.')
             raise
-    readChunk.description = (
-        Description('Upload a chunk of a file with multipart/form-data.')
-        .consumes('multipart/form-data')
-        .param('uploadId', 'The ID of the upload record.', paramType='form')
-        .param('offset', 'Offset of the chunk in the file.', dataType='integer',
-               paramType='form')
-        .param('chunk', 'The actual bytes of the chunk. For external upload '
-               'behaviors, this may be set to an opaque string that will be '
-               'handled by the assetstore adapter.',
-               dataType='File', paramType='body')
-        .errorResponse('ID was invalid.')
-        .errorResponse('Received too many bytes.')
-        .errorResponse('Chunk is smaller than the minimum size.')
-        .errorResponse('You are not the user who initiated the upload.', 403)
-        .errorResponse('Failed to store upload.', 500))
 
     @access.cookie
     @access.public
     @loadmodel(model='file', level=AccessType.READ)
+    @describeRoute(
+        Description('Download a file.')
+        .notes('This endpoint also accepts the HTTP "Range" header for partial '
+               'file downloads.')
+        .param('id', 'The ID of the file.', paramType='path')
+        .param('offset', 'Start downloading at this offset in bytes within '
+               'the file.', dataType='integer', required=False)
+        .param('endByte', 'If you only wish to download part of the file, '
+               'pass this as the index of the last byte to download. Unlike '
+               'the HTTP Range header, the endByte parameter is non-inclusive, '
+               'so you should set it to the index of the byte one past the '
+               'final byte you wish to receive.', dataType='integer',
+               required=False)
+        .errorResponse('ID was invalid.')
+        .errorResponse('Read access was denied on the parent folder.', 403)
+    )
     def download(self, file, params):
         """
         Defers to the underlying assetstore adapter to stream a file out.
@@ -240,27 +265,10 @@ class File(Resource):
                 endByte = int(endByte)
 
         return self.model('file').download(file, offset, endByte=endByte)
-    download.description = (
-        Description('Download a file.')
-        .notes('This endpoint also accepts the HTTP "Range" header for partial '
-               'file downloads.')
-        .param('id', 'The ID of the file.', paramType='path')
-        .param('offset', 'Start downloading at this offset in bytes within '
-               'the file.', dataType='integer', required=False)
-        .param('endByte', 'If you only wish to download part of the file, '
-               'pass this as the index of the last byte to download. Unlike '
-               'the HTTP Range header, the endByte parameter is non-inclusive, '
-               'so you should set it to the index of the byte one past the '
-               'final byte you wish to receive.', dataType='integer',
-               required=False)
-        .errorResponse('ID was invalid.')
-        .errorResponse('Read access was denied on the parent folder.', 403))
 
     @access.cookie
     @access.public
-    def downloadWithName(self, id, name, params):
-        return self.download(id=id, params=params)
-    downloadWithName.description = (
+    @describeRoute(
         Description('Download a file.')
         .param('id', 'The ID of the file.', paramType='path')
         .param('name', 'The name of the file.  This is ignored.',
@@ -271,20 +279,30 @@ class File(Resource):
                'download clients save files based on the last part of a path, '
                'and specifying the name satisfies those clients.')
         .errorResponse('ID was invalid.')
-        .errorResponse('Read access was denied on the parent folder.', 403))
+        .errorResponse('Read access was denied on the parent folder.', 403)
+    )
+    def downloadWithName(self, id, name, params):
+        return self.download(id=id, params=params)
 
     @access.user
     @loadmodel(model='file', level=AccessType.WRITE)
-    def deleteFile(self, file, params):
-        self.model('file').remove(file)
-    deleteFile.description = (
+    @describeRoute(
         Description('Delete a file by ID.')
         .param('id', 'The ID of the file.', paramType='path')
         .errorResponse('ID was invalid.')
-        .errorResponse('Write access was denied on the parent folder.', 403))
+        .errorResponse('Write access was denied on the parent folder.', 403)
+    )
+    def deleteFile(self, file, params):
+        self.model('file').remove(file)
 
     @access.user
     @loadmodel(model='upload')
+    @describeRoute(
+        Description('Cancel a partially completed upload.')
+        .param('id', 'The ID of the upload.', paramType='path')
+        .errorResponse('ID was invalid.')
+        .errorResponse('You lack permission to cancel this upload.', 403)
+    )
     def cancelUpload(self, upload, params):
         user = self.getCurrentUser()
 
@@ -293,14 +311,17 @@ class File(Resource):
 
         self.model('upload').cancelUpload(upload)
         return {'message': 'Upload canceled.'}
-    cancelUpload.description = (
-        Description('Cancel a partially completed upload.')
-        .param('id', 'The ID of the upload.', paramType='path')
-        .errorResponse('ID was invalid.')
-        .errorResponse('You lack permission to cancel this upload.', 403))
 
     @access.user
     @loadmodel(model='file', level=AccessType.WRITE)
+    @describeRoute(
+        Description('Change file metadata such as name or MIME type.')
+        .param('id', 'The ID of the file.', paramType='path')
+        .param('name', 'The name to set on the file.', required=False)
+        .param('mimeType', 'The MIME type of the file.', required=False)
+        .errorResponse('ID was invalid.')
+        .errorResponse('Write access was denied on the parent folder.', 403)
+    )
     def updateFile(self, file, params):
         file['name'] = params.get('name', file['name']).strip()
         file['mimeType'] = params.get('mimeType',
@@ -308,16 +329,16 @@ class File(Resource):
         fileModel = self.model('file')
         return fileModel.filter(
             fileModel.updateFile(file), self.getCurrentUser())
-    updateFile.description = (
-        Description('Change file metadata such as name or MIME type.')
-        .param('id', 'The ID of the file.', paramType='path')
-        .param('name', 'The name to set on the file.', required=False)
-        .param('mimeType', 'The MIME type of the file.', required=False)
-        .errorResponse('ID was invalid.')
-        .errorResponse('Write access was denied on the parent folder.', 403))
 
     @access.user
     @loadmodel(model='file', level=AccessType.WRITE)
+    @describeRoute(
+        Description('Change the contents of an existing file.')
+        .param('id', 'The ID of the file.', paramType='path')
+        .param('size', 'Size in bytes of the new file.', dataType='integer')
+        .notes('After calling this, send the chunks just like you would with a '
+               'normal file upload.')
+    )
     def updateFileContents(self, file, params):
         self.requireParams('size', params)
         user = self.getCurrentUser()
@@ -331,23 +352,18 @@ class File(Resource):
         else:
             return self.model('file').filter(
                 self.model('upload').finalizeUpload(upload), user)
-    updateFileContents.description = (
-        Description('Change the contents of an existing file.')
-        .param('id', 'The ID of the file.', paramType='path')
-        .param('size', 'Size in bytes of the new file.', dataType='integer')
-        .notes('After calling this, send the chunks just like you would with a '
-               'normal file upload.'))
 
     @access.user
     @loadmodel(model='file', level=AccessType.READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.WRITE)
+    @describeRoute(
+        Description('Copy a file.')
+        .param('id', 'The ID of the file.', paramType='path')
+        .param('itemId', 'The item to copy the file to.', required=True)
+    )
     def copy(self, file, item, params):
         user = self.getCurrentUser()
         fileModel = self.model('file')
         newFile = fileModel.copyFile(file, user, item=item)
 
         return fileModel.filter(newFile, user)
-    copy.description = (
-        Description('Copy a file.')
-        .param('id', 'The ID of the file.', paramType='path')
-        .param('itemId', 'The item to copy the file to.', required=True))

--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -280,4 +280,15 @@ class AbstractAssetstoreAdapter(ModelImporter):
         """
         raise NotImplementedError(
             'The %s assetstore type does not support importing existing data.'
-            % self.__class__.__name__)  # pragma: no cover)
+            % self.__class__.__name__)  # pragma: no cover
+
+    def fileUpdated(self, file):
+        """
+        This is called when the file document has been changed. Any assetstore
+        implementation that needs to do anything when the file document changes
+        should override this method.
+
+        :param file: The updated file document.
+        :type file: dict
+        """
+        pass

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -490,7 +490,7 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
             return
 
         disp = 'attachment; filename="%s"' % file['name']
-        mime = file.get('mimeType', '')
+        mime = file.get('mimeType') or ''
 
         if key.content_type != mime or key.content_disposition != disp:
             key.set_remote_metadata(metadata_plus={

--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -469,8 +469,12 @@ class AssetstoreTestCase(base.TestCase):
         self.assertStatusOk(resp)
         self.assertEqual(resp.json['size'], 1024)
         self.assertEqual(resp.json['assetstoreId'], str(assetstore['_id']))
-        self.assertTrue('s3Key' in resp.json)
-        self.assertTrue(resp.json['relpath'].startswith('/bucketname/foo/bar/'))
+        self.assertFalse('s3Key' in resp.json)
+        self.assertFalse('relpath' in resp.json)
+
+        file = self.model('file').load(resp.json['_id'], force=True)
+        self.assertTrue('s3Key' in file)
+        self.assertRegexpMatches(file['relpath'], '^/bucketname/foo/bar/')
 
         # Test init for a multi-chunk upload
         params['size'] = 1024 * 1024 * 1024 * 5

--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -627,15 +627,16 @@ class AssetstoreTestCase(base.TestCase):
                             user=self.admin)
         self.assertStatusOk(resp)
         self.assertEqual(len(resp.json), 1)
-        file = resp.json[0]
+        self.assertFalse('imported' in resp.json[0])
+        self.assertFalse('relpath' in resp.json[0])
+        file = self.model('file').load(resp.json[0]['_id'], force=True)
         self.assertTrue(file['imported'])
         self.assertFalse('relpath' in file)
         self.assertEqual(file['size'], 0)
-        self.assertEqual(file['assetstoreId'], str(assetstore['_id']))
-
-        # Deleting an imported file should not delete it from S3
+        self.assertEqual(file['assetstoreId'], assetstore['_id'])
         self.assertTrue(bucket.get_key('/foo/bar/test') is not None)
 
+        # Deleting an imported file should not delete it from S3
         with mock.patch('girder.events.daemon.trigger') as daemon:
             resp = self.request('/item/%s' % str(item['_id']), method='DELETE',
                                 user=self.admin)

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -688,16 +688,16 @@ class FileTestCase(base.TestCase):
         # Make sure metadata is updated in S3 when file info changes
         # (moto API doesn't cover this at all, so we manually mock.)
         with mock.patch('boto.s3.key.Key.set_remote_metadata') as m:
-            resp = self.request('/file/%s' % str(file['_id']), method='PUT',
-                                user=self.user, params={
-                                    'mimeType': 'application/csv',
-                                    'name': 'new name'
-                                })
+            resp = self.request(
+                '/file/%s' % str(file['_id']), method='PUT', params={
+                    'mimeType': 'application/csv',
+                    'name': 'new name'
+                }, user=self.user)
             self.assertEqual(len(m.mock_calls), 1)
             self.assertEqual(m.mock_calls[0][2], {
                 'metadata_plus': {
                     'Content-Type': 'application/csv',
-                    'Content-Disposition': 'attachment; filename="new name"'
+                    'Content-Disposition': b'attachment; filename="new name"'
                 },
                 'metadata_minus': [],
                 'preserve_acl': True


### PR DESCRIPTION
This PR adds a new optional method to assetstore adapters to hook into when file information such as name and MIME type is changed. The only adapter that currently needs to take advantage of this is the S3 adapter.