### PR TITLE
change autoconf option name to autobuild

### DIFF
--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -534,7 +534,7 @@ key to your **plugin.json** file.
         {
         "file" : "Gruntfile.js",
         "defaultTargets": [ "MY_PLUGIN_TASK" ],
-        "autoconf": true
+        "autobuild": true
         }
     }
 
@@ -547,7 +547,7 @@ and add any target to the default one using the "defaultTargets" array.
 
 .. note:: Girder creates a number of grunt build tasks that expect plugins to be
    organized according to a certain convention.  To opt out of these tasks, add
-   an **autoconf** key (default: **true**) within the **grunt** object and set
+   an **autobuild** key (default: **true**) within the **grunt** object and set
    it to **false**.
 
 All paths within your custom Grunt tasks must be relative to the root directory

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -184,14 +184,14 @@ module.exports = function (grunt) {
                 config = grunt.file.readYAML(yml);
             }
 
-            var doAutoConfig = (
+            var doAutoBuild = (
                !_.isObject(config.grunt) ||
-                _.isUndefined(config.grunt.autoconf) ||
-                _.isNull(config.grunt.autoconf) ||
-              !!config.grunt.autoconf
+                _.isUndefined(config.grunt.autobuild) ||
+                _.isNull(config.grunt.autobuild) ||
+              !!config.grunt.autobuild
             );
 
-            if (doAutoConfig) {
+            if (doAutoBuild) {
                 // merge in configuration for the main plugin build tasks
                 configurePlugin(plugin);
             }


### PR DESCRIPTION
Supplants #1207.  I've had reservations with my initial choice of `autoconf` for the name of the option, and it looks like I'm not alone.

This PR renames the option to autobuild to avoid confusion with the `autoconf` build tool.

I'll let this PR hang for a few days in case other folks want to chime in with other name suggestions.