### PR TITLE
Scoped access decorators

### DIFF
--- a/girder/api/access.py
+++ b/girder/api/access.py
@@ -76,11 +76,11 @@ def user(*args, **kwargs):
             @six.wraps(fun)
             def wrapped(*iargs, **ikwargs):
                 token = rest.getCurrentToken()
-                if (not _tokenModel.hasScope(token, kwargs.get('scope')) and
-                        not rest.getCurrentUser()):
+                if not rest.getCurrentUser():
                     raise AccessException('You must be logged in.')
                 return fun(*iargs, **ikwargs)
             wrapped.accessLevel = 'user'
+            wrapped.requiredScopes = kwargs.get('scope')
             return wrapped
         return dec
 

--- a/girder/api/access.py
+++ b/girder/api/access.py
@@ -141,26 +141,16 @@ def cookie(*args, **kwargs):
 
     While allowing cookie authentication on other types of routes exposes an
     application to Cross-Site Request Forgery (CSRF) attacks, an optional
-    ``force=True`` argument may be passed to the decorator to make it effective
+    ``force=True`` kwarg may be passed to the decorator to make it effective
     on any type of route.
     """
     if len(args) == 1 and callable(args[0]):  # Used as a raw decorator
         force = False
         args[0].cookieAuth = (True, force)
         return args[0]
-
     else:  # Used with arguments
-        if len(args) == 1 and isinstance(args[0], bool):
-            force = args[0]
-        elif 'force' in kwargs:
-            force = kwargs['force']
-        elif (not args) and (not kwargs):
-            force = False
-        else:
-            raise TypeError('Unsupported extra decorator arguments.')
-
         def decorator(fun):
-            fun.cookieAuth = (True, force)
+            fun.cookieAuth = (True, kwargs.get('force', False))
             return fun
 
         return decorator

--- a/girder/api/access.py
+++ b/girder/api/access.py
@@ -46,11 +46,10 @@ def admin(*args, **kwargs):
         def dec(fun):
             @six.wraps(fun)
             def wrapped(*iargs, **ikwargs):
-                token = rest.getCurrentToken()
-                if not _tokenModel.hasScope(token, kwargs.get('scope')):
-                    rest.requireAdmin(rest.getCurrentUser())
+                rest.requireAdmin(rest.getCurrentUser())
                 return fun(*iargs, **ikwargs)
             wrapped.accessLevel = 'admin'
+            wrapped.requiredScopes = kwargs.get('scope')
             return wrapped
         return dec
 

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -222,11 +222,14 @@ class loadmodel(ModelImporter):  # noqa: class name
     :type plugin: str
     :param level: Access level, if this is an access controlled model.
     :type level: AccessType
-    :param force:
+    :param force: Force loading of the model (skip access check).
     :type force: bool
+    :param exc: Whether an exception should be raised for a nonexistent
+        resource.
+    :type exc: bool
     """
     def __init__(self, map=None, model=None, plugin='_core', level=None,
-                 force=False):
+                 force=False, exc=True):
         if map is None:
             self.map = {'id': model}
         else:
@@ -236,6 +239,7 @@ class loadmodel(ModelImporter):  # noqa: class name
         self.force = force
         self.modelName = model
         self.plugin = plugin
+        self.exc = exc
 
     def _getIdValue(self, kwargs, idParam):
         if idParam in kwargs:
@@ -261,7 +265,7 @@ class loadmodel(ModelImporter):  # noqa: class name
                 else:
                     kwargs[converted] = model.load(id)
 
-                if kwargs[converted] is None:
+                if kwargs[converted] is None and self.exc:
                     raise RestException(
                         'Invalid %s id (%s).' % (model.name, str(id)))
 

--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -109,7 +109,7 @@ class System(Resource):
 
         return True
 
