### PR TITLE
Allow accordion collapse widgets to be clicked anywhere

### DIFF
--- a/clients/web/src/templates/widgets/accessEntry.jade
+++ b/clients/web/src/templates/widgets/accessEntry.jade
@@ -1,7 +1,8 @@
 div(class="g-#{type}-access-entry", resourceid="#{entry.id}")
   .g-access-col-left
     - var icon = type === 'group' ? 'users' : 'user';
-    .g-access-icon: i(class="icon-#{icon}")
+    .g-access-icon
+      i(class="icon-#{icon}")
     .g-access-desc
       .g-desc-title #{entry.title}
       .g-desc-subtitle #{entry.subtitle}

--- a/clients/web/src/templates/widgets/groupAdminList.jade
+++ b/clients/web/src/templates/widgets/groupAdminList.jade
@@ -17,12 +17,14 @@
                 i.icon-down-big
                 i.icon-down-dir
               ul.dropdown-menu.pull-right(role="menu")
-                li(role="presentation"): a.g-demote-moderator(role="menuitem")
-                  i.icon-minus
-                  | Demote to moderator
-                li(role="presentation"): a.g-demote-member(role="menuitem")
-                  i.icon-minus
-                  | Demote to member
+                li(role="presentation")
+                  a.g-demote-moderator(role="menuitem")
+                    i.icon-minus
+                    span Demote to moderator
+                li(role="presentation")
+                  a.g-demote-member(role="menuitem")
+                    i.icon-minus
+                    span Demote to member
             a.g-group-admin-remove(title="Remove user from the group")
               i.icon-block
     if (!admins.length)

--- a/clients/web/src/templates/widgets/groupAdminList.jade
+++ b/clients/web/src/templates/widgets/groupAdminList.jade
@@ -1,6 +1,6 @@
 .g-group-admins-header.g-group-list-header(title="Group administrators can edit group properties and can add, invite, and remove group members, moderators, and administrators.")
   i.icon-star
-  |  Administrators
+  span Administrators
 
 .g-group-admins-body
   ul.g-group-admins
@@ -8,7 +8,7 @@
       li(userid="#{userAccess.id}", username="#{userAccess.name}")
         a.g-member-name
           i.icon-user
-          |  #{userAccess.name} (#{userAccess.login})
+          span #{userAccess.name} (#{userAccess.login})
         .g-group-member-controls.pull-right
           if level >= accessType.ADMIN
             span.dropdown
@@ -28,4 +28,4 @@
     if (!admins.length)
       .g-member-list-empty
         i.icon-info-circled
-        |  There are no administrators in this group.
+        span There are no administrators in this group.

--- a/clients/web/src/templates/widgets/groupInviteDialog.jade
+++ b/clients/web/src/templates/widgets/groupInviteDialog.jade
@@ -5,9 +5,9 @@
       h4.modal-title Invite user to group
       .g-dialog-subtitle
         i.icon-user
-        | #{user.text}
+        span #{user.text}
     .modal-body
