### PR TITLE
OAuth improvements

### DIFF
--- a/plugins/oauth/plugin_tests/oauth_test.py
+++ b/plugins/oauth/plugin_tests/oauth_test.py
@@ -17,12 +17,16 @@
 #  limitations under the License.
 ###############################################################################
 
-import httmock
+import datetime
 import json
 import re
+from six.moves import urllib
+
+import httmock
+import requests
+import six
 
 from girder.constants import SettingKey
-from six.moves import urllib
 from tests import base
 
 
@@ -40,7 +44,11 @@ class OauthTest(base.TestCase):
     def setUp(self):
         base.TestCase.setUp(self)
 
-        self.admin = self.model('user').createUser(
+        # girder.plugins is not available until setUp is running
+        global PluginSettings
+        from girder.plugins.oauth.constants import PluginSettings
+
+        self.adminUser = self.model('user').createUser(
             email='admin@mail.com',
             login='admin',
             firstName='first',
@@ -49,79 +57,87 @@ class OauthTest(base.TestCase):
             admin=True
         )
 
+        # Specifies which test account (typically "new" or "existing") a
+        # redirect to a provider will simulate authentication for
+        self.accountType = None
+
+
     def testDeriveLogin(self):
         """
         Unit tests the _deriveLogin method of the provider classes.
         """
-        from girder.plugins.oauth.providers import Google
-        provider = Google(None)
+        from girder.plugins.oauth.providers.base import ProviderBase
 
-        login = provider._deriveLogin('1234@mail.com', 'John', 'Doe')
+        login = ProviderBase._deriveLogin('1234@mail.com', 'John', 'Doe')
         self.assertEqual(login, 'johndoe')
 
-        login = provider._deriveLogin('hello.world.foo@mail.com', 'A', 'B')
+        login = ProviderBase._deriveLogin('hello.world.foo@mail.com', 'A', 'B')
         self.assertEqual(login, 'helloworldfoo')
 
-        login = provider._deriveLogin('hello.world@mail.com', 'A', 'B', 'user2')
+        login = ProviderBase._deriveLogin('hello.world@mail.com', 'A', 'B', 'user2')
         self.assertEqual(login, 'user2')
 
-        login = provider._deriveLogin('admin@admin.com', 'A', 'B', 'admin')
+        login = ProviderBase._deriveLogin('admin@admin.com', 'A', 'B', 'admin')
         self.assertEqual(login, 'admin1')
 
-    def _getCsrfToken(self, resp, providerName):
-        for provider in resp.json:
-            if provider['id'] == providerName:
-                providerUrl = provider['url']
-                urlParts = urllib.parse.urlparse(providerUrl)
-                queryParams = urllib.parse.parse_qs(urlParts.query)
-                csrfToken = queryParams['state'][0]
-                return csrfToken
-        else:
-            self.fail()
 
-    def testGoogleOauth(self):
-        from girder.plugins.oauth.constants import PluginSettings
-
-        # Close registration to start off.
+    def _testOauth(self, providerInfo):
+        # Close registration to start off, and simulate a new user
         self.model('setting').set(SettingKey.REGISTRATION_POLICY, 'closed')
+        self.accountType = 'new'
 
-        # We should get a 500 if no client ID is set
+        # We should get an empty listing when no providers are set up
+        params = {
+            'key': PluginSettings.PROVIDERS_ENABLED,
+            'value': []
+        }
+        resp = self.request(
+            '/system/setting', user=self.adminUser, method='PUT', params=params)
+        self.assertStatusOk(resp)
+
+        resp = self.request('/oauth/provider', exception=True, params={
+            'redirect': 'http://localhost/#foo/bar',
+            'list': True
+        })
+        self.assertStatusOk(resp)
+        self.assertFalse(resp.json)
+
+        # Turn on provider, but don't set other settings
+        params = {
+            'list': json.dumps([{
+                'key': PluginSettings.PROVIDERS_ENABLED,
+                'value': [providerInfo['id']]
+            }])
+        }
+        resp = self.request(
+            '/system/setting', user=self.adminUser, method='PUT', params=params)
+        self.assertStatusOk(resp)
+
         resp = self.request('/oauth/provider', exception=True, params={
             'redirect': 'http://localhost/#foo/bar'})
         self.assertStatus(resp, 500)
-        self.assertTrue(
-            resp.json['message'].find(
-                'No Google client ID setting is present.'
-            ) >= 0
-        )
 
-        params = {
-            'list': json.dumps([{
-                'key': PluginSettings.GOOGLE_CLIENT_ID,
-                'value': 'foo'
-            }, {
-                'key': PluginSettings.GOOGLE_CLIENT_SECRET,
-                'value': 'bar'
-            }])
-        }
-
-        resp = self.request(
-            '/system/setting', user=self.admin, method='PUT', params=params)
-        self.assertStatusOk(resp)
-
+        # Set up provider normally
         params = {
             'list': json.dumps([
-                PluginSettings.GOOGLE_CLIENT_ID,
-                PluginSettings.GOOGLE_CLIENT_SECRET
+                {
+                    'key': PluginSettings.PROVIDERS_ENABLED,
+                    'value': [providerInfo['id']]
+                }, {
+                    'key': providerInfo['client_id']['key'],
+                    'value': providerInfo['client_id']['value']
+                }, {
+                    'key': providerInfo['client_secret']['key'],
+                    'value': providerInfo['client_secret']['value']
+                }
             ])
         }
         resp = self.request(
-            '/system/setting', user=self.admin, method='GET', params=params)
+            '/system/setting', user=self.adminUser, method='PUT',
+            params=params)
         self.assertStatusOk(resp)
-        self.assertEqual(resp.json, {
-            PluginSettings.GOOGLE_CLIENT_ID: 'foo',
-            PluginSettings.GOOGLE_CLIENT_SECRET: 'bar'
-        })
+        # No need to re-fetch and test all of these settings values; they will
+        # be implicitly tested later
 
         # Make sure that if no list param is passed, we receive the old format
         resp = self.request('/oauth/provider', params={
@@ -129,187 +145,178 @@ class OauthTest(base.TestCase):
         })
         self.assertStatusOk(resp)
         self.assertIsInstance(resp.json, dict)
-        self.assertEqual(list(resp.json.keys()), ['Google'])
+        self.assertEqual(len(resp.json), 1)
+        self.assertIn(providerInfo['name'], resp.json)
         self.assertRegexpMatches(
-            resp.json['Google'],
-            r'^https://accounts\.google\.com/o/oauth2/auth')
+            resp.json[providerInfo['name']],
+            providerInfo['url_re'])
 
