### PR TITLE
Disable pip's cache when testing girder installation

### DIFF
--- a/tests/packaging/pip_install_girder.sh
+++ b/tests/packaging/pip_install_girder.sh
@@ -7,7 +7,7 @@ virtualenv_dir="${4}"
 unset PYTHONPATH
 
 "${virtualenv_pip}" uninstall -y girder > /dev/null
-"${virtualenv_pip}" install -U "${PROJECT_SOURCE_DIR}"/girder-[0-9].[0-9]*.tar.gz
+"${virtualenv_pip}" --no-cache-dir install -U "${PROJECT_SOURCE_DIR}"/girder-[0-9].[0-9]*.tar.gz
 if [ $? -ne 0 ]; then
     echo "Error during pip install girder package"
     exit 1


### PR DESCRIPTION
For a while, the `packaging_install` test has been spitting out messages that look like [this](https://travis-ci.org/girder/girder/jobs/103215239):
```
127:   creating build/bdist.linux-x86_64/wheel/girder-1.4.1.dist-info/WHEEL
127:   error: [Errno 2] No such file or directory: 'build/bdist.linux-x86_64/wheel/girder/clients/web/static/lib/bootstrap/css/bootstrap-switch.min.css'
127:   
127:   ----------------------------------------
127: Failed to build girder
127: Installing collected packages: pycparser, cffi, six, bcrypt, boto, CherryPy, MarkupSafe, Mako, pymongo, PyYAML, requests, psutil, pytz, girder
127:   Running setup.py install for girder
127: Successfully installed CherryPy-4.0.0 Mako-1.0.3 MarkupSafe-0.23 PyYAML-3.11 bcrypt-2.0.0 boto-2.38.0 cffi-1.5.0 girder-1.4.1 psutil-3.4.1 pycparser-2.14 pymongo-3.2 pytz-2015.7 requests-2.9.1 six-1.10.0
127: /home/travis/build/girder/girder/_build/env/bin/girder-server
127: /home/travis/build/girder/girder/_build/env/lib/python2.7/site-packages/girder/mail_templates/_header.mako
 70/131 Test #127: packaging_install ............................................................   Passed   12.15 sec
```
I have no idea what specific component is causing that error to be raised or why it is silently ignored.  There is a good chance the client side components are actually broken in some way after they have been installed by this test, but the only way to detect that would be to rerun the test suite against the installation.

I believe what is causing the error message is some sort of caching that pip is doing between test instances because we are maintaining the same girder version number for each build.  The missing file it is complaining about was removed from the build in #1161.  Clearly something in the cache via a manifest or something else still references it.

This PR runs the install in the test without caching (which is what we should be doing anyway).  By the looks of the build log, it successfully got rid of the error message.