### PR TITLE
Make job status values extensible

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -39,22 +39,33 @@ plugins that are in charge of actually scheduling a job for execution should the
 call ``scheduleJob``, which triggers the ``jobs.schedule`` event with the job
 document as the event info.
 
-For controlling what fields of a job are visible in the REST API, downstream plugins
-should bind to the ``jobs.filter`` event, which receives a dictionary with ``job``
-and ``user`` keys as its info. They can modify any existing fields or the job
-document as needed, and can also expose or redact fields. To make some fields
-visible while redacting others, you can use the event response with ``exposeFields``
-and/or ``removeFields`` keys, e.g.
+The jobs plugin contains several built-in status codes within the
+``girder.plugins.jobs.constants.JobStatus`` namespace. These codes represent
+various states a job can be in, which are:
+
+- INACTIVE (0)
+- QUEUED (1)
+- RUNNING (2)
+- SUCCESS (3)
+- ERROR (4)
+- CANCELED (5)
+
+Downstream plugins that wish to expose their own custom job statuses must hook
+into the ``jobs.status.validate`` event for any new valid status value, which by convention
+must be integer values. To validate a status code, the default must be prevented
+on the event, and the handler must add a ``True`` response to the event. For example, a
+downstream plugin with a custom job status with the value *1234* would add the following hook:
 
 .. code-block:: python
 
-  def filterJob(event):
-      event.addResponse({
-          'exposeFields': ['_some_other_field'],
-          'removeFields': ['created']
-      })
+    from girder import events
 
-  events.bind('jobs.filter', 'a_downstream_plugin', filterJob)
+    def validateJobStatus(event):
+        if event.info == 1234:
+            event.preventDefault().addResponse(True)
+
+    def load(info):
+        events.bind('jobs.status.validate', 'my_plugin', validateJobStatus):
 
 
 Geospatial

--- a/plugins/jobs/server/constants.py
+++ b/plugins/jobs/server/constants.py
@@ -17,7 +17,7 @@
 #  limitations under the License.
 ###############################################################################
 
-
+from girder import events
 from girder.models.notification import ProgressState
 
 JOB_HANDLER_LOCAL = 'jobs._local'
@@ -34,6 +34,11 @@ class JobStatus(object):
 
     @staticmethod
     def isValid(status):
+        event = events.trigger('jobs.status.validate', info=status)
+
+        if event.defaultPrevented and len(event.responses):
+            return event.responses[-1]
+
         return status in (JobStatus.INACTIVE, JobStatus.QUEUED,
                           JobStatus.RUNNING, JobStatus.SUCCESS, JobStatus.ERROR,
                           JobStatus.CANCELED)

--- a/plugins/jobs/web_client/js/misc.js
+++ b/plugins/jobs/web_client/js/misc.js
@@ -20,6 +20,13 @@ girder.jobs_JobStatus = {
     },
 
     /**
+     * Convert this status text into a value appropriate for an HTML class name.
+     */
+    classAffix: function (status) {
+        return this.text(status).toLowerCase().replace(/ /g, '-');
+    },
+
+    /**
      * Add new job statuses. The argument should be an object mapping the enum
      * symbol name to an information object for that status. The info object
      * must include a "value" field (its integer value), a "text" field, which

--- a/plugins/jobs/web_client/js/misc.js
+++ b/plugins/jobs/web_client/js/misc.js
@@ -9,39 +9,7 @@ girder.collections.JobCollection = girder.Collection.extend({
 
 // The same job status enum as the server.
 girder.jobs_JobStatus = {
-    INACTIVE: 0,
-    QUEUED: 1,
-    RUNNING: 2,
-    SUCCESS: 3,
-    ERROR: 4,
-    CANCELED: 5,
-
-    _map: {
-        0: {
-            text: 'Inactive',
-            icon: 'icon-pause'
-        },
-        1: {
-            text: 'Queued',
-            icon: 'icon-ellipsis'
-        },
-        2: {
-            text: 'Running',
-            icon: 'icon-spin3 animate-spin'
-        },
-        3: {
-            text: 'Success',
-            icon: 'icon-ok'
-        },
-        4: {
-            text: 'Error',
-            icon: 'icon-cancel'
-        },
-        5: {
-            text: 'Canceled',
-            icon: 'icon-cancel'
-        }
-    },
+    _map: {},
 
     text: function (status) {
         return this._map[status].text;
@@ -49,8 +17,58 @@ girder.jobs_JobStatus = {
 
     icon: function (status) {
         return this._map[status].icon;
+    },
+
+    /**
+     * Add new job statuses. The argument should be an object mapping the enum
+     * symbol name to an information object for that status. The info object
+     * must include a "value" field (its integer value), a "text" field, which
+     * is how the status should be rendered as text, and an "icon" field for
+     * what classes to apply to the icon for this status.
+     */
+    registerStatus: function (status) {
+        _.each(status, function (info, name) {
+            this[name] = info.value;
+            this._map[info.value] = {
+                text: info.text,
+                icon: info.icon
+            };
+        }, this);
     }
 };