-        resp = self.request('/oauth/provider', params={
-            'redirect': 'http://localhost/#foo/bar',
-            'list': True
-        })
-        self.assertStatusOk(resp)
-        self.assertIsInstance(resp.json, list)
-        for provider in resp.json:
-            self.assertHasKeys(provider, ('id', 'name', 'url'))
-            if provider['id'] == 'google':
-                self.assertEqual(provider['name'], 'Google')
-                providerUrl = provider['url']
-                break
-        else:
-            self.fail()
-        urlParts = urllib.parse.urlparse(providerUrl)
-        queryParams = urllib.parse.parse_qs(urlParts.query)
-        self.assertEqual(urlParts.scheme, 'https')
-        self.assertEqual(urlParts.netloc, 'accounts.google.com')
-        self.assertEqual(queryParams['response_type'], ['code'])
-        self.assertEqual(queryParams['access_type'], ['online'])
-        self.assertEqual(queryParams['client_id'], ['foo'])
-        self.assertRegexpMatches(queryParams['redirect_uri'][0],
-            r'http://127\.0\.0\.1(?::\d+)?/api/v1/oauth/google/callback')
-        self.assertEqual(queryParams['state'][0].partition('.')[2],
-                         'http://localhost/#foo/bar')
-        self.assertEqual(queryParams['scope'], ['profile email'])
+        # This will need to be called several times, to get fresh tokens
+        def getProviderResp():
+            resp = self.request('/oauth/provider', params={
+                'redirect': 'http://localhost/#foo/bar',
+                'list': True
+            })
+            self.assertStatusOk(resp)
+            self.assertIsInstance(resp.json, list)
+            self.assertEqual(len(resp.json), 1)
+            providerResp = resp.json[0]
+            self.assertSetEqual(
+                set(six.viewkeys(providerResp)),
+                {'id', 'name', 'url'})
+            self.assertEqual(providerResp['id'], providerInfo['id'])
+            self.assertEqual(providerResp['name'], providerInfo['name'])
+            self.assertRegexpMatches(
+                providerResp['url'],
+                providerInfo['url_re'])
+            redirectParams = urllib.parse.parse_qs(
+                urllib.parse.urlparse(providerResp['url']).query)
+            csrfTokenParts = redirectParams['state'][0].partition('.')
+            token = self.model('token').load(
+                csrfTokenParts[0], force=True, objectId=False)
+            self.assertLess(
+                token['expires'],
+                datetime.datetime.utcnow() + datetime.timedelta(days=0.30))
+            self.assertEqual(
+                csrfTokenParts[2],
+                'http://localhost/#foo/bar')
+            return providerResp
 
-        # Test the error condition for google callback
-        resp = self.request('/oauth/google/callback', params={
-            'code': None,
-            'error': 'access_denied',
-        }, exception=True)
+        # Try the new format listing
+        getProviderResp()
+
+        # Try callback, for a non-existant provider
+        resp = self.request('/oauth/foobar/callback')
+        self.assertStatus(resp, 400)
+
+        # Try callback, without providing any params
+        resp = self.request('/oauth/%s/callback' % providerInfo['id'])
+        self.assertStatus(resp, 400)
+
+        # Try callback, providing params as though the provider failed
+        resp = self.request(
+            '/oauth/%s/callback' % providerInfo['id'],
+            params={
+                'code': None,
+                'error': 'some_custom_error',
+            }, exception=True)
         self.assertStatus(resp, 502)
         self.assertEqual(
             resp.json['message'],
-            "Provider returned error: 'access_denied'."
-        )
+            "Provider returned error: 'some_custom_error'.")
 
-        # Test logging in with an existing user
-
-        email = 'admin@mail.com'
-
-        @httmock.all_requests
-        def googleMock(url, request):
-            if url.netloc == 'accounts.google.com':
-                params = urllib.parse.parse_qs(request.body)
-                if params.get('code') != ['12345']:
-                    return {
-                        'status_code': 401,
-                        'content': json.dumps({
-                            'error': 'Bad code'
-                        })
-                    }
-                return json.dumps({
-                    'token_type': 'Bearer',
-                    'access_token': 'abcd'
-                })
-            elif url.netloc == 'www.googleapis.com':
-                return json.dumps({
-                    'name': {
-                        'givenName': 'John',
-                        'familyName': 'Doe'
-                    },
-                    'emails': [{
-                        'type': 'account',
-                        'value': email
-                    }],
-                    'id': 9876
-                })
-            else:
-                raise Exception('Unexpected url %s' % url)
-
-        with httmock.HTTMock(googleMock):
-            # Try a request where the CSRF token is incorrect
-            resp = self.request('/oauth/google/callback', params={
-                'code': '12345',
-                'state': 'blah'
-            })
-            self.assertStatus(resp, 403)
-            self.assertTrue(resp.json['message'].startswith(
-                'Invalid CSRF token'))
-
-        # Test login in with a new user
-
-        # Get a fresh token
-        resp = self.request('/oauth/provider', params={
-            'redirect': 'http://localhost/#foo/bar',
-            'list': True
-        })
-        self.assertStatusOk(resp)
-        csrfToken = self._getCsrfToken(resp, 'google')
-
-        email = 'anotheruser@mail.com'
-        with httmock.HTTMock(googleMock):
-            resp = self.request('/oauth/google/callback', params={
-                'code': '12345',
-                'state': csrfToken
-            })
-        self.assertStatus(resp, 400)
-        self.assertEqual(resp.json['message'],
-                         'Registration on this instance is closed. Contact an '
-                         'administrator to create an account for you.')
-
-        # Open registration
-        self.model('setting').set(SettingKey.REGISTRATION_POLICY, 'open')
-
-        # Get a fresh token
-        resp = self.request('/oauth/provider', params={
-            'redirect': 'http://localhost/#foo/bar',
-            'list': True
-        })
-        self.assertStatusOk(resp)
-        csrfToken = self._getCsrfToken(resp, 'google')
-
-        with httmock.HTTMock(googleMock):
-            resp = self.request('/oauth/google/callback', isJson=False, params={
-                'code': '12345',
-                'state': csrfToken
-            })
-        self.assertStatus(resp, 303)
-        self.assertEqual(resp.headers['Location'],
-                         'http://localhost/#foo/bar')
-        self.assertTrue('girderToken' in resp.cookie)
-
-        token = self.model('token').load(resp.cookie['girderToken'].value,
-                                         force=True, objectId=False)
-        newUser = self.model('user').load(token['userId'], force=True)
-        self.assertEqual(newUser['login'], 'anotheruser')
-        self.assertEqual(newUser['email'], 'anotheruser@mail.com')
-        self.assertIn({'provider': 'google', 'id': 9876}, newUser['oauth'])
-        self.assertEqual(newUser['firstName'], 'John')
-        self.assertEqual(newUser['lastName'], 'Doe')
-
-        # Logging in as OAuth-only user should give reasonable error
-        resp = self.request('/user/authentication',
-                            basicAuth='anotheruser:mypassword')
-        self.assertStatus(resp, 400)
-        self.assertEqual(resp.json['message'], 'You don\'t have a password. '
-                         'Please log in with Google, or use the password reset '
-                         'link.')
-
-        # Test receiving a bad status from Google, make sure we show some
-        # helpful output.
-        errorContent = {'message': 'error'}
-        @httmock.all_requests
-        def errorResponse(url, request):
-            return httmock.response(
-                status_code=403, content=json.dumps(errorContent))
-
-        resp = self.request('/oauth/provider', params={
-            'redirect': 'http://localhost/#foo/bar',
-            'list': True
-        })
-        self.assertStatusOk(resp)
-        csrfToken = self._getCsrfToken(resp, 'google')
-
-        with httmock.HTTMock(errorResponse):
-            resp = self.request('/oauth/google/callback', params={
-                'code': '12345',
-                'state': csrfToken
-            }, exception=True)
-            self.assertStatus(resp, 502)
+        # This will need to be called several times, to use fresh tokens
+        def getCallbackParams(providerResp):
+            resp = requests.get(providerResp['url'], allow_redirects=False)
+            self.assertEqual(resp.status_code, 302)
+            callbackLoc = urllib.parse.urlparse(resp.headers['location'])
             self.assertEqual(
-                resp.json['message'],
-                'Got 403 from https://accounts.google.com/o/oauth2/token, '
-                'response="{"message": "error"}".')
+                callbackLoc.path,
+                r'/api/v1/oauth/%s/callback' % providerInfo['id'])
+            callbackLocQuery = urllib.parse.parse_qs(callbackLoc.query)
+            self.assertNotHasKeys(callbackLocQuery, ('error',))
+            callbackParams = {
+                key: val[0] for key, val in six.viewitems(callbackLocQuery)
+            }
+            return callbackParams
 
