### PR TITLE
Gravatar plugin was causing an error on user info update

### DIFF
--- a/plugins/gravatar/plugin_tests/gravatar_test.py
+++ b/plugins/gravatar/plugin_tests/gravatar_test.py
@@ -95,3 +95,21 @@ class GravatarTest(base.TestCase):
         self.assertStatusOk(resp)
         self.admin = self.model('user').load(self.admin['_id'], force=True)
         self.assertFalse('gravatar_baseUrl' in self.admin)
+
+    def testUserInfoUpdate(self):
+        user = self.model('user').createUser(
+            email='normaluser@mail.com',
+            login='normal',
+            firstName='normal',
+            lastName='normal',
+            password='password',
+            admin=False
+        )
+
+        resp = self.request('/user/%s' % str(user['_id']), method='PUT',
+                            user=user, params={
+                                'email': 'newemail@mail.com',
+                                'firstName': 'normal',
+                                'lastName': 'normal'
+                            })
+        self.assertStatusOk(resp)

--- a/plugins/gravatar/plugin_tests/gravatar_test.py
+++ b/plugins/gravatar/plugin_tests/gravatar_test.py
@@ -57,35 +57,24 @@ class GravatarTest(base.TestCase):
         """
         self.model('setting').set(PluginSettings.DEFAULT_IMAGE, 'mm')
 
-        # Initially we should not have a gravatar_baseUrl value cached
+        # Gravatar base URL should be computed on user creation
         resp = self.request('/user/{}'.format(self.admin['_id']))
         self.assertStatusOk(resp)
-        self.assertTrue('gravatar_baseUrl' not in resp.json)
+        self.assertTrue('gravatar_baseUrl' in resp.json)
 
-        resp = self.request('/user/{}/gravatar'.format(self.admin['_id']),
+        resp = self.request('/user/%s/gravatar' % str(self.admin['_id']),
                             isJson=False)
         md5 = hashlib.md5(self.admin['email'].encode()).hexdigest()
         self.assertRedirect(resp,
-            'https://www.gravatar.com/avatar/{}?d=mm&s=64'.format(md5))
+            'https://www.gravatar.com/avatar/%s?d=identicon&s=64' % md5)
 
         # We should now have the gravatar_baseUrl cached on the user
         resp = self.request('/user/{}'.format(self.admin['_id']))
         self.assertStatusOk(resp)
         self.assertTrue('gravatar_baseUrl' in resp.json)
+        oldBaseUrl = resp.json['gravatar_baseUrl']
 
-        # Update the user info without changing the email
-        resp = self.request('/user/{}'.format(self.admin['_id']), method='PUT',
-                            user=self.admin, params={
-                                'firstName': 'first',
-                                'lastName': 'last',
-                                'email': self.admin['email']
-                            })
-        self.assertStatusOk(resp)
-
-        # Cached value should still be there since we didn't change email
-        self.assertTrue('gravatar_baseUrl' in resp.json)
-
-        # Changing the email address should remove the cached value
+        # Changing the email address should change the cached value
         resp = self.request('/user/{}'.format(self.admin['_id']), method='PUT',
                             user=self.admin, params={
                                 'firstName': 'first',
@@ -94,7 +83,14 @@ class GravatarTest(base.TestCase):
                             })
         self.assertStatusOk(resp)
         self.admin = self.model('user').load(self.admin['_id'], force=True)
-        self.assertFalse('gravatar_baseUrl' in self.admin)
+        self.assertNotEqual(self.admin['gravatar_baseUrl'], oldBaseUrl)
+
+        # Make sure we picked up the new default setting
+        resp = self.request('/user/%s/gravatar' % str(self.admin['_id']),
+                            isJson=False)
+        md5 = hashlib.md5(self.admin['email'].encode()).hexdigest()
+        self.assertRedirect(resp,
+            'https://www.gravatar.com/avatar/%s?d=mm&s=64' % md5)
 
     def testUserInfoUpdate(self):
         user = self.model('user').createUser(

--- a/plugins/gravatar/server/__init__.py
+++ b/plugins/gravatar/server/__init__.py
@@ -83,6 +83,7 @@ def _validateSettings(event):
         _cachedDefaultImage = None
 
 
+@access.user
 def _userUpdate(event):
     """
     Called when the user document is being changed. If the email field changes,

