### PR TITLE
Fix CMake add_web_client_test flags

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -223,11 +223,12 @@ and then run in your build directory ::
 
 before running your tests.
 
-A client side test can specify several options, including which plugins should be loaded at the time of the test, for example ::
+A client side test can specify several options, for example ::
 
-    add_web_client_test(some_client_test "someSpec.js" ENABLEDPLUGINS "gravatar" "jobs")
+    add_web_client_test(some_client_test "someSpec.js" PLUGIN "my_plugin" ENABLEDPLUGINS "my_plugin" "gravatar" "jobs")
 
-would add a test which ensured the gravatar and jobs plugins were loaded when run.
+The ``PLUGIN`` argument indicates that "my_plugin" is the owner of ``some_client_test``, while ``ENABLEDPLUGINS`` determines which plugins are going to be loaded when running
+``some_client_test``. In this case my_plugin, gravatar, jobs, and all of their dependencies will be loaded in the proper order at the time of this test.
 
 .. note:: Core functionality shouldn't depend on plugins being enabled, this test definition is more suitable for a plugin. Information for testing plugins can be found under :doc:`plugin-development`.
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -223,6 +223,14 @@ and then run in your build directory ::
 
 before running your tests.
 
+A client side test can specify several options, including which plugins should be loaded at the time of the test, for example ::
+
+    add_web_client_test(some_client_test "someSpec.js" ENABLEDPLUGINS "gravatar" "jobs")
+
+would add a test which ensured the gravatar and jobs plugins were loaded when run.
+
+.. note:: Core functionality shouldn't depend on plugins being enabled, this test definition is more suitable for a plugin. Information for testing plugins can be found under :doc:`plugin-development`.
+
 You will find many useful methods for client side testing in the ``girderTest`` object
 defined at ``/clients/web/test/testUtils.js``.
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -223,12 +223,17 @@ and then run in your build directory ::
 
 before running your tests.
 
-A client side test can specify several options, for example ::
+An example of a very simple client side test would be as follows ::
 
-    add_web_client_test(some_client_test "someSpec.js" PLUGIN "my_plugin" ENABLEDPLUGINS "my_plugin" "gravatar" "jobs")
+    add_web_client_test(some_client_test "someSpec.js" PLUGIN "my_plugin")
 
-The ``PLUGIN`` argument indicates that "my_plugin" is the owner of ``some_client_test``, while ``ENABLEDPLUGINS`` determines which plugins are going to be loaded when running
-``some_client_test``. In this case my_plugin, gravatar, jobs, and all of their dependencies will be loaded in the proper order at the time of this test.
+The ``PLUGIN`` argument indicates that "my_plugin" is the owner of ``some_client_test``, at the time of the test my_plugin and all of its dependencies will be loaded.
+
+If additional plugins are needed for a specific test, that can be achieved using the ``ENABLEDPLUGINS`` argument ::
+
+    add_web_client_test(another_client_test "anotherSpec.js" PLUGIN "my_plugin" ENABLEDPLUGINS "my_plugin" "jobs")
+
+Here ``ENABLEDPLUGINS`` ensures that my_plugin *and* the jobs plugin are loaded, along with their dependencies at the time of ``another_client_test``.
 
 .. note:: Core functionality shouldn't depend on plugins being enabled, this test definition is more suitable for a plugin. Information for testing plugins can be found under :doc:`plugin-development`.
 

--- a/tests/JavascriptTests.cmake
+++ b/tests/JavascriptTests.cmake
@@ -125,8 +125,8 @@ function(add_web_client_test case specFile)
   set(testname "web_client_${case}")
 
   set(_options NOCOVERAGE)
-  set(_args PLUGIN ASSETSTORE WEBSECURITY BASEURL PLUGIN_DIRS)
-  set(_multival_args RESOURCE_LOCKS TIMEOUT ENABLEDPLUGINS)
+  set(_args PLUGIN ASSETSTORE WEBSECURITY BASEURL PLUGIN_DIRS TIMEOUT)
+  set(_multival_args RESOURCE_LOCKS ENABLEDPLUGINS)
   cmake_parse_arguments(fn "${_options}" "${_args}" "${_multival_args}" ${ARGN})
 
   if(fn_PLUGIN)

--- a/tests/JavascriptTests.cmake
+++ b/tests/JavascriptTests.cmake
@@ -168,6 +168,10 @@ function(add_web_client_test case specFile)
   set_property(TEST ${testname} PROPERTY FAIL_REGULAR_EXPRESSION
     "View created with no parentView property")
 
