### PR TITLE
Exclusively use the describeRoute decorator

### DIFF
--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -150,10 +150,10 @@ and will allow users to interact with it via that UI. See the
 :ref:`RESTful API docs<restapi>` for more information about the Swagger page.
 
 If you are creating routes that you explicitly do not wish to be exposed in the
-Swagger documentation for whatever reason, you can set the handler's description
-to ``None``, and then no warning will appear. ::
+Swagger documentation for whatever reason, you can pass ``None`` to the
+``describeRoute`` decorator, and no warning will appear. ::
 
-    myHandler.description = None
+    @describeRoute(None)
 
 Adding a new resource type to the web API
 *****************************************

--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -42,8 +42,9 @@ class Description(object):
     """
     This class provides convenient chainable semantics to allow api route
     handlers to describe themselves to the documentation. A route handler
-    function can set a description property on itself to an instance of this
-    class in order to describe itself.
+    function can apply the :py:class:`girder.api.describe.describeRoute`
+    decorator to itself (called with an instance of this class) in order to
+    describe itself.
     """
     def __init__(self, summary):
         self._summary = summary
@@ -260,13 +261,13 @@ class Describe(Resource):
 class describeRoute(object):  # noqa: class name
     def __init__(self, description):
         """
-        This returns a decorator that can be used in lieu of setting the
-        description property on a route handler. Pass the Description object
-        (or None) that you want to use to describe this route. It should be
-        used like the following example:
+        This returns a decorator to set the API documentation on a route
+        handler. Pass the Description object (or None) that you want to use to
+        describe this route. It should be used like the following example:
 
-            @describeRoute(Description('Do something')
-                           .param('foo', 'Some parameter', ...)
+            @describeRoute(
+                Description('Do something')
+               .param('foo', 'Some parameter', ...)
             )
             def routeHandler(...)
 

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -632,11 +632,10 @@ class Resource(ModelImporter):
             resource = self.resourceName
         elif resource is None:
             resource = handler.__module__.rsplit('.', 1)[-1]
-        if handler and hasattr(handler, 'description'):
-            if handler.description is not None:
-                docs.removeRouteDocs(
-                    resource=resource, route=route, method=method,
-                    info=handler.description.asDict(), handler=handler)
+        if handler and getattr(handler, 'description', None) is not None:
+            docs.removeRouteDocs(
+                resource=resource, route=route, method=method,
+                info=handler.description.asDict(), handler=handler)
 
     def _shouldInsertRoute(self, a, b):
         """

--- a/girder/api/v1/assetstore.py
+++ b/girder/api/v1/assetstore.py
@@ -17,7 +17,7 @@
 #  limitations under the License.
 ###############################################################################
 
-from ..describe import Description
+from ..describe import Description, describeRoute
 from ..rest import Resource, RestException, loadmodel
 from girder import events
 from girder.constants import AccessType, AssetstoreType
@@ -41,16 +41,23 @@ class Assetstore(Resource):
 
     @access.admin
     @loadmodel(model='assetstore')
-    def getAssetstore(self, assetstore, params):
-        self.model('assetstore').addComputedInfo(assetstore)
-        return assetstore
-    getAssetstore.description = (
+    @describeRoute(
         Description('Get information about an assetstore.')
         .param('id', 'The assetstore ID.', paramType='path')
         .errorResponse()
-        .errorResponse('You are not an administrator.', 403))
+        .errorResponse('You are not an administrator.', 403)
+    )
+    def getAssetstore(self, assetstore, params):
+        self.model('assetstore').addComputedInfo(assetstore)
+        return assetstore
 
     @access.admin
