### PR TITLE
Proposal: change web client build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_install:
 install:
     - pip install -r requirements.txt -r requirements-dev.txt -e .
     - npm install
+    - npm run build
 script:
     - mkdir _build
     - cd _build

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,5 @@ RUN pip install -e .[plugins]
 
 RUN npm install -g grunt-cli && npm cache clear
 RUN npm install --unsafe-perm && npm cache clear
+RUN npm run build
 ENTRYPOINT ["python", "-m", "girder"]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,7 @@ recursive-include clients/web *
 recursive-include girder/mail_templates *
 recursive-include grunt_tasks *
 recursive-include plugins *
+recursive-include scripts/node *
 global-exclude *.pyc *.pyo *.cmake
 prune clients/web/static/built
 prune clients/web/dev

--- a/cmake/aiur_nightly.cmake
+++ b/cmake/aiur_nightly.cmake
@@ -17,7 +17,7 @@ ctest_start("Nightly")
 ctest_update(SOURCE ${CTEST_SOURCE_DIRECTORY})
 
 # We must run grunt so the correct git hash gets built into the version file
-execute_process(COMMAND npm install WORKING_DIRECTORY ${CTEST_SOURCE_DIRECTORY})
+execute_process(COMMAND npm run build WORKING_DIRECTORY ${CTEST_SOURCE_DIRECTORY})
 
 ctest_configure()
 ctest_build()

--- a/cmake/run_aiur_dashboard.sh
+++ b/cmake/run_aiur_dashboard.sh
@@ -5,6 +5,7 @@ workon girder
 cd /home/cpatrick/Dashboards/girder
 ./scripts/InstallPythonRequirements.py --mode=dev
 npm install
+npm run build
 python setup.py install
 # Copy compile plugin template files so that the javascript coverage locates
 # them properly.  There are certainly nicer ways to do this.

--- a/devops/ansible/playbook.yml
+++ b/devops/ansible/playbook.yml
@@ -48,21 +48,11 @@
     pip: name='file:///vagrant/girder[plugins]' editable=yes
     sudo: yes
 
-  - name: install grunt and globally
-    npm: name={{ item }} global=yes
-    with_items:
-      - grunt
-      - grunt-cli
-    sudo: yes
-
   - name: run npm install
     npm: path=/vagrant
 
-  - name: run grunt init
-    command: grunt init chdir=/vagrant
-
-  - name: run grunt
-    command: grunt chdir=/vagrant
+  - name: run npm build
+    command: npm run build chdir=/vagrant
 
   - name: disable default nginx site
     command: rm /etc/nginx/sites-enabled/default removes=/etc/nginx/sites-enabled/default

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -106,7 +106,7 @@ example, we have the following:
 After modifying the configuration, always remember to rebuild Girder by
 changing to the Girder directory and issuing the following command: ::
 
-    $ npm install
+    $ npm install && npm run build
 
 Docker Container
 ----------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -115,7 +115,7 @@ to install the plugins as well.
 To build the client-side code project, cd into the root of the repository
 and run: ::
 
-    npm install
+    npm install && npm run build
 
 This will run multiple `Grunt <http://gruntjs.com>`_ tasks, to build all of
 the Javascript and CSS files needed to run the web client application.

--- a/girder/utility/install.py
+++ b/girder/utility/install.py
@@ -60,19 +60,23 @@ def fix_path(path):
 
 def runNpmInstall(wd=None, dev=False, npm='npm'):
     """
-    Use this to run `npm install` inside the package.
+    Use this to run `npm install` inside the package. Also builds the web code
+    using `npm run build`.
     """
     wd = wd or constants.PACKAGE_DIR
+    commands = []
 
-    args = (npm, 'install', '--production', '--unsafe-perm') if not dev \
-        else (npm, 'install', '--unsafe-perm')
+    commands.append((npm, 'install', '--unsafe-perm') if dev
+                    else (npm, 'install', '--production', '--unsafe-perm'))
+    commands.append((npm, 'run', 'build'))
 
-    proc = subprocess.Popen(args, cwd=wd)
-    proc.communicate()
+    for command in commands:
+        proc = subprocess.Popen(command, cwd=wd)
+        proc.communicate()
 
-    if proc.returncode != 0:
-        raise Exception('Web client install failed: npm install returned %s.' %
-                        proc.returncode)
+        if proc.returncode != 0:
+            raise Exception('Web client install failed: `%s` returned %s.' %
+                            (' '.join(command), proc.returncode))
 
 
 def install_web(opts=None):