--- a/plugins/gravatar/server/__init__.py
+++ b/plugins/gravatar/server/__init__.py
@@ -22,7 +22,7 @@ import hashlib
 
 from girder import events
 from girder.api import access
-from girder.api.describe import Description
+from girder.api.describe import Description, describeRoute
 from girder.api.rest import loadmodel
 from girder.models.model_base import AccessType
 from girder.utility.model_importer import ModelImporter
@@ -37,8 +37,9 @@ class PluginSettings(object):
 
 def computeBaseUrl(user):
     """
-    Compute the base gravatar URL for a user and save the value in the user
-    document. For the moment, the current default image is cached in this URL.
+    Compute the base gravatar URL for a user and return it. For the moment, the
+    current default image is cached in this URL. It is the caller's
+    responsibility to save this value on the user document.
     """
     global _cachedDefaultImage
     if _cachedDefaultImage is None:
@@ -46,31 +47,26 @@ def computeBaseUrl(user):
             PluginSettings.DEFAULT_IMAGE, default='identicon')
 
     md5 = hashlib.md5(user['email'].encode('utf8')).hexdigest()
-    url = 'https://www.gravatar.com/avatar/%s?d=%s' % (md5, _cachedDefaultImage)
-
-    user['gravatar_baseUrl'] = url
-    ModelImporter.model('user').save(user)
-
-    return url
+    return 'https://www.gravatar.com/avatar/%s?d=%s' % (
+        md5, _cachedDefaultImage)
 
 
 @access.public
 @loadmodel(model='user', level=AccessType.READ)
-def getGravatar(user, params):
-    size = int(params.get('size', 64))
-
-    if user.get('gravatar_baseUrl'):
-        baseUrl = user['gravatar_baseUrl']
-    else:
-        baseUrl = computeBaseUrl(user)
-
-    raise cherrypy.HTTPRedirect(baseUrl + '&s=%d' % size)
-getGravatar.description = (
+@describeRoute(
     Description('Redirects to the gravatar image for a user.')
     .param('id', 'The ID of the user.', paramType='path')
     .param('size', 'Size in pixels for the image (default=64).', required=False,
            dataType='int')
-    .notes('This should only be used if the gravatar_baseUrl property of'))
+)
+def getGravatar(user, params):
+    size = int(params.get('size', 64))
+
+    if not user.get('gravatar_baseUrl'):
+        # the save hook will cause the gravatar base URL to be computed
+        user = ModelImporter.model('user').save(user)
+
+    raise cherrypy.HTTPRedirect(user['gravatar_baseUrl'] + '&s=%d' % size)
 
 
 def _validateSettings(event):
@@ -83,18 +79,12 @@ def _validateSettings(event):
         _cachedDefaultImage = None
 
 
-@access.user
 def _userUpdate(event):
     """
-    Called when the user document is being changed. If the email field changes,
-    we wipe the cached gravatar URL so it will be recomputed on next request.
+    Called when the user document is being changed. We update the cached
+    gravatar URL.
     """
-    if 'email' in event.info['params']:
-        user = ModelImporter.model('user').load(event.info['id'], force=True)
-        if (user['email'] != event.info['params']['email'] and
-                user.get('gravatar_baseUrl')):
-            del user['gravatar_baseUrl']
-            ModelImporter.model('user').save(user)
+    event.info['gravatar_baseUrl'] = computeBaseUrl(event.info)
 
 
 def load(info):
@@ -104,4 +94,4 @@ def load(info):
         level=AccessType.READ, fields='gravatar_baseUrl')
 
     events.bind('model.setting.validate', 'gravatar', _validateSettings)
-    events.bind('rest.put.user/:id.before', 'gravatar', _userUpdate)
+    events.bind('model.user.save', 'gravatar', _userUpdate)


### PR DESCRIPTION
Non-admin users were getting a cryptic "Administrator access
required" error when trying to update their user information. This
was because the gravatar plugin had registered a handler to a
REST hook without declaring an access level on itself.

@kotfic this fixes the bug I was running into when testing your branch.