### PR TITLE
add "autoconf" option to plugin.json

### DIFF
--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -533,7 +533,8 @@ key to your **plugin.json** file.
     "grunt":
         {
         "file" : "Gruntfile.js",
-        "defaultTargets": [ "MY_PLUGIN_TASK" ]
+        "defaultTargets": [ "MY_PLUGIN_TASK" ],
+        "autoconf": true
         }
     }
 
@@ -543,6 +544,11 @@ and add any target to the default one using the "defaultTargets" array.
 .. note:: The **file** key within the **grunt** object must be a path that is
    relative to the root directory of your plugin. It does not have to be called
    ``Gruntfile.js``, it can be called anything you want.
+
+.. note:: Girder creates a number of grunt build tasks that expect plugins to be
+   organized according to a certain convention.  To opt out of these tasks, add
+   an **autoconf** key (default: **true**) within the **grunt** object and set
+   it to **false**.
 
 All paths within your custom Grunt tasks must be relative to the root directory
 of the Girder source repository, rather than relative to the plugin directory.

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -185,13 +185,13 @@ module.exports = function (grunt) {
             }
 
             var doAutoConfig = (
-                typeof config.grunt !== "object" ||
-                config.grunt.autoconf === (void 0) ||
-                config.grunt.autoconf === (null) ||
+               !_.isObject(config.grunt) ||
+                _.isUndefined(config.grunt.autoconf) ||
+                _.isNull(config.grunt.autoconf) ||
               !!config.grunt.autoconf
             );
 
-            if(doAutoConfig) {
+            if (doAutoConfig) {
                 // merge in configuration for the main plugin build tasks
                 configurePlugin(plugin);
             }

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -177,14 +177,23 @@ module.exports = function (grunt) {
                 'Found plugin: ' + plugin
             ).bold);
 
-            // merge in configuration for the main plugin build tasks
-            configurePlugin(plugin);
-
             if (fs.existsSync(json)) {
                 config = grunt.file.readYAML(json);
             }
             if (fs.existsSync(yml)) {
                 config = grunt.file.readYAML(yml);
+            }
+
+            var doAutoConfig = (
+                typeof config.grunt !== "object" ||
+                config.grunt.autoconf === (void 0) ||
+                config.grunt.autoconf === (null) ||
+              !!config.grunt.autoconf
+            );
+
+            if(doAutoConfig) {
+                // merge in configuration for the main plugin build tasks
+                configurePlugin(plugin);
             }
 
             if (config.grunt) {


### PR DESCRIPTION
Allows plugins to explicitly opt-out of the default grunt tasks created for each plugin.
Good idea? Bad idea? Got a better name for the option? Discuss.