### PR TITLE
Fix plugin topological ordering

### DIFF
--- a/girder/models/setting.py
+++ b/girder/models/setting.py
@@ -22,7 +22,7 @@ import cherrypy
 import six
 
 from ..constants import SettingDefault
-from .model_base import Model, ValidationException, GirderException
+from .model_base import Model, ValidationException
 from girder.utility import camelcase, plugin_utilities
 from bson.objectid import ObjectId
 

--- a/girder/models/setting.py
+++ b/girder/models/setting.py
@@ -49,7 +49,7 @@ class Setting(Model):
             getattr(self, funcName)(doc)
         else:
             raise ValidationException(
-                'Invalid setting key "{}".'.format(key), 'key')
+                'Invalid setting key "%s".' % key, 'key')
 
         return doc
 
@@ -63,27 +63,8 @@ class Setting(Model):
             raise ValidationException(
                 'Plugins enabled setting must be a list.', 'value')
 
-        allPlugins = plugin_utilities.findAllPlugins()
-        doc['value'] = set(doc['value'])
-
-        def addDeps(plugin):
-            for dep in allPlugins[plugin]['dependencies']:
-                if dep not in doc['value']:
-                    doc['value'].add(dep)
-
-                if dep not in allPlugins:
-                    raise GirderException(
-                        'Required dependency %s does not exist.' % dep)
-                else:
-                    addDeps(dep)
-
-        for enabled in list(doc['value']):
-            if enabled in allPlugins:
-                addDeps(enabled)
-            else:
-                doc['value'].remove(enabled)
-
-        doc['value'] = list(doc['value'])
+        # Add all transitive dependencies and store in toposorted order
+        doc['value'] = list(plugin_utilities.getToposortedPlugins(doc['value']))
 
     def validateCoreAddToGroupPolicy(self, doc):
         doc['value'] = doc['value'].lower()
@@ -172,7 +153,7 @@ class Setting(Model):
             host = '://'.join((cherrypy.request.scheme,
                                cherrypy.request.local.name))
             if cherrypy.request.local.port != 80:
-                host += ':{}'.format(cherrypy.request.local.port)
+                host += ':%s' % cherrypy.request.local.port
             return host
 
     def validateCoreRegistrationPolicy(self, doc):

--- a/girder/utility/plugin_utilities.py
+++ b/girder/utility/plugin_utilities.py
@@ -38,6 +38,7 @@ import yaml
 
 from girder.constants import PACKAGE_DIR, ROOT_DIR, ROOT_PLUGINS_PACKAGE, \
     TerminalColor
+from girder.models.model_base import ValidationException
 from girder.utility import mail_utils, config
 
 
@@ -101,6 +102,10 @@ def getToposortedPlugins(plugins, curConfig=None):
     visited = set()
 
     def addDeps(plugin):
+        if plugin not in allPlugins:
+            raise ValidationException(
+                'Required plugin %s does not exist.' % plugin)
+
         deps = allPlugins[plugin]['dependencies']
         dag[plugin] = deps
 
@@ -297,7 +302,6 @@ def findAllPlugins(curConfig=None):
                                 ('ERROR: Plugin "%s": '
                                  'plugin.json is not valid JSON.') % plugin))
                         print(e)
-                        continue
             elif os.path.isfile(configYml):
                 with open(configYml) as conf:
                     try:
@@ -308,7 +312,6 @@ def findAllPlugins(curConfig=None):
                                 ('ERROR: Plugin "%s": '
                                  'plugin.yml is not valid YAML.') % plugin))
                         print(e)
-                        continue
 
             allPlugins[plugin] = {
                 'name': data.get('name', plugin),

--- a/girder/utility/server.py
+++ b/girder/utility/server.py
@@ -121,7 +121,8 @@ def configureServer(test=False, plugins=None, curConfig=None):
     })
 
     root, appconf, _ = plugin_utilities.loadPlugins(
-        plugins, root, appconf, root.api.v1, curConfig=curConfig)
+        plugins, root, appconf, root.api.v1, curConfig=curConfig,
+        buildDag=False)
 
     return root, appconf
 

--- a/girder/utility/server.py
+++ b/girder/utility/server.py
@@ -105,6 +105,7 @@ def configureServer(test=False, plugins=None, curConfig=None):
         plugins = settings.get(constants.SettingKey.PLUGINS_ENABLED,
                                default=())
 
