### PR TITLE
Download content disposition

### DIFF
--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -266,7 +266,15 @@ class File(Resource):
             if endByte is not None:
                 endByte = int(endByte)
 
-        return self.model('file').download(file, offset, endByte=endByte)
+        contentDisp = params.get('contentDisposition', None)
+        allowed = ['inline', 'attachment']
+        if contentDisp is not None and contentDisp not in allowed:
+            raise RestException('Unallowed contentDisposition type "%s".' %
+                                contentDisp)
+
+        return \
+            self.model('file').download(file, offset, endByte=endByte,
+                                        contentDisposition=contentDisp)
 
     @access.cookie
     @access.public

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -246,7 +246,7 @@ class File(Resource):
                required=False)
         .param('contentDisposition', 'Specify the Content-Disposition response '
                'header disposition-type value', required=False,
-               enum=['inline', 'attachment'])
+               enum=['inline', 'attachment'], default='attachment')
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied on the parent folder.', 403)
     )
@@ -270,8 +270,8 @@ class File(Resource):
                 endByte = int(endByte)
 
         contentDisp = params.get('contentDisposition', None)
-        allowed = ['inline', 'attachment']
-        if contentDisp is not None and contentDisp not in allowed:
+        if (contentDisp is not None and
+           contentDisp not in {'inline', 'attachment'}):
             raise RestException('Unallowed contentDisposition type "%s".' %
                                 contentDisp)
 

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -244,6 +244,8 @@ class File(Resource):
                'so you should set it to the index of the byte one past the '
                'final byte you wish to receive.', dataType='integer',
                required=False)
+        .param('contentDisposition', 'Specify the Content-Disposition response '
+               'header disposition-type value', required=False)
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied on the parent folder.', 403)
     )

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -245,7 +245,8 @@ class File(Resource):
                'final byte you wish to receive.', dataType='integer',
                required=False)
         .param('contentDisposition', 'Specify the Content-Disposition response '
-               'header disposition-type value', required=False)
+               'header disposition-type value', required=False,
+               enum=['inline', 'attachment'])
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied on the parent folder.', 403)
     )
@@ -274,9 +275,8 @@ class File(Resource):
             raise RestException('Unallowed contentDisposition type "%s".' %
                                 contentDisp)
 
-        return \
-            self.model('file').download(file, offset, endByte=endByte,
-                                        contentDisposition=contentDisp)
+        return self.model('file').download(file, offset, endByte=endByte,
+                                           contentDisposition=contentDisp)
 
     @access.cookie
     @access.public

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -231,7 +231,7 @@ class Item(Resource):
                required=False)
         .param('contentDisposition', 'Specify the Content-Disposition response '
                'header disposition-type value, only applied for single file '
-               'items.', required=False)
+               'items.', required=False, enum=['inline', 'attachment'])
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -231,7 +231,8 @@ class Item(Resource):
                required=False)
         .param('contentDisposition', 'Specify the Content-Disposition response '
                'header disposition-type value, only applied for single file '
-               'items.', required=False, enum=['inline', 'attachment'])
+               'items.', required=False, enum=['inline', 'attachment'],
+               default='attachment')
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )
@@ -244,8 +245,8 @@ class Item(Resource):
             raise RestException('Unsupported format.')
         if len(files) == 1 and format != 'zip':
             contentDisp = params.get('contentDisposition', None)
-            allowed = ['inline', 'attachment']
-            if contentDisp is not None and contentDisp not in allowed:
+            if (contentDisp is not None and
+               contentDisp not in {'inline', 'attachment'}):
                 raise RestException('Unallowed contentDisposition type "%s".' %
                                     contentDisp)
             return self.model('file').download(files[0], offset,

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -229,6 +229,9 @@ class Item(Resource):
                'as that file, and other items are downloaded as a zip '
                'archive.  If \'zip\', a zip archive is always sent.',
                required=False)
+        .param('contentDisposition', 'Specify the Content-Disposition response '
+               'header disposition-type value, only applied for single file '
+               'items.', required=False)
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )
@@ -240,7 +243,13 @@ class Item(Resource):
         if format not in (None, '', 'zip'):
             raise RestException('Unsupported format.')
         if len(files) == 1 and format != 'zip':
-            return self.model('file').download(files[0], offset)
+            contentDisp = params.get('contentDisposition', None)
+            allowed = ['inline', 'attachment']
+            if contentDisp is not None and contentDisp not in allowed:
+                raise RestException('Unallowed contentDisposition type "%s".' %
+                                    contentDisp)
+            return self.model('file').download(files[0], offset,
+                                               contentDisposition=contentDisp)
         else:
             return self._downloadMultifileItem(item, user)
 

