### PR TITLE
Upgrade Girder, Minerva, Romanesco common dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # girder core
 coverage==4.0.3
-flake8==2.5.1
+flake8==2.5.2
 flake8-blind-except==0.1.0
 flake8-docstrings==0.2.4
 httmock==1.2.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,25 +1,27 @@
 # girder core
-coverage==3.7.1
-flake8==2.2.2
+coverage==4.0.3
+flake8==2.5.1
 flake8-blind-except==0.1.0
-flake8-docstrings==0.2.1.post1
-httmock==1.2.2
-mccabe==0.3
-mock==1.0.1
+flake8-docstrings==0.2.4
+httmock==1.2.4
+mccabe==0.4.0
+mock==1.3.0
 moto==0.4.0
-Sphinx==1.2.2
-sphinx_rtd_theme==0.1.6
+Sphinx==1.3.5
+sphinx_rtd_theme==0.1.9
 virtualenv==14.0.1
 
 # dependencies of dependencies
 docutils==0.12
 Flask==0.10.1
 httpretty==0.8.10
+funcsigs==0.4
 itsdangerous==0.24
 Jinja2==2.8
+pbr==1.8.1
 pep257==0.7.0
-pep8==1.6.2
+pep8==1.7.0
 pyflakes==1.0.0
-Pygments==2.0.2
+Pygments==2.1
 Werkzeug==0.11.3
 xmltodict==0.9.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,24 +4,34 @@ flake8==2.5.1
 flake8-blind-except==0.1.0
 flake8-docstrings==0.2.4
 httmock==1.2.4
-mccabe==0.4.0
 mock==1.3.0
 moto==0.4.0
 Sphinx==1.3.5
 sphinx_rtd_theme==0.1.9
 virtualenv==14.0.5
 
-# dependencies of dependencies
-docutils==0.12
-Flask==0.10.1
-httpretty==0.8.10
-funcsigs==0.4
-itsdangerous==0.24
-Jinja2==2.8
-pbr==1.8.1
-pep257==0.7.0
+# dependencies of flake8
+mccabe==0.4.0
 pep8==1.7.0
 pyflakes==1.0.0
-Pygments==2.1
+
+# dependencies of flake8-docstrings
+pep257==0.7.0
+
+# dependencies of mock
+funcsigs==0.4
+pbr==1.8.1
+
+# dependencies of moto
+Flask==0.10.1
+httpretty==0.8.10
+itsdangerous==0.24
 Werkzeug==0.11.3
 xmltodict==0.9.2
+
+# dependencies of Sphinx
+docutils==0.12
+Pygments==2.1
+
+# dependencies of moto + Sphinx
+Jinja2==2.8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ mock==1.3.0
 moto==0.4.0
 Sphinx==1.3.5
 sphinx_rtd_theme==0.1.9
-virtualenv==14.0.1
+virtualenv==14.0.5
 
 # dependencies of dependencies
 docutils==0.12

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,8 +30,11 @@ Werkzeug==0.11.3
 xmltodict==0.9.2
 
 # dependencies of Sphinx
+alabaster==0.7.7
+Babel==2.2.0
 docutils==0.12
 Pygments==2.1
+snowballstemmer==1.2.1
 
 # dependencies of moto + Sphinx
 Jinja2==2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,10 +12,10 @@ pytz==2015.7
 six==1.10.0
 
 # celery_jobs
-celery==3.1.19
+celery==3.1.20
 
 # geospatial
-geojson==1.3.1
+geojson==1.3.2
 
 # hdfs_assetstore
 snakebite==2.7.3 ; python_version < '3.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,11 +28,17 @@ hachoir-parser==1.3.4   ; python_version < '3.0'
 # thumbnails
 Pillow==3.1.0
 
-# dependencies of dependencies
+# dependencies of celery
 amqp==1.4.9
 anyjson==0.3.3
 billiard==3.3.0.22
 kombu==3.0.33
-MarkupSafe==0.23
-protobuf==2.6.1
+
+# dependencies of cffi
 pycparser==2.14
+
+# dependencies of Mako
+MarkupSafe==0.23
+
+# dependencies of snakebite
+protobuf==2.6.1

--- a/tests/PythonTests.cmake
+++ b/tests/PythonTests.cmake
@@ -95,7 +95,7 @@ function(add_python_test case)
     add_test(
       NAME ${name}
       WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-      COMMAND "${PYTHON_COVERAGE_EXECUTABLE}" run -p --append "--rcfile=${py_coverage_rc}"
+      COMMAND "${PYTHON_COVERAGE_EXECUTABLE}" run --parallel-mode "--rcfile=${py_coverage_rc}"
               "--source=girder,${PROJECT_SOURCE_DIR}/clients/python/girder_client${other_covg}"
               -m unittest -v ${module}
     )


### PR DESCRIPTION
Celery changes at:
http://docs.celeryproject.org/en/latest/changelog.html

Coverage changes at:
https://coverage.readthedocs.org/en/coverage-4.0.3/changes.html

Flake8 changes at:
https://flake8.readthedocs.org/en/latest/changes.html

Flake8-Docstrings changes at:
https://gitlab.com/pycqa/flake8-docstrings/blob/master/HISTORY.rst

HTTMock changes at (raw form):
https://github.com/patrys/httmock/compare/1.2.2...1.2.4

McCabe changes at:
https://github.com/PyCQA/mccabe#changes

Mock changes at:
https://mock.readthedocs.org/en/latest/changelog.html

Sphinx changes at:
http://www.sphinx-doc.org/en/stable/changes.html

Sphix-RTD-Theme changes at:
https://github.com/snide/sphinx_rtd_theme/#changelog

prb and funcsigs are new dependencies of Mock.