### PR TITLE
Only install what we need from clients dir

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ class InstallWithOptions(install):
         dest = os.path.join(self.install_lib, 'girder')
         shutil.copy('Gruntfile.js', dest)
         shutil.copy('package.json', dest)
-        self.mergeDir('clients', dest)
+        self.mergeDir(os.path.join('clients', 'web', 'src'), dest)
+        self.mergeDir(os.path.join('clients', 'web', 'static'), dest)
         self.mergeDir('grunt_tasks', dest)
         self.mergeDir('plugins', dest)
 


### PR DESCRIPTION
The symlink in the test dir was breaking our `python setup.py install` command, which was also breaking our RTD build. This branch fixes that as a side effect; the real change here is to clean up our sdist to only include what we need from the clients dir, which is just the prod-required content within the web client dir.