--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -72,7 +72,8 @@ class File(acl_mixin.AccessControlMixin, Model):
 
         Model.remove(self, file)
 
-    def download(self, file, offset=0, headers=True, endByte=None):
+    def download(self, file, offset=0, headers=True, endByte=None,
+                 contentDisposition=None):
         """
         Use the appropriate assetstore adapter for whatever assetstore the
         file is stored in, and call downloadFile on it. If the file is a link
@@ -87,12 +88,16 @@ class File(acl_mixin.AccessControlMixin, Model):
         :param endByte: Final byte to download. If ``None``, downloads to the
             end of the file.
         :type endByte: int or None
+        :param contentDisposition: Content-Disposition response header
+            disposition-type value.
+        :type contentDisposition: str or None
         """
         if file.get('assetstoreId'):
             assetstore = self.model('assetstore').load(file['assetstoreId'])
             adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
             return adapter.downloadFile(
-                file, offset=offset, headers=headers, endByte=endByte)
+                file, offset=offset, headers=headers, endByte=endByte,
+                contentDisposition=contentDisposition)
         elif file.get('linkUrl'):
             if headers:
                 raise cherrypy.HTTPRedirect(file['linkUrl'])

--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -125,7 +125,8 @@ class AbstractAssetstoreAdapter(ModelImporter):
         raise NotImplementedError('Must override deleteFile in %s.' %
                                   self.__class__.__name__)  # pragma: no cover
 
-    def downloadFile(self, file, offset=0, headers=True, endByte=None):
+    def downloadFile(self, file, offset=0, headers=True, endByte=None,
+                     contentDisposition=None):
         """
         This method is in charge of returning a value to the RESTful endpoint
         that can be used to download the file. This can return a generator
@@ -141,6 +142,9 @@ class AbstractAssetstoreAdapter(ModelImporter):
         :param endByte: Final byte to download. If ``None``, downloads to the
             end of the file.
         :type endByte: int or None
+        :param contentDisposition: Value for Content-Disposition response
+            header disposition-type value.
+        :type contentDisposition: str or None
         """
         raise NotImplementedError('Must override downloadFile in %s.' %
                                   self.__class__.__name__)  # pragma: no cover
@@ -196,7 +200,7 @@ class AbstractAssetstoreAdapter(ModelImporter):
         else:
             return len(chunk)
 
-    def setContentHeaders(self, file, offset, endByte):
+    def setContentHeaders(self, file, offset, endByte, contentDisposition=None):
         """
         Sets the Content-Length, Content-Disposition, Content-Type, and also
         the Content-Range header if this is a partial download.
@@ -206,11 +210,19 @@ class AbstractAssetstoreAdapter(ModelImporter):
         :type offset: int
         :param endByte: The end byte of the download (non-inclusive).
         :type endByte: int
+        :param contentDisposition: Content-Disposition response header
+            disposition-type value, if None, Content-Disposition will
+            be set to 'attachment; filename=$filename'.
+        :type contentDisposition: str or None
         """
         cherrypy.response.headers['Content-Type'] = \
             file.get('mimeType') or 'application/octet-stream'
-        cherrypy.response.headers['Content-Disposition'] = \
-            'attachment; filename="%s"' % file['name']
+        if contentDisposition == 'inline':
+            cherrypy.response.headers['Content-Disposition'] = \
+                contentDisposition
+        else:
+            cherrypy.response.headers['Content-Disposition'] = \
+                'attachment; filename="%s"' % file['name']
         cherrypy.response.headers['Content-Length'] = max(endByte - offset, 0)
 
         if (offset or endByte < file['size']) and file['size']:

--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -219,7 +219,7 @@ class AbstractAssetstoreAdapter(ModelImporter):
             file.get('mimeType') or 'application/octet-stream'
         if contentDisposition == 'inline':
             cherrypy.response.headers['Content-Disposition'] = \
-                contentDisposition
+                'inline; filename="%s"' % file['name']
         else:
             cherrypy.response.headers['Content-Disposition'] = \
                 'attachment; filename="%s"' % file['name']