--- a/grunt_tasks/package.js
+++ b/grunt_tasks/package.js
@@ -38,8 +38,8 @@ module.exports = function (grunt) {
 
                         var fname = 'girder-' + grunt.config.get('pkg').version +
                             '.tar.gz';
-                        var stat = fs.statSync(fname);
-                        if (!err && stat.isFile() && stat.size > 0) {
+                        var stat = fs.existsSync(fname) && fs.statSync(fname);
+                        if (!err && stat && stat.isFile() && stat.size > 0) {
                             grunt.verbose.write(stdout);
                             grunt.log.write('Created ' + fname.cyan + ' (' +
                                             stat.size + ' bytes)\n');

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -26,8 +26,6 @@ module.exports = function (grunt) {
     /**
      * Adds configuration for plugin related multitasks:
      *
-     *   * shell:plugin-<plugin name>
-     *      Runs npm install in the plugin directory
      *   * jade:plugin-<plugin name>
      *      Compiles jade templates into the plugin's template.js
      *   * stylus:plugin-<plugin name>
@@ -45,43 +43,18 @@ module.exports = function (grunt) {
             staticPath = path.resolve(
                 grunt.config.get('staticDir'), 'built', 'plugins', plugin
             ),
-            packageJson = path.resolve(pluginPath, 'package.json'),
             cfg = {
-                shell: {},
                 jade: {},
                 stylus: {},
                 uglify: {},
                 copy: {},
                 watch: {},
                 default: {},
-                plugin: {},
-                'plugin-install': {}
+                plugin: {}
             };
 
         // create the plugin's build directory under the web-root
         grunt.file.mkdir(staticPath);
-
-        cfg.shell[pluginTarget] = {
-            command: function () {
-
-                // do nothing if it has no package.json file
-                if (!fs.existsSync(packageJson)) {
-                    grunt.verbose.writeln('Skipping npm install');
-                    return 'true';
-                }
-                return 'npm install';
-            },
-            options: {
-                execOptions: {
-                    cwd: pluginPath
-                }
-            },
-            src: [packageJson]
-        };
-        cfg.watch[pluginTarget + '-shell'] = {
-            files: [packageJson],
-            tasks: ['shell:' + pluginTarget]
-        };
 
         cfg.jade[pluginTarget] = {
             files: [{
@@ -147,21 +120,12 @@ module.exports = function (grunt) {
             ]
         };
 
-        // finally, 'plugin-install:<plugin name>' is a task alias for
-        // tasks that are run with `grunt init`
-        cfg['plugin-install'][plugin] = {
-            tasks: ['shell:' + pluginTarget]
-        };
-
         grunt.config.merge(cfg);
     };
 
     grunt.config.merge({
         default: {
             plugin: {}
-        },
-        init: {
-            'plugin-install': {}
         }
     });
 
@@ -225,25 +189,6 @@ module.exports = function (grunt) {
                 });
             }
         });
-
-    /**
-     * Create a multi-task for all plugin npm installs.
-     */
-    grunt.registerMultiTask(
-        'plugin-install',
-        'Run npm install in plugin directories',
-        function () {
-            var plugin = this.target,
-                tasks = 'plugin-install.' + plugin + '.tasks';
-
-            this.requiresConfig(tasks);
-
-            // queue the install tasks
-            grunt.config.get(tasks).forEach(function (task) {
-                grunt.task.run(task);
-            });
-        }
-    );
 
     /**
      * Register a "meta" task that will configure and run other tasks

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "jscs": "2.5.1"
   },
   "scripts": {
-    "postinstall": "grunt init && grunt"
+    "postinstall": "node scripts/node/install.js",
+    "build": "grunt init && grunt",
+    "watch": "grunt watch"
   }
 }

--- a/scripts/node/install.js
+++ b/scripts/node/install.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+require('colors');
+var fs = require('fs');
+var path = require('path');
+var childProcess = require('child_process');
+
+var pluginsDir = path.join(path.dirname(path.dirname(__dirname)), 'plugins');
+
+fs.readdirSync(pluginsDir).forEach(function (plugin) {
+    var pluginDir = path.join(pluginsDir, plugin);
+
+    if (!fs.statSync(pluginDir).isDirectory()) {
+        return;
+    }
+
+    if (fs.existsSync(path.join(pluginDir, 'package.json'))) {
+        console.log('Installing npm dependencies for plugin '.bold + plugin.green);
+        childProcess.execSync('npm install', {cwd: pluginDir});
+    }
+
+    // TODO also install bower deps if they exist?
+});

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ class InstallWithOptions(install):
         self.mergeDir(os.path.join('clients', 'web', 'static'), dest)
         self.mergeDir('grunt_tasks', dest)
         self.mergeDir('plugins', dest)
+        self.mergeDir(os.path.join('scripts', 'node'), dest)
 
 with open('README.rst') as f:
     readme = f.read()


### PR DESCRIPTION
This is the first proposed v2.0 PR, so I don't expect it to be merged for quite some time, but I had talked about this last week as the first step toward a better, more abstracted web client build process. The main change here is simply that our web client build process changes from:

    npm install

to

    npm install && npm run build

While the decomposition into two separate steps isn't strictly necessary, it makes the process a bit cleaner and more standardized. With this change, `npm install` installs all required core npm packages, and then recursively installs any packages listed in the `package.json` of any plugin directories. It no longer performs the build. This change moves some of our plugin building logic out of grunt and into raw node scripts, which will make our build code more portable if/when we decide to use something other than grunt. `npm run build` is now the officially sanctioned command for building the web client assets.

I'd like us to also consider whether the `npm install` step should also install any bower requirements from plugins.

One other small API change here is that `grunt watch` will be officially supplanted by `npm run watch`.