### PR TITLE
Trigger g:logout on logout instead of g:login

### DIFF
--- a/clients/web/src/init.js
+++ b/clients/web/src/init.js
@@ -202,8 +202,8 @@ _.extend(girder, {
             girder.currentUser = null;
             girder.currentToken = null;
 
-            girder.events.trigger('g:login', null);
             girder.events.trigger('g:logout.success');
+            girder.events.trigger('g:logout');
         }, function (jqxhr) {
             girder.events.trigger('g:logout.error', jqxhr.status, jqxhr);
         });


### PR DESCRIPTION
On login:
- `g:login` is triggered
- `g:login.success` or `g:login.error` is triggered

On logout:
- `g:login` is triggered
- `g:logout.success` or `g:logout.error` is triggered

Girder uses `g:logout` in 2 places even though it's never defined. It happens to be in places where `g:login` is bound to the same function - so it accidentally works :).

This is a judgement call for Girder developers, as it technically breaks backwards compatibility.