--- a/girder/utility/filesystem_assetstore_adapter.py
+++ b/girder/utility/filesystem_assetstore_adapter.py
@@ -227,7 +227,7 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
             return os.path.join(self.assetstore['root'], file['path'])
 
     def downloadFile(self, file, offset=0, headers=True, endByte=None,
-                     **kwargs):
+                     contentDisposition=None, **kwargs):
         """
         Returns a generator function that will be used to stream the file from
         disk to the response.
@@ -245,7 +245,7 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
 
         if headers:
             cherrypy.response.headers['Accept-Ranges'] = 'bytes'
-            self.setContentHeaders(file, offset, endByte)
+            self.setContentHeaders(file, offset, endByte, contentDisposition)
 
         def stream():
             bytesRead = offset

--- a/girder/utility/gridfs_assetstore_adapter.py
+++ b/girder/utility/gridfs_assetstore_adapter.py
@@ -216,7 +216,7 @@ class GridFsAssetstoreAdapter(AbstractAssetstoreAdapter):
         return file
 
     def downloadFile(self, file, offset=0, headers=True, endByte=None,
-                     **kwargs):
+                     contentDisposition=None, **kwargs):
         """
         Returns a generator function that will be used to stream the file from
         the database to the response.
@@ -226,7 +226,7 @@ class GridFsAssetstoreAdapter(AbstractAssetstoreAdapter):
 
         if headers:
             cherrypy.response.headers['Accept-Ranges'] = 'bytes'
-            self.setContentHeaders(file, offset, endByte)
+            self.setContentHeaders(file, offset, endByte, contentDisposition)
 
         # If the file is empty, we stop here
         if endByte - offset <= 0:

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -393,11 +393,11 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
         if headers:
             if file['size'] > 0:
                 queryParams = {}
-                if contentDisposition is not None:
-                    # Tell S3 to set Content-Disposition respoinse header,
+                if contentDisposition == 'inline':
+                    # Tell S3 to set Content-Disposition response header,
                     # though this only works for non-anonymous connections.
                     queryParams['response-content-disposition'] = \
-                        contentDisposition
+                        'inline; filename="%s"' % file['name']
                 url = urlFn(key=file['s3Key'], queryParams=queryParams)
                 raise cherrypy.HTTPRedirect(url)
             else:

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -395,7 +395,10 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
                 queryParams = {}
                 if contentDisposition == 'inline':
                     # Tell S3 to set Content-Disposition response header,
-                    # though this only works for non-anonymous connections.
+                    # though AWS only will set the response header for
+                    # non-anonymous connections.
+                    # Girder sets the Content-Disposition for files uploaded
+                    # to S3 to be 'attachment; filename="{}"'.
                     queryParams['response-content-disposition'] = \
                         'inline; filename="%s"' % file['name']
                 url = urlFn(key=file['s3Key'], queryParams=queryParams)

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -379,7 +379,7 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
         return file
 
     def downloadFile(self, file, offset=0, headers=True, endByte=None,
-                     **kwargs):
+                     contentDisposition=None, **kwargs):
         """
         When downloading a single file with HTTP, we redirect to S3. Otherwise,
         e.g. when downloading as part of a zip stream, we connect to S3 and
@@ -392,7 +392,13 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
 
         if headers:
             if file['size'] > 0:
-                url = urlFn(key=file['s3Key'])
+                queryParams = {}
+                if contentDisposition is not None:
+                    # Tell S3 to set Content-Disposition respoinse header,
+                    # though this only works for non-anonymous connections.
+                    queryParams['response-content-disposition'] = \
+                        contentDisposition
+                url = urlFn(key=file['s3Key'], queryParams=queryParams)
                 raise cherrypy.HTTPRedirect(url)
             else:
                 self.setContentHeaders(file, 0, 0)
@@ -640,11 +646,15 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
 
         return url
 
-    def _anonDownloadUrl(self, key):
+    def _anonDownloadUrl(self, key, **kwargs):
         """
         Generate and return an anonymous download URL for the given key. This
         is necessary as a workaround for a limitation of boto's generate_url,
         documented here: https://github.com/boto/boto/issues/1540