-      label.control-label(for="g-role") Select a role for this user
+      label.control-label Select a role for this user
       .panel-group#g-invite-role-container
         .panel.panel-default
           .panel-heading(data-toggle="collapse",
@@ -23,11 +23,11 @@
                 group, but may not change properties of the group.
               .g-invite-as-member.btn.btn-primary
                 i.icon-mail
-                |  Invite as member
+                span Invite as member
               if mayAdd
                 .g-add-as-member.btn.btn-warning.g-add-user-button
                   i.icon-plus
-                  | Add as member
+                  span Add as member
 
         if (level >= accessType.ADMIN)
           .panel.panel-default
@@ -43,11 +43,11 @@
                   granted the power to add and remove users from the group.
                 .g-invite-as-moderator.btn.btn-primary
                   i.icon-mail
-                  |  Invite as moderator
+                  span Invite as moderator
                 if mayAdd
                   .g-add-as-moderator.btn.btn-warning.g-add-user-button
                     i.icon-plus
-                    | Add as moderator
+                    span Add as moderator
 
         if (level >= accessType.ADMIN)
           .panel.panel-default
@@ -65,11 +65,11 @@
                   group entirely.
                 .g-invite-as-admin.btn.btn-primary
                   i.icon-mail
-                  |  Invite as administrator
+                  span Invite as administrator
                 if mayAdd
                   .g-add-as-admin.btn.btn-warning.g-add-user-button
                     i.icon-plus
-                    | Add as administrator
+                    span Add as administrator
 
       .g-validation-failed-message
     .modal-footer

--- a/clients/web/src/templates/widgets/groupInviteDialog.jade
+++ b/clients/web/src/templates/widgets/groupInviteDialog.jade
@@ -10,9 +10,11 @@
       label.control-label(for="g-role") Select a role for this user
       .panel-group#g-invite-role-container
         .panel.panel-default
-          .panel-heading: .panel-title
-            a(data-toggle="collapse", data-parent="#g-invite-role-container",
-              href="#g-invite-role-member") Invite as member
+          .panel-heading(data-toggle="collapse",
+                         data-parent="#g-invite-role-container",
+                         data-target="#g-invite-role-member")
+            .panel-title
+              a Invite as member
           #g-invite-role-member.panel-collapse.collapse.in
             .panel-body
               p.
@@ -29,9 +31,11 @@
 
         if (level >= accessType.ADMIN)
           .panel.panel-default
-            .panel-heading: .panel-title
-              a(data-toggle="collapse", data-parent="#g-invite-role-container",
-                href="#g-invite-role-moderator") Invite as moderator
+            .panel-heading(data-toggle="collapse",
+                           data-parent="#g-invite-role-container",
+                           data-target="#g-invite-role-moderator")
+              .panel-title
+                a Invite as moderator
             #g-invite-role-moderator.panel-collapse.collapse
               .panel-body
                 p.
@@ -47,9 +51,11 @@
 
         if (level >= accessType.ADMIN)
           .panel.panel-default
-            .panel-heading: .panel-title
-              a(data-toggle="collapse", data-parent="#g-invite-role-container",
-                href="#g-invite-role-admin") Invite as administrator
+            .panel-heading(data-toggle="collapse",
+                           data-parent="#g-invite-role-container",
+                           data-target="#g-invite-role-moderator")
+              .panel-title
+                a Invite as administrator
             #g-invite-role-admin.panel-collapse.collapse
               .panel-body
                 p.

--- a/clients/web/src/templates/widgets/groupInviteDialog.jade
+++ b/clients/web/src/templates/widgets/groupInviteDialog.jade
@@ -53,7 +53,7 @@
           .panel.panel-default
             .panel-heading(data-toggle="collapse",
                            data-parent="#g-invite-role-container",
-                           data-target="#g-invite-role-moderator")
+                           data-target="#g-invite-role-admin")
               .panel-title
                 a Invite as administrator
             #g-invite-role-admin.panel-collapse.collapse

--- a/clients/web/src/templates/widgets/groupInviteList.jade
+++ b/clients/web/src/templates/widgets/groupInviteList.jade
@@ -3,7 +3,7 @@ ul.g-group-invites
     li(cid="#{user.cid}", username="#{user.name()}")
       a.g-member-name
         i.icon-user
-        |  #{user.name()} (#{user.get('login')})
+        span #{user.name()} (#{user.get('login')})
       .g-group-member-controls.pull-right
         if level >= accessType.WRITE
           a.g-group-uninvite(title="Uninvite this user")
@@ -11,4 +11,4 @@ ul.g-group-invites
   if (!invitees.length)
     .g-member-list-empty
       i.icon-info-circled
-      |  There are no pending invitations to this group.
+      span There are no pending invitations to this group.

--- a/clients/web/src/templates/widgets/groupMemberList.jade
+++ b/clients/web/src/templates/widgets/groupMemberList.jade
@@ -1,6 +1,6 @@
 .g-group-members-header.g-group-list-header
   i.icon-users
-  |  Members
+  span Members
   if level >= accessType.WRITE
     form.g-group-invite-form.form-inline(role="form")
       span: i.icon-mail-alt
@@ -12,12 +12,12 @@
       li(cid="#{member.cid}")
         a.g-member-name
           i.icon-user
