### PR TITLE
Upgrade Girder, Minerva, Romanesco common requirements

### DIFF
--- a/clients/python/requirements.txt
+++ b/clients/python/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.7.0
-six==1.9.0
+requests==2.9.1
+six==1.10.0

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -255,16 +255,18 @@ Girder's standard procedure is to use a tool like
 third-party library requirements on a quarterly basis (typically near the dates
 of the solstices and equinoxes). Library packages should generally be upgraded
 to the latest released version, except when:
-1. Doing so would introduce any new unfixable bugs or regressions.
-2. Other closely-affiliated projects (e.g.
-   `Romanesco <https://romanesco.readthedocs.org/>`_ use the same library *and*
-   the other project cannot also feasibly be upgraded simultaneously.
-3. The library has undergone a major API change, and development resources do
-   not permit updating Girder accordingly *or* Girder exposes parts
-   of the library as members of Girder's API surface (e.g. CherryPy) and
-   upgrading would cause incompatible API changes to be exposed. In this
-   case, the library should still be upgraded to the highest non-breaking
-   version that is available at the time.
+
+* Doing so would introduce any new unfixable bugs or regressions.
+* Other closely-affiliated projects (e.g.
+  `Romanesco <https://romanesco.readthedocs.org/>`_,
+  `Minerva <https://minervadocs.readthedocs.org/>`_) use the same library *and*
+  the other project cannot also feasibly be upgraded simultaneously.
+* The library has undergone a major API change, and development resources do
+  not permit updating Girder accordingly *or* Girder exposes parts of the
+  library as members of Girder's API surface (e.g. CherryPy) and upgrading
+  would cause incompatible API changes to be exposed. In this case, the library
+  should still be upgraded to the highest non-breaking version that is
+  available at the time.
 
 .. note:: In the event that a security vulnerability is discovered in a
    third-party library used by Girder, the library *must* be upgraded to patch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,21 @@
 # girder core
 bcrypt==2.0.0
 boto==2.38.0
-cffi==1.3.1
+cffi==1.5.0
 CherryPy==3.8.0
 Mako==1.0.3
-pymongo==3.0.3
+pymongo==3.2
 PyYAML==3.11
-requests==2.7.0
+requests==2.9.1
 psutil==3.2.2
 pytz==2015.7
-six==1.9.0
+six==1.10.0
 
 # celery_jobs
-celery==3.1.16
+celery==3.1.19
 
 # geospatial
-geojson==1.0.7
+geojson==1.3.1
 
 # hdfs_assetstore
 snakebite==2.5.1 ; python_version < '3.0'
@@ -26,13 +26,13 @@ hachoir-metadata==1.3.3 ; python_version < '3.0'
 hachoir-parser==1.3.4   ; python_version < '3.0'
 
 # thumbnails
-Pillow==3.0.0
+Pillow==3.1.0
 
 # dependencies of dependencies
-amqp==1.4.8
+amqp==1.4.9
 anyjson==0.3.3
 billiard==3.3.0.22
-kombu==3.0.30
+kombu==3.0.33
 MarkupSafe==0.23
 protobuf==2.6.1
 pycparser==2.14


### PR DESCRIPTION
amqp changes at (not up to date):
https://github.com/celery/py-amqp/blob/master/Changelog

Celery changes at:
http://docs.celeryproject.org/en/latest/changelog.html

cffi changes at:
https://cffi.readthedocs.org/en/latest/whatsnew.html#v1-5-0

GeoJSON changes at:
https://github.com/frewsxcv/python-geojson/blob/master/CHANGELOG.rst

Kombu changes at:
http://docs.celeryproject.org/projects/kombu/en/latest/changelog.html

Pillow changes at:
https://pillow.readthedocs.org/en/3.1.x/releasenotes/3.1.0.html

PyMongo changes at:
https://api.mongodb.org/python/current/changelog.html

Requests changes at:
http://docs.python-requests.org/en/latest/community/updates/#release-and-version-history

Six changes at:
https://bitbucket.org/gutworth/six/src/1991f8b5b654f077e773f05695a08e0506b7367f/CHANGES