+    @describeRoute(
+        Description('List assetstores.')
+        .pagingParams(defaultSort='name')
+        .errorResponse()
+        .errorResponse('You are not an administrator.', 403)
+    )
     def find(self, params):
         """
         Get a list of assetstores.
@@ -64,40 +71,9 @@ class Assetstore(Resource):
 
         return list(self.model('assetstore').list(
             offset=offset, limit=limit, sort=sort))
-    find.description = (
-        Description('List assetstores.')
-        .pagingParams(defaultSort='name')
-        .errorResponse()
-        .errorResponse('You are not an administrator.', 403))
 
     @access.admin
-    def createAssetstore(self, params):
-        """Create a new assetstore."""
-        self.requireParams(('type', 'name'), params)
-
-        assetstoreType = int(params['type'])
-
-        if assetstoreType == AssetstoreType.FILESYSTEM:
-            self.requireParams('root', params)
-            return self.model('assetstore').createFilesystemAssetstore(
-                name=params['name'], root=params['root'])
-        elif assetstoreType == AssetstoreType.GRIDFS:
-            self.requireParams('db', params)
-            return self.model('assetstore').createGridFsAssetstore(
-                name=params['name'], db=params['db'],
-                mongohost=params.get('mongohost', None),
-                replicaset=params.get('replicaset', None))
-        elif assetstoreType == AssetstoreType.S3:
-            self.requireParams(('bucket'), params)
-            return self.model('assetstore').createS3Assetstore(
-                name=params['name'], bucket=params['bucket'],
-                prefix=params.get('prefix', ''), secret=params.get('secret'),
-                accessKeyId=params.get('accessKeyId'),
-                service=params.get('service', ''),
-                readOnly=self.boolParam('readOnly', params, default=False))
-        else:
-            raise RestException('Invalid type parameter')
-    createAssetstore.description = (
+    @describeRoute(
         Description('Create a new assetstore.')
         .responseClass('Assetstore')
         .notes('You must be an administrator to call this.')
@@ -125,10 +101,55 @@ class Assetstore(Resource):
         .param('readOnly', 'If this assetstore is read-only, set this to true.',
                required=False, dataType='boolean')
         .errorResponse()
-        .errorResponse('You are not an administrator.', 403))
+        .errorResponse('You are not an administrator.', 403)
+    )
+    def createAssetstore(self, params):
+        """Create a new assetstore."""
+        self.requireParams(('type', 'name'), params)
+
+        assetstoreType = int(params['type'])
+
+        if assetstoreType == AssetstoreType.FILESYSTEM:
+            self.requireParams('root', params)
+            return self.model('assetstore').createFilesystemAssetstore(
+                name=params['name'], root=params['root'])
+        elif assetstoreType == AssetstoreType.GRIDFS:
+            self.requireParams('db', params)
+            return self.model('assetstore').createGridFsAssetstore(
+                name=params['name'], db=params['db'],
+                mongohost=params.get('mongohost', None),
+                replicaset=params.get('replicaset', None))
+        elif assetstoreType == AssetstoreType.S3:
+            self.requireParams(('bucket'), params)
+            return self.model('assetstore').createS3Assetstore(
+                name=params['name'], bucket=params['bucket'],
+                prefix=params.get('prefix', ''), secret=params.get('secret'),
+                accessKeyId=params.get('accessKeyId'),
+                service=params.get('service', ''),
+                readOnly=self.boolParam('readOnly', params, default=False))
+        else:
+            raise RestException('Invalid type parameter')
 
     @access.admin
     @loadmodel(model='assetstore')
+    @describeRoute(
+        Description('Import existing data into an assetstore.')
+        .notes('This does not move or copy the existing data, it just creates '
+               'references to it in the Girder data hierarchy. Deleting '
+               'those references will not delete the underlying data. This '
+               'operation is currently only supported for S3 assetstores.')
+        .param('id', 'The ID of the assetstore.', paramType='path')
+        .param('importPath', 'Root path within the underlying storage system '
+               'to import.', required=False)
+        .param('destinationId', 'ID of a folder, collection, or user in Girder '
+               'under which the data will be imported.')
+        .param('destinationType', 'Type of the destination resource.',
+               enum=('folder', 'collection', 'user'))
+        .param('progress', 'Whether to record progress on the import.',
+               dataType='boolean', default=False, required=False)
+        .errorResponse()
+        .errorResponse('You are not an administrator.', 403)
+    )
     def importData(self, assetstore, params):
         self.requireParams(('destinationId', 'destinationType'), params)
 
@@ -148,26 +169,40 @@ class Assetstore(Resource):
             return self.model('assetstore').importData(
                 assetstore, parent=parent, parentType=parentType, params=params,
                 progress=ctx, user=user)
-    importData.description = (
-        Description('Import existing data into an assetstore.')
-        .notes('This does not move or copy the existing data, it just creates '
-               'references to it in the Girder data hierarchy. Deleting '
-               'those references will not delete the underlying data. This '
-               'operation is currently only supported for S3 assetstores.')
-        .param('id', 'The ID of the assetstore.', paramType='path')
-        .param('importPath', 'Root path within the underlying storage system '
-               'to import.', required=False)
-        .param('destinationId', 'ID of a folder, collection, or user in Girder '
-               'under which the data will be imported.')
-        .param('destinationType', 'Type of the destination resource.',
-               enum=('folder', 'collection', 'user'))
-        .param('progress', 'Whether to record progress on the import.',
-               dataType='boolean', default=False, required=False)
-        .errorResponse()
-        .errorResponse('You are not an administrator.', 403))
 
     @access.admin
     @loadmodel(model='assetstore')
+    @describeRoute(
+        Description('Update an existing assetstore.')
+        .responseClass('Assetstore')
+        .param('id', 'The ID of the assetstore.', paramType='path')
+        .param('name', 'Unique name for the assetstore')
+        .param('root', 'Root path on disk (for Filesystem type)',
+               required=False)
+        .param('db', 'Database name (for GridFS type)', required=False)
+        .param('mongohost', 'Mongo host URI (for GridFS type)', required=False)
+        .param('replicaset', 'Replica set name (for GridFS type)',
+               required=False)
+        .param('bucket', 'The S3 bucket to store data in (for S3 type).',
+               required=False)
+        .param('prefix', 'Optional path prefix within the bucket under which '
+               'files will be stored (for S3 type).', required=False)
+        .param('accessKeyId', 'The AWS access key ID to use for authentication '
+               '(for S3 type).', required=False)
+        .param('secret', 'The AWS secret key to use for authentication (for '
+               'S3 type).', required=False)
+        .param('service', 'The S3 service host (for S3 type).  Default is '
+               's3.amazonaws.com.  This can be used to specify a protocol and '
+               'port as well using the form '
+               '[http[s]://](host domain)[:(port)].  Do not include the '
+               'bucket name here.', required=False)
+        .param('readOnly', 'If this assetstore is read-only, set this to true.',
+               required=False, dataType='boolean')
+        .param('current', 'Whether this is the current assetstore',
+               dataType='boolean')
+        .errorResponse()
+        .errorResponse('You are not an administrator.', 403)
+    )
     def updateAssetstore(self, assetstore, params):
         self.requireParams(('name', 'current'), params)
 
@@ -201,46 +236,17 @@ class Assetstore(Resource):
             if event.defaultPrevented:
                 return
         return self.model('assetstore').save(assetstore)
-    updateAssetstore.description = (
-        Description('Update an existing assetstore.')
-        .responseClass('Assetstore')
-        .param('id', 'The ID of the assetstore.', paramType='path')
-        .param('name', 'Unique name for the assetstore')
-        .param('root', 'Root path on disk (for Filesystem type)',
-               required=False)
-        .param('db', 'Database name (for GridFS type)', required=False)
-        .param('mongohost', 'Mongo host URI (for GridFS type)', required=False)
-        .param('replicaset', 'Replica set name (for GridFS type)',
-               required=False)
-        .param('bucket', 'The S3 bucket to store data in (for S3 type).',
-               required=False)
-        .param('prefix', 'Optional path prefix within the bucket under which '
-               'files will be stored (for S3 type).', required=False)
-        .param('accessKeyId', 'The AWS access key ID to use for authentication '
-               '(for S3 type).', required=False)
-        .param('secret', 'The AWS secret key to use for authentication (for '
-               'S3 type).', required=False)
-        .param('service', 'The S3 service host (for S3 type).  Default is '
-               's3.amazonaws.com.  This can be used to specify a protocol and '
-               'port as well using the form '
-               '[http[s]://](host domain)[:(port)].  Do not include the '
-               'bucket name here.', required=False)
-        .param('readOnly', 'If this assetstore is read-only, set this to true.',
-               required=False, dataType='boolean')
-        .param('current', 'Whether this is the current assetstore',
-               dataType='boolean')
-        .errorResponse()
-        .errorResponse('You are not an administrator.', 403))
 
     @access.admin
     @loadmodel(model='assetstore')
-    def deleteAssetstore(self, assetstore, params):
-        self.model('assetstore').remove(assetstore)
-        return {'message': 'Deleted assetstore %s.' % assetstore['name']}
-    deleteAssetstore.description = (
+    @describeRoute(
         Description('Delete an assetstore.')
         .notes('This will fail if there are any files in the assetstore.')
         .param('id', 'The ID of the assetstore.', paramType='path')
         .errorResponse()
         .errorResponse('The assetstore is not empty.')
-        .errorResponse('You are not an administrator.', 403))
+        .errorResponse('You are not an administrator.', 403)
+    )
+    def deleteAssetstore(self, assetstore, params):
+        self.model('assetstore').remove(assetstore)
+        return {'message': 'Deleted assetstore %s.' % assetstore['name']}

--- a/girder/api/v1/group.py
+++ b/girder/api/v1/group.py
@@ -110,17 +110,18 @@ class Group(Resource):
     @access.public
     @loadmodel(model='group', level=AccessType.READ)
     @filtermodel(model='group')
+    @describeRoute(
+        Description('Get a group by ID.')
+        .responseClass('Group')
+        .param('id', 'The ID of the group.', paramType='path')
+        .errorResponse('ID was invalid.')
+        .errorResponse('Read access was denied for the group.', 403)
+    )
     def getGroup(self, group, params):
         # Add in the current setting for adding to groups
         group['_addToGroupPolicy'] = self.model('setting').get(
             SettingKey.ADD_TO_GROUP_POLICY)
         return group
-    getGroup.description = (
-        Description('Get a group by ID.')
-        .responseClass('Group')
-        .param('id', 'The ID of the group.', paramType='path')
-        .errorResponse('ID was invalid.')
-        .errorResponse('Read access was denied for the group.', 403))
 
     @access.public
     @loadmodel(model='group', level=AccessType.READ)

--- a/girder/api/v1/notification.py
+++ b/girder/api/v1/notification.py
@@ -21,7 +21,7 @@ import cherrypy
 import json
 import time
 
-from ..describe import Description
+from ..describe import Description, describeRoute
 from ..rest import Resource
 from girder.api import access
 
@@ -48,6 +48,21 @@ class Notification(Resource):
 
     @access.cookie
     @access.token
+    @describeRoute(
+        Description('Stream notifications for a given user via the SSE '
+                    'protocol.')
+        .notes('This uses long-polling to keep the connection open for '
+               'several minutes at a time (or longer) and should be requested '
+               'with an EventSource object or other SSE-capable client. '
+               '<p>Notifications are returned within a few seconds of when '
+               'they occur.  When no notification occurs for the timeout '
+               'duration, the stream is closed. '
+               '<p>This connection can stay open indefinitely long.')
+        .param('timeout', 'The duration without a notification before the '
+               'stream is closed.', dataType='integer', required=False)
+        .errorResponse()
+        .errorResponse('You are not logged in.', 403)
+    )
     def stream(self, params):
         """
         Streams notifications using the server-sent events protocol. Closes