-        # Reset password as oauth user should work
+        # Call (simulated) external provider
+        getCallbackParams(getProviderResp())
+
+        # Try callback, with incorrect CSRF token
+        params = getCallbackParams(getProviderResp())
+        params['state'] = 'something_wrong'
+        resp = self.request('/oauth/%s/callback' % providerInfo['id'],
+                            params=params)
+        self.assertStatus(resp, 403)
+        self.assertTrue(
+            resp.json['message'].startswith('Invalid CSRF token'))
+
+        # Try callback, with expired CSRF token
+        params = getCallbackParams(getProviderResp())
+        token = self.model('token').load(
+            params['state'].partition('.')[0], force=True, objectId=False)
+        token['expires'] -= datetime.timedelta(days=1)
+        self.model('token').save(token)
+        resp = self.request('/oauth/%s/callback' % providerInfo['id'],
+                            params=params)
+        self.assertStatus(resp, 403)
+        self.assertTrue(
+            resp.json['message'].startswith('Expired CSRF token'))
+
+        # Try callback, with a valid CSRF token but no redirect
+        params = getCallbackParams(getProviderResp())
+        params['state'] = params['state'].partition('.')[0]
+        resp = self.request('/oauth/%s/callback' % providerInfo['id'],
+                            params=params)
+        self.assertStatus(resp, 400)
+        self.assertTrue(
+            resp.json['message'].startswith('No redirect location'))
+
+        # Try callback, with incorrect code
+        params = getCallbackParams(getProviderResp())
+        params['code'] = 'something_wrong'
+        resp = self.request('/oauth/%s/callback' % providerInfo['id'],
+                            params=params)
+        self.assertStatus(resp, 502)
+
+        # Try callback, with real parameters from provider, but still for the
+        # 'new' account
+        params = getCallbackParams(getProviderResp())
+        resp = self.request('/oauth/%s/callback' % providerInfo['id'],
+                     params=params)
+        self.assertStatus(resp, 400)
+        self.assertTrue(
+            resp.json['message'].startswith(
+                'Registration on this instance is closed.'))
+
+        # This will need to be called several times, and will do a normal login
+        def doOauthLogin(accountType):
+            self.accountType = accountType
+            params = getCallbackParams(getProviderResp())
+            resp = self.request('/oauth/%s/callback' % providerInfo['id'],
+                         params=params, isJson=False)
+            self.assertStatus(resp, 303)
+            self.assertEqual(resp.headers['Location'],
+                             'http://localhost/#foo/bar')
+            self.assertTrue('girderToken' in resp.cookie)
+
+            resp = self.request('/user/me',
+                                token=resp.cookie['girderToken'].value)
+            self.assertStatusOk(resp)
+            self.assertEqual(resp.json['email'],
+                providerInfo['accounts'][accountType]['user']['email'])
+            self.assertEqual(resp.json['login'],
+                providerInfo['accounts'][accountType]['user']['login'])
+            self.assertEqual(resp.json['firstName'],
+                providerInfo['accounts'][accountType]['user']['firstName'])
+            self.assertEqual(resp.json['lastName'],
+                providerInfo['accounts'][accountType]['user']['lastName'])
+
+        # Try callback for the 'existing' account, which should succeed
+        doOauthLogin('existing')
+
+        # Try callback for the 'new' account, with open registration
+        self.model('setting').set(SettingKey.REGISTRATION_POLICY, 'open')
+        doOauthLogin('new')
+
+        # Password login for 'new' OAuth-only user should fail gracefully
+        newUser = providerInfo['accounts']['new']['user']
+        resp = self.request('/user/authentication',
+                            basicAuth='%s:mypasswd' % newUser['login'])
+        self.assertStatus(resp, 400)
+        self.assertTrue(
+            resp.json['message'].startswith('You don\'t have a password.'))
+
+        # Reset password for 'new' OAuth-only user should work
         self.assertTrue(base.mockSmtp.isMailQueueEmpty())