-          |  #{member.name()} (#{member.get('login')})
+          span #{member.name()} (#{member.get('login')})
         .g-group-member-controls.pull-right
           if level >= accessType.ADMIN
             span.dropdown
               a.g-group-member-promote.dropdown-toggle(title="Promote user",
-                data-toggle="dropdown")
+                                                       data-toggle="dropdown")
                 i.icon-up-big
                 i.icon-down-dir
               ul.dropdown-menu.pull-right(role="menu")
@@ -33,4 +33,4 @@
     if (!members.length)
       .g-member-list-empty
         i.icon-info-circled
-        |  There are no members in this group.
+        span There are no members in this group.

--- a/clients/web/src/templates/widgets/groupMemberList.jade
+++ b/clients/web/src/templates/widgets/groupMemberList.jade
@@ -3,7 +3,8 @@
   span Members
   if level >= accessType.WRITE
     form.g-group-invite-form.form-inline(role="form")
-      span: i.icon-mail-alt
+      span
+        i.icon-mail-alt
       .form-group.g-group-invite-container
   .g-member-pagination
 .g-group-members-body
@@ -21,12 +22,14 @@
                 i.icon-up-big
                 i.icon-down-dir
               ul.dropdown-menu.pull-right(role="menu")
-                li(role="presentation"): a.g-promote-moderator(role="menuitem")
-                  i.icon-plus
-                  | Promote to moderator
-                li(role="presentation"): a.g-promote-admin(role="menuitem")
-                  i.icon-plus
-                  | Promote to administrator
+                li(role="presentation")
+                  a.g-promote-moderator(role="menuitem")
+                    i.icon-plus
+                    span Promote to moderator
+                li(role="presentation")
+                  a.g-promote-admin(role="menuitem")
+                    i.icon-plus
+                    span Promote to administrator
           if level >= accessType.WRITE
             a.g-group-member-remove(title="Remove user from the group")
               i.icon-block

--- a/clients/web/src/templates/widgets/groupModList.jade
+++ b/clients/web/src/templates/widgets/groupModList.jade
@@ -1,6 +1,6 @@
 .g-group-mods-header.g-group-list-header(title="Group moderators can invite and approve group members.")
   i.icon-shield
-  |  Moderators
+  span Moderators
 
 .g-group-mods-body
   ul.g-group-mods
@@ -8,7 +8,7 @@
       li(userid="#{userAccess.id}", username="#{userAccess.name}")
         a.g-member-name
           i.icon-user
-          |  #{userAccess.name} (#{userAccess.login})
+          span #{userAccess.name} (#{userAccess.login})
         .g-group-member-controls.pull-right
           if level >= accessType.ADMIN
             a.g-group-mod-promote(title="Promote to administrator")
@@ -20,4 +20,4 @@
     if (!moderators.length)
       .g-member-list-empty
         i.icon-info-circled
-        |  There are no moderators in this group.
+        span There are no moderators in this group.

--- a/clients/web/src/templates/widgets/newAssetstore.jade
+++ b/clients/web/src/templates/widgets/newAssetstore.jade
@@ -6,9 +6,7 @@
       .panel-title
         a
           i.icon-hdd
-          |  Create new
-          b  Filesystem
-          |  assetstore
+          span Create new #[b Filesystem] assetstore
     #g-create-fs-tab.panel-collapse.collapse
       .panel-body
         p.
@@ -40,17 +38,14 @@
       .panel-title
         a
           i.icon-leaf
-          |  Create new
-          b  GridFS
-          |  assetstore
+          span Create new #[b GridFS] assetstore
     #g-create-gridfs-tab.panel-collapse.collapse
       .panel-body
-        p
-          | This type of assetstore uses mongoDB's
-          a(target="_blank",
-            href="http://docs.mongodb.org/manual/core/gridfs/")  GridFS
-          |  storage engine. The files should be stored in a separate database
-          |  from the rest of the server's information to avoid locking issues.
+        p.
+          This type of assetstore uses
+          MongoDB's #[a(target="_blank", href="http://docs.mongodb.org/manual/core/gridfs/") GridFS]
+          storage engine. The files should be stored in a separate database
+          from the rest of the server's information to avoid locking issues.
         form#g-new-gridfs-form(role="form")
           .form-group
             label.control-label(for="g-new-gridfs-name") Assetstore name