+  # Treat plugins as a space separated string for the environment variable
+  # to be set properly
+  string(REPLACE ";" " " plugins "${plugins}")
+
   set_property(TEST ${testname} PROPERTY ENVIRONMENT
     "SPEC_FILE=${specFile}"
     "ASSETSTORE_TYPE=${assetstoreType}"

--- a/tests/JavascriptTests.cmake
+++ b/tests/JavascriptTests.cmake
@@ -111,9 +111,9 @@ function(add_web_client_test case specFile)
   #     running the test.  Defaults to 'filesystem'
   # WEBSECURITY (boolean) : if false, don't use CORS validatation.  Defaults to
   #     'true'
-  # ENABLEDPLUGINS (list of plugins): A list of plugins to load.  If PLUGIN is
-  #     specified, this overrides loading that plugin, so it probably should be
-  #     included in this list, too.
+  # ENABLEDPLUGINS (list of plugins): A list of plugins to load. This overrides the
+  # PLUGIN parameter, so if you intend to load PLUGIN it must be included in this
+  # list.
   # RESOURCE_LOCKS (list of resources): A list of resources that this test
   #     needs exclusive access to.  Defaults to mongo and cherrypy.
   # TIMEOUT (seconds): An overall test timeout.

--- a/tests/JavascriptTests.cmake
+++ b/tests/JavascriptTests.cmake
@@ -188,14 +188,11 @@ function(add_web_client_test case specFile)
   if(fn_RESOURCE_LOCKS)
     set_property(TEST ${testname} PROPERTY RESOURCE_LOCK ${fn_RESOURCE_LOCKS})
   endif()
-  #if(fn_RESOURCE_LOCKS)
-  #  set_property(TEST ${testname} PROPERTY RESOURCE_LOCK mongo cherrypy ${fn_RESOURCE_LOCKS})
-  #else()
-  #  set_property(TEST ${testname} PROPERTY RESOURCE_LOCK mongo cherrypy)
-  #endif()
+
   if(fn_TIMEOUT)
     set_property(TEST ${testname} PROPERTY TIMEOUT ${fn_TIMEOUT})
   endif()
+
   if(fn_BASEURL)
     set_property(TEST ${testname} APPEND PROPERTY ENVIRONMENT
         "BASEURL=${fn_BASEURL}"

--- a/tests/JavascriptTests.cmake
+++ b/tests/JavascriptTests.cmake
@@ -103,8 +103,9 @@ function(add_web_client_test case specFile)
   # :param case: the name of this test case
   # :param specFile: the path of the spec file to run
   # Optional parameters:
-  # PLUGIN (name of plugin) : this plugin is loaded (unless overridden with
-  #     ENABLEDPLUGINS) and the test name includes the plugin name
+  # PLUGIN (name of plugin) : this plugin and all dependencies are loaded
+  # (unless overridden with ENABLEDPLUGINS) and the test name includes the
+  # plugin name
   # PLUGIN_DIRS (list of plugin dirs) : A list of directories plugins
   # should live in.
   # ASSETSTORE (assetstore type) : use the specified assetstore type when
@@ -113,7 +114,7 @@ function(add_web_client_test case specFile)
   #     'true'
   # ENABLEDPLUGINS (list of plugins): A list of plugins to load. This overrides the
   # PLUGIN parameter, so if you intend to load PLUGIN it must be included in this
-  # list.
+  # list. All dependencies of ENABLEDPLUGINS are also loaded.
   # RESOURCE_LOCKS (list of resources): A list of resources that this test
   #     needs exclusive access to.  Defaults to mongo and cherrypy.
   # TIMEOUT (seconds): An overall test timeout.


### PR DESCRIPTION
@zachmullen 
The major fix here is `ENABLEDPLUGINS` now functions properly. 

@mgrauer This means that [this line](https://github.com/Kitware/minerva/blob/0e27615ed32c342bd048152a0a6899c2457c2d04/plugin.cmake#L68) in Minerva is mostly useless, only the gravatar plugin is actually loaded during client side testing (since it's first), this should fix that.

Also, I made `TIMEOUT` a regular argument instead of a multival argument (seemed like a bug).

Maybe a 2.0 note for consistency:
`ENABLEDPLUGINS` in CMake corresponds to `ENABLED_PLUGINS` in python
Same goes for `WEBSECURITY` -> `WEB_SECURITY`