### PR TITLE
Add a superclass constructor call to the API's Resource class

### DIFF
--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -35,6 +35,7 @@ class Resource(BaseResource):
     API Endpoints that deal with operations across multiple resource types.
     """
     def __init__(self):
+        super(Resource, self).__init__()
         self.resourceName = 'resource'
         self.route('GET', ('search',), self.search)
         self.route('GET', ('lookup',), self.lookup)


### PR DESCRIPTION
This fixes a warning during Girder startup.