+
+girder.jobs_JobStatus.registerStatus({
+    INACTIVE: {
+        value: 0,
+        text: 'Inactive',
+        icon: 'icon-pause'
+    },
+    QUEUED: {
+        value: 1,
+        text: 'Queued',
+        icon: 'icon-ellipsis'
+    },
+    RUNNING: {
+        value: 2,
+        text: 'Running',
+        icon: 'icon-spin3 animate-spin'
+    },
+    SUCCESS: {
+        value: 3,
+        text: 'Success',
+        icon: 'icon-ok'
+    },
+    ERROR: {
+        value: 4,
+        text: 'Error',
+        icon: 'icon-cancel'
+    },
+    CANCELED: {
+        value: 5,
+        text: 'Canceled',
+        icon: 'icon-cancel'
+    }
+});
 
 /**
  * Add an entry to the user dropdown menu to navigate to user's job list view.

--- a/plugins/jobs/web_client/js/views/JobDetailsWidget.js
+++ b/plugins/jobs/web_client/js/views/JobDetailsWidget.js
@@ -16,9 +16,11 @@ girder.views.jobs_JobDetailsWidget = girder.View.extend({
     },
 
     render: function () {
+        var status = this.job.get('status');
         this.$el.html(girder.templates.jobs_jobDetails({
             job: this.job,
-            statusText: girder.jobs_JobStatus.text(this.job.get('status')),
+            statusText: girder.jobs_JobStatus.text(status),
+            colorClass: 'g-job-color-' + girder.jobs_JobStatus.classAffix(status),
             girder: girder,
             _: _
         }));
@@ -49,7 +51,7 @@ girder.views.jobs_JobDetailsWidget = girder.View.extend({
                 start: stamp.time,
                 end: timestamps[i + 1].time,
                 tooltip: statusText + ': %r s',
-                class: 'g-job-color-' + statusText.toLowerCase()
+                class: 'g-job-color-' + girder.jobs_JobStatus.classAffix(stamp.status)
             };
         }, this));
 
@@ -65,7 +67,7 @@ girder.views.jobs_JobDetailsWidget = girder.View.extend({
                 time: stamp.time,
                 tooltip: 'Moved to ' + statusText + ' at ' +
                          new Date(stamp.time).toISOString(),
-                class: 'g-job-color-' + statusText.toLowerCase()
+                class: 'g-job-color-' + girder.jobs_JobStatus.classAffix(stamp.status)
             };
         }, this));
 

--- a/plugins/jobs/web_client/templates/jobs_jobDetails.jade
+++ b/plugins/jobs/web_client/templates/jobs_jobDetails.jade
@@ -6,8 +6,7 @@
   .g-job-info-value.inline(property="_id")= job.get('_id')
 .g-field-container
   .g-job-info-key.inline(property="status") Status:
-  .g-job-status-badge(status=statusText.toLowerCase(),
-                      class='g-job-color-' + statusText.toLowerCase())
+  .g-job-status-badge(status=statusText.toLowerCase(), class=colorClass)
     i(class=girder.jobs_JobStatus.icon(job.get('status')))
     |  #{statusText}
 if job.get('timestamps') && job.get('timestamps').length


### PR DESCRIPTION
We add a simple event hook for allowing job status values
beyond the ones built into the jobs plugin.

We will need this for https://github.com/Kitware/romanesco/pull/200