@@ -84,17 +99,3 @@ class Notification(Resource):
 
                 time.sleep(wait)
         return streamGen
-    stream.description = (
-        Description('Stream notifications for a given user via the SSE '
-                    'protocol.')
-        .notes('This uses long-polling to keep the connection open for '
-               'several minutes at a time (or longer) and should be requested '
-               'with an EventSource object or other SSE-capable client. '
-               '<p>Notifications are returned within a few seconds of when '
-               'they occur.  When no notification occurs for the timeout '
-               'duration, the stream is closed. '
-               '<p>This connection can stay open indefinitely long.')
-        .param('timeout', 'The duration without a notification before the '
-               'stream is closed.', dataType='integer', required=False)
-        .errorResponse()
-        .errorResponse('You are not logged in.', 403))

--- a/girder/api/v1/token.py
+++ b/girder/api/v1/token.py
@@ -18,7 +18,7 @@
 ###############################################################################
 
 from ..rest import Resource
-from ..describe import Description
+from ..describe import Description, describeRoute
 from girder.api import access
 from girder.constants import TokenScope
 
@@ -35,14 +35,21 @@ class Token(Resource):
         self.route('GET', ('current',), self.currentSession)
 
     @access.public
+    @describeRoute(
+        Description('Retrieve the current session information.')
+        .responseClass('Token')
+    )
     def currentSession(self, params):
         token = self.getCurrentToken()
         return token