@@ -82,17 +77,15 @@
       .panel-title
         a
           i.icon-upload-cloud
-          |  Create new
-          b  Amazon S3
-          |  assetstore
+          span Create new #[b Amazon S3] assetstore
     #g-create-s3-tab.panel-collapse.collapse
       .panel-body
-        p
-          | This type of assetstore keeps files in an
-          a(target="_blank", href="http://aws.amazon.com/s3/")  Amazon S3
-          |  bucket.  The service defaults to s3.amazonaws.com.  You can
-          |  specify an alternate service, including an optional protocol and
-          |  port using the form [http[s]://](service domain)[:(port)].
+        p.
+          This type of assetstore keeps files in
+          an #[a(target="_blank", href="http://aws.amazon.com/s3/") Amazon S3]
+          bucket. The service defaults to s3.amazonaws.com. You can specify an
+          alternate service, including an optional protocol and port using the
+          form [http[s]://](service domain)[:(port)].
         form#g-new-s3-form(role="form")
           .form-group
             label.control-label(for="g-new-s3-name") Assetstore name

--- a/clients/web/src/templates/widgets/newAssetstore.jade
+++ b/clients/web/src/templates/widgets/newAssetstore.jade
@@ -1,9 +1,10 @@
 .panel-group#g-assetstore-accordion
   .panel.panel-default
-    .panel-heading
+    .panel-heading(data-toggle="collapse",
+                   data-parent="#g-assetstore-accordion",
+                   data-target="#g-create-fs-tab")
       .panel-title
-        a(data-toggle="collapse", data-parent="#g-assetstore-accordion",
-          href="#g-create-fs-tab")
+        a
           i.icon-hdd
           |  Create new
           b  Filesystem
@@ -33,10 +34,11 @@
 
 
   .panel.panel-default
-    .panel-heading
+    .panel-heading(data-toggle="collapse",
+                   data-parent="#g-assetstore-accordion",
+                   data-target="#g-create-gridfs-tab")
       .panel-title
-        a(data-toggle="collapse", data-parent="#g-assetstore-accordion",
-          href="#g-create-gridfs-tab")
+        a
           i.icon-leaf
           |  Create new
           b  GridFS
@@ -74,10 +76,11 @@
 
 
   .panel.panel-default
-    .panel-heading
+    .panel-heading(data-toggle="collapse",
+                   data-parent="#g-assetstore-accordion",
+                   data-target="#g-create-s3-tab")
       .panel-title
-        a(data-toggle="collapse", data-parent="#g-assetstore-accordion",
-          href="#g-create-s3-tab")
+        a
           i.icon-upload-cloud
           |  Create new
           b  Amazon S3

--- a/clients/web/src/templates/widgets/paginateWidget.jade
+++ b/clients/web/src/templates/widgets/paginateWidget.jade
@@ -1,4 +1,7 @@
 ul.pagination.pagination-sm
-  li.g-page-prev.disabled: a &laquo; Prev
-  li.active: a.g-page-number Page #{collection.pageNum() + 1}
-  li.g-page-next.disabled: a Next &raquo;
+  li.g-page-prev.disabled
+    a &laquo; Prev
+  li.active
+    a.g-page-number Page #{collection.pageNum() + 1}
+  li.g-page-next.disabled
+    a Next &raquo;

--- a/clients/web/test/spec/adminSpec.js
+++ b/clients/web/test/spec/adminSpec.js
@@ -152,7 +152,7 @@ describe('Test the assetstore page', function () {
         it('Create, switch to, and delete a '+assetstore+' assetstore', function () {
             /* create the assetstore */
             runs(function () {
-                $("[href='#"+tab+"']").click();
+                $("[data-target='#"+tab+"']").click();
             });
             waitsFor(function () {
                 return $('#'+tab+' .g-new-assetstore-submit:visible').length > 0;

--- a/girder/utility/gridfs_assetstore_adapter.py
+++ b/girder/utility/gridfs_assetstore_adapter.py
@@ -40,7 +40,7 @@ CHUNK_SIZE = 2097152
 
 class GridFsAssetstoreAdapter(AbstractAssetstoreAdapter):
     """
-    This assetstore type stores files within mongoDB using the GridFS data
+    This assetstore type stores files within MongoDB using the GridFS data
     model.
     """
 

--- a/plugins/hdfs_assetstore/web_client/templates/hdfs_assetstore_create.jade
+++ b/plugins/hdfs_assetstore/web_client/templates/hdfs_assetstore_create.jade
@@ -4,10 +4,7 @@
                  data-target="#g-create-hdfs-tab")
     .panel-title
       a
-        i.icon-share
-        |  Create new
-        b  HDFS
-        |  assetstore
+        i.icon-share Create new #[b HDFS] assetstore
   #g-create-hdfs-tab.panel-collapse.collapse
     .panel-body
       p.

--- a/plugins/hdfs_assetstore/web_client/templates/hdfs_assetstore_create.jade
+++ b/plugins/hdfs_assetstore/web_client/templates/hdfs_assetstore_create.jade
@@ -1,8 +1,9 @@
 .panel.panel-default
-  .panel-heading
+  .panel-heading(data-toggle="collapse",
+                 data-parent="#g-assetstore-accordion"
+                 data-target="#g-create-hdfs-tab")
     .panel-title
-      a(data-toggle="collapse" data-parent="#g-assetstore-accordion"
-        href="#g-create-hdfs-tab")
+      a
         i.icon-share
         |  Create new
         b  HDFS

--- a/plugins/jobs/web_client/templates/jobs_jobList.jade
+++ b/plugins/jobs/web_client/templates/jobs_jobList.jade
@@ -18,9 +18,11 @@ table.g-jobs-list-table
             i(class="#{girder.jobs_JobStatus.icon(job.get('status'))}")
         if columns & columnEnum.COLUMN_TITLE
           if triggerJobClick
-            td: a.g-job-trigger-link(cid="#{job.cid}")= job.get('title')
+            td
+              a.g-job-trigger-link(cid="#{job.cid}")= job.get('title')
           else if linkToJob
-            td: a(href="#job/#{job.id}")= job.get('title')
+            td
+              a(href="#job/#{job.id}")= job.get('title')
           else
             td= job.get('title')
         if columns & columnEnum.COLUMN_UPDATED

--- a/plugins/oauth/web_client/templates/oauth_config.jade
+++ b/plugins/oauth/web_client/templates/oauth_config.jade
@@ -6,10 +6,11 @@ p Only fill in the information for the OAuth2 providers you wish to enable.
 .panel-group#g-oauth-provider-accordion
   each provider in providers
     .panel.panel-default
-      .panel-heading
+      .panel-heading(data-toggle="collapse",
+                     data-parent="#g-oauth-provider-accordion",
+                     data-target="#g-oauth-provider-#{provider.id}")
         .panel-title
-          a(data-toggle="collapse", data-parent="#g-oauth-provider-accordion",
-            href="#g-oauth-provider-#{provider.id}")
+          a
             i(class="icon-#{provider.icon}")
             |  #{provider.name}
       .panel-collapse.collapse(id="g-oauth-provider-#{provider.id}")

--- a/plugins/oauth/web_client/templates/oauth_config.jade
+++ b/plugins/oauth/web_client/templates/oauth_config.jade
@@ -12,7 +12,7 @@ p Only fill in the information for the OAuth2 providers you wish to enable.
         .panel-title
           a
             i(class="icon-#{provider.icon}")
-            |  #{provider.name}
+            span #{provider.name}
       .panel-collapse.collapse(id="g-oauth-provider-#{provider.id}")
         .panel-body
           p= provider.instructions


### PR DESCRIPTION
* Allow accordion collapse widgets to be clicked anywhere
 * The Bootstrap examples don't provide the optimal placement of the ``data-toggle`` property. It should be placed on the ``.panel-heading`` div, not the ``a`` element inside the ``.panel-title``.
* Convert some usage of Jade pipes into spans or block text continuations
 * In addition to being more maintainable, this actually slightly improves the spacing of the compiled HTML, making precise text selection in a browser easier.
 * Also, correct the spelling of "MongoDB".
* Remove inline nested elements from Jade templates
 * This syntax is less clear and more difficult to maintain.