+    plugins = list(plugin_utilities.getToposortedPlugins(plugins, curConfig))
     root.updateHtmlVars({
         'apiRoot': curConfig['server']['api_root'],
         'staticRoot': curConfig['server']['static_root'],

--- a/tests/cases/system_test.py
+++ b/tests/cases/system_test.py
@@ -259,8 +259,8 @@ class SystemTestCase(base.TestCase):
                                   'test_plugins')
         conf = config.getConfig()
         conf['plugins'] = {'plugin_directory': pluginRoot}
-        # Try to enable a good plugin and a bad plugin.  Only the good plugin
-        # should be enabled.
+
+        # Enabling plugins with bad JSON/YML should still work.
         resp = self.request(
             path='/system/plugins', method='PUT', user=self.users[0],
             params={'plugins': '["test_plugin","bad_json","bad_yaml"]'})

--- a/tests/cases/system_test.py
+++ b/tests/cases/system_test.py
@@ -107,10 +107,19 @@ class SystemTestCase(base.TestCase):
         }, user=users[0])
         self.assertStatus(resp, 400)
 
-        # Set a valid setting key
+        # Set an invalid setting value, should fail
         resp = self.request(path='/system/setting', method='PUT', params={
             'key': SettingKey.PLUGINS_ENABLED,
             'value': json.dumps(obj)
+        }, user=users[0])
+        self.assertStatus(resp, 400)
+        self.assertEqual(resp.json['message'],
+                         'Required plugin _invalid_ does not exist.')
+
+        # Set a valid value
+        resp = self.request(path='/system/setting', method='PUT', params={
+            'key': SettingKey.PLUGINS_ENABLED,
+            'value': json.dumps(['geospatial', 'oauth'])
         }, user=users[0])
         self.assertStatusOk(resp)
 
@@ -139,7 +148,7 @@ class SystemTestCase(base.TestCase):
         # We should also be able to put several setting using a JSON list
         resp = self.request(path='/system/setting', method='PUT', params={
             'list': json.dumps([
-                {'key': SettingKey.PLUGINS_ENABLED, 'value': json.dumps(obj)},
+                {'key': SettingKey.PLUGINS_ENABLED, 'value': json.dumps(())},
                 {'key': SettingKey.COOKIE_LIFETIME, 'value': None},
             ])
         }, user=users[0])
@@ -153,8 +162,7 @@ class SystemTestCase(base.TestCase):
             ])
         }, user=users[0])
         self.assertStatusOk(resp)
-        self.assertEqual(set(resp.json[SettingKey.PLUGINS_ENABLED]),
-                         set(['oauth', 'geospatial']))
+        self.assertEqual(resp.json[SettingKey.PLUGINS_ENABLED], [])
 
         # We can get the default values, or ask for no value if the current
         # value is taken from the default
@@ -241,9 +249,9 @@ class SystemTestCase(base.TestCase):
             path='/system/plugins', method='PUT', user=self.users[0],
             params={'plugins': '["has_nonexistent_deps"]'},
             exception=True)
-        self.assertStatus(resp, 500)
+        self.assertStatus(resp, 400)
         self.assertEqual(resp.json['message'],
-                         ("Required dependency a_plugin_that_does_not_exist"
+                         ("Required plugin a_plugin_that_does_not_exist"
                           " does not exist."))
 
     def testBadPlugin(self):
@@ -257,11 +265,8 @@ class SystemTestCase(base.TestCase):
             path='/system/plugins', method='PUT', user=self.users[0],
             params={'plugins': '["test_plugin","bad_json","bad_yaml"]'})
         self.assertStatusOk(resp)
-        enabled = resp.json['value']
-        self.assertEqual(len(enabled), 1)
-        self.assertTrue('test_plugin' in enabled)
-        self.assertTrue('bad_json' not in enabled)
-        self.assertTrue('bad_yaml' not in enabled)
+        enabled = set(resp.json['value'])
+        self.assertEqual({'test_plugin', 'bad_json', 'bad_yaml'}, enabled)
 
     def testRestart(self):
         resp = self.request(path='/system/restart', method='PUT',


### PR DESCRIPTION
Transitive plugin dependencies were broken. This unifies the code
path for DAG traversal and toposorting of plugins between the
storage code in the setting model and the loading code, and now
properly supports transitive dependency ordering. This also dies
gracefully if cycles exist.