-    currentSession.description = (
-        Description('Retrieve the current session information.')
-        .responseClass('Token'))
 
     @access.public
+    @describeRoute(
+        Description('Get an anonymous session token for the system.')
+        .notes('If you are logged in, this will return a token associated '
+               'with that login.')
+        .responseClass('Token')
+    )
     def getSession(self, params):
         """
         Create an anonymous session.  Sends an auth cookie in the response on
@@ -60,20 +67,16 @@ class Token(Resource):
             'token': token['_id'],
             'expires': token['expires']
         }
-    getSession.description = (
-        Description('Get an anonymous session token for the system.')
-        .notes('If you are logged in, this will return a token associated '
-               'with that login.')
-        .responseClass('Token'))
 
     @access.token
+    @describeRoute(
+        Description('Remove a session from the system.')
+        .responseClass('Token')
+        .notes('Attempts to delete your authentication cookie.')
+    )
     def deleteSession(self, params):
         token = self.getCurrentToken()
         if token:
             self.model('token').remove(token)
         self.deleteAuthTokenCookie()
         return {'message': 'Session deleted.'}
-    deleteSession.description = (
-        Description('Remove a session from the system.')
-        .responseClass('Token')
-        .notes('Attempts to delete your authentication cookie.'))

--- a/plugins/google_analytics/server/rest.py
+++ b/plugins/google_analytics/server/rest.py
@@ -19,7 +19,7 @@
 
 from . import constants
 from girder.api import access
-from girder.api.describe import Description
+from girder.api.describe import Description, describeRoute
 from girder.api.rest import Resource
 
 
@@ -30,10 +30,10 @@ class GoogleAnalytics(Resource):
         self.route('GET', ('id',), self.getId)
 
     @access.public
+    @describeRoute(
+        Description('Public url for getting the Google Analytics tracking id.')
+    )
     def getId(self, params):
         trackingId = self.model('setting').get(
             constants.PluginSettings.GOOGLE_ANALYTICS_TRACKING_ID)
         return {'google_analytics_id': trackingId}
-    getId.description = (
-        Description('Public url for getting the Google Analytics tracking id.')
-    )

--- a/plugins/hdfs_assetstore/server/rest.py
+++ b/plugins/hdfs_assetstore/server/rest.py
@@ -20,7 +20,7 @@
 import posixpath
 
 from girder.api import access
-from girder.api.describe import Description
+from girder.api.describe import Description, describeRoute
 from girder.api.rest import Resource, loadmodel, RestException
 from girder.utility.progress import ProgressContext
 from snakebite.client import Client as HdfsClient
@@ -84,6 +84,22 @@ class HdfsAssetstoreResource(Resource):
 
     @access.admin
     @loadmodel(model='assetstore')
+    @describeRoute(
+        Description('Import a data hierarchy from an HDFS instance.')
+        .notes('Only site administrators may use this endpoint.')
+        .param('id', 'The ID of the assetstore representing the HDFS instance.',
+               paramType='path')
+        .param('parentId', 'The ID of the parent object in the Girder data '
+               'hierarchy under which to import the files.')
+        .param('parentType', 'The type of the parent object to import into.',
+               enum=('folder', 'user', 'collection'), required=False)
+        .param('path', 'Root of the directory structure (relative to the root '
+               'of the HDFS) to import.')
+        .param('progress', 'Whether to record progress on this operation ('
+               'default=False)', required=False, dataType='boolean')
+        .errorResponse()
+        .errorResponse('You are not an administrator.', 403)
+    )
     def importData(self, assetstore, params):
         self.requireParams(('parentId', 'path'), params)
 
@@ -108,18 +124,3 @@ class HdfsAssetstoreResource(Resource):
                     parentType, parent, assetstore, client, path, ctx, user)
             except FileNotFoundException:
                 raise RestException('File not found: %s.' % path)
-    importData.description = (
-        Description('Import a data hierarchy from an HDFS instance.')
-        .notes('Only site administrators may use this endpoint.')
-        .param('id', 'The ID of the assetstore representing the HDFS instance.',
-               paramType='path')
-        .param('parentId', 'The ID of the parent object in the Girder data '
-               'hierarchy under which to import the files.')
-        .param('parentType', 'The type of the parent object to import into.',
-               enum=('folder', 'user', 'collection'), required=False)
-        .param('path', 'Root of the directory structure (relative to the root '
-               'of the HDFS) to import.')
-        .param('progress', 'Whether to record progress on this operation ('
-               'default=False)', required=False, dataType='boolean')
-        .errorResponse()
-        .errorResponse('You are not an administrator.', 403))

--- a/plugins/mongo_search/server/__init__.py
+++ b/plugins/mongo_search/server/__init__.py
@@ -22,13 +22,24 @@ import bson.json_util
 from girder import events
 from girder.constants import AccessType
 from girder.utility.model_importer import ModelImporter
-from girder.api.describe import Description
+from girder.api.describe import Description, describeRoute
 from girder.api.rest import Resource, RestException
 from girder.api import access
 
 
 class ResourceExt(Resource):
     @access.public
+    @describeRoute(
+        Description('Run any search against a set of mongo collections.')
+        .notes('Results will be filtered by permissions.')
+        .param('type', 'The name of the collection to search, e.g. "item".')
+        .param('q', 'The search query as a JSON object.')
+        .param('limit', "Result set size limit (default=50).", required=False,
+               dataType='int')
+        .param('offset', "Offset into result set (default=0).", required=False,
+               dataType='int')
+        .errorResponse()
+    )
     def mongoSearch(self, params):
         self.requireParams(('type', 'q'), params)
         allowed = {
@@ -60,17 +71,6 @@ class ResourceExt(Resource):
         else:
             return list(model.find(query, fields=allowed[coll], limit=limit,
                                    offset=offset))
-
-    mongoSearch.description = (
-        Description('Run any search against a set of mongo collections.')
-        .notes('Results will be filtered by permissions.')
-        .param('type', 'The name of the collection to search, e.g. "item".')
-        .param('q', 'The search query as a JSON object.')
-        .param('limit', "Result set size limit (default=50).", required=False,
-               dataType='int')
-        .param('offset', "Offset into result set (default=0).", required=False,
-               dataType='int')
-        .errorResponse())
 
 
 def load(info):

--- a/plugins/oauth/server/rest.py
+++ b/plugins/oauth/server/rest.py
@@ -22,7 +22,7 @@ import datetime
 import six
 
 from girder.constants import AccessType
-from girder.api.describe import Description
+from girder.api.describe import Description, describeRoute
 from girder.api.rest import Resource, RestException
 from girder.api import access
 from . import constants, providers
@@ -69,6 +69,15 @@ class OAuth(Resource):
         return redirect
 
     @access.public
+    @describeRoute(
+        Description('Get the list of enabled OAuth2 providers and their URLs.')
+        .notes('By default, returns an object mapping names of providers to '
+               'the appropriate URL.')
+        .param('redirect', 'Where the user should be redirected upon completion'
+               ' of the OAuth2 flow.')
+        .param('list', 'Whether to return the providers as an ordered list.',
+               required=False, dataType='boolean', default=False)
+    )
     def listProviders(self, params):
         self.requireParams(('redirect',), params)
         redirect = params['redirect']
@@ -101,16 +110,9 @@ class OAuth(Resource):
                 provider.getProviderName(external=True): provider.getUrl(state)
                 for provider in enabledProviders
             }
-    listProviders.description = (
-        Description('Get the list of enabled OAuth2 providers and their URLs.')
-        .notes('By default, returns an object mapping names of providers to '
-               'the appropriate URL.')
-        .param('redirect', 'Where the user should be redirected upon completion'
-               ' of the OAuth2 flow.')
-        .param('list', 'Whether to return the providers as an ordered list.',
-               required=False, dataType='boolean', default=False))
 
     @access.public
+    @describeRoute(None)
     def callback(self, provider, params):
         if 'error' in params:
             raise RestException("Provider returned error: '%s'." %
@@ -132,4 +134,3 @@ class OAuth(Resource):
         self.sendAuthTokenCookie(user)
 
         raise cherrypy.HTTPRedirect(redirect)
-    callback.description = None

--- a/plugins/provenance/server/resource.py
+++ b/plugins/provenance/server/resource.py
@@ -24,7 +24,7 @@ import six
 from bson.objectid import ObjectId
 from girder import events
 from girder.api import access
-from girder.api.describe import Description
+from girder.api.describe import Description, describeRoute
 from girder.api.rest import Resource, RestException
 from girder.constants import AccessType
 from girder.models.model_base import AccessControlledModel
@@ -128,6 +128,16 @@ class ResourceExt(Resource):
         return getattr(self, key)
 
     @access.public
+    @describeRoute(
+        Description('Get the provenance for a given resource.')
+        .param('id', 'The resource ID', paramType='path')
+        .param('version', 'The provenance version for the resource.  If not '
+               'specified, the latest provenance data is returned.  If "all" '
+               'is specified, a list of all provenance data is returned.  '
+               'Negative indices can also be used (-1 is the latest '
+               'provenance, -2 second latest, etc.).', required=False)
+        .errorResponse()
+    )
     def provenanceGetHandler(self, id, params, resource=None):
         user = self.getCurrentUser()
         model = self.model(resource)
@@ -161,15 +171,6 @@ class ResourceExt(Resource):
             'resourceId': id,
             'provenance': result
         }
-    provenanceGetHandler.description = (
-        Description('Get the provenance for a given resource.')
-        .param('id', 'The resource ID', paramType='path')
-        .param('version', 'The provenance version for the resource.  If not '
-               'specified, the latest provenance data is returned.  If "all" '
-               'is specified, a list of all provenance data is returned.  '
-               'Negative indices can also be used (-1 is the latest '
-               'provenance, -2 second latest, etc.).', required=False)
-        .errorResponse())
 
     # These methods maintain the provenance
 

--- a/plugins/user_quota/server/quota.py
+++ b/plugins/user_quota/server/quota.py
@@ -23,7 +23,7 @@ import six
 from bson.objectid import ObjectId, InvalidId
 from girder import logger
 from girder.api import access
-from girder.api.describe import Description
+from girder.api.describe import Description, describeRoute
 from girder.api.rest import Resource, RestException, loadmodel
 from girder.constants import AccessType
 from girder.models.model_base import GirderException
@@ -194,6 +194,12 @@ class QuotaPolicy(Resource):
 
     @access.public
     @loadmodel(model='collection', level=AccessType.READ)
+    @describeRoute(
+        Description('Get quota and assetstore policies for the collection.')
+        .param('id', 'The collection ID', paramType='path')
+        .errorResponse('ID was invalid.')
+        .errorResponse('Read permission denied on the collection.', 403)
+    )
     def getCollectionQuota(self, collection, params):
         if QUOTA_FIELD not in collection:
             collection[QUOTA_FIELD] = {}
@@ -201,51 +207,49 @@ class QuotaPolicy(Resource):
             '_currentFileSizeQuota'] = self._getFileSizeQuota(
             'collection', collection)
         return self._filter('collection', collection)
-    getCollectionQuota.description = (
-        Description('Get quota and assetstore policies for the collection.')
-        .param('id', 'The collection ID', paramType='path')
-        .errorResponse('ID was invalid.')
-        .errorResponse('Read permission denied on the collection.', 403))
 
     @access.public
     @loadmodel(model='collection', level=AccessType.ADMIN)
-    def setCollectionQuota(self, collection, params):
-        return self._setResourceQuota('collection', collection, params)
-    setCollectionQuota.description = (
+    @describeRoute(
         Description('Set quota and assetstore policies for the collection.')
         .param('id', 'The collection ID', paramType='path')
         .param('policy', 'A JSON object containing the policies.  This is a '
                'dictionary of keys and values.  Any key that is not specified '
                'does not change.', required=True)
         .errorResponse('ID was invalid.')
-        .errorResponse('Read permission denied on the collection.', 403))
+        .errorResponse('Read permission denied on the collection.', 403)
+    )
+    def setCollectionQuota(self, collection, params):
+        return self._setResourceQuota('collection', collection, params)
 
     @access.public
     @loadmodel(model='user', level=AccessType.READ)
+    @describeRoute(
+        Description('Get quota and assetstore policies for the user.')
+        .param('id', 'The user ID', paramType='path')
+        .errorResponse('ID was invalid.')
+        .errorResponse('Read permission denied on the user.', 403)
+    )
     def getUserQuota(self, user, params):
         if QUOTA_FIELD not in user:
             user[QUOTA_FIELD] = {}
         user[QUOTA_FIELD]['_currentFileSizeQuota'] = self._getFileSizeQuota(
             'user', user)
         return self._filter('user', user)
-    getUserQuota.description = (
-        Description('Get quota and assetstore policies for the user.')
-        .param('id', 'The user ID', paramType='path')
-        .errorResponse('ID was invalid.')
-        .errorResponse('Read permission denied on the user.', 403))
 
     @access.public
     @loadmodel(model='user', level=AccessType.ADMIN)
-    def setUserQuota(self, user, params):
-        return self._setResourceQuota('user', user, params)
-    setUserQuota.description = (
+    @describeRoute(
         Description('Set quota and assetstore policies for the user.')
         .param('id', 'The user ID', paramType='path')
         .param('policy', 'A JSON object containing the policies.  This is a '
                'dictionary of keys and values.  Any key that is not specified '
                'does not change.', required=True)
         .errorResponse('ID was invalid.')
-        .errorResponse('Read permission denied on the user.', 403))
+        .errorResponse('Read permission denied on the user.', 403)
+    )
+    def setUserQuota(self, user, params):
+        return self._setResourceQuota('user', user, params)
 
     def _checkAssetstore(self, assetstoreSpec):
         """