-    @access.admin(scope=TokenScope.READ_SETTINGS)
+    @access.admin(scope=TokenScope.SETTINGS_READ)
     @describeRoute(
         Description('Get the value of a system setting, or a list of them.')
         .notes('Must be a system administrator to call this.')
@@ -147,7 +147,7 @@ class System(Resource):
             self.requireParams('key', params)
             return getFunc(params['key'], **funcParams)
 
-    @access.admin(scope=TokenScope.READ_SETTINGS)
+    @access.admin(scope=TokenScope.PLUGINS_ENABLED_READ)
     @describeRoute(
         Description('Get the lists of all available and all enabled plugins.')
         .notes('Must be a system administrator to call this.')

--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -26,7 +26,7 @@ import six
 import os
 
 from girder.api import access
-from girder.constants import SettingKey, VERSION
+from girder.constants import SettingKey, TokenScope, VERSION
 from girder.models.model_base import GirderException
 from girder.utility import plugin_utilities
 from girder.utility import system
@@ -109,7 +109,7 @@ class System(Resource):
 
         return True
 
-    @access.admin
+    @access.admin(scope=TokenScope.READ_SETTINGS)
     @describeRoute(
         Description('Get the value of a system setting, or a list of them.')
         .notes('Must be a system administrator to call this.')
@@ -147,17 +147,13 @@ class System(Resource):
             self.requireParams('key', params)
             return getFunc(params['key'], **funcParams)
 
-    @access.admin
+    @access.admin(scope=TokenScope.READ_SETTINGS)
     @describeRoute(
         Description('Get the lists of all available and all enabled plugins.')
         .notes('Must be a system administrator to call this.')
         .errorResponse('You are not a system administrator.', 403)
     )
     def getPlugins(self, params):
-        """
-        Return the plugin information for the system. This includes a list of
-        all of the currently enabled plugins, as well as
-        """
         return {
             'all': plugin_utilities.findAllPlugins(),
             'enabled': self.model('setting').get(SettingKey.PLUGINS_ENABLED)
@@ -203,7 +199,7 @@ class System(Resource):
         self.requireParams('key', params)
         return self.model('setting').unset(params['key'])
 
-    @access.admin
+    @access.admin(scope=TokenScope.PARTIAL_UPLOAD_READ)
     @describeRoute(
         Description('Get a list of uploads that have not been finished.')
         .notes("Must be a system administrator to call this.")
@@ -246,7 +242,7 @@ class System(Resource):
                 uploadList += untrackedList[:limit-len(uploadList)]
         return uploadList
 
-    @access.admin
+    @access.admin(scope=TokenScope.PARTIAL_UPLOAD_CLEAN)
     @describeRoute(
         Description('Discard uploads that have not been finished.')
         .notes("""Must be a system administrator to call this. This frees

--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -202,7 +202,7 @@ class System(Resource):
     @access.admin(scope=TokenScope.PARTIAL_UPLOAD_READ)
     @describeRoute(
         Description('Get a list of uploads that have not been finished.')
-        .notes("Must be a system administrator to call this.")
+        .notes('Must be a system administrator to call this.')
         .param('uploadId', 'List only a specific upload.', required=False)
         .param('userId', 'Restrict listing uploads to those started by a '
                'specific user.', required=False)

--- a/girder/constants.py
+++ b/girder/constants.py
@@ -195,11 +195,12 @@ class TokenScope:
     ANONYMOUS_SESSION = 'core.anonymous_session'
     USER_AUTH = 'core.user_auth'
     TEMPORARY_USER_AUTH = 'core.user_auth.temporary'
-    READ_SETTINGS = 'core.setting.read'
-    READ_ASSETSTORES = 'core.assetstore.read'
+    PLUGINS_ENABLED_READ = 'core.plugins.read'
+    SETTINGS_READ = 'core.setting.read'
+    ASSETSTORES_READ = 'core.assetstore.read'
     PARTIAL_UPLOAD_READ = 'core.partial_upload.read'
     PARTIAL_UPLOAD_CLEAN = 'core.partial_upload.clean'
-    USER_EMAIL_READ = 'core.user_email_read'
+    DATA_READ = 'core.data_read'
 
 
 class CoreEventHandler(object):

--- a/girder/constants.py
+++ b/girder/constants.py
@@ -199,6 +199,7 @@ class TokenScope:
     READ_ASSETSTORES = 'core.assetstore.read'
     PARTIAL_UPLOAD_READ = 'core.partial_upload.read'
     PARTIAL_UPLOAD_CLEAN = 'core.partial_upload.clean'
+    USER_EMAIL_READ = 'core.user_email_read'
 
 
 class CoreEventHandler(object):

--- a/girder/constants.py
+++ b/girder/constants.py
@@ -195,6 +195,10 @@ class TokenScope:
     ANONYMOUS_SESSION = 'core.anonymous_session'
     USER_AUTH = 'core.user_auth'
     TEMPORARY_USER_AUTH = 'core.user_auth.temporary'
+    READ_SETTINGS = 'core.setting.read'
+    READ_ASSETSTORES = 'core.assetstore.read'
+    PARTIAL_UPLOAD_READ = 'core.partial_upload.read'
+    PARTIAL_UPLOAD_CLEAN = 'core.partial_upload.clean'
 
 
 class CoreEventHandler(object):

--- a/girder/models/token.py
+++ b/girder/models/token.py
@@ -128,6 +128,12 @@ class Token(AccessControlledModel):
             of the given token's allowed scopes.
         :type scope: str or list of str
         """
+        if token is None:
+            return False
+
+        if scope is None:
+            return True
+
         if isinstance(scope, six.string_types):
             scope = (scope,)
         return set(scope).issubset(set(self.getAllowedScopes(token)))

--- a/plugins/thumbnails/server/worker.py
+++ b/plugins/thumbnails/server/worker.py
@@ -139,7 +139,6 @@ def attachThumbnail(file, thumbnail, attachToType, attachToId, width, height):
     :type height: int
     :returns: The updated thumbnail file document.
     """
-
     parentModel = ModelImporter.model(attachToType)
     parent = parentModel.load(attachToId, force=True)
     parent['_thumbnails'] = parent.get('_thumbnails', [])

--- a/tests/cases/notification_test.py
+++ b/tests/cases/notification_test.py
@@ -48,7 +48,7 @@ class NotificationTestCase(base.TestCase):
         self.assertStatus(resp, 401)
         self.assertEqual(
             resp.json['message'],
-            'You must be logged in or supply a valid session token.')
+            'You must be logged in or have a valid auth token.')
 
         resp = self.request(path='/notification/stream', method='GET',
                             user=user, token=token, isJson=False,

--- a/tests/cases/system_test.py
+++ b/tests/cases/system_test.py
@@ -26,7 +26,7 @@ from subprocess import check_output, CalledProcessError
 
 from .. import base
 from girder.api.describe import API_VERSION
-from girder.constants import SettingKey, SettingDefault, ROOT_DIR, TokenScope
+from girder.constants import SettingKey, SettingDefault, ROOT_DIR
 from girder.utility import config
 
 

--- a/tests/cases/system_test.py
+++ b/tests/cases/system_test.py
@@ -352,32 +352,3 @@ class SystemTestCase(base.TestCase):
             '=== Last 0 bytes of %s/info.log: ===\n\n' % logRoot)
 
         del config.getConfig()['logging']
-
-    def testTokenScopeAuthorization(self):
-        resp = self.request('/system/setting')
-        self.assertStatus(resp, 401)
-
-        # Make sure a normal user can't use the endpoint
-        resp = self.request('/system/setting', user=self.users[1])
-        self.assertStatus(resp, 403)
-        self.assertEqual(resp.json['message'], 'Administrator access required.')
-
-        # Make sure an admin can use the endpoint
-        params = {'key': SettingKey.SMTP_HOST}
-        resp = self.request('/system/setting', user=self.users[0],
-                            params=params)
-        self.assertStatusOk(resp)
-        val = resp.json
-
-        # Token with the wrong scope should fail
-        token = self.model('token').createToken(
-            scope=TokenScope.READ_ASSETSTORES)
-        resp = self.request('/system/setting', token=token, params=params)
-        self.assertStatus(resp, 401)
-        print(resp.json)
-
-        # Token with correct scope should succeed
-        token = self.model('token').createToken(scope=TokenScope.READ_SETTINGS)
-        resp = self.request('/system/setting', token=token, params=params)
-        self.assertStatusOk(resp)
-        self.assertEqual(resp.json, val)

--- a/tests/cases/system_test.py
+++ b/tests/cases/system_test.py
@@ -373,7 +373,7 @@ class SystemTestCase(base.TestCase):
         token = self.model('token').createToken(
             scope=TokenScope.READ_ASSETSTORES)
         resp = self.request('/system/setting', token=token, params=params)
-        self.assertStatus(resp, 403)
+        self.assertStatus(resp, 401)
         print(resp.json)
 
         # Token with correct scope should succeed

--- a/tests/cases/token_test.py
+++ b/tests/cases/token_test.py
@@ -20,7 +20,6 @@
 import random
 
 from .. import base
-from girder.constants import SettingKey, TokenScope
 from girder.models.token import genToken
 
 
@@ -43,7 +42,7 @@ class TokensTestCase(base.TestCase):
 
         self.assertNotEqual(token1, token2)
 
-    def atestGetAndDeleteSessiona(self):
+    def testGetAndDeleteSession(self):
         resp = self.request(path='/token/session', method='GET')
         self.assertStatusOk(resp)
         token = resp.json['token']
@@ -75,47 +74,4 @@ class TokensTestCase(base.TestCase):
         self.assertStatusOk(resp)
         # Now the token is gone, so it should fail
         resp = self.request(path='/token/session', method='DELETE', token=token)
-        self.assertStatus(resp, 401)
-
-    def testTokenScopes(self):
-        admin = self.model('user').createUser(
-            email='admin@admin.com', firstName='admin', lastName='admin',
-            login='admin', password='passwd')
-        nonadmin = self.model('user').createUser(
-            email='normal@normal.com', firstName='normal', lastName='normal',
-            login='normal', password='passwd')
-        adminSettingToken = self.model('token').createToken(
-            user=admin, scope=TokenScope.READ_SETTINGS)
-        adminEmailToken = self.model('token').createToken(
-            user=admin, scope=TokenScope.USER_EMAIL_READ)
-        nonadminToken = self.model('token').createToken(
-            user=nonadmin, scope=TokenScope.READ_SETTINGS)
-
-        # Reading settings as admin should work
-        params = {'key': SettingKey.SMTP_PORT}
-        path = '/system/setting'
-        resp = self.request(path=path, params=params, user=admin)
-        self.assertStatusOk(resp)
-        self.assertEqual(resp.json, 25)
-
-        # Reading setting as non-admin should fail
-        resp = self.request(path=path, params=params, user=nonadmin)
-        self.assertStatus(resp, 403)
-
-        # Reading settings with a properly scoped token should work
-        resp = self.request(path=path, params=params, token=adminSettingToken)
-        self.assertStatusOk(resp)
-        self.assertEqual(resp.json, 25)
-
-        # Reading settings with an improperly scoped token should fail
-        resp = self.request(path=path, params=params, token=adminEmailToken)
-        self.assertStatus(resp, 401)
-
-        # Non-admin user with this token scope should still not work
-        resp = self.request(path=path, params=params, token=nonadminToken)
-        self.assertStatus(resp, 403)
-        self.assertEqual(resp.json['message'], 'Administrator access required.')
-
-        # The setting-scope token should not grant access to other endpoints
-        resp = self.request(path='/assetstore', token=adminSettingToken)
         self.assertStatus(resp, 401)


### PR DESCRIPTION
This branch has been lingering for a long while, I think it would be good to have @girder/developers look at it. This creates the initial infrastructure necessary for us to scope our tokens to allow third-party systems limited authenticated access to the server. This is the first step toward allowing girder to act as an OAuth provider.

The discussion of exactly what scopes should exist and what endpoints should correspond to what scopes is up for debate; I selected a minimal set that I think is sensible to start with. Anything that doesn't fall under these scopes is currently only accessible in the old way, i.e. normal authenticated user access. My hope is that we can slowly open up more and more endpoints to scoped access.