### PR TITLE
Change all Python strings to use old-style formatting

### DIFF
--- a/clients/ansible/girder.py
+++ b/clients/ansible/girder.py
@@ -533,7 +533,7 @@ class GirderClientModule(GirderClient):
         if type(params) is dict:
             for arg_name in self.spec[method]['required']:
                 if arg_name not in params.keys():
-                    self.fail("{} is required for {}".format(arg_name, method))
+                    self.fail("%s is required for %s" % (arg_name, method))
                 args.append(params[arg_name])
 
             for kwarg_name in self.spec[method]['optional']:
@@ -570,9 +570,8 @@ class GirderClientModule(GirderClient):
 
         # Fail if plugins are passed in that are not available
         if not plugins <= set(available_plugins["all"].keys()):
-            self.fail("{}, not available!".format(
-                ",".join(list(plugins - available_plugins))
-            ))
+            self.fail("%s, not available!" %
+                      ",".join(list(plugins - available_plugins)))
 
         # If we're trying to ensure plugins are present
         if self.module.params['state'] == 'present':
@@ -606,8 +605,8 @@ class GirderClientModule(GirderClient):
             for var_name, var in [('firstName', firstName),
                                   ('lastName', lastName), ('email', email)]:
                 if var is None:
-                    self.fail("{} must be set if state "
-                              "is 'present'".format(var_name))
+                    self.fail("%s must be set if state "
+                              "is 'present'" % var_name)
 
             try:
                 ret = self.authenticate(username=login,
@@ -623,7 +622,7 @@ class GirderClientModule(GirderClient):
                 if set([(k, v) for k, v in me.items() if k in updateable]) ^ \
                    set(zip(updateable, passed_in)):
 
-                    self.put("user/{}".format(me['_id']),
+                    self.put("user/%s" % me['_id'],
                              parameters={
                                  "login": login,
                                  "firstName": firstName,
@@ -652,7 +651,7 @@ class GirderClientModule(GirderClient):
 
                 me = self.get("user/me")
 
-                self.delete('user/{}'.format(me['_id']))
+                self.delete('user/%s' % me['_id'])
                 self.changed = True
             # User does not exist (with this login info)
             except AuthenticationError:
@@ -679,7 +678,7 @@ class GirderClientModule(GirderClient):
 
             # Fail if somehow we have an asset type not in assetstore_types
         if type not in self.assetstore_types.keys():
-            self.fail("assetstore type {} is not implemented!".format(type))
+            self.fail("assetstore type %s is not implemented!" % type)
 
         argument_hash = {
             "filesystem": {'name': name,
@@ -711,7 +710,7 @@ class GirderClientModule(GirderClient):
         for k, v in argument_hash[type].items():
             if v is None:
                 self.fail("assetstores of type "
-                          "{} require attribute {}".format(type, k))
+                          "%s require attribute %s" % (type, k))
 
         # Set optional arguments in the hash
         argument_hash[type]['readOnly'] = readOnly
@@ -760,7 +759,7 @@ class GirderClientModule(GirderClient):
                 # if arg_hash_items not a proper subset of assetstore_items
                 if not arg_hash_items <= assetstore_items:
                     # Update
-                    ret = self.put("assetstore/{}".format(id),
+                    ret = self.put("assetstore/%s" % id,
                                    parameters=argument_hash[type])
 
                     self.changed = True
@@ -771,8 +770,8 @@ class GirderClientModule(GirderClient):
                     # If __validate_[type]_assetstore exists then call the
                     # function with argument_hash. E.g.,  to check if the
                     # HDFS plugin is enabled
-                    getattr(self, "__validate_{}_assetstore"
-                            .format(type))(**argument_hash)
+                    getattr(self, "__validate_%s_assetstore" % type
+                            )(**argument_hash)
                 except AttributeError:
                     pass
 
@@ -784,7 +783,7 @@ class GirderClientModule(GirderClient):
             # And the assetstore exists
             if name in assetstores.keys():
                 id = assetstores[name]['_id']
-                ret = self.delete("assetstore/{}".format(id),
+                ret = self.delete("assetstore/%s" % id,
                                   parameters=argument_hash[type])
 
         return ret
@@ -838,15 +837,14 @@ def main():
 
     except HttpError as e:
         import traceback
-        module.fail_json(msg="{}:{}\n{}\n{}".format(e.__class__, str(e),
-                                                    e.responseText,
-                                                    traceback.format_exc()))
+        module.fail_json(msg="%s:%s\n%s\n%s" % (e.__class__, str(e),
+                                                e.responseText,
+                                                traceback.format_exc()))
     except Exception as e:
         import traceback
         # exc_type, exc_obj, exec_tb = sys.exc_info()
-        module.fail_json(msg="{}: {}\n\n{}".format(e.__class__,
-                                                   str(e),
-                                                   traceback.format_exc()))
+        module.fail_json(msg="%s: %s\n\n%s" % (e.__class__, str(e),
+                                               traceback.format_exc()))
 
 
 if __name__ == '__main__':

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -59,8 +59,7 @@ class HttpError(Exception):
     Raised if the server returns an error status code from a request.
     """
     def __init__(self, status, text, url, method):
-        Exception.__init__(self, 'HTTP error {}: {} {}'.format(
-                           status, method, url))
+        Exception.__init__(self, 'HTTP error %s: %s %s' % (status, method, url))
         self.status = status
         self.responseText = text
         self.url = url

--- a/girder/__init__.py
+++ b/girder/__init__.py
@@ -52,8 +52,9 @@ class LogFormatter(logging.Formatter):
             '  Query string: ' + cherrypy.request.query_string,
             '  Remote IP: ' + cherrypy.request.remote.ip
         ))
-        return '%s\nAdditional info:\n%s' % (
-            logging.Formatter.formatException(self, exc), info)
+        return ('%s\n'
+                'Additional info:\n'
+                '%s' % (logging.Formatter.formatException(self, exc), info))
 
 
 def getLogPaths():

--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -202,7 +202,7 @@ class Describe(Resource):
         return {
             'apiVersion': API_VERSION,
             'swaggerVersion': SWAGGER_VERSION,
-            'apis': [{'path': '/{}'.format(resource)}
+            'apis': [{'path': '/%s' % resource}
                      for resource in sorted(six.viewkeys(docs.routes))]
         }
 
@@ -240,7 +240,7 @@ class Describe(Resource):
     @access.public
     def describeResource(self, resource, params):
         if resource not in docs.routes:
-            raise RestException('Invalid resource: {}'.format(resource))
+            raise RestException('Invalid resource: %s' % resource)
         return {
             'apiVersion': API_VERSION,
             'swaggerVersion': SWAGGER_VERSION,

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -478,9 +478,10 @@ def ensureTokenScopes(token, scope):
         if isinstance(scope, six.string_types):
             scope = (scope,)
         raise AccessException(
-            'Invalid token scope.\nRequired: {}.\nAllowed: {}'
-            .format(' '.join(scope),
-                    ' '.join(tokenModel.getAllowedScopes(token))))
+            'Invalid token scope.\n'
+            'Required: %s.\n'
+            'Allowed: %s' % (
+                ' '.join(scope), ' '.join(tokenModel.getAllowedScopes(token))))
 
 
 def _setCommonCORSHeaders():
@@ -585,15 +586,15 @@ class Resource(ModelImporter):
         elif not nodoc:
             routePath = '/'.join([resource] + list(route))
             print(TerminalColor.warning(
-                'WARNING: No description docs present for route {} {}'
-                .format(method, routePath)))
+                'WARNING: No description docs present for route %s %s' % (
+                    method, routePath)))
 
         # Warn if there is no access decorator on the handler function
         if not hasattr(handler, 'accessLevel'):
             routePath = '/'.join([resource] + list(route))
             print(TerminalColor.warning(
-                'WARNING: No access level specified for route {} {}'
-                .format(method, routePath)))
+                'WARNING: No access level specified for route %s %s' % (
+                    method, routePath)))
 
         if method.lower() not in ('head', 'get') \
             and hasattr(handler, 'cookieAuth') \
@@ -602,8 +603,8 @@ class Resource(ModelImporter):
             routePath = '/'.join([resource] + list(route))
             print(TerminalColor.warning(
                   'WARNING: Cannot allow cookie authentication for '
-                  'route {} {} without specifying "force=True"'
-                  .format(method, routePath)))
+                  'route %s %s without specifying "force=True"' % (
+                      method, routePath)))
 
     def removeRoute(self, method, route, handler=None, resource=None):
         """
@@ -739,7 +740,7 @@ class Resource(ModelImporter):
 
             return val
 
-        raise RestException('No matching route for "{} {}"'.format(
+        raise RestException('No matching route for "%s %s"' % (
             method.upper(), '/'.join(path)))
 
     def _matchRoute(self, path, route):

--- a/girder/api/v1/assetstore.py
+++ b/girder/api/v1/assetstore.py
@@ -236,7 +236,7 @@ class Assetstore(Resource):
     @loadmodel(model='assetstore')
     def deleteAssetstore(self, assetstore, params):
         self.model('assetstore').remove(assetstore)
-        return {'message': 'Deleted assetstore {}.'.format(assetstore['name'])}
+        return {'message': 'Deleted assetstore %s.' % assetstore['name']}
     deleteAssetstore.description = (
         Description('Delete an assetstore.')
         .notes('This will fail if there are any files in the assetstore.')

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -146,8 +146,8 @@ class File(Resource):
         # complete the upload.
         if upload['received'] != upload['size'] and 'behavior' not in upload:
             raise RestException(
-                'Server has only received {} bytes, but the file should be {} '
-                'bytes.'.format(upload['received'], upload['size']))
+                'Server has only received %s bytes, but the file should be %s '
+                'bytes.' % (upload['received'], upload['size']))
 
         file = self.model('upload').finalizeUpload(upload)
         extraKeys = file.get('additionalFinalizeKeys', ())
@@ -216,8 +216,8 @@ class File(Resource):
 
         if upload['received'] != offset:
             raise RestException(
-                'Server has received {} bytes, but client sent offset {}.'
-                .format(upload['received'], offset))
+                'Server has received %s bytes, but client sent offset %s.' % (
+                    upload['received'], offset))
         try:
             if type(chunk) == cherrypy._cpreqbody.Part:
                 return self.model('upload').handleChunk(upload, chunk.file)

--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -137,7 +137,7 @@ class Folder(Resource):
         """
         cherrypy.response.headers['Content-Type'] = 'application/zip'
         cherrypy.response.headers['Content-Disposition'] = \
-            u'attachment; filename="{}{}"'.format(folder['name'], '.zip')
+            'attachment; filename="%s%s"' % (folder['name'], '.zip')
 
         user = self.getCurrentUser()
 

--- a/girder/api/v1/group.py
+++ b/girder/api/v1/group.py
@@ -419,4 +419,4 @@ class Group(Resource):
     )
     def deleteGroup(self, group, params):
         self.model('group').remove(group)
-        return {'message': 'Deleted the group {}.'.format(group['name'])}
+        return {'message': 'Deleted the group %s.' % group['name']}

--- a/girder/api/v1/notification.py
+++ b/girder/api/v1/notification.py
@@ -37,7 +37,7 @@ def sseMessage(event):
     """
     Serializes an event into the server-sent events protocol.
     """
-    return 'data: {}\n\n'.format(json.dumps(event, default=str))
+    return 'data: %s\n\n' % json.dumps(event, default=str)
 
 
 class Notification(Resource):

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -177,7 +177,7 @@ class Resource(BaseResource):
                 return candidateChild, candidateModel
 
         # if no folder, item, or file matches, give up
-        raise RestException('Child resource not found: {}({})->{}'.format(
+        raise RestException('Child resource not found: %s(%s)->%s' % (
             parentType, parent.get('name', parent.get('_id')), token))
 
     def _lookUpPath(self, path, user):
@@ -190,7 +190,7 @@ class Resource(BaseResource):
             parent = self.model('user').findOne({'login': username})
 
             if parent is None:
-                raise RestException('User not found: {}'.format(username))
+                raise RestException('User not found: %s' % username)
 
         elif model == 'collection':
             collectionName = pathArray[1]
@@ -198,7 +198,7 @@ class Resource(BaseResource):
 
             if parent is None:
                 raise RestException(
-                    'Collection not found: {}'.format(collectionName))
+                    'Collection not found: %s' % collectionName)
 
         else:
             raise RestException('Invalid path format')
@@ -210,7 +210,7 @@ class Resource(BaseResource):
                 document, model = self._lookUpToken(token, model, document)
                 self.model(model).requireAccess(document, user)
         except RestException:
-            raise RestException('Path not found: {}'.format(path))
+            raise RestException('Path not found: %s' % path)
 
         result = self.model(model).filter(document, user)
         return result
@@ -385,7 +385,7 @@ class Resource(BaseResource):
                     if not doc:
                         raise RestException('Resource %s %s not found.' %
                                             (kind, id))
-                    ctx.update(message=u'Moving {} {}'.format(
+                    ctx.update(message='Moving %s %s' % (
                         kind, doc.get('name', '')))
                     if kind == 'item':
                         if parent['_id'] != doc['folderId']:
@@ -438,9 +438,9 @@ class Resource(BaseResource):
                 for id in resources[kind]:
                     doc = model.load(id=id, user=user, level=AccessType.READ)
                     if not doc:
-                        raise RestException('Resource not found.  No {} with '
-                                            'id {}'.format(kind, id))
-                    ctx.update(message=u'Copying {} {}'.format(
+                        raise RestException('Resource not found. No %s with '
+                                            'id %s' % (kind, id))
+                    ctx.update(message='Copying %s %s' % (
                         kind, doc.get('name', '')))
                     if kind == 'item':
                         model.copyItem(doc, folder=parent, creator=user)
@@ -451,8 +451,8 @@ class Resource(BaseResource):
                             creator=user, progress=ctx)
     copyResources.description = (
         Description('Copy a set of items and folders.')
-        .param('resources', 'A JSON-encoded list of types to copy.  Each type '
-               'is a list of ids.  Only folders and items may be specified.  '
+        .param('resources', 'A JSON-encoded list of types to copy. Each type '
+               'is a list of ids. Only folders and items may be specified.  '
                'For example: {"item": [(item id 1), (item id2)], "folder": '
                '[(folder id 1)]}.')
         .param('parentType', 'Parent type for the new parent of these '

--- a/girder/models/group.py
+++ b/girder/models/group.py
@@ -376,7 +376,7 @@ class Group(AccessControlledModel):
             yield {
                 'id': userId,
                 'login': user['login'],
-                'name': '{} {}'.format(user['firstName'], user['lastName'])
+                'name': '%s %s' % (user['firstName'], user['lastName'])
             }
 
     def hasAccess(self, doc, user=None, level=AccessType.READ):

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -345,7 +345,7 @@ class Model(ModelImporter):
             document = self.validate(document)
 
         if triggerEvents:
-            event = events.trigger('model.{}.save'.format(self.name), document)
+            event = events.trigger('model.%s.save' % self.name, document)
             if event.defaultPrevented:
                 return document
 
@@ -458,13 +458,13 @@ class Model(ModelImporter):
             try:
                 id = ObjectId(id)
             except InvalidId:
-                raise ValidationException('Invalid ObjectId: {}'.format(id),
+                raise ValidationException('Invalid ObjectId: %s' % id,
                                           field='id')
         doc = self.findOne({'_id': id}, fields=fields)
 
         if doc is None and exc is True:
-            raise ValidationException('No such {}: {}'.format(
-                                      self.name, id), field='id')
+            raise ValidationException('No such %s: %s' % (self.name, id),
+                                      field='id')
 
         return doc
 

--- a/girder/models/setting.py
+++ b/girder/models/setting.py
@@ -153,7 +153,7 @@ class Setting(Model):
             host = '://'.join((cherrypy.request.scheme,
                                cherrypy.request.local.name))
             if cherrypy.request.local.port != 80:
-                host += ':%s' % cherrypy.request.local.port
+                host += ':%d' % cherrypy.request.local.port
             return host
 
     def validateCoreRegistrationPolicy(self, doc):

--- a/girder/utility/filesystem_assetstore_adapter.py
+++ b/girder/utility/filesystem_assetstore_adapter.py
@@ -63,11 +63,11 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
             try:
                 os.makedirs(doc['root'])
             except OSError:
-                raise ValidationException('Could not make directory "{}".'
-                                          .format(doc['root'], 'root'))
+                raise ValidationException(
+                    'Could not make directory "%s".' % doc['root'])
         if not os.access(doc['root'], os.W_OK):
-            raise ValidationException('Unable to write into directory "{}".'
-                                      .format(doc['root'], 'root'))
+            raise ValidationException(
+                'Unable to write into directory "%s".' % doc['root'])
 
     @staticmethod
     def fileIndexFields():
@@ -91,7 +91,7 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
             except OSError:
                 self.unavailable = True
                 logger.exception('Failed to create filesystem assetstore '
-                                 'directories {}'.format(self.tempDir))
+                                 'directories %s' % self.tempDir)
         elif not os.access(assetstore['root'], os.W_OK):
             self.unavailable = True
             logger.error('Could not write to assetstore root: %s',

--- a/girder/utility/mail_utils.py
+++ b/girder/utility/mail_utils.py
@@ -41,7 +41,7 @@ def getEmailUrlPrefix():
         host = '://'.join((cherrypy.request.scheme,
                            cherrypy.request.local.name))
         if cherrypy.request.local.port != 80:
-            host += ':%s' % cherrypy.request.local.port
+            host += ':%d' % cherrypy.request.local.port
 
     return host
 

--- a/girder/utility/mail_utils.py
+++ b/girder/utility/mail_utils.py
@@ -41,7 +41,7 @@ def getEmailUrlPrefix():
         host = '://'.join((cherrypy.request.scheme,
                            cherrypy.request.local.name))
         if cherrypy.request.local.port != 80:
-            host += ':{}'.format(cherrypy.request.local.port)
+            host += ':%s' % cherrypy.request.local.port
 
     return host
 

--- a/girder/utility/model_importer.py
+++ b/girder/utility/model_importer.py
@@ -35,14 +35,14 @@ def _loadModel(model, module, plugin):
     try:
         imported = importlib.import_module(module)
     except ImportError:
-        logger.exception('Could not load model "{}".'.format(module))
+        logger.exception('Could not load model "%s".' % module)
         raise
 
     try:
         constructor = getattr(imported, className)
     except AttributeError:  # pragma: no cover
-        raise Exception('Incorrect model class name "{}" for model "{}".'
-                        .format(className, module))
+        raise Exception('Incorrect model class name "%s" for model "%s".' % (
+            className, module))
 
     _modelInstances[plugin][model] = constructor()
 
@@ -86,9 +86,9 @@ class ModelImporter(object):
 
         if model not in _modelInstances[plugin]:
             if plugin == '_core':
-                module = 'girder.models.{}'.format(model)
+                module = 'girder.models.%s' % model
             else:
-                module = 'girder.plugins.{}.models.{}'.format(plugin, model)
+                module = 'girder.plugins.%s.models.%s' % (plugin, model)
 
             _loadModel(model, module, plugin)
 

--- a/girder/utility/plugin_utilities.py
+++ b/girder/utility/plugin_utilities.py
@@ -91,8 +91,7 @@ def loadPlugins(plugins, root, appconf, apiRoot=None, curConfig=None,
         try:
             root, appconf, apiRoot = loadPlugin(
                 plugin, root, appconf, apiRoot, curConfig=curConfig)
-            print(TerminalColor.success('Loaded plugin "{}"'
-                                        .format(plugin)))
+            print(TerminalColor.success('Loaded plugin "%s"' % plugin))
         except Exception:
             print(TerminalColor.error(
                 'ERROR: Failed to load plugin "%s":' % plugin))
@@ -177,7 +176,7 @@ def loadPlugin(name, root, appconf, apiRoot=None, curConfig=None):
     isPluginDir = os.path.isdir(os.path.join(pluginDir, 'server'))
     isPluginFile = os.path.isfile(os.path.join(pluginDir, 'server.py'))
     if not os.path.exists(pluginDir):
-        raise Exception('Plugin directory does not exist: {}'.format(pluginDir))
+        raise Exception('Plugin directory does not exist: %s' % pluginDir)
     if not isPluginDir and not isPluginFile:
         # This plugin does not have any server-side python code.
         return root, appconf, apiRoot

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -144,8 +144,8 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
                 conn.get_bucket(bucket_name=doc['bucket'], validate=True)
             except Exception:
                 logger.exception('S3 assetstore validation exception')
-                raise ValidationException('Unable to connect to bucket "{}".'
-                                          .format(doc['bucket']), 'bucket')
+                raise ValidationException('Unable to connect to bucket "%s".' %
+                                          doc['bucket'], 'bucket')
         else:
             try:
                 bucket = conn.get_bucket(bucket_name=doc['bucket'],
@@ -156,8 +156,8 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
                 testKey.set_contents_from_string('')
             except Exception:
                 logger.exception('S3 assetstore validation exception')
-                raise ValidationException('Unable to write into bucket "{}".'
-                                          .format(doc['bucket']), 'bucket')
+                raise ValidationException('Unable to write into bucket "%s".' %
+                                          doc['bucket'], 'bucket')
 
         return doc
 
@@ -174,8 +174,7 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
 
     def _getRequestHeaders(self, upload):
         return {
-            'Content-Disposition': 'attachment; filename="{}"'
-                                   .format(upload['name']),
+            'Content-Disposition': 'attachment; filename="%s"' % upload['name'],
             'Content-Type': upload.get('mimeType', ''),
             'x-amz-acl': 'private',
             'x-amz-meta-uploader-id': str(upload['userId']),
@@ -192,7 +191,7 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
         uid = uuid.uuid4().hex
         key = '/'.join(filter(None, (self.assetstore.get('prefix', ''),
                        uid[0:2], uid[2:4], uid)))
-        path = '/{}/{}'.format(self.assetstore['bucket'], key)
+        path = '/%s/%s' % (self.assetstore['bucket'], key)
         headers = self._getRequestHeaders(upload)
 
         chunked = upload['size'] > self.CHUNK_LEN

--- a/plugins/celery_jobs/server/__init__.py
+++ b/plugins/celery_jobs/server/__init__.py
@@ -57,7 +57,7 @@ def getCeleryUser():
     user = ModelImporter.model('user').load(userId, force=True)
 
     if not user:
-        raise Exception('Celery user does not exist ({}).'.format(userId))
+        raise Exception('Celery user does not exist (%s).' % userId)
 
     return user
 

--- a/plugins/geospatial/plugin_tests/geospatial_test.py
+++ b/plugins/geospatial/plugin_tests/geospatial_test.py
@@ -119,7 +119,7 @@ class GeospatialItemTestCase(base.TestCase):
         newName = 'RTP'
         newItem = self.model('item').createItem(newName, self._creator,
                                                 self._privateFolder)
-        path = '/item/{}/geospatial'.format(newItem['_id'])
+        path = '/item/%s/geospatial' % newItem['_id']
         newGeometry = {
             'type': 'Point',
             'coordinates': [-78.863640, 35.899168]  # [longitude, latitude]

--- a/plugins/geospatial/server/geospatial.py
+++ b/plugins/geospatial/server/geospatial.py
@@ -91,9 +91,9 @@ class GeospatialItem(Resource):
                     raise RestException('Property names must be at least one'
                                         ' character long.')
                 if '.' in key or key[0] == '$':
-                    raise RestException('The property name {} must not contain'
-                                        ' a period or begin with a dollar sign.'
-                                        .format(key))
+                    raise RestException('The property name %s must not contain'
+                                        ' a period or begin with a dollar'
+                                        ' sign.' % key)
 
             data.append({'name': name,
                          'description': description,
@@ -190,10 +190,10 @@ class GeospatialItem(Resource):
             raise RestException("Invalid GeoJSON passed as 'geometry'"
                                 " parameter.")
 
-        if params['field'][:3] == '{}.'.format(GEOSPATIAL_FIELD):
+        if params['field'][:3] == '%s.' % GEOSPATIAL_FIELD:
             field = params['field'].strip()
         else:
-            field = '{}.{}'.format(GEOSPATIAL_FIELD, params['field'].strip())
+            field = '%s.%s' % (GEOSPATIAL_FIELD, params['field'].strip())
 
         query = {
             field: {
@@ -263,15 +263,15 @@ class GeospatialItem(Resource):
                         raise ValueError
 
                 except ValueError:
-                    raise RestException("Parameter '{}' must be a number."
-                                        .format(param))
+                    raise RestException("Parameter '%s' must be a number." %
+                                        param)
 
                 condition['$'+param] = distance
 
-        if params['field'][:3] == '{}.'.format(GEOSPATIAL_FIELD):
+        if params['field'][:3] == '%s.' % GEOSPATIAL_FIELD:
             field = params['field'].strip()
         else:
-            field = '{}.{}'.format(GEOSPATIAL_FIELD, params['field'].strip())
+            field = '%s.%s' % (GEOSPATIAL_FIELD, params['field'].strip())
 
         if params.get('ensureIndex', False):
             user = self.getCurrentUser()
@@ -292,8 +292,8 @@ class GeospatialItem(Resource):
         try:
             items = self._find(query, limit, offset, sort)
         except OperationFailure:
-            raise RestException("Field '{}' must be indexed by a 2dsphere"
-                                " index.".format(field))
+            raise RestException("Field '%s' must be indexed by a 2dsphere"
+                                " index." % field)
 
         return items
 
@@ -386,10 +386,10 @@ class GeospatialItem(Resource):
             raise RestException("Either parameter 'geometry' or both parameters"
                                 " 'center' and 'radius' are required.")
 
-        if params['field'][:3] == '{}.'.format(GEOSPATIAL_FIELD):
+        if params['field'][:3] == '%s.' % GEOSPATIAL_FIELD:
             field = params['field'].strip()
         else:
-            field = '{}.{}'.format(GEOSPATIAL_FIELD, params['field'].strip())
+            field = '%s.%s' % (GEOSPATIAL_FIELD, params['field'].strip())
 
         limit, offset, sort = self.getPagingParameters(params, 'lowerName')
 
@@ -463,16 +463,14 @@ class GeospatialItem(Resource):
 
         for k, v in six.viewitems(geospatial):
             if '.' in k or k[0] == '$':
-                raise RestException('Geospatial key name {} must not contain a'
-                                    ' period or begin with a dollar sign.'
-                                    .format(k))
+                raise RestException('Geospatial key name %s must not contain a'
+                                    ' period or begin with a dollar sign.' % k)
             if v:
                 try:
                     GeoJSON.to_instance(v, strict=True)
                 except ValueError:
-                    raise RestException('Geospatial field with key {} does not'
-                                        ' contain valid GeoJSON: {}'
-                                        .format(k, v))
+                    raise RestException('Geospatial field with key %s does not'
+                                        ' contain valid GeoJSON: %s' % (k, v))
 
         if GEOSPATIAL_FIELD not in item:
             item[GEOSPATIAL_FIELD] = dict()

--- a/plugins/gravatar/plugin_tests/gravatar_test.py
+++ b/plugins/gravatar/plugin_tests/gravatar_test.py
@@ -58,7 +58,7 @@ class GravatarTest(base.TestCase):
         self.model('setting').set(PluginSettings.DEFAULT_IMAGE, 'mm')
 
         # Gravatar base URL should be computed on user creation
-        resp = self.request('/user/{}'.format(self.admin['_id']))
+        resp = self.request('/user/%s' % self.admin['_id'])
         self.assertStatusOk(resp)
         self.assertTrue('gravatar_baseUrl' in resp.json)
 
@@ -69,13 +69,13 @@ class GravatarTest(base.TestCase):
             'https://www.gravatar.com/avatar/%s?d=identicon&s=64' % md5)
 
         # We should now have the gravatar_baseUrl cached on the user
-        resp = self.request('/user/{}'.format(self.admin['_id']))
+        resp = self.request('/user/%s' % self.admin['_id'])
         self.assertStatusOk(resp)
         self.assertTrue('gravatar_baseUrl' in resp.json)
         oldBaseUrl = resp.json['gravatar_baseUrl']
 
         # Changing the email address should change the cached value
-        resp = self.request('/user/{}'.format(self.admin['_id']), method='PUT',
+        resp = self.request('/user/%s' % self.admin['_id'], method='PUT',
                             user=self.admin, params={
                                 'firstName': 'first',
                                 'lastName': 'last',

--- a/plugins/hdfs_assetstore/plugin_tests/assetstore_test.py
+++ b/plugins/hdfs_assetstore/plugin_tests/assetstore_test.py
@@ -250,7 +250,7 @@ class HdfsAssetstoreTest(base.TestCase):
             'total': 1000
         })
 
-        path = '/hdfs_assetstore/{}/import'.format(assetstore['_id'])
+        path = '/hdfs_assetstore/%s/import' % assetstore['_id']
         params = {
             'progress': 'true',
             'parentType': 'user',
@@ -300,13 +300,13 @@ class HdfsAssetstoreTest(base.TestCase):
             item=helloItem, user=self.admin).next()
 
         # Download the file
-        resp = self.request(path='/file/{}/download'.format(file['_id']),
+        resp = self.request(path='/file/%s/download' % file['_id'],
                             user=self.admin, isJson=False)
         self.assertStatusOk(resp)
         self.assertEqual(resp.collapse_body().strip(), 'hello')
 
         # Test download with range header
-        resp = self.request(path='/file/{}/download'.format(file['_id']),
+        resp = self.request(path='/file/%s/download' % file['_id'],
                             user=self.admin, isJson=False,
                             additionalHeaders=[('Range', 'bytes=1-3')])
         self.assertStatus(resp, 206)
@@ -316,7 +316,7 @@ class HdfsAssetstoreTest(base.TestCase):
         self.assertEqual(resp.headers['Content-Range'], 'bytes 1-3/6')
 
         # Test download with range header with skipped chunk
-        resp = self.request(path='/file/{}/download'.format(file['_id']),
+        resp = self.request(path='/file/%s/download' % file['_id'],
                             user=self.admin, isJson=False,
                             additionalHeaders=[('Range', 'bytes=4-')])
         self.assertStatus(resp, 206)
@@ -402,7 +402,7 @@ class HdfsAssetstoreTest(base.TestCase):
             file = resp.json
 
         # Download the file
-        resp = self.request('/file/{}/download'.format(file['_id']),
+        resp = self.request('/file/%s/download' % file['_id'],
                             isJson=False, user=self.admin)
         self.assertStatusOk(resp)
         self.assertEqual(resp.collapse_body(), chunk1 + chunk2)

--- a/plugins/jobs/plugin_tests/jobs_test.py
+++ b/plugins/jobs/plugin_tests/jobs_test.py
@@ -43,7 +43,7 @@ class JobsTestCase(base.TestCase):
         base.TestCase.setUp(self)
 
         self.users = [self.model('user').createUser(
-            'usr' + str(n), 'passwd', 'tst', 'usr', 'u%s@u.com' % n)
+            'usr' + str(n), 'passwd', 'tst', 'usr', 'u%d@u.com' % n)
             for n in range(3)]
 
     def testJobs(self):

--- a/plugins/jobs/plugin_tests/jobs_test.py
+++ b/plugins/jobs/plugin_tests/jobs_test.py
@@ -43,7 +43,7 @@ class JobsTestCase(base.TestCase):
         base.TestCase.setUp(self)
 
         self.users = [self.model('user').createUser(
-            'usr' + str(n), 'passwd', 'tst', 'usr', 'u{}@u.com'.format(n))
+            'usr' + str(n), 'passwd', 'tst', 'usr', 'u%s@u.com' % n)
             for n in range(3)]
 
     def testJobs(self):
@@ -72,7 +72,7 @@ class JobsTestCase(base.TestCase):
         self.assertEqual(self.job['status'], JobStatus.RUNNING)
 
         # Since the job is not public, user 2 should not have access
-        path = '/job/{}'.format(job['_id'])
+        path = '/job/%s' % job['_id']
         resp = self.request(path, user=self.users[2])
         self.assertStatus(resp, 403)
         resp = self.request(path, user=self.users[2], method='PUT')
@@ -169,14 +169,14 @@ class JobsTestCase(base.TestCase):
         job['_some_other_field'] = 'foo'
         job = self.model('job', 'jobs').save(job)
 
-        resp = self.request('/job/{}'.format(job['_id']))
+        resp = self.request('/job/%s' % job['_id'])
         self.assertStatusOk(resp)
         self.assertTrue('created' in resp.json)
         self.assertTrue('_some_other_field' not in resp.json)
         self.assertTrue('kwargs' not in resp.json)
         self.assertTrue('args' not in resp.json)
 
-        resp = self.request('/job/{}'.format(job['_id']), user=self.users[0])
+        resp = self.request('/job/%s' % job['_id'], user=self.users[0])
         self.assertTrue('kwargs' in resp.json)
         self.assertTrue('args' in resp.json)
 
@@ -189,7 +189,7 @@ class JobsTestCase(base.TestCase):
 
         events.bind('jobs.filter', 'test', filterJob)
 
-        resp = self.request('/job/{}'.format(job['_id']))
+        resp = self.request('/job/%s' % job['_id'])
         self.assertStatusOk(resp)
         self.assertEqual(resp.json['_some_other_field'], 'bar')
         self.assertTrue('created' not in resp.json)

--- a/plugins/mongo_search/server/__init__.py
+++ b/plugins/mongo_search/server/__init__.py
@@ -43,7 +43,7 @@ class ResourceExt(Resource):
         events.trigger('mongo_search.allowed_collections', info=allowed)
 
         if coll not in allowed:
-            raise RestException('Invalid resource type: {}'.format(coll))
+            raise RestException('Invalid resource type: %s' % coll)
 
         try:
             query = bson.json_util.loads(params['q'])

--- a/plugins/oauth/plugin_tests/oauth_test.py
+++ b/plugins/oauth/plugin_tests/oauth_test.py
@@ -204,7 +204,7 @@ class OauthTest(base.TestCase):
                     'id': 9876
                 })
             else:
-                raise Exception('Unexpected url {}'.format(url))
+                raise Exception('Unexpected url %s' % url)
 
         with httmock.HTTMock(googleMock):
             # Try a request where the CSRF token is incorrect

--- a/plugins/provenance/plugin_tests/provenance_test.py
+++ b/plugins/provenance/plugin_tests/provenance_test.py
@@ -118,14 +118,14 @@ class ProvenanceTestCase(base.TestCase):
         if version is not None:
             params = {'version': version}
         resp = self.request(
-            path='/{}/{}/provenance'.format(resource, item['_id']),
+            path='/%s/%s/provenance' % (resource, item['_id']),
             method='GET', user=user, type='application/json', params=params)
         if checkOk:
             self.assertStatusOk(resp)
         return resp
 
     def _getProvenanceAfterMetadata(self, item, meta, user):
-        resp = self.request(path='/item/{}/metadata'.format(item['_id']),
+        resp = self.request(path='/item/%s/metadata' % item['_id'],
                             method='PUT', user=user, body=json.dumps(meta),
                             type='application/json')
         self.assertStatusOk(resp)
@@ -199,7 +199,7 @@ class ProvenanceTestCase(base.TestCase):
 
         # Change the item name and description
         params = {'name': 'Renamed object', 'description': 'New description'}
-        resp = self.request(path='/item/{}'.format(item['_id']), method='PUT',
+        resp = self.request(path='/item/%s' % item['_id'], method='PUT',
                             user=admin, params=params)
         self.assertStatusOk(resp)
         params['lowerName'] = params['name'].lower()
@@ -207,7 +207,7 @@ class ProvenanceTestCase(base.TestCase):
 
         # Copy the item and check that we marked it as copied
         params = {'name': 'Copied object'}
-        resp = self.request(path='/item/{}/copy'.format(item['_id']),
+        resp = self.request(path='/item/%s/copy' % item['_id'],
                             method='POST', user=admin, params=params)
         self.assertStatusOk(resp)
         newItem = resp.json
@@ -248,7 +248,7 @@ class ProvenanceTestCase(base.TestCase):
                                                 'size': len(fileData1),
                                                 'name': fileName1}})
         # Edit the file name
-        resp = self.request(path='/file/{}'.format(file1['_id']), method='PUT',
+        resp = self.request(path='/file/%s' % file1['_id'], method='PUT',
                             user=admin, params={'name': fileName2})
         self.assertStatusOk(resp)
         self._checkProvenance(None, item, 3, admin, 'fileUpdate',
@@ -256,7 +256,7 @@ class ProvenanceTestCase(base.TestCase):
                                         'old': {'name': fileName1},
                                         'new': {'name': fileName2}})
         # Reupload the file
-        resp = self.request(path='/file/{}/contents'.format(file1['_id']),
+        resp = self.request(path='/file/%s/contents' % file1['_id'],
                             method='PUT', user=admin,
                             params={'size': len(fileData2)})
         self.assertStatusOk(resp)
@@ -272,7 +272,7 @@ class ProvenanceTestCase(base.TestCase):
                                         'old': {'size': len(fileData1)},
                                         'new': {'size': len(fileData2)}})
         # Delete the file
-        resp = self.request(path='/file/{}'.format(file1['_id']),
+        resp = self.request(path='/file/%s' % file1['_id'],
                             method='DELETE', user=admin)
         self.assertStatusOk(resp)
         self._checkProvenance(None, item, 5, admin, 'fileRemoved',
@@ -292,7 +292,7 @@ class ProvenanceTestCase(base.TestCase):
                               resource='folder')
         # Edit the folder and check again
         params1 = {'name': 'Renamed folder', 'description': 'New description'}
-        resp = self.request(path='/folder/{}'.format(folder1['_id']),
+        resp = self.request(path='/folder/%s' % folder1['_id'],
                             method='PUT', user=user, params=params1)
         self.assertStatusOk(resp)
         params1['lowerName'] = params1['name'].lower()
@@ -308,7 +308,7 @@ class ProvenanceTestCase(base.TestCase):
         # While folder provenance is off, create a second folder and edit the
         # first folder
         params2 = {'name': 'Renamed Again', 'description': 'Description 2'}
-        resp = self.request(path='/folder/{}'.format(folder1['_id']),
+        resp = self.request(path='/folder/%s' % folder1['_id'],
                             method='PUT', user=user, params=params2)
         self.assertStatusOk(resp)
         params2['lowerName'] = params2['name'].lower()
@@ -329,7 +329,7 @@ class ProvenanceTestCase(base.TestCase):
         # Changing folder1 again should now show this change, and the old value
         # should show the gap in the data
         params3 = {'name': 'Renamed C', 'description': 'Description 3'}
-        resp = self.request(path='/folder/{}'.format(folder1['_id']),
+        resp = self.request(path='/folder/%s' % folder1['_id'],
                             method='PUT', user=user, params=params3)
         self.assertStatusOk(resp)
         params3['lowerName'] = params3['name'].lower()
@@ -343,7 +343,7 @@ class ProvenanceTestCase(base.TestCase):
         # Edit the new folder; it should show the unknown history followed by
         # the edit
         params4 = {'description': 'Folder 2 Description'}
-        resp = self.request(path='/folder/{}'.format(folder2['_id']),
+        resp = self.request(path='/folder/%s' % folder2['_id'],
                             method='PUT', user=user, params=params4)
         self.assertStatusOk(resp)
         resp = self._getProvenance(folder2, user, 1, resource='folder')
@@ -378,7 +378,7 @@ class ProvenanceTestCase(base.TestCase):
             'notification': False,
             'unknown': True}
         for key in checkList:
-            eventName = 'model.{}.save'.format(key)
+            eventName = 'model.%s.save' % key
             self.assertTrue((eventName in events._mapping and 'provenance' in
                             [h['name'] for h in events._mapping[eventName]])
                             is checkList[key])
@@ -387,7 +387,7 @@ class ProvenanceTestCase(base.TestCase):
         self.model('setting').set(
             constants.PluginSettings.PROVENANCE_RESOURCES, '')
         for key in checkList:
-            eventName = 'model.{}.save'.format(key)
+            eventName = 'model.%s.save' % key
             self.assertTrue((eventName in events._mapping and 'provenance' in
                             [h['name'] for h in events._mapping[eventName]])
                             is (key == 'item'))

--- a/plugins/provenance/server/resource.py
+++ b/plugins/provenance/server/resource.py
@@ -80,9 +80,9 @@ class ResourceExt(Resource):
         self.unbindModels(resources)
         for resource in resources:
             if resource not in self.boundResources:
-                events.bind('model.{}.save'.format(resource), 'provenance',
+                events.bind('model.%s.save' % resource, 'provenance',
                             self.resourceSaveHandler)
-                events.bind('model.{}.copy.prepare'.format(resource),
+                events.bind('model.%s.copy.prepare' % resource,
                             'provenance', self.resourceCopyHandler)
                 if hasattr(self.loadInfo['apiRoot'], resource):
                     getattr(self.loadInfo['apiRoot'], resource).route(
@@ -97,8 +97,8 @@ class ResourceExt(Resource):
         for oldresource in list(six.viewkeys(self.boundResources)):
             if oldresource not in resources:
                 # Unbind this and remove it from the api
-                events.unbind('model.{}.save'.format(oldresource), 'provenance')
-                events.unbind('model.{}.copy.prepare'.format(oldresource),
+                events.unbind('model.%s.save' % oldresource, 'provenance')
+                events.unbind('model.%s.copy.prepare' % oldresource,
                               'provenance')
                 if hasattr(self.loadInfo['apiRoot'], oldresource):
                     getattr(self.loadInfo['apiRoot'], oldresource).removeRoute(

--- a/tests/base.py
+++ b/tests/base.py
@@ -394,9 +394,10 @@ class TestCase(unittest.TestCase, model_importer.ModelImporter):
 
         self._buildHeaders(headers, cookie, user, token, basicAuth, authHeader)
 
+        # Python2 will not match Unicode URLs
+        url = str(prefix + path)
         try:
-            response = request.run(method, prefix + path, qs, 'HTTP/1.1',
-                                   headers, fd)
+            response = request.run(method, url, qs, 'HTTP/1.1', headers, fd)
         finally:
             if fd:
                 fd.close()
@@ -465,9 +466,10 @@ class TestCase(unittest.TestCase, model_importer.ModelImporter):
             headers.append(('Girder-Token', self._genToken(user)))
 
         fd = io.BytesIO(body)
+        # Python2 will not match Unicode URLs
+        url = str(prefix + path)
         try:
-            response = request.run(method, prefix + path, None, 'HTTP/1.1',
-                                   headers, fd)
+            response = request.run(method, url, None, 'HTTP/1.1', headers, fd)
         finally:
             fd.close()
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -97,8 +97,7 @@ def dropTestDatabase(dropModels=True):
     dbName = cherrypy.config['database']['uri'].split('/')[-1]
 
     if 'girder_test_' not in dbName:
-        raise Exception('Expected a testing database name, but got {}'
-                        .format(dbName))
+        raise Exception('Expected a testing database name, but got %s' % dbName)
     db_connection.drop_database(dbName)
 
     if dropModels:
@@ -331,7 +330,7 @@ class TestCase(unittest.TestCase, model_importer.ModelImporter):
 
         if basicAuth is not None:
             auth = base64.b64encode(basicAuth.encode('utf8'))
-            headers.append((authHeader, 'Basic {}'.format(auth.decode())))
+            headers.append((authHeader, 'Basic %s' % auth.decode()))
 
     def request(self, path='/', method='GET', params=None, user=None,
                 prefix='/api/v1', isJson=True, basicAuth=None, body=None,
@@ -497,7 +496,7 @@ class MultipartFormdataEncoder(object):
     def __init__(self):
         self.boundary = uuid.uuid4().hex
         self.contentType = \
-            'multipart/form-data; boundary={}'.format(self.boundary)
+            'multipart/form-data; boundary=%s' % self.boundary
 
     @classmethod
     def u(cls, s):
@@ -511,9 +510,9 @@ class MultipartFormdataEncoder(object):
         encoder = codecs.getencoder('utf-8')
         for (key, value) in fields:
             key = self.u(key)
-            yield encoder('--{}\r\n'.format(self.boundary))
+            yield encoder('--%s\r\n' % self.boundary)
             yield encoder(self.u('Content-Disposition: form-data; '
-                                 'name="{}"\r\n').format(key))
+                                 'name="%s"\r\n') % key)
             yield encoder('\r\n')
             if isinstance(value, int) or isinstance(value, float):
                 value = str(value)
@@ -522,15 +521,15 @@ class MultipartFormdataEncoder(object):
         for (key, filename, content) in files:
             key = self.u(key)
             filename = self.u(filename)
-            yield encoder('--{}\r\n'.format(self.boundary))
-            yield encoder(self.u('Content-Disposition: form-data; name="{}";'
-                          ' filename="{}"\r\n').format(key, filename))
+            yield encoder('--%s\r\n' % self.boundary)
+            yield encoder(self.u('Content-Disposition: form-data; name="%s";'
+                          ' filename="%s"\r\n' % (key, filename)))
             yield encoder('Content-Type: application/octet-stream\r\n')
             yield encoder('\r\n')
 
             yield (content, len(content))
             yield encoder('\r\n')
-        yield encoder('--{}--\r\n'.format(self.boundary))
+        yield encoder('--%s--\r\n' % self.boundary)
 
     def encode(self, fields, files):
         body = io.BytesIO()

--- a/tests/cases/access_test.py
+++ b/tests/cases/access_test.py
@@ -188,8 +188,8 @@ class AccessTestCase(base.TestCase):
                     self.assertStatusOk(resp)
 
     def testLoadModelPlainFn(self):
-        resp = self.request(path='/accesstest/test_loadmodel_plain/{}'.format(
-                            self.user['_id']), method='GET')
+        resp = self.request(path='/accesstest/test_loadmodel_plain/%s' %
+                                 self.user['_id'], method='GET')
         self.assertStatusOk(resp)
         self.assertEqual(resp.json['_id'], str(self.user['_id']))
 

--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -551,7 +551,7 @@ class AssetstoreTestCase(base.TestCase):
         params = {'contentDisposition': 'inline'}
         inlineRegex = r'response-content-disposition=' + \
                       'inline%3B\+filename%3D%22My\+File.txt%22'
-        resp = self.request(path='/file/{}/download'.format(largeFile['_id']),
+        resp = self.request(path='/file/%s/download' % largeFile['_id'],
                             user=self.admin, method='GET', isJson=False,
                             params=params)
         self.assertStatus(resp, 303)

--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -116,7 +116,7 @@ class AssetstoreTestCase(base.TestCase):
             'root': assetstore['root'],
             'current': True
         }
-        resp = self.request(path='/assetstore/{}'.format(assetstore['_id']),
+        resp = self.request(path='/assetstore/%s' % assetstore['_id'],
                             method='PUT', user=self.admin, params=params)
         self.assertStatusOk(resp)
         assetstore = self.model('assetstore').load(resp.json['_id'])
@@ -260,7 +260,7 @@ class AssetstoreTestCase(base.TestCase):
         self.assertEqual(current['_id'], assetstore['_id'])
 
         # Anonymous user should not be able to delete assetstores
-        resp = self.request(path='/assetstore/{}'.format(assetstore['_id']),
+        resp = self.request(path='/assetstore/%s' % assetstore['_id'],
                             method='DELETE')
         self.assertStatus(resp, 401)
 
@@ -274,18 +274,18 @@ class AssetstoreTestCase(base.TestCase):
             size=1, assetstore=assetstore, mimeType='text/plain')
         file['sha512'] = 'x'  # add this dummy value to simulate real file
 
-        resp = self.request(path='/assetstore/{}'.format(assetstore['_id']),
+        resp = self.request(path='/assetstore/%s' % assetstore['_id'],
                             method='DELETE', user=self.admin)
         self.assertStatus(resp, 400)
         self.assertEqual(resp.json['message'], 'You may not delete an '
                          'assetstore that contains files.')
         # Delete the offending file, we can now delete the assetstore
         self.model('file').remove(file)
-        resp = self.request(path='/assetstore/{}'.format(assetstore['_id']),
+        resp = self.request(path='/assetstore/%s' % assetstore['_id'],
                             method='DELETE', user=self.admin)
         self.assertStatusOk(resp)
         self.assertEqual(resp.json['message'],
-                         'Deleted assetstore {}.'.format(assetstore['name']))
+                         'Deleted assetstore %s.' % assetstore['name'])
 
         resp = self.request(path='/assetstore', method='GET', user=self.admin)
         self.assertStatusOk(resp)
@@ -328,7 +328,7 @@ class AssetstoreTestCase(base.TestCase):
             'db': assetstore['db'],
             'current': True
         }
-        resp = self.request(path='/assetstore/{}'.format(assetstore['_id']),
+        resp = self.request(path='/assetstore/%s' % assetstore['_id'],
                             method='PUT', user=self.admin, params=params)
         self.assertStatusOk(resp)
         assetstore = self.model('assetstore').load(resp.json['_id'])
@@ -425,7 +425,7 @@ class AssetstoreTestCase(base.TestCase):
         # Set the assetstore to current.  This is really to test the edit
         # assetstore code.
         params['current'] = True
-        resp = self.request(path='/assetstore/{}'.format(assetstore['_id']),
+        resp = self.request(path='/assetstore/%s' % assetstore['_id'],
                             method='PUT', user=self.admin, params=params)
         self.assertStatusOk(resp)
 
@@ -532,7 +532,7 @@ class AssetstoreTestCase(base.TestCase):
         self.assertFalse('s3' in resp.json)
 
         # Test download for an empty file
-        resp = self.request(path='/file/{}/download'.format(emptyFile['_id']),
+        resp = self.request(path='/file/%s/download' % emptyFile['_id'],
                             user=self.admin, method='GET', isJson=False)
         self.assertStatusOk(resp)
         self.assertEqual(self.getBody(resp), '')
@@ -541,7 +541,7 @@ class AssetstoreTestCase(base.TestCase):
                          'attachment; filename="My File.txt"')
 
         # Test download of a non-empty file
-        resp = self.request(path='/file/{}/download'.format(largeFile['_id']),
+        resp = self.request(path='/file/%s/download' % largeFile['_id'],
                             user=self.admin, method='GET', isJson=False)
         self.assertStatus(resp, 303)
         six.assertRegex(self, resp.headers['Location'], s3Regex)
@@ -565,11 +565,11 @@ class AssetstoreTestCase(base.TestCase):
                     url.scheme == 'https'):
                 return 'dummy file contents'
             else:
-                raise Exception('Unexpected url {}'.format(url))
+                raise Exception('Unexpected url %s' % url)
 
         with httmock.HTTMock(s3_pipe_mock):
             resp = self.request(
-                '/folder/{}/download'.format(parentFolder['_id']),
+                '/folder/%s/download' % parentFolder['_id'],
                 method='GET', user=self.admin, isJson=False)
             self.assertStatusOk(resp)
             zip = zipfile.ZipFile(io.BytesIO(self.getBody(resp, text=False)),
@@ -663,12 +663,12 @@ class AssetstoreTestCase(base.TestCase):
         key.set_contents_from_string("test")
 
         # Test delete for a non-empty file
-        resp = self.request(path='/file/{}'.format(largeFile['_id']),
+        resp = self.request(path='/file/%s' % largeFile['_id'],
                             user=self.admin, method='DELETE')
         self.assertStatusOk(resp)
 
         # The file should be gone now
-        resp = self.request(path='/file/{}/download'.format(largeFile['_id']),
+        resp = self.request(path='/file/%s/download' % largeFile['_id'],
                             user=self.admin, method='GET', isJson=False)
         self.assertStatus(resp, 400)
         # The actual delete may still be in the event queue, so we want to

--- a/tests/cases/collection_test.py
+++ b/tests/cases/collection_test.py
@@ -114,13 +114,13 @@ class CollectionTestCase(base.TestCase):
         self.assertEqual(resp.json[0]['name'], 'New collection')
 
         # Test collection get
-        resp = self.request(path='/collection/{}'.format(newCollId),
+        resp = self.request(path='/collection/%s' % newCollId,
                             user=self.admin)
         self.assertStatusOk(resp)
         self.assertEqual(resp.json['_accessLevel'], AccessType.ADMIN)
 
         # Test collection update
-        resp = self.request(path='/collection/{}'.format(newCollId),
+        resp = self.request(path='/collection/%s' % newCollId,
                             method='PUT', user=self.admin,
                             params={'id': newCollId,
                                     'name': 'New collection name'})

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -469,7 +469,7 @@ class FileTestCase(base.TestCase):
         file = self._testUploadFile('helloWorld1.txt')
 
         # Test editing of the file info
-        resp = self.request(path='/file/{}'.format(file['_id']), method='PUT',
+        resp = self.request(path='/file/%s' % file['_id'], method='PUT',
                             user=self.user, params={'name': ' newName.json'})
         self.assertStatusOk(resp)
         self.assertEqual(resp.json['name'], 'newName.json')
@@ -487,7 +487,7 @@ class FileTestCase(base.TestCase):
 
         # Make sure access control is enforced on download
         resp = self.request(
-            path='/file/{}/download'.format(file['_id']), method='GET')
+            path='/file/%s/download' % file['_id'], method='GET')
         self.assertStatus(resp, 401)
 
         # Make sure access control is enforced on get info
@@ -510,7 +510,7 @@ class FileTestCase(base.TestCase):
         self.assertFalse('sha512' in resp.json)
 
         resp = self.request(
-            path='/folder/{}/download'.format(self.privateFolder['_id']),
+            path='/folder/%s/download' % self.privateFolder['_id'],
             method='GET')
         self.assertStatus(resp, 401)
 
@@ -525,7 +525,7 @@ class FileTestCase(base.TestCase):
         # Test updating of the file contents
         newContents = 'test'
         resp = self.request(
-            path='/file/{}/contents'.format(file['_id']), method='PUT',
+            path='/file/%s/contents' % file['_id'], method='PUT',
             user=self.user, params={'size': len(newContents)})
         self.assertStatusOk(resp)
 
@@ -548,7 +548,7 @@ class FileTestCase(base.TestCase):
 
         # Test updating an empty file
         resp = self.request(
-            path='/file/{}/contents'.format(file['_id']), method='PUT',
+            path='/file/%s/contents' % file['_id'], method='PUT',
             user=self.user, params={'size': 1})
         self.assertStatusOk(resp)
 
@@ -795,14 +795,14 @@ class FileTestCase(base.TestCase):
 
         # Attempt to download the link file, make sure we are redirected
         resp = self.request(
-            path='/file/{}/download'.format(file['_id']), method='GET',
+            path='/file/%s/download' % file['_id'], method='GET',
             isJson=False, user=self.user)
         self.assertStatus(resp, 303)
         self.assertEqual(resp.headers['Location'], params['linkUrl'].strip())
 
         # Download containing folder as zip file
         resp = self.request(
-            path='/folder/{}/download'.format(self.privateFolder['_id']),
+            path='/folder/%s/download' % self.privateFolder['_id'],
             method='GET', user=self.user, isJson=False)
         self.assertEqual(resp.headers['Content-Type'], 'application/zip')
         body = self.getBody(resp, text=False)

--- a/tests/cases/folder_test.py
+++ b/tests/cases/folder_test.py
@@ -103,7 +103,7 @@ class FolderTestCase(base.TestCase):
 
         # Change properties of a folder
         resp = self.request(
-            path='/folder/{}'.format(publicFolder['_id']), method='PUT',
+            path='/folder/%s' % publicFolder['_id'], method='PUT',
             user=self.admin, params={
                 'name': 'New name ',
                 'description': ' A description '
@@ -114,7 +114,7 @@ class FolderTestCase(base.TestCase):
 
         # Move should fail with a bogus parent
         resp = self.request(
-            path='/folder/{}'.format(publicFolder['_id']), method='PUT',
+            path='/folder/%s' % publicFolder['_id'], method='PUT',
             user=self.admin, params={
                 'parentType': 'badParent',
                 'parentId': privateFolder['_id']
@@ -123,7 +123,7 @@ class FolderTestCase(base.TestCase):
 
         # Move the public folder underneath the private folder
         resp = self.request(
-            path='/folder/{}'.format(publicFolder['_id']), method='PUT',
+            path='/folder/%s' % publicFolder['_id'], method='PUT',
             user=self.admin, params={
                 'parentType': 'folder',
                 'parentId': privateFolder['_id']
@@ -140,7 +140,7 @@ class FolderTestCase(base.TestCase):
         publicFolder = self.model('folder').setUserAccess(
             publicFolder, self.user, AccessType.WRITE, save=True)
         resp = self.request(
-            path='/folder/{}'.format(publicFolder['_id']), method='PUT',
+            path='/folder/%s' % publicFolder['_id'], method='PUT',
             user=self.user, params={
                 'parentId': self.admin['_id'],
                 'parentType': 'user'
@@ -259,7 +259,7 @@ class FolderTestCase(base.TestCase):
         folder = resp.json
 
         # Test that bad json fails
-        resp = self.request(path='/folder/{}/metadata'.format(folder['_id']),
+        resp = self.request(path='/folder/%s/metadata' % folder['_id'],
                             method='PUT', user=self.admin,
                             body='badJSON', type='application/json')
         self.assertStatus(resp, 400)
@@ -269,7 +269,7 @@ class FolderTestCase(base.TestCase):
             'foo': 'bar',
             'test': 2
         }
-        resp = self.request(path='/folder/{}/metadata'.format(folder['_id']),
+        resp = self.request(path='/folder/%s/metadata' % folder['_id'],
                             method='PUT', user=self.admin,
                             body=json.dumps(metadata), type='application/json')
 
@@ -280,7 +280,7 @@ class FolderTestCase(base.TestCase):
         # Edit and remove metadata
         metadata['test'] = None
         metadata['foo'] = 'baz'
-        resp = self.request(path='/folder/{}/metadata'.format(folder['_id']),
+        resp = self.request(path='/folder/%s/metadata' % folder['_id'],
                             method='PUT', user=self.admin,
                             body=json.dumps(metadata), type='application/json')
 
@@ -293,7 +293,7 @@ class FolderTestCase(base.TestCase):
         metadata = {
             'foo.bar': 'notallowed'
         }
-        resp = self.request(path='/folder/{}/metadata'.format(folder['_id']),
+        resp = self.request(path='/folder/%s/metadata' % folder['_id'],
                             method='PUT', user=self.admin,
                             body=json.dumps(metadata), type='application/json')
         self.assertStatus(resp, 400)
@@ -306,7 +306,7 @@ class FolderTestCase(base.TestCase):
         metadata = {
             '$foobar': 'alsonotallowed'
         }
-        resp = self.request(path='/folder/{}/metadata'.format(folder['_id']),
+        resp = self.request(path='/folder/%s/metadata' % folder['_id'],
                             method='PUT', user=self.admin,
                             body=json.dumps(metadata), type='application/json')
         self.assertStatus(resp, 400)
@@ -484,7 +484,7 @@ class FolderTestCase(base.TestCase):
             name='Folder')
 
         resp = self.request(
-            path='/folder/{}/access'.format(folder['_id']), method='GET',
+            path='/folder/%s/access' % folder['_id'], method='GET',
             user=self.admin)
         self.assertStatusOk(resp)
         access = resp.json
@@ -493,24 +493,24 @@ class FolderTestCase(base.TestCase):
                 'login': self.admin['login'],
                 'level': AccessType.ADMIN,
                 'id': str(self.admin['_id']),
-                'name': '{} {}'.format(self.admin['firstName'],
-                                       self.admin['lastName'])}],
+                'name': '%s %s' % (
+                    self.admin['firstName'], self.admin['lastName'])}],
             'groups': []
         })
         self.assertTrue(not folder.get('public'))
         # Setting the access list with bad json should throw an error
         resp = self.request(
-            path='/folder/{}/access'.format(folder['_id']), method='PUT',
+            path='/folder/%s/access' % folder['_id'], method='PUT',
             user=self.admin, params={'access': 'badJSON'})
         self.assertStatus(resp, 400)
         # Change the access to public
         resp = self.request(
-            path='/folder/{}/access'.format(folder['_id']), method='PUT',
+            path='/folder/%s/access' % folder['_id'], method='PUT',
             user=self.admin,
             params={'access': json.dumps(access), 'public': True})
         self.assertStatusOk(resp)
         resp = self.request(
-            path='/folder/{}'.format(folder['_id']), method='GET',
+            path='/folder/%s' % folder['_id'], method='GET',
             user=self.admin)
         self.assertStatusOk(resp)
         self.assertEqual(resp.json['public'], True)
@@ -554,12 +554,12 @@ class FolderTestCase(base.TestCase):
             'Sub Item', creator=self.admin, folder=subFolder)
         metadata = {'key': 'value'}
         resp = self.request(
-            path='/folder/{}/metadata'.format(mainFolder['_id']), method='PUT',
+            path='/folder/%s/metadata' % mainFolder['_id'], method='PUT',
             user=self.admin, body=json.dumps(metadata),
             type='application/json')
         self.assertStatusOk(resp)
         resp = self.request(
-            path='/folder/{}/copy'.format(mainFolder['_id']), method='POST',
+            path='/folder/%s/copy' % mainFolder['_id'], method='POST',
             user=self.admin, type='application/json', body='')
         self.assertStatusOk(resp)
         # Check our new folder name
@@ -567,7 +567,7 @@ class FolderTestCase(base.TestCase):
         self.assertEqual(newFolder['name'], 'Main Folder (1)')
         # Check its metadata
         resp = self.request(
-            path='/folder/{}'.format(newFolder['_id']), method='GET',
+            path='/folder/%s' % newFolder['_id'], method='GET',
             user=self.admin, type='application/json')
         self.assertStatusOk(resp)
         self.assertEqual(resp.json['meta'], metadata)
@@ -601,7 +601,7 @@ class FolderTestCase(base.TestCase):
         self.assertNotEqual(str(newSubItem['_id']), str(subItem['_id']))
         # Test copying the subFolder
         resp = self.request(
-            path='/folder/{}/copy'.format(subFolder['_id']), method='POST',
+            path='/folder/%s/copy' % subFolder['_id'], method='POST',
             user=self.admin, params={'public': 'original', 'progress': True})
         self.assertStatusOk(resp)
         # Check our new folder name
@@ -609,12 +609,12 @@ class FolderTestCase(base.TestCase):
         self.assertEqual(newSubFolder['name'], 'Sub Folder (1)')
         # Test that a bogus parentType throws an error
         resp = self.request(
-            path='/folder/{}/copy'.format(subFolder['_id']), method='POST',
+            path='/folder/%s/copy' % subFolder['_id'], method='POST',
             user=self.admin, params={'parentType': 'badValue'})
         self.assertStatus(resp, 400)
         # Test that when we copy a folder into itself we don't recurse
         resp = self.request(
-            path='/folder/{}/copy'.format(subFolder['_id']), method='POST',
+            path='/folder/%s/copy' % subFolder['_id'], method='POST',
             user=self.admin, params={
                 'progress': True,
                 'parentType': 'folder',

--- a/tests/cases/group_test.py
+++ b/tests/cases/group_test.py
@@ -50,7 +50,7 @@ class GroupTestCase(base.TestCase):
             group, self.users[1], AccessType.WRITE))
 
         # Admin user can add user 1 directly if they pass force=True.
-        resp = self.request(path='/group/{}/invitation'.format(group['_id']),
+        resp = self.request(path='/group/%s/invitation' % group['_id'],
                             method='POST', user=self.users[0],
                             params={
                                 'force': 'true',
@@ -67,7 +67,7 @@ class GroupTestCase(base.TestCase):
         self.assertTrue(group['_id'] in user1['groups'])
 
         # User 1 should not be able to use the force option.
-        resp = self.request(path='/group/{}/invitation'.format(group['_id']),
+        resp = self.request(path='/group/%s/invitation' % group['_id'],
                             method='POST', user=self.users[1],
                             params={
                                 'force': 'true',
@@ -116,7 +116,7 @@ class GroupTestCase(base.TestCase):
             'public ', self.users[0], public=True)
 
         # Error: Invalid GET URL
-        resp = self.request(path='/group/{}/foo'.format(publicGroup['_id']),
+        resp = self.request(path='/group/%s/foo' % publicGroup['_id'],
                             method='GET')
         self.assertStatus(resp, 400)
 
@@ -200,7 +200,7 @@ class GroupTestCase(base.TestCase):
             'description': ' a description. '
         }
 
-        resp = self.request(path='/group/{}'.format(group['_id']),
+        resp = self.request(path='/group/%s' % group['_id'],
                             method='PUT', user=self.users[0], params=params)
         self.assertStatusOk(resp)
 
@@ -282,7 +282,7 @@ class GroupTestCase(base.TestCase):
 
         # We should see the invitation in the list
         resp = self.request(
-            path='/group/{}/invitation'.format(privateGroup['_id']),
+            path='/group/%s/invitation' % privateGroup['_id'],
             user=self.users[0], method='GET')
         self.assertStatusOk(resp)
         self.assertEqual(len(resp.json), 1)
@@ -324,7 +324,7 @@ class GroupTestCase(base.TestCase):
 
         # User 1 should not yet be in the member list
         resp = self.request(
-            path='/group/{}/member'.format(privateGroup['_id']),
+            path='/group/%s/member' % privateGroup['_id'],
             user=self.users[0], method='GET')
         self.assertStatusOk(resp)
         self.assertEqual(len(resp.json), 1)
@@ -338,7 +338,7 @@ class GroupTestCase(base.TestCase):
 
         # User 1 should now be in the member list
         resp = self.request(
-            path='/group/{}/member'.format(privateGroup['_id']),
+            path='/group/%s/member' % privateGroup['_id'],
             user=self.users[0], method='GET')
         self.assertStatusOk(resp)
         self.assertEqual(len(resp.json), 2)
@@ -365,7 +365,7 @@ class GroupTestCase(base.TestCase):
 
         # We promote user 1 to moderator
         resp = self.request(
-            path='/group/{}/moderator'.format(privateGroup['_id']),
+            path='/group/%s/moderator' % privateGroup['_id'],
             user=self.users[0], method='POST', params={
                 'userId': self.users[1]['_id']
             })
@@ -381,13 +381,13 @@ class GroupTestCase(base.TestCase):
         # User 1 should be able to invite someone with write access
         params['level'] = AccessType.WRITE
         resp = self.request(
-            path='/group/{}/invitation'.format(privateGroup['_id']),
+            path='/group/%s/invitation' % privateGroup['_id'],
             user=self.users[1], method='POST', params=params)
         self.assertStatusOk(resp)
 
         # Have user 2 join the group
         resp = self.request(
-            path='/group/{}/member'.format(privateGroup['_id']), method='POST',
+            path='/group/%s/member' % privateGroup['_id'], method='POST',
             user=self.users[2])
         self.assertStatusOk(resp)
 
@@ -410,7 +410,7 @@ class GroupTestCase(base.TestCase):
 
         # We promote user 1 to admin
         resp = self.request(
-            path='/group/{}/admin'.format(privateGroup['_id']),
+            path='/group/%s/admin' % privateGroup['_id'],
             user=self.users[0], method='POST', params={
                 'userId': self.users[1]['_id']
             })
@@ -422,7 +422,7 @@ class GroupTestCase(base.TestCase):
 
         # User 1 should now be able to promote and demote members
         resp = self.request(
-            path='/group/{}/admin'.format(privateGroup['_id']),
+            path='/group/%s/admin' % privateGroup['_id'],
             user=self.users[1], method='POST', params={
                 'userId': self.users[2]['_id']
             })
@@ -433,7 +433,7 @@ class GroupTestCase(base.TestCase):
                                                       AccessType.ADMIN))
 
         resp = self.request(
-            path='/group/{}/admin'.format(privateGroup['_id']),
+            path='/group/%s/admin' % privateGroup['_id'],
             user=self.users[1], method='DELETE', params={
                 'userId': self.users[2]['_id']
             })
@@ -448,7 +448,7 @@ class GroupTestCase(base.TestCase):
             self.users[2]['_id'], force=True)
         self.assertTrue(privateGroup['_id'] in self.users[2]['groups'])
         resp = self.request(
-            path='/group/{}/member'.format(privateGroup['_id']),
+            path='/group/%s/member' % privateGroup['_id'],
             user=self.users[2], method='DELETE')
         self.assertStatusOk(resp)
         self.users[2] = self.model('user').load(
@@ -474,8 +474,8 @@ class GroupTestCase(base.TestCase):
             path='/group/%s' % privateGroup['_id'], user=self.users[0],
             method='DELETE')
         self.assertStatusOk(resp)
-        self.assertEqual(resp.json['message'], 'Deleted the group {}.'.format(
-            privateGroup['name']))
+        self.assertEqual(resp.json['message'],
+                         'Deleted the group %s.' % privateGroup['name'])
         privateGroup = self.model('group').load(privateGroup['_id'], force=True)
         self.assertTrue(privateGroup is None)
 
@@ -529,7 +529,7 @@ class GroupTestCase(base.TestCase):
                                                 public=True)
         for user in [1, 2, 3]:
             resp = self.request(
-                path='/group/{}/invitation'.format(group['_id']),
+                path='/group/%s/invitation' % group['_id'],
                 params={
                     'force': 'true',
                     'userId': self.users[user]['_id'],
@@ -550,7 +550,7 @@ class GroupTestCase(base.TestCase):
                 self.assertStatusOk(resp)
                 for user in range(5):
                     resp = self.request(
-                        path='/group/{}/invitation'.format(group['_id']),
+                        path='/group/%s/invitation' % group['_id'],
                         params={
                             'force': 'true',
                             'userId': self.users[5]['_id'],

--- a/tests/cases/item_test.py
+++ b/tests/cases/item_test.py
@@ -120,7 +120,7 @@ class ItemTestCase(base.TestCase):
 
         # Test downloading the item with contentDisposition=inline.
         params = {'contentDisposition': 'inline'}
-        resp = self.request(path='/item/{}/download'.format(item['_id']),
+        resp = self.request(path='/item/%s/download' % item['_id'],
                             method='GET', user=user, isJson=False,
                             params=params)
         self.assertStatusOk(resp)

--- a/tests/cases/item_test.py
+++ b/tests/cases/item_test.py
@@ -111,7 +111,7 @@ class ItemTestCase(base.TestCase):
         :param contents: The expected contents.
         :type contents: str
         """
-        resp = self.request(path='/item/{}/download'.format(item['_id']),
+        resp = self.request(path='/item/%s/download' % item['_id'],
                             method='GET', user=user, isJson=False)
         self.assertStatusOk(resp)
         self.assertEqual(contents, self.getBody(resp))
@@ -129,7 +129,7 @@ class ItemTestCase(base.TestCase):
                          'inline; filename="file_1"')
 
         # Test downloading with an offset
-        resp = self.request(path='/item/{}/download'.format(item['_id']),
+        resp = self.request(path='/item/%s/download' % item['_id'],
                             method='GET', user=user, isJson=False,
                             params={'offset': 1})
         self.assertStatus(resp, 206)
@@ -140,7 +140,7 @@ class ItemTestCase(base.TestCase):
         params = None
         if format:
             params = {'format': format}
-        resp = self.request(path='/item/{}/download'.format(item['_id']),
+        resp = self.request(path='/item/%s/download' % item['_id'],
                             method='GET', user=user, isJson=False,
                             params=params)
         self.assertStatusOk(resp)
@@ -170,7 +170,7 @@ class ItemTestCase(base.TestCase):
 
         self._testUploadFileToItem(curItem, 'file_2', self.users[0], 'foobz')
 
-        resp = self.request(path='/item/{}/files'.format(curItem['_id']),
+        resp = self.request(path='/item/%s/files' % curItem['_id'],
                             method='GET', user=self.users[0])
         self.assertStatusOk(resp)
         self.assertEqual(resp.json[0]['name'], 'file_1')
@@ -278,7 +278,7 @@ class ItemTestCase(base.TestCase):
             'name': 'changed name',
             'description': 'new description'
         }
-        resp = self.request(path='/item/{}'.format(item['_id']), method='PUT',
+        resp = self.request(path='/item/%s' % item['_id'], method='PUT',
                             params=params, user=self.users[0])
         self.assertStatusOk(resp)
         self.assertEqual(resp.json['name'], params['name'])
@@ -287,7 +287,7 @@ class ItemTestCase(base.TestCase):
         # Test moving an item to the public folder
         item = self.model('item').load(item['_id'], force=True)
         self.assertFalse(self.model('item').hasAccess(item))
-        resp = self.request(path='/item/{}'.format(item['_id']), method='PUT',
+        resp = self.request(path='/item/%s' % item['_id'], method='PUT',
                             user=self.users[0], params={
                                 'folderId': self.publicFolder['_id']})
         self.assertStatusOk(resp)
@@ -298,7 +298,7 @@ class ItemTestCase(base.TestCase):
         # destination folder
         self.publicFolder = self.model('folder').setUserAccess(
             self.publicFolder, self.users[1], AccessType.WRITE, save=True)
-        resp = self.request(path='/item/{}'.format(item['_id']), method='PUT',
+        resp = self.request(path='/item/%s' % item['_id'], method='PUT',
                             user=self.users[1], params={
                                 'folderId': self.privateFolder['_id']})
         self.assertStatus(resp, 403)
@@ -311,7 +311,7 @@ class ItemTestCase(base.TestCase):
         self.assertStatus(resp, 400)
 
         # Try a bad endpoint (should 400)
-        resp = self.request(path='/item/{}/blurgh'.format(item['_id']),
+        resp = self.request(path='/item/%s/blurgh' % item['_id'],
                             method='GET',
                             user=self.users[1])
         self.assertStatus(resp, 400)
@@ -359,7 +359,7 @@ class ItemTestCase(base.TestCase):
             'foo': 'bar',
             'test': 2
         }
-        resp = self.request(path='/item/{}/metadata'.format(item['_id']),
+        resp = self.request(path='/item/%s/metadata' % item['_id'],
                             method='PUT', user=self.users[0],
                             body=json.dumps(metadata), type='application/json')
 
@@ -370,7 +370,7 @@ class ItemTestCase(base.TestCase):
         # Edit and remove metadata
         metadata['test'] = None
         metadata['foo'] = 'baz'
-        resp = self.request(path='/item/{}/metadata'.format(item['_id']),
+        resp = self.request(path='/item/%s/metadata' % item['_id'],
                             method='PUT', user=self.users[0],
                             body=json.dumps(metadata), type='application/json')
 
@@ -382,7 +382,7 @@ class ItemTestCase(base.TestCase):
         metadata = {
             'test': 'allowed'
         }
-        resp = self.request(path='/item/{}/metadata'.format(item['_id']),
+        resp = self.request(path='/item/%s/metadata' % item['_id'],
                             method='PUT', user=self.users[0],
                             body=json.dumps(metadata).replace('"', "'"),
                             type='application/json')
@@ -395,7 +395,7 @@ class ItemTestCase(base.TestCase):
         metadata = {
             'foo.bar': 'notallowed'
         }
-        resp = self.request(path='/item/{}/metadata'.format(item['_id']),
+        resp = self.request(path='/item/%s/metadata' % item['_id'],
                             method='PUT', user=self.users[0],
                             body=json.dumps(metadata), type='application/json')
         self.assertStatus(resp, 400)
@@ -408,7 +408,7 @@ class ItemTestCase(base.TestCase):
         metadata = {
             '$foobar': 'alsonotallowed'
         }
-        resp = self.request(path='/item/{}/metadata'.format(item['_id']),
+        resp = self.request(path='/item/%s/metadata' % item['_id'],
                             method='PUT', user=self.users[0],
                             body=json.dumps(metadata), type='application/json')
         self.assertStatus(resp, 400)
@@ -420,7 +420,7 @@ class ItemTestCase(base.TestCase):
         metadata = {
             '': 'stillnotallowed'
         }
-        resp = self.request(path='/item/{}/metadata'.format(item['_id']),
+        resp = self.request(path='/item/%s/metadata' % item['_id'],
                             method='PUT', user=self.users[0],
                             body=json.dumps(metadata), type='application/json')
         self.assertStatus(resp, 400)
@@ -474,7 +474,7 @@ class ItemTestCase(base.TestCase):
         baseItem = self.model('item').createItem('blah', self.users[0],
                                                  secondChild, 'foo')
 
-        resp = self.request(path='/item/{}/rootpath'.format(baseItem['_id']),
+        resp = self.request(path='/item/%s/rootpath' % baseItem['_id'],
                             method='GET')
         self.assertStatusOk(resp)
         pathToRoot = resp.json
@@ -564,7 +564,7 @@ class ItemTestCase(base.TestCase):
             'foo': 'value1',
             'test': 2
         }
-        self.request(path='/item/{}/metadata'.format(origItem['_id']),
+        self.request(path='/item/%s/metadata' % origItem['_id'],
                      method='PUT', user=self.users[0],
                      body=json.dumps(metadata), type='application/json')
         self._testUploadFileToItem(origItem, 'file_1', self.users[0], 'foobar')
@@ -584,11 +584,11 @@ class ItemTestCase(base.TestCase):
         params = {
             'name': 'copied_item'
         }
-        resp = self.request(path='/item/{}/copy'.format(origItem['_id']),
+        resp = self.request(path='/item/%s/copy' % origItem['_id'],
                             method='POST', user=self.users[0], params=params)
         self.assertStatusOk(resp)
         # Now ask for the new item explicitly and check its metadata
-        self.request(path='/item/{}'.format(resp.json['_id']),
+        self.request(path='/item/%s' % resp.json['_id'],
                      user=self.users[0], type='application/json')
         self.assertStatusOk(resp)
         newItem = resp.json
@@ -596,7 +596,7 @@ class ItemTestCase(base.TestCase):
         self.assertEqual(newItem['meta']['foo'], metadata['foo'])
         self.assertEqual(newItem['meta']['test'], metadata['test'])
         # Check if we can download the files from the new item
-        resp = self.request(path='/item/{}/files'.format(newItem['_id']),
+        resp = self.request(path='/item/%s/files' % newItem['_id'],
                             method='GET', user=self.users[0])
         self.assertStatusOk(resp)
         newFiles = resp.json
@@ -622,7 +622,7 @@ class ItemTestCase(base.TestCase):
         self.assertEqual(newItem['_id'], resp.json[0]['_id'])
         # Check if we can download the files from the old item and that they
         # are distinct from the files in the original item
-        resp = self.request(path='/item/{}/files'.format(origItem['_id']),
+        resp = self.request(path='/item/%s/files' % origItem['_id'],
                             method='GET', user=self.users[0])
         self.assertStatusOk(resp)
         origFiles = resp.json
@@ -681,19 +681,19 @@ class ItemTestCase(base.TestCase):
                                 'cookie_auth_download', '', self.users[0])
         self._testUploadFileToItem(item, 'file', self.users[0], 'foo')
         token = self.model('token').createToken(self.users[0])
-        cookie = 'girderToken={}'.format(token['_id'])
+        cookie = 'girderToken=%s' % token['_id']
 
         # We should be able to download a private item using a cookie token
-        resp = self.request(path='/item/{}/download'.format(item['_id']),
+        resp = self.request(path='/item/%s/download' % item['_id'],
                             isJson=False, cookie=cookie)
         self.assertStatusOk(resp)
         self.assertEqual(self.getBody(resp), 'foo')
 
         # We should not be able to call GET /item/:id with a cookie token
-        resp = self.request(path='/item/{}'.format(item['_id']), cookie=cookie)
+        resp = self.request(path='/item/%s' % item['_id'], cookie=cookie)
         self.assertStatus(resp, 401)
 
         # Make sure the cookie has to be a valid token
-        resp = self.request(path='/item/{}/download'.format(item['_id']),
+        resp = self.request(path='/item/%s/download' % item['_id'],
                             cookie='girderToken=invalid_token')
         self.assertStatus(resp, 401)

--- a/tests/cases/resource_test.py
+++ b/tests/cases/resource_test.py
@@ -334,14 +334,14 @@ class ResourceTestCase(base.TestCase):
 
     def testGetResourceById(self):
         self._createFiles()
-        resp = self.request(path='/resource/{}'.format(self.admin['_id']),
+        resp = self.request(path='/resource/%s' % self.admin['_id'],
                             method='GET', user=self.admin,
                             params={'type': 'user'})
         self.assertStatusOk(resp)
         self.assertEqual(str(resp.json['_id']), str(self.admin['_id']))
         self.assertEqual(resp.json['email'], 'good@email.com')
         # Get a file via this method
-        resp = self.request(path='/resource/{}'.format(self.file1['_id']),
+        resp = self.request(path='/resource/%s' % self.file1['_id'],
                             method='GET', user=self.admin,
                             params={'type': 'file'})
         self.assertStatusOk(resp)
@@ -442,7 +442,7 @@ class ResourceTestCase(base.TestCase):
                 'progress': True
             })
         self.assertStatusOk(resp)
-        resp = self.request(path='/item/{}'.format(self.items[0]['_id']),
+        resp = self.request(path='/item/%s' % self.items[0]['_id'],
                             method='GET', user=self.admin)
         self.assertStatusOk(resp)
         self.assertEqual(resp.json['folderId'],
@@ -478,13 +478,13 @@ class ResourceTestCase(base.TestCase):
                 'progress': True
             })
         self.assertStatusOk(resp)
-        resp = self.request(path='/item/{}'.format(self.items[0]['_id']),
+        resp = self.request(path='/item/%s' % self.items[0]['_id'],
                             method='GET', user=self.admin)
         self.assertStatusOk(resp)
         self.assertEqual(resp.json['folderId'],
                          str(self.adminPrivateFolder['_id']))
         resp = self.request(
-            path='/folder/{}'.format(self.adminSubFolder['_id']), method='GET',
+            path='/folder/%s' % self.adminSubFolder['_id'], method='GET',
             user=self.admin)
         self.assertStatusOk(resp)
         self.assertEqual(resp.json['parentId'],
@@ -511,7 +511,7 @@ class ResourceTestCase(base.TestCase):
             })
         self.assertStatusOk(resp)
         resp = self.request(
-            path='/folder/{}'.format(self.adminSubFolder['_id']), method='GET',
+            path='/folder/%s' % self.adminSubFolder['_id'], method='GET',
             user=self.admin)
         self.assertStatusOk(resp)
         self.assertEqual(resp.json['parentCollection'], 'user')

--- a/tests/cases/size_test.py
+++ b/tests/cases/size_test.py
@@ -125,7 +125,7 @@ class SizeTestCase(base.TestCase):
 
         # Move item1 down from top level folder to subfolder
         resp = self.request(
-            path='/item/{}'.format(self.item1['_id']), method='PUT',
+            path='/item/%s' % self.item1['_id'], method='PUT',
             user=self.admin, params={
                 'folderId': self.folder2['_id']
             })
@@ -139,7 +139,7 @@ class SizeTestCase(base.TestCase):
 
         # Delete item1
         resp = self.request(
-            path='/item/{}'.format(self.item1['_id']), method='DELETE',
+            path='/item/%s' % self.item1['_id'], method='DELETE',
             user=self.admin)
         self.assertStatusOk(resp)
 
@@ -150,7 +150,7 @@ class SizeTestCase(base.TestCase):
     def testMoveAndDeleteFolder(self):
         # Ensure we cannot move a folder under itself
         resp = self.request(
-            path='/folder/{}'.format(self.folder1['_id']), method='PUT',
+            path='/folder/%s' % self.folder1['_id'], method='PUT',
             user=self.admin, params={
                 'parentId': self.folder2['_id'],
                 'parentType': 'folder'
@@ -164,7 +164,7 @@ class SizeTestCase(base.TestCase):
 
         # Move top level folder from coll1 to coll2
         resp = self.request(
-            path='/folder/{}'.format(self.folder1['_id']), method='PUT',
+            path='/folder/%s' % self.folder1['_id'], method='PUT',
             user=self.admin, params={
                 'parentId': self.coll2['_id'],
                 'parentType': 'collection'
@@ -176,7 +176,7 @@ class SizeTestCase(base.TestCase):
 
         # Move subfolder as top level folder under admin user
         resp = self.request(
-            path='/folder/{}'.format(self.folder2['_id']), method='PUT',
+            path='/folder/%s' % self.folder2['_id'], method='PUT',
             user=self.admin, params={
                 'parentId': self.admin['_id'],
                 'parentType': 'user'
@@ -187,7 +187,7 @@ class SizeTestCase(base.TestCase):
 
         # Delete the sub folder
         resp = self.request(
-            path='/folder/{}'.format(self.folder2['_id']), method='DELETE',
+            path='/folder/%s' % self.folder2['_id'], method='DELETE',
             user=self.admin)
         self.assertStatusOk(resp)
         self.assertNodeSize(self.admin, 'user', 0)

--- a/tests/cases/user_test.py
+++ b/tests/cases/user_test.py
@@ -247,7 +247,7 @@ class UserTestCase(base.TestCase):
         self.assertStatus(resp, 400)
         self.assertEqual(resp.json['message'], 'Invalid ObjectId: bad_id')
 
-        resp = self.request(path='/user/{}'.format(user['_id']))
+        resp = self.request(path='/user/%s' % user['_id'])
         self._verifyUserDocument(resp.json, admin=False)
 
         params = {
@@ -255,13 +255,13 @@ class UserTestCase(base.TestCase):
             'firstName': 'NewFirst ',
             'lastName': ' New Last ',
         }
-        resp = self.request(path='/user/{}'.format(user['_id']), method='PUT',
+        resp = self.request(path='/user/%s' % user['_id'], method='PUT',
                             user=user, params=params)
         self.assertStatus(resp, 400)
         self.assertEqual(resp.json['message'], 'Invalid email address.')
 
         params['email'] = 'valid@email.com '
-        resp = self.request(path='/user/{}'.format(user['_id']), method='PUT',
+        resp = self.request(path='/user/%s' % user['_id'], method='PUT',
                             user=user, params=params)
         self.assertStatusOk(resp)
         self._verifyUserDocument(resp.json)
@@ -276,7 +276,7 @@ class UserTestCase(base.TestCase):
             'lastName': ' New Last ',
             'admin': 'true'
         }
-        resp = self.request(path='/user/{}'.format(user['_id']), method='PUT',
+        resp = self.request(path='/user/%s' % user['_id'], method='PUT',
                             user=user, params=params)
         self.assertStatusOk(resp)
         self._verifyUserDocument(resp.json)
@@ -284,7 +284,7 @@ class UserTestCase(base.TestCase):
 
         # test admin flag as non-admin
         params['admin'] = 'true'
-        resp = self.request(path='/user/{}'.format(nonAdminUser['_id']),
+        resp = self.request(path='/user/%s' % nonAdminUser['_id'],
                             method='PUT', user=nonAdminUser, params=params)
         self.assertStatus(resp, 403)
 

--- a/tests/js_coverage_tool.py
+++ b/tests/js_coverage_tool.py
@@ -50,8 +50,8 @@ def combine_report(args):
     report them into the desired output format(s).
     """
     if not os.path.exists(args.coverage_dir):
-        raise Exception('Coverage directory {} does not exist.'.format(
-            args.coverage_dir))
+        raise Exception('Coverage directory %s does not exist.' %
+                        args.coverage_dir)
 
     # Step 1: Read and combine intermediate reports
     combined = collections.defaultdict(lambda: collections.defaultdict(int))
@@ -95,7 +95,7 @@ def report(args, combined, stats):
     directory.
     """
     percent = float(stats['totalHits']) / float(stats['totalSloc']) * 100
-    print('Overall total: {} / {} ({:.2f}%)'.format(
+    print('Overall total: %s / %s (%.2f%%)' % (
         stats['totalHits'], stats['totalSloc'], percent))
 
     coverageEl = ET.Element('coverage', {
@@ -134,7 +134,7 @@ def report(args, combined, stats):
     tree = ET.ElementTree(coverageEl)
     tree.write('js_coverage.xml')
     if percent < args.threshold:
-        print('FAIL: Coverage below threshold ({}%)'.format(args.threshold))
+        print('FAIL: Coverage below threshold (%s%)' % args.threshold)
         sys.exit(1)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Without this, Unicode user names are causing 500 errors when ``/api/v1/group/<id>/access`` is called.