-        resp = self.request(path='/user/password/temporary', method='PUT',
-                            params={'email': email})
+        resp = self.request('/user/password/temporary',
+            method='PUT', params={
+                'email': providerInfo['accounts']['new']['user']['email']})
         self.assertStatusOk(resp)
         self.assertEqual(resp.json['message'], 'Sent temporary access email.')
         self.assertTrue(base.mockSmtp.waitForMail())
         msg = base.mockSmtp.getMail()
-
         # Pull out the auto-generated token from the email
         search = re.search('<a href="(.*)">', msg)
         link = search.group(1)
@@ -318,163 +325,430 @@ class OauthTest(base.TestCase):
         tokenId = linkParts[-1]
         tempToken = self.model('token').load(
             tokenId, force=True, objectId=False)
-
-        path = '/user/password/temporary/' + str(newUser['_id'])
-        resp = self.request(path=path, method='GET', params={'token': tokenId})
+        resp = self.request('/user/password/temporary/' + userId,
+            method='GET', params={
+                'token': tokenId})
         self.assertStatusOk(resp)
-        user = resp.json['user']
-
+        self.assertEqual(resp.json['user']['login'], newUser['login'])
         # We should now be able to change the password
-        resp = self.request(path='/user/password', method='PUT', params={
-            'old': tokenId,
-            'new': 'mypasswd'
-        }, user=user)
+        resp = self.request('/user/password',
+            method='PUT', user=resp.json['user'], params={
+                'old': tokenId,
+                'new': 'mypasswd'})
         self.assertStatusOk(resp)
-
         # The temp token should get deleted on password change
         token = self.model('token').load(tempToken, force=True, objectId=False)
         self.assertEqual(token, None)
 
-    def _createCsrfCookie(self, cookie):
-        info = json.loads(cookie['oauthLogin'].value)
-        return 'oauthLogin="%s"' % json.dumps({
-            'redirect': info['redirect'],
-            'token': info['token'],
-        }).replace('"', r'\"')
-
-    def testGitHubOauth(self):
-        from girder.plugins.oauth.constants import PluginSettings
-
-        self.model('setting').set(PluginSettings.PROVIDERS_ENABLED, ['github'])
-
-        resp = self.request('/oauth/provider', exception=True, params={
-            'redirect': 'http://localhost/#foo/bar'})
-        self.assertStatus(resp, 500)
-        self.assertTrue(
-            resp.json['message'].find(
-                'No GitHub client ID setting is present.'
-            ) >= 0
-        )
-
-        self.model('setting').set(PluginSettings.GITHUB_CLIENT_ID, 'abc')
-        self.model('setting').set(PluginSettings.GITHUB_CLIENT_SECRET, '123')
-
-        resp = self.request('/oauth/provider', exception=True, params={
-            'redirect': 'http://localhost/#foo/bar',
-            'list': True
-        })
-
+        # Password login for 'new' OAuth-only user should now succeed
+        resp = self.request('/user/authentication',
+                            basicAuth='%s:mypasswd' % newUser['login'])
         self.assertStatusOk(resp)
-        for provider in resp.json:
-            self.assertHasKeys(provider, ('id', 'name', 'url'))
-            if provider['id'] == 'github':
-                self.assertEqual(provider['name'], 'GitHub')
-                providerUrl = provider['url']
-                break
-        else:
-            self.fail()
-        self.assertEqual(len(resp.json), 1)  # Only one provider enabled
-        urlParts = urllib.parse.urlparse(providerUrl)
-        queryParams = urllib.parse.parse_qs(urlParts.query)
-        self.assertEqual(urlParts.scheme, 'https')
-        self.assertEqual(urlParts.netloc, 'github.com')
-        self.assertEqual(urlParts.path, '/login/oauth/authorize')
-        self.assertEqual(queryParams['client_id'], ['abc'])
-        self.assertRegexpMatches(queryParams['redirect_uri'][0],
-            r'http://127\.0\.0\.1(?::\d+)?/api/v1/oauth/github/callback')
-        self.assertEqual(queryParams['state'][0].partition('.')[2],
-                         'http://localhost/#foo/bar')
-        self.assertEqual(queryParams['scope'], ['user:email'])
-        # Save this valid token for later
-        csrfToken = self._getCsrfToken(resp, 'github')
 
-        # Test the error condition for callback
-        resp = self.request('/oauth/github/callback', params={
-            'code': None,
-            'error': 'access_denied',
-        }, exception=True)
-        self.assertStatus(resp, 502)
-        self.assertEqual(
-            resp.json['message'],
-            "Provider returned error: 'access_denied'."
-        )
 
-        # Test login with a new user
+    @httmock.all_requests
+    def mockOtherRequest(self, url, request):
+        raise Exception('Unexpected url %s' % str(request.url))
 