+
+        S3 GET Requests lack the ability to specify response headers for
+        anonymous authentication, and there is no way to sign anonymous download
+        URLs, so we cannot display public anonymous resources inline.
         """
         if self.assetstore['service']:
             return '/'.join((

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -398,7 +398,7 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
                     # though AWS only will set the response header for
                     # non-anonymous connections.
                     # Girder sets the Content-Disposition for files uploaded
-                    # to S3 to be 'attachment; filename="{}"'.
+                    # to S3 to be 'attachment; filename="{}"' by default.
                     queryParams['response-content-disposition'] = \
                         'inline; filename="%s"' % file['name']
                 url = urlFn(key=file['s3Key'], queryParams=queryParams)

--- a/plugins/hdfs_assetstore/server/assetstore.py
+++ b/plugins/hdfs_assetstore/server/assetstore.py
@@ -114,13 +114,13 @@ class HdfsAssetstoreAdapter(AbstractAssetstoreAdapter):
             }
 
     def downloadFile(self, file, offset=0, headers=True, endByte=None,
-                     **kwargs):
+                     contentDisposition=None, **kwargs):
         if endByte is None or endByte > file['size']:
             endByte = file['size']
 
         if headers:
             cherrypy.response.headers['Accept-Ranges'] = 'bytes'
-            self.setContentHeaders(file, offset, endByte)
+            self.setContentHeaders(file, offset, endByte, contentDisposition)
 
         if file['hdfs'].get('imported'):
             path = file['hdfs']['path']

--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -546,6 +546,18 @@ class AssetstoreTestCase(base.TestCase):
         self.assertStatus(resp, 303)
         six.assertRegex(self, resp.headers['Location'], s3Regex)
 
+        # Test download of a non-empty file, with Content-Disposition=inline.
+        # Expect the special S3 header response-content-disposition.
+        params = {'contentDisposition': 'inline'}
+        inlineRegex = r'response-content-disposition=' + \
+                      'inline%3B\+filename%3D%22My\+File.txt%22'
+        resp = self.request(path='/file/{}/download'.format(largeFile['_id']),
+                            user=self.admin, method='GET', isJson=False,
+                            params=params)
+        self.assertStatus(resp, 303)
+        six.assertRegex(self, resp.headers['Location'], s3Regex)
+        six.assertRegex(self, resp.headers['Location'], inlineRegex)
+
         # Test download as part of a streaming zip
         @httmock.all_requests
         def s3_pipe_mock(url, request):

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -218,6 +218,22 @@ class FileTestCase(base.TestCase):
         if contents:
             self.assertEqual(resp.headers['Content-Type'],
                              'text/plain;charset=utf-8')
+            self.assertEqual(resp.headers['Content-Disposition'],
+                             'attachment; filename="%s"' % file['name'])
+
+        self.assertEqual(contents, self.getBody(resp))
+
+        # Test downloading the file with contentDisposition=inline.
+        params = {'contentDisposition': 'inline'}
+        resp = self.request(path='/file/%s/download' % str(file['_id']),
+                            method='GET', user=self.user, isJson=False,
+                            params=params)
+        self.assertStatusOk(resp)
+        if contents:
+            self.assertEqual(resp.headers['Content-Type'],
+                             'text/plain;charset=utf-8')
+            self.assertEqual(resp.headers['Content-Disposition'],
+                             'inline; filename="%s"' % file['name'])
 
         self.assertEqual(contents, self.getBody(resp))
 
@@ -457,6 +473,7 @@ class FileTestCase(base.TestCase):
                             user=self.user, params={'name': ' newName.json'})
         self.assertStatusOk(resp)
         self.assertEqual(resp.json['name'], 'newName.json')
+        file = resp.json
 
         # We want to make sure the file got uploaded correctly into
         # the assetstore and stored at the right location

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -473,7 +473,7 @@ class FileTestCase(base.TestCase):
                             user=self.user, params={'name': ' newName.json'})
         self.assertStatusOk(resp)
         self.assertEqual(resp.json['name'], 'newName.json')
-        file = resp.json
+        file['name'] = resp.json['name']
 
         # We want to make sure the file got uploaded correctly into
         # the assetstore and stored at the right location

--- a/tests/cases/item_test.py
+++ b/tests/cases/item_test.py
@@ -114,8 +114,19 @@ class ItemTestCase(base.TestCase):
         resp = self.request(path='/item/{}/download'.format(item['_id']),
                             method='GET', user=user, isJson=False)
         self.assertStatusOk(resp)
-
         self.assertEqual(contents, self.getBody(resp))
+        self.assertEqual(resp.headers['Content-Disposition'],
+                         'attachment; filename="file_1"')
+
+        # Test downloading the item with contentDisposition=inline.
+        params = {'contentDisposition': 'inline'}
+        resp = self.request(path='/item/{}/download'.format(item['_id']),
+                            method='GET', user=user, isJson=False,
+                            params=params)
+        self.assertStatusOk(resp)
+        self.assertEqual(contents, self.getBody(resp))
+        self.assertEqual(resp.headers['Content-Disposition'],
+                         'inline; filename="file_1"')
 
         # Test downloading with an offset
         resp = self.request(path='/item/{}/download'.format(item['_id']),


### PR DESCRIPTION
This allows setting the content-disposition on a download of a single file.

This works for all files except for anonymously accessed files stored in S3 assetstores, due to a limitation from Amazon.  S3 allows you to specify the content-disposition parameter of a download URL, except in this case.

From the S3 [GET Object documentation](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGET.html)

>You must sign the request, either using an Authorization header or a pre-signed URL, when using these parameters. They cannot be used with an unsigned (anonymous) request.

I've whitelisted two values for Content-Disposition at the REST layer, "inline" and "attachment", to address @brianhelba 's concerns.  


Still need to add tests on this PR.

Fixes #1118.