### PR TITLE
add version number escaping in grunt_tasks/plugin.js

### DIFF
--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -192,12 +192,18 @@ module.exports = function (grunt) {
                     'Found plugin: ' + plugin + ' (custom Gruntfile)'
                 ).bold);
 
+                // install any additional npm packages during init
                 npm = (
                     _(config.grunt.dependencies || [])
                         .map(function (version, dep) {
+                            // escape any periods in the dependecy version so
+                            // that grunt.config.set does not descend on each
+                            // version number component
+                            var escapedVersion = version.replace(/\./g, '\\.');
+
                             return [
                                 dep,
-                                version.replace(/\./g, '\\.')
+                                escapedVersion
                             ].join('@');
                         })
                 );

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -196,7 +196,7 @@ module.exports = function (grunt) {
                 npm = (
                     _(config.grunt.dependencies || [])
                         .map(function (version, dep) {
-                            // escape any periods in the dependecy version so
+                            // escape any periods in the dependency version so
                             // that grunt.config.set does not descend on each
                             // version number component
                             var escapedVersion = version.replace(/\./g, '\\.');

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -192,10 +192,16 @@ module.exports = function (grunt) {
                     'Found plugin: ' + plugin + ' (custom Gruntfile)'
                 ).bold);
 
-                // install any additional npm packages during init
-                npm = _(config.grunt.dependencies || []).map(function (version, dep) {
-                    return dep + '@' + version;
-                });
+                npm = (
+                    _(config.grunt.dependencies || [])
+                        .map(function (version, dep) {
+                            return [
+                                dep,
+                                version.replace(/\./g, "\\.")
+                            ].join("@");
+                        })
+                );
+
                 if (npm.length) {
                     grunt.config.set(
                         'init.npm-install:' + npm.join(':'), {}

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -197,8 +197,8 @@ module.exports = function (grunt) {
                         .map(function (version, dep) {
                             return [
                                 dep,
-                                version.replace(/\./g, "\\.")
-                            ].join("@");
+                                version.replace(/\./g, '\\.')
+                            ].join('@');
                         })
                 );
 

--- a/tests/test_plugins/has_grunt_deps/plugin.json
+++ b/tests/test_plugins/has_grunt_deps/plugin.json
@@ -1,0 +1,7 @@
+{
+    "grunt": {
+        "dependencies": {
+            "no-op": "^1.0.3"
+        }
+    }
+}


### PR DESCRIPTION
Fixes an issue where the version numbers for dependencies listed in a plugin's `plugin.json` file are not properly escaped prior to passing to grunt.