--- a/tests/cases/api_describe_test.py
+++ b/tests/cases/api_describe_test.py
@@ -47,9 +47,11 @@ class DummyResource(Resource):
             self.route(method, pathElements, self.handler)
 
     @access.public
+    @describe.describeRoute(
+        describe.Description('Does nothing')
+    )
     def handler(self, **kwargs):
         return kwargs
-    handler.description = describe.Description('Does nothing')
 
 
 testModel = {
@@ -80,12 +82,13 @@ class ModelResource(Resource):
         self.route('POST', (), self.hasModel)
 
     @access.public
-    def hasModel(self, params):
-        pass
-
-    hasModel.description = describe.Description('What a model') \
+    @describe.describeRoute(
+        describe.Description('What a model')
         .param('body', 'Where its at!', dataType='Body', required=True,
                paramType='body')
+    )
+    def hasModel(self, params):
+        pass
 
 
 def setUpModule():

--- a/tests/cases/rest_decorator_test.py
+++ b/tests/cases/rest_decorator_test.py
@@ -40,7 +40,7 @@ def tearDownModule():
 
 
 class TestEndpointDecoratorException(base.TestCase):
-    'Tests the endpoint decorator exception handling'
+    """Tests the endpoint decorator exception handling."""
 
     @endpoint
     def pointlessEndpointAscii(self, path, params):

--- a/tests/cases/routes_test.py
+++ b/tests/cases/routes_test.py
@@ -19,7 +19,7 @@
 
 from .. import base
 from girder.api import access
-from girder.api.describe import Description
+from girder.api.describe import Description, describeRoute
 from girder.api.rest import Resource, RestException
 from girder.constants import SettingKey, SettingDefault
 
@@ -52,12 +52,13 @@ class DummyResource(Resource):
         self.route('PATCH', ('test', ), self.handler)
 
     @access.public
+    @describeRoute(
+        Description('Dummy handler.')
+    )
     def handler(self, **kwargs):
         return kwargs
     # We want to test adding and removing documentation when we add and remove
     # routes.
-    handler.description = (
-        Description('Dummy handler.'))
 
 
 class RoutesTestCase(base.TestCase):

--- a/tests/test_plugins/test_plugin/server.py
+++ b/tests/test_plugins/test_plugin/server.py
@@ -27,20 +27,20 @@ from girder.utility.server import staticFile
 
 @access.public
 @boundHandler()
+@describeRoute(None)
 def unboundHandlerDefault(self, params):
     self.requireParams('val', params)
     return not self.boolParam('val', params)
-unboundHandlerDefault.description = None
 
 
 @access.public
 @boundHandler(Collection())
+@describeRoute(None)
 def unboundHandlerExplicit(self, params):
     return {
         'user': self.getCurrentUser(),
         'name': self.resourceName
     }
-unboundHandlerExplicit.description = None
 
 
 class CustomAppRoot(object):
@@ -75,9 +75,11 @@ class Other(Resource):
         return b'this is also a raw response'
 
     @access.public
+    @describeRoute(
+        Description('Get something.')
+    )
     def getResource(self, params):
         return ['custom REST route']
-    getResource.description = Description('Get something.')
 
 
 def load(info):

--- a/tests/web_client_test.py
+++ b/tests/web_client_test.py
@@ -25,7 +25,7 @@ import time
 
 from girder import config
 from girder.api import access
-from girder.api.describe import Description
+from girder.api.describe import Description, describeRoute
 from girder.api.rest import Resource, RestException
 from girder.constants import ROOT_DIR
 from girder.utility.progress import ProgressContext
@@ -68,6 +68,13 @@ class WebClientTestEndpoints(Resource):
         self.stop = False
 
     @access.token
+    @describeRoute(
+        Description('Test progress contexts from the web')
+        .param('test', 'Name of test to run.  These include "success" and '
+               '"failure".', required=False)
+        .param('duration', 'Duration of the test in seconds', required=False,
+               dataType='int')
+    )
     def testProgress(self, params):
         test = params.get('test', 'success')
         duration = int(params.get('duration', 10))
@@ -84,20 +91,16 @@ class WebClientTestEndpoints(Resource):
                     time.sleep(wait)
             if test == 'error':
                 raise RestException('Progress error test.')
-    testProgress.description = (
-        Description('Test progress contexts from the web')
-        .param('test', 'Name of test to run.  These include "success" and '
-               '"failure".', required=False)
-        .param('duration', 'Duration of the test in seconds', required=False,
-               dataType='int'))
 
     @access.token
+    @describeRoute(
+        Description('Halt all progress tests')
+    )
     def testProgressStop(self, params):
         self.stop = True
-    testProgressStop.description = (
-        Description('Halt all progress tests'))
 
     @access.user
+    @describeRoute(None)
     def uploadFile(self, params):
         """
         Providing this works around a limitation in phantom that makes us
@@ -119,7 +122,6 @@ class WebClientTestEndpoints(Resource):
             file = self.model('upload').handleChunk(upload, fd)
 
         return file
-    uploadFile.description = None
 
 
 class WebClientTestCase(base.TestCase):


### PR DESCRIPTION
* Update all route handlers to use ``@describeRoute``
* Update docs to only refer to ``@describeRoute`` for applying ``Descriptions``
 * This makes directly setting the ``.description`` property on routes fully deprecated and undocumented (though it will still work).
* Make a test case use the proper type of docstring 