-        @httmock.all_requests
-        def githubMock(url, request):
-            if (url.netloc == 'github.com' and
-                    url.path == '/login/oauth/access_token'):
-                return json.dumps({
+
+    def testGoogleOauth(self):
+        providerInfo = {
+            'id': 'google',
+            'name': 'Google',
+            'client_id': {
+                'key': PluginSettings.GOOGLE_CLIENT_ID,
+                'value': 'google_test_client_id'
+            },
+            'client_secret': {
+                'key': PluginSettings.GOOGLE_CLIENT_SECRET,
+                'value': 'google_test_client_secret'
+            },
+            'allowed_callback_re':
+                r'^http://127\.0\.0\.1(?::\d+)?/api/v1/oauth/google/callback$',
+            'url_re': r'^https://accounts\.google\.com/o/oauth2/auth',
+            'accounts': {
+                'existing': {
+                    'auth_code': 'google_existing_auth_code',
+                    'access_token': 'google_existing_test_token',
+                    'user': {
+                        'login': self.adminUser['login'],
+                        'email': self.adminUser['email'],
+                        'firstName': self.adminUser['firstName'],
+                        'lastName': self.adminUser['lastName'],
+                        'oauth': {
+                            'provider': 'google',
+                            'id': '5326'
+                        }
+                    }
+                },
+                'new': {
+                    'auth_code': 'google_new_auth_code',
+                    'access_token': 'google_new_test_token',
+                    'user': {
+                        # this login will be created internally by _deriveLogin
+                        'login': 'googleuser',
+                        'email': 'google_user@mail.com',
+                        'firstName': 'John',
+                        'lastName': 'Doe',
+                        'oauth': {
+                            'provider': 'google',
+                            'id': '9876'
+                        }
+                    }
+                }
+            }
+        }
+
+        @httmock.urlmatch(scheme='https', netloc='^accounts.google.com$',
+                          path='^/o/oauth2/auth$', method='GET')
+        def mockGoogleRedirect(url, request):
+            try:
+                params = urllib.parse.parse_qs(url.query)
+                self.assertEqual(
+                    params['response_type'],
+                    ['code'])
+                self.assertEqual(
+                    params['access_type'],
+                    ['online'])
+                self.assertEqual(
+                    params['scope'],
+                    ['profile email'])
+            except (KeyError, AssertionError) as e:
+                return {
+                    'status_code': 400,
+                    'content': json.dumps({
+                        'error': e.message
+                    })
+                }
+            try:
+                self.assertEqual(
+                    params['client_id'],
+                    [providerInfo['client_id']['value']])
+            except (KeyError, AssertionError) as e:
+                return {
+                    'status_code': 401,
+                    'content': json.dumps({
+                        'error': e.message
+                    })
+                }
+            try:
+                self.assertRegexpMatches(
+                    params['redirect_uri'][0],
+                    providerInfo['allowed_callback_re'])
+                state = params['state'][0]
+                # Nothing to test for state, since provider doesn't care
+            except (KeyError, AssertionError) as e:
+                return {
+                    'status_code': 400,
+                    'content': json.dumps({
+                        'error': e.message
+                    })
+                }
+            returnQuery = urllib.parse.urlencode({
+                'state': state,
+                'code': providerInfo['accounts'][self.accountType]['auth_code']
+            })
+            return {
+                'status_code': 302,
+                'headers': {
+                    'Location': '%s?%s' % (params['redirect_uri'][0],
+                                           returnQuery)
+                }
+            }
+
+        @httmock.urlmatch(scheme='https', netloc='^accounts.google.com$',
+                          path='^/o/oauth2/token$', method='POST')
+        def mockGoogleToken(url, request):
+            try:
+                params = urllib.parse.parse_qs(request.body)
+                self.assertEqual(
+                    params['client_id'],
+                    [providerInfo['client_id']['value']])
+            except (KeyError, AssertionError) as e:
+                return {
+                    'status_code': 401,
+                    'content': json.dumps({
+                        'error': e.message
+                    })
+                }
+            try:
+                self.assertEqual(
+                    params['grant_type'],
+                    ['authorization_code'])
+                self.assertEqual(
+                    params['client_secret'],
+                    [providerInfo['client_secret']['value']])
+                self.assertRegexpMatches(
+                    params['redirect_uri'][0],
+                    providerInfo['allowed_callback_re'])
+                for account in six.viewvalues(providerInfo['accounts']):
+                    if account['auth_code'] == params['code'][0]:
+                        break
+                else:
+                    self.fail()
+            except (KeyError, AssertionError) as e:
+                return {
+                    'status_code': 400,
+                    'content': json.dumps({
+                        'error': e.message
+                    })
+                }
+            return json.dumps({
+                'token_type': 'Bearer',
+                'access_token': account['access_token'],
+                'expires_in': 3546,
+                'id_token': 'google_id_token'
+            })
+
+        @httmock.urlmatch(scheme='https', netloc='^www.googleapis.com$',
+                          path='^/plus/v1/people/me$', method='GET')
+        def mockGoogleApi(url, request):
+            try:
+                for account in six.viewvalues(providerInfo['accounts']):
+                    if 'Bearer %s' % account['access_token'] == \
+                            request.headers['Authorization']:
+                        break
+                else:
+                    self.fail()
+
+                params = urllib.parse.parse_qs(url.query)
+                self.assertSetEqual(
+                    set(params['fields'][0].split(',')),
+                    {'id', 'emails', 'name'})
+            except AssertionError as e:
+                return {
+                    'status_code': 401,
+                    'content': json.dumps({
+                        'error': e.message
+                    })
+                }
+            return json.dumps({
+                'id': account['user']['oauth']['id'],
+                'name': {
+                    'givenName': account['user']['firstName'],
+                    'familyName': account['user']['lastName']
+                },
+                'emails': [
+                    {
+                        'type': 'other',
+                        'value': 'secondary@email.com'
+                    }, {
+                        'type': 'account',
+                        'value': account['user']['email']
+                    }
+                ]
+            })
+
+        with httmock.HTTMock(
+            mockGoogleRedirect,
+            mockGoogleToken,
+            mockGoogleApi,
+            # Must keep "mockOtherRequest" last
+            self.mockOtherRequest
+        ):
+            self._testOauth(providerInfo)
+
+
+    def testGithubOauth(self):
+        providerInfo = {
+            'id': 'github',
+            'name': 'GitHub',
+            'client_id': {
+                'key': PluginSettings.GITHUB_CLIENT_ID,
+                'value': 'github_test_client_id'
+            },
+            'client_secret': {
+                'key': PluginSettings.GITHUB_CLIENT_SECRET,
+                'value': 'github_test_client_secret'
+            },
+            'allowed_callback_re':
+                r'^http://127\.0\.0\.1(?::\d+)?/api/v1/oauth/github/callback$',
+            'url_re': r'^https://github\.com/login/oauth/authorize',
+            'accounts': {
+                'existing': {
+                    'auth_code': 'github_existing_auth_code',
+                    'access_token': 'github_existing_test_token',
+                    'user': {
+                        'login': self.adminUser['login'],
+                        'email': self.adminUser['email'],
+                        'firstName': self.adminUser['firstName'],
+                        'lastName': self.adminUser['lastName'],
+                        'oauth': {
+                            'provider': 'github',
+                            'id': '2399'
+                        }
+                    }
+                },
+                'new': {
+                    'auth_code': 'github_new_auth_code',
+                    'access_token': 'github_new_test_token',
+                    'user': {
+                        # login may be provided externally by GitHub; for
+                        # simplicity here, do not use a username with whitespace
+                        # or underscores
+                        'login': 'jane83',
+                        'email': 'github_user@mail.com',
+                        'firstName': 'Jane',
+                        'lastName': 'Doe',
+                        'oauth': {
+                            'provider': 'github',
+                            'id': 1234
+                        }
+                    }
+                }
+            }
+        }
+
+        @httmock.urlmatch(scheme='https', netloc='^github.com$',
+                          path='^/login/oauth/authorize$', method='GET')
+        def mockGithubRedirect(url, request):
+            redirectUri = None
+            try:
+                params = urllib.parse.parse_qs(url.query)
+                # Check redirect_uri first, so other errors can still redirect
+                redirectUri = params['redirect_uri'][0]
+                self.assertEqual(
+                    params['client_id'],
+                    [providerInfo['client_id']['value']])
+            except (KeyError, AssertionError) as e:
+                return {
+                    'status_code': 404,
+                    'content': json.dumps({
+                        'error': e.message
+                    })
+                }
+            try:
+                self.assertRegexpMatches(
+                    redirectUri,
+                    providerInfo['allowed_callback_re'])
+                state = params['state'][0]
+                # Nothing to test for state, since provider doesn't care
+                self.assertEqual(
+                    params['scope'],
+                    ['user:email'])
+            except (KeyError, AssertionError) as e:
+                returnQuery = urllib.parse.urlencode({
+                    'error': e.message,
+                })
+            else:
+                returnQuery = urllib.parse.urlencode({
+                    'state': state,
+                    'code': providerInfo['accounts'][self.accountType]['auth_code']
+                })
+            return {
+                'status_code': 302,
+                'headers': {
+                    'Location': '%s?%s' % (redirectUri, returnQuery)
+                }
+            }
+
+        @httmock.urlmatch(scheme='https', netloc='^github.com$',
+                          path='^/login/oauth/access_token$', method='POST')
+        def mockGithubToken(url, request):
+            try:
+                self.assertEqual(request.headers['Accept'], 'application/json')
+                params = urllib.parse.parse_qs(request.body)
+                self.assertEqual(
+                    params['client_id'],
+                    [providerInfo['client_id']['value']])
+            except (KeyError, AssertionError) as e:
+                return {
+                    'status_code': 404,
+                    'content': json.dumps({
+                        'error': e.message
+                    })
+                }
+            try:
+                for account in six.viewvalues(providerInfo['accounts']):
+                    if account['auth_code'] == params['code'][0]:
+                        break
+                else:
+                    self.fail()
+                self.assertEqual(
+                    params['client_secret'],
+                    [providerInfo['client_secret']['value']])
+                self.assertRegexpMatches(
+                    params['redirect_uri'][0],
+                    providerInfo['allowed_callback_re'])
+            except (KeyError, AssertionError) as e:
+                returnBody = json.dumps({
+                    'error': e.message,
+                    'error_description': e.message
+                })
+            else:
+                returnBody = json.dumps({
                     'token_type': 'bearer',
-                    'access_token': 'abcd',
-                    'scope': ['user:email']
+                    'access_token': account['access_token'],
+                    'scope': 'user:email'
                 })
-            elif (url.netloc == 'api.github.com' and
-                    url.path == '/user'):
-                return json.dumps({
-                    'name': 'John Doe',
-                    'login': 'johndoe',
-                    'id': 1234
-                })
-            elif (url.netloc == 'api.github.com' and
-                    url.path == '/user/emails'):
-                return json.dumps([{
+            return {
+                'status_code': 200,
+                'headers': {
+                    'Content-Type': 'application/json'
+                },
+                'content': returnBody
+            }
+
+
+        @httmock.urlmatch(scheme='https', netloc='^api.github.com$',
+                          path='^/user$', method='GET')
+        def mockGithubApiUser(url, request):
+            try:
+                for account in six.viewvalues(providerInfo['accounts']):
+                    if 'token %s' % account['access_token'] == \
+                            request.headers['Authorization']:
+                        break
+                else:
+                    self.fail()
+            except AssertionError as e:
+                return {
+                    'status_code': 401,
+                    'content': json.dumps({
+                        'message': e.message
+                    })
+                }
+            return json.dumps({
+                'id': account['user']['oauth']['id'],
+                'login': account['user']['login'],
+                'name': '%s %s' % (account['user']['firstName'],
+                                   account['user']['lastName'])
+            })
+
+        @httmock.urlmatch(scheme='https', netloc='^api.github.com$',
+                          path='^/user/emails$', method='GET')
+        def mockGithubApiEmail(url, request):
+            try:
+                for account in six.viewvalues(providerInfo['accounts']):
+                    if 'token %s' % account['access_token'] == \
+                            request.headers['Authorization']:
+                        break
+                else:
+                    self.fail()
+            except AssertionError as e:
+                return {
+                    'status_code': 401,
+                    'content': json.dumps({
+                        'message': e.message
+                    })
+                }
+            return json.dumps([
+                {
                     'primary': False,
                     'email': 'secondary@email.com',
                     'verified': True
                 }, {
                     'primary': True,
-                    'email': 'primary@email.com',
+                    'email': account['user']['email'],
                     'verified': True
-                }])
-            else:
-                raise Exception('Unexpected url %s' % str(url))
+                }
+            ])
 
-        with httmock.HTTMock(githubMock):
-            resp = self.request('/oauth/github/callback', isJson=False, params={
-                'code': '12345',
-                'state': csrfToken
-            })
-
-        self.assertStatus(resp, 303)
-        self.assertEqual(resp.headers['Location'],
-                         'http://localhost/#foo/bar')
-        self.assertTrue('girderToken' in resp.cookie)
-
-        resp = self.request('/user/me', token=resp.cookie['girderToken'].value)
-        self.assertStatusOk(resp)
-        self.assertEqual(resp.json['email'], 'primary@email.com')
-        self.assertEqual(resp.json['login'], 'johndoe')
-        self.assertEqual(resp.json['firstName'], 'John')
-        self.assertEqual(resp.json['lastName'], 'Doe')
-        newUserId = resp.json['_id']
-
-        # Test login as an existing user
-        email = 'admin@mail.com'
-
-        # Get a fresh token
-        resp = self.request('/oauth/provider', params={
-            'redirect': 'http://localhost/#foo/bar',
-            'list': True
-        })
-        self.assertStatusOk(resp)
-        csrfToken = self._getCsrfToken(resp, 'github')
-
-        with httmock.HTTMock(githubMock):
-            resp = self.request('/oauth/github/callback', isJson=False, params={
-                'code': '12345',
-                'state': csrfToken
-            })
-
-        self.assertStatus(resp, 303)
-        self.assertEqual(resp.headers['Location'],
-                         'http://localhost/#foo/bar')
-        self.assertTrue('girderToken' in resp.cookie)
-
-        token = self.model('token').load(resp.cookie['girderToken'].value,
-                                         force=True, objectId=False)
-        newUser = self.model('user').load(token['userId'], force=True)
-        self.assertEqual(str(newUser['_id']), newUserId)
-        self.assertEqual(newUser['email'], 'primary@email.com')
-        self.assertIn({'provider': 'github', 'id': 1234}, newUser['oauth'])
+        with httmock.HTTMock(
+            mockGithubRedirect,
+            mockGithubToken,
+            mockGithubApiUser,
+            mockGithubApiEmail,
+            # Must keep "mockOtherRequest" last
+            self.mockOtherRequest
+        ):
+            self._testOauth(providerInfo)

--- a/plugins/oauth/plugin_tests/oauth_test.py
+++ b/plugins/oauth/plugin_tests/oauth_test.py
@@ -417,7 +417,7 @@ class OauthTest(base.TestCase):
                 return {
                     'status_code': 400,
                     'content': json.dumps({
-                        'error': e.message
+                        'error': repr(e)
                     })
                 }
             try:
@@ -428,7 +428,7 @@ class OauthTest(base.TestCase):
                 return {
                     'status_code': 401,
                     'content': json.dumps({
-                        'error': e.message
+                        'error': repr(e)
                     })
                 }
             try:
@@ -441,7 +441,7 @@ class OauthTest(base.TestCase):
                 return {
                     'status_code': 400,
                     'content': json.dumps({
-                        'error': e.message
+                        'error': repr(e)
                     })
                 }
             returnQuery = urllib.parse.urlencode({
@@ -468,7 +468,7 @@ class OauthTest(base.TestCase):
                 return {
                     'status_code': 401,
                     'content': json.dumps({
-                        'error': e.message
+                        'error': repr(e)
                     })
                 }
             try:
@@ -490,7 +490,7 @@ class OauthTest(base.TestCase):
                 return {
                     'status_code': 400,
                     'content': json.dumps({
-                        'error': e.message
+                        'error': repr(e)
                     })
                 }
             return json.dumps({
@@ -519,7 +519,7 @@ class OauthTest(base.TestCase):
                 return {
                     'status_code': 401,
                     'content': json.dumps({
-                        'error': e.message
+                        'error': repr(e)
                     })
                 }
             return json.dumps({
@@ -614,7 +614,7 @@ class OauthTest(base.TestCase):
                 return {
                     'status_code': 404,
                     'content': json.dumps({
-                        'error': e.message
+                        'error': repr(e)
                     })
                 }
             try:
@@ -628,7 +628,7 @@ class OauthTest(base.TestCase):
                     ['user:email'])
             except (KeyError, AssertionError) as e:
                 returnQuery = urllib.parse.urlencode({
-                    'error': e.message,
+                    'error': repr(e),
                 })
             else:
                 returnQuery = urllib.parse.urlencode({
@@ -655,7 +655,7 @@ class OauthTest(base.TestCase):
                 return {
                     'status_code': 404,
                     'content': json.dumps({
-                        'error': e.message
+                        'error': repr(e)
                     })
                 }
             try:
@@ -672,8 +672,8 @@ class OauthTest(base.TestCase):
                     providerInfo['allowed_callback_re'])
             except (KeyError, AssertionError) as e:
                 returnBody = json.dumps({
-                    'error': e.message,
-                    'error_description': e.message
+                    'error': repr(e),
+                    'error_description': repr(e)
                 })
             else:
                 returnBody = json.dumps({
@@ -704,7 +704,7 @@ class OauthTest(base.TestCase):
                 return {
                     'status_code': 401,
                     'content': json.dumps({
-                        'message': e.message
+                        'message': repr(e)
                     })
                 }
             return json.dumps({
@@ -728,7 +728,7 @@ class OauthTest(base.TestCase):
                 return {
                     'status_code': 401,
                     'content': json.dumps({
-                        'message': e.message
+                        'message': repr(e)
                     })
                 }
             return json.dumps([

--- a/plugins/oauth/server/providers/base.py
+++ b/plugins/oauth/server/providers/base.py
@@ -94,7 +94,8 @@ class ProviderBase(model_importer.ModelImporter):
         """
         raise NotImplementedError()
 
-    def _getJson(self, **kwargs):
+    @staticmethod
+    def _getJson(**kwargs):
         """
         Make an HTTP request using the specified kwargs, then parse it as JSON
         and return the value. If an error occurs, this raises an appropriate
@@ -119,9 +120,10 @@ class ProviderBase(model_importer.ModelImporter):
         except ValueError:
             raise RestException('Non-JSON response: %s' % content, code=502)
 
-    def _createOrReuseUser(self, oauthId, email, firstName, lastName,
+    @classmethod
+    def _createOrReuseUser(cls, oauthId, email, firstName, lastName,
                            userName=None):
-        providerName = self.getProviderName()
+        providerName = cls.getProviderName()
 
         # Try finding by ID first, since a user can change their email address
         query = {
@@ -135,24 +137,24 @@ class ProviderBase(model_importer.ModelImporter):
             # The Google provider was previously stored as capitalized, and
             # legacy databases may still have these entries
             query['oauth.provider'] = {'$in': ['google', 'Google']}
-        user = self.model('user').findOne(query)
+        user = cls.model('user').findOne(query)
         setId = not user
 
         # Existing users using OAuth2 for the first time will not have an ID
         if not user:
-            user = self.model('user').findOne({'email': email})
+            user = cls.model('user').findOne({'email': email})
 
         dirty = False
         # Create the user if it's still not found
         if not user:
-            policy = self.model('setting').get(SettingKey.REGISTRATION_POLICY)
+            policy = cls.model('setting').get(SettingKey.REGISTRATION_POLICY)
             if policy != 'open':
                 raise RestException(
                     'Registration on this instance is closed. Contact an '
                     'administrator to create an account for you.')
-            login = self._deriveLogin(email, firstName, lastName, userName)
+            login = cls._deriveLogin(email, firstName, lastName, userName)
 
-            user = self.model('user').createUser(
+            user = cls.model('user').createUser(
                 login=login, password=None, firstName=firstName,
                 lastName=lastName, email=email)
         else:
@@ -179,11 +181,12 @@ class ProviderBase(model_importer.ModelImporter):
                 })
             dirty = True
         if dirty:
-            user = self.model('user').save(user)
+            user = cls.model('user').save(user)
 
         return user
 
-    def _generateLogins(self, email, firstName, lastName, userName=None):
+    @classmethod
+    def _generateLogins(cls, email, firstName, lastName, userName=None):
         """
         Generate a series of reasonable login names for a new user based on
         their basic information sent to us by the provider.
@@ -208,7 +211,8 @@ class ProviderBase(model_importer.ModelImporter):
         for i in range(1, 6):
             yield '%s%s%d' % (firstName, lastName, i)
 
-    def _deriveLogin(self, email, firstName, lastName, userName=None):
+    @classmethod
+    def _deriveLogin(cls, email, firstName, lastName, userName=None):
         """
         Attempt to automatically create a login name from existing user
         information from OAuth2 providers. Attempts to generate it from the
@@ -221,15 +225,16 @@ class ProviderBase(model_importer.ModelImporter):
         """
         # Note, the user's OAuth2 ID should never be used to form a login name,
         # as many OAuth2 services consider that to be private data
-        for login in self._generateLogins(email, firstName, lastName, userName):
+        for login in cls._generateLogins(email, firstName, lastName, userName):
             login = login.lower()
-            if self._testLogin(login):
+            if cls._testLogin(login):
                 return login
 
         raise Exception('Could not generate a unique login name for %s (%s %s)'
                         % (email, firstName, lastName))
 
-    def _testLogin(self, login):
+    @classmethod
+    def _testLogin(cls, login):
         """
         When attempting to generate a username, use this to test if the given
         name is valid.
@@ -241,5 +246,5 @@ class ProviderBase(model_importer.ModelImporter):
             return False
 
         # See if this is already taken.
-        user = self.model('user').findOne({'login': login})
+        user = cls.model('user').findOne({'login': login})
         return not user

--- a/plugins/oauth/server/providers/base.py
+++ b/plugins/oauth/server/providers/base.py
@@ -111,8 +111,8 @@ class ProviderBase(model_importer.ModelImporter):
             resp.raise_for_status()
         except requests.HTTPError:
             raise RestException(
-                'Got %s from %s, response="%s".' % (
-                    resp.status_code, kwargs['url'], content
+                'Got %s code from provider, response="%s".' % (
+                    resp.status_code, content
                 ), code=502)
 
         try:

--- a/plugins/oauth/server/providers/github.py
+++ b/plugins/oauth/server/providers/github.py
@@ -64,9 +64,15 @@ class GitHub(ProviderBase):
             'client_secret': self.clientSecret,
             'redirect_uri': self.redirectUri,
         }
+        # GitHub returns application/x-www-form-urlencoded unless
+        # otherwise specified with Accept
         resp = self._getJson(method='POST', url=self._TOKEN_URL,
                              data=params,
                              headers={'Accept': 'application/json'})
+        if 'error' in resp:
+            raise RestException(
+                'Got an error exchanging token from provider: "%s".' % resp,
+                code=502)
         return resp
 
     def getUser(self, token):

--- a/plugins/oauth/server/providers/github.py
+++ b/plugins/oauth/server/providers/github.py
@@ -89,7 +89,7 @@ class GitHub(ProviderBase):
         emails = [
             email.get('email')
             for email in resp
-            if email.get('primary')
+            if email.get('primary') and email.get('verified')
         ]
         if not emails:
             raise RestException(

--- a/plugins/oauth/web_client/js/ConfigView.js
+++ b/plugins/oauth/web_client/js/ConfigView.js
@@ -31,7 +31,7 @@ girder.views.oauth_ConfigView = girder.View.extend({
         }, {
             id: 'github',
             name: 'GitHub',
-            icon: 'github',
+            icon: 'github-circled',
             hasAuthorizedOrigins: false,
             instructions: 'Client IDs and secret keys are managed in the ' +
                           'Applications page of your GitHub account settings. ' +

--- a/plugins/oauth/web_client/stylesheets/login.styl
+++ b/plugins/oauth/web_client/stylesheets/login.styl
@@ -50,7 +50,7 @@
 
 .g-oauth-button-github
   // http://brandcolors.net?brands=76
-  $brandColor = #666666
+  $brandColor = #333333
 
   background-color $brandColor
   border 1px solid darken($brandColor, 30%)

--- a/plugins/oauth/web_client/templates/oauth_config.jade
+++ b/plugins/oauth/web_client/templates/oauth_config.jade
@@ -23,15 +23,20 @@ p Only fill in the information for the OAuth2 providers you wish to enable.
           .g-oauth-value-container
             b Authorized redirect URI:
             span.g-oauth-value= origin + apiRoot + '/oauth/' + provider.id + '/callback'
-          form.g-oauth-provider-form(role="form" id="g-oauth-provider-#{provider.id}-form"
+          form.g-oauth-provider-form(role="form",
+                                     id="g-oauth-provider-#{provider.id}-form",
                                      provider-id=provider.id)
             .form-group
               label.control-label(for="g-oauth-provider-#{provider.id}-client-id") #{provider.name} client ID
-              input.input-sm.form-control(id="g-oauth-provider-#{provider.id}-client-id"
-                type="text" placeholder="Client ID")
+              input.input-sm.form-control(id="g-oauth-provider-#{provider.id}-client-id",
+                                          type="text",
+                                          placeholder="Client ID")
             .form-group
               label.control-label(for="g-oauth-provider-#{provider.id}-client-secret") #{provider.name} client secret
-              input.input-sm.form-control(id="g-oauth-provider-#{provider.id}-client-secret"
-                type="text" placeholder="Client secret")
+              input.input-sm.form-control(id="g-oauth-provider-#{provider.id}-client-secret",
+                                          type="text",
+                                          placeholder="Client secret")
             p.g-validation-failed-message(id="g-oauth-provider-#{provider.id}-error-message")
-            input.btn.btn-sm.btn-primary(type="submit" value="Save" provider-id=provider.id)
+            input.btn.btn-sm.btn-primary(type="submit",
+                                         value="Save",
+                                         provider-id=provider.id)


### PR DESCRIPTION
* Refactor OAuth plugin testing
 * This will make additional OAuth providers much easier to test.
* Fix a small security issue in OAuth
 * This prevents possibly private information from leaking in an error message.
* Fix an unhandled potential error in GitHub login
* Require verified email addresses from GitHub
* Update GitHub icon and colors to be more correct
* Fix Jade syntax on OAuth config page
 * Commas delimiting attributes are technically required.
