### PR TITLE
Update to Swagger Spec 2.0

### DIFF
--- a/clients/web/static/girder-swagger.js
+++ b/clients/web/static/girder-swagger.js
@@ -8,11 +8,13 @@ $(function () {
         url: 'describe',
         dom_id: 'swagger-ui-container',
         supportHeaderParams: false,
-        supportedSubmitMethods: ['get', 'post', 'put', 'delete'],
+        supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
         onComplete: function (swaggerApi, swaggerUi) {
             $('pre code').each(function (i, e) {
                 hljs.highlightBlock(e);
             });
+
+            addApiKeyAuthorization();
         },
         onFailure: function (data) {
             if (console) {
@@ -20,20 +22,29 @@ $(function () {
                 console.log(data);
             }
         },
-        docExpansion: "none"
+        docExpansion: "none",
+        jsonEditor: false,
+        apisSorter: "alpha",
+        defaultModelRendering: "schema",
+        showRequestHeaders: false,
+        validatorUrl: null
     });
 
-    var cookieParams = document.cookie.split(';').map(function (m) {
-        return m.replace(/^\s+/, '').replace(/\s+$/, '');
-    });
-    $.each(cookieParams, function (i, val) {
-        var arr = val.split('=');
-        if (arr[0] === 'girderToken') {
-            // Make swagger send the Girder-Token header with each request.
-            window.authorizations.add("key",
-                new ApiKeyAuthorization("Girder-Token", arr[1], "header"));
-        }
-    });
+    function addApiKeyAuthorization() {
+        var cookieParams = document.cookie.split(';').map(function (m) {
+            return m.replace(/^\s+/, '').replace(/\s+$/, '');
+        });
+        $.each(cookieParams, function (i, val) {
+            var arr = val.split('=');
+            if (arr[0] === 'girderToken') {
+                // Make swagger send the Girder-Token header with each request.
+                var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization(
+                    "Girder-Token", arr[1], "header");
+                window.swaggerUi.api.clientAuthorizations.add(
+                    "Girder-Token", apiKeyAuth);
+            }
+        });
+    }
 
-    swaggerUi.load();
+    window.swaggerUi.load();
 });

--- a/clients/web/static/girder-swagger.js
+++ b/clients/web/static/girder-swagger.js
@@ -25,10 +25,35 @@ $(function () {
         docExpansion: "none",
         jsonEditor: false,
         apisSorter: "alpha",
+        operationsSorter: sortOperations,
         defaultModelRendering: "schema",
         showRequestHeaders: false,
         validatorUrl: null
     });
+
+    var methodOrder = ['get', 'put', 'post', 'patch', 'delete'];
+
+    // Comparator to sort operations by path and method.
+    // Methods not in the pre-defined ordered list are placed at the end and
+    // sorted alphabetically.
+    function sortOperations(op1, op2) {
+        var pathCmp = op1.path.localeCompare(op2.path);
+        if (pathCmp !== 0) {
+            return pathCmp;
+        }
+        var index1 = methodOrder.indexOf(op1.method);
+        var index2 = methodOrder.indexOf(op2.method);
+        if (index1 > -1 && index2 > -1) {
+            return index1 > index2 ? 1 : (index1 < index2 ? -1 : 0);
+        }
+        if (index1 > -1) {
+            return -1;
+        }
+        if (index2 > -1) {
+            return 1;
+        }
+        return op1.method.localeCompare(op2.method);
+    }
 
     function addApiKeyAuthorization() {
         var cookieParams = document.cookie.split(';').map(function (m) {

--- a/clients/web/test/spec/swaggerSpec.js
+++ b/clients/web/test/spec/swaggerSpec.js
@@ -22,19 +22,19 @@ function jasmineTests() {
                 $('li#resource_system.resource .heading h2 a').click();
             });
             waitsFor(function () {
-                return $('#system_getVersion:visible').length > 0;
+                return $('#system_system_getVersion:visible').length > 0;
             }, 'end points to be visible');
             runs(function () {
-                $('#system_getVersion h3 a').click();
+                $('#system_system_getVersion h3 a').click();
             });
             waitsFor(function () {
-                return $('#system_getVersion .sandbox_header input.submit[name="commit"]:visible').length > 0;
+                return $('#system_system_getVersion .sandbox_header input.submit:visible').length > 0;
             }, 'version try out button to be visible');
             runs(function () {
-                $('#system_getVersion .sandbox_header input.submit[name="commit"]').click();
+                $('#system_system_getVersion .sandbox_header input.submit').click();
             });
             waitsFor(function () {
-                return $('#system_getVersion .response_body.json').text().indexOf('apiVersion') >= 0;
+                return $('#system_system_getVersion .response_body.json').text().indexOf('apiVersion') >= 0;
             }, 'version information was returned');
         });
     });

--- a/girder/api/api_docs.mako
+++ b/girder/api/api_docs.mako
@@ -13,6 +13,9 @@
       .response_throbber {
         content: url("${staticRoot}/built/swagger/images/throbber.gif");
       }
+      #api_info {
+        display: none;
+      }
     </style>
   </head>
   <body>
@@ -44,13 +47,13 @@
     <script src="${staticRoot}/built/swagger/lib/jquery.slideto.min.js"></script>
     <script src="${staticRoot}/built/swagger/lib/jquery.wiggle.min.js"></script>
     <script src="${staticRoot}/built/swagger/lib/jquery.ba-bbq.min.js"></script>
-    <script src="${staticRoot}/built/swagger/lib/handlebars-1.0.0.js"></script>
+    <script src="${staticRoot}/built/swagger/lib/handlebars-2.0.0.js"></script>
     <script src="${staticRoot}/built/swagger/lib/underscore-min.js"></script>
     <script src="${staticRoot}/built/swagger/lib/backbone-min.js"></script>
-    <script src="${staticRoot}/built/swagger/lib/shred.bundle.js"></script>
-    <script src="${staticRoot}/built/swagger/lib/swagger.js"></script>
     <script src="${staticRoot}/built/swagger/swagger-ui.min.js"></script>
     <script src="${staticRoot}/built/swagger/lib/highlight.7.3.pack.js"></script>
+    <script src='${staticRoot}/built/swagger/lib/jsoneditor.min.js'></script>
+    <script src='${staticRoot}/built/swagger/lib/marked.js'></script>
     <script src="${staticRoot}/girder-swagger.js"></script>
   </body>
 </html>

--- a/girder/api/api_docs.mako
+++ b/girder/api/api_docs.mako
@@ -50,6 +50,9 @@
     <script src="${staticRoot}/built/swagger/lib/handlebars-2.0.0.js"></script>
     <script src="${staticRoot}/built/swagger/lib/underscore-min.js"></script>
     <script src="${staticRoot}/built/swagger/lib/backbone-min.js"></script>
+    % if mode == 'testing':
+    <script src="${staticRoot}/built/polyfill.min.js"></script>
+    % endif
     <script src="${staticRoot}/built/swagger/swagger-ui.min.js"></script>
     <script src="${staticRoot}/built/swagger/lib/highlight.7.3.pack.js"></script>
     <script src='${staticRoot}/built/swagger/lib/jsoneditor.min.js'></script>

--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -22,6 +22,7 @@ import six
 
 from girder import constants
 from girder.constants import TerminalColor
+from girder.utility import config
 from girder.utility.webroot import WebrootBase
 from . import docs, access
 from .rest import Resource, getApiUrl, getUrlParts
@@ -288,10 +289,14 @@ class ApiDocs(WebrootBase):
                                         'api', 'api_docs.mako')
         super(ApiDocs, self).__init__(templatePath)
 
+        curConfig = config.getConfig()
+        mode = curConfig['server'].get('mode', '')
+
         self.vars = {
             'apiRoot': '',
             'staticRoot': '',
-            'title': 'Girder - REST API Documentation'
+            'title': 'Girder - REST API Documentation',
+            'mode': mode
         }
 
 

--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -17,14 +17,14 @@
 #  limitations under the License.
 ###############################################################################
 
-import functools
 import os
 import six
 
 from girder import constants
+from girder.constants import TerminalColor
 from girder.utility.webroot import WebrootBase
 from . import docs, access
-from .rest import Resource, RestException, getApiUrl
+from .rest import Resource, getApiUrl, getUrlParts
 
 """
 Whenever we add new return values or new options we should increment the
@@ -35,7 +35,7 @@ the top level package.json.
 """
 API_VERSION = constants.VERSION['apiVersion']
 
-SWAGGER_VERSION = '1.2'
+SWAGGER_VERSION = '2.0'
 
 
 class Description(object):
@@ -45,10 +45,32 @@ class Description(object):
     function can set a description property on itself to an instance of this
     class in order to describe itself.
     """
+
+    # Data Type map from common name or type to (type, format)
+    # See Data Type spec:
+    #   https://github.com/OAI/OpenAPI-Specification/blob/
+    #   0122c22e7fb93b571740dd3c6e141c65563a18be/versions/2.0.md#data-types
+    _dataTypeMap = {
+        # Primitives
+        'integer': ('integer', 'int32'),
+        'long': ('integer', 'int64'),
+        'number': ('number', None),
+        'float': ('number', 'float'),
+        'double': ('number', 'double'),
+        'string': ('string', None),
+        'byte': ('string', 'byte'),
+        'binary': ('string', 'binary'),
+        'boolean': ('boolean', None),
+        'date': ('string', 'date'),
+        'dateTime': ('string', 'date-time'),
+        'password': ('string', 'password'),
+        'file': ('file', None)
+    }
+
     def __init__(self, summary):
         self._summary = summary
         self._params = []
-        self._responses = []
+        self._responses = {}
         self._consumes = []
         self._responseClass = None
         self._notes = None
@@ -57,13 +79,27 @@ class Description(object):
         """
         Returns this description object as an appropriately formatted dict
         """
+
+        # Responses Object spec:
+        # The Responses Object MUST contain at least one response code, and it
+        # SHOULD be the response for a successful operation call.
+        if '200' not in self._responses:
+            self._responses['200'] = {
+                'description': 'Success'
+            }
+        if self._responseClass is not None:
+            self._responses['200']['schema'] = {
+                '$ref': '#/definitions/%s' % self._responseClass
+            }
+
         resp = {
             'summary': self._summary,
-            'notes': self._notes,
             'parameters': self._params,
-            'responseMessages': self._responses,
-            'responseClass': self._responseClass
+            'responses': self._responses
         }
+
+        if self._notes is not None:
+            resp['description'] = self._notes
 
         if self._consumes:
             resp['consumes'] = self._consumes
@@ -81,43 +117,88 @@ class Description(object):
         common options as defaults, so you won't have to repeat yourself as much
         when declaring the APIs.
 
-        Note that we could expose more parameters: allowMultiple, format,
-        defaultValue, minimum, maximum, uniqueItems, $ref, type (return type).
-        We also haven't exposed the complex data types.
+        Note that we could expose more parameters from the Parameter Object
+        spec, for example: format, allowEmptyValue, minimum, maximum, pattern,
+        uniqueItems.
 
         :param name: name of the parameter used in the REST query.
         :param description: explanation of the parameter.
         :param paramType: how is the parameter sent.  One of 'query', 'path',
-                          'body', 'header', or 'form'.
-        :param dataType: the data type expected in the parameter.  This is one
+                          'body', 'header', or 'formData'.
+        :param dataType: the data type expected in the parameter. This is one
                          of 'integer', 'long', 'float', 'double', 'string',
-                         'byte', 'boolean', 'date', 'dateType', 'array', or
-                         'File'.
+                         'byte', 'binary', 'boolean', 'date', 'dateTime',
+                         'password', or 'file'.
         :param required: True if the request will fail if this parameter is not
                          present, False if the parameter is optional.
         :param enum: a fixed list of possible values for the field.
         """
+        # Legacy data type conversions
         if dataType == 'int':
             dataType = 'integer'
+        elif dataType == 'File':
+            print(TerminalColor.warning(
+                "WARNING: dataType 'File' should be updated to 'file'"))
+            dataType = 'file'
+
+        # Get type and format from common name
+        dataTypeFormat = None
+        if dataType in self._dataTypeMap:
+            (dataType, dataTypeFormat) = self._dataTypeMap[dataType]
+        else:
+            print(TerminalColor.warning(
+                "WARNING: Invalid dataType '%s' specified for parameter "
+                "named '%s'" % (dataType, name)))
+
+        # Parameter Object spec:
+        # Since the parameter is not located at the request body, it is limited
+        # to simple types (that is, not an object).
+        if paramType != 'body':
+            if dataType not in ('string', 'number', 'integer', 'boolean',
+                                'array', 'file'):
+                print(TerminalColor.warning(
+                    "WARNING: Invalid dataType '%s' specified for parameter "
+                    "named '%s'" % (dataType, name)))
+
+        if paramType == 'form':
+            print(TerminalColor.warning(
+                "WARNING: paramType 'form' should be updated to 'formData'"))
+            paramType = 'formData'
+
+        # Parameter Object spec:
+        # If type is "file", then consumes MUST be either
+        # "multipart/form-data", "application/x-www-form-urlencoded" or both
+        # and the parameter MUST be in "formData".
+        if dataType == 'file':
+            if paramType != 'formData':
+                print(TerminalColor.warning(
+                    "WARNING: Invalid paramType '%s' specified for dataType "
+                    "'file' in parameter named '%s'"
+                    % (paramType, name)))
+                paramType = 'formData'
 
         param = {
             'name': name,
             'description': description,
-            'paramType': paramType,
-            'type': dataType,
-            'allowMultiple': False,
+            'in': paramType,
             'required': required
         }
+
+        if paramType == 'body':
+            param['schema'] = {
+                'type': dataType
+            }
+        else:
+            param['type'] = dataType
+
+        if dataTypeFormat is not None:
+            param['format'] = dataTypeFormat
+
         if enum:
             param['enum'] = enum
 
         if default is not None:
-            if dataType == 'boolean':
-                param['defaultValue'] = 'true' if default else 'false'
-            elif dataType == 'integer' and default == 0:
-                param['defaultValue'] = '0'  # workaround swagger-ui bug
-            else:
-                param['defaultValue'] = default
+            param['default'] = default
 
         self._params.append(param)
         return self
@@ -162,10 +243,18 @@ class Description(object):
         endpoints will be able to use the default parameter values for one of
         their responses.
         """
-        self._responses.append({
-            'message': reason,
-            'code': code
-        })
+        code = str(code)
+
+        if code in self._responses:
+            print(TerminalColor.warning(
+                "WARNING: Error response for code '%s' is already defined "
+                "(old: '%s', new: '%s')"
+                % (code, self._responses[code]['description'], reason)))
+
+        self._responses[code] = {
+            'description': reason
+        }
+
         return self
 
 
@@ -199,11 +288,51 @@ class Describe(Resource):
 
     @access.public
     def listResources(self, params):
+        # Paths Object
+        paths = {}
+
+        # Definitions Object
+        definitions = dict(**docs.models[None])
+
+        # List of Tag Objects
+        tags = []
+
+        for resource in sorted(six.viewkeys(docs.routes)):
+            # Update Definitions Object
+            if resource in docs.models:
+                for name, model in six.viewitems(docs.models[resource]):
+                    definitions[name] = model
+
+            # Tag Object
+            tags.append({
+                'name': resource
+            })
+
+            for route, methods in six.viewitems(docs.routes[resource]):
+                # Path Item Object
+                pathItem = {}
+                for method, operation in six.viewitems(methods):
+                    # Operation Object
+                    pathItem[method.lower()] = operation
+
+                paths[route] = pathItem
+
+        apiUrl = getApiUrl()
+        urlParts = getUrlParts(apiUrl)
+        host = urlParts.netloc
+        basePath = urlParts.path
+
         return {
-            'apiVersion': API_VERSION,
-            'swaggerVersion': SWAGGER_VERSION,
-            'apis': [{'path': '/%s' % resource}
-                     for resource in sorted(six.viewkeys(docs.routes))]
+            'swagger': SWAGGER_VERSION,
+            'info': {
+                'title': 'Girder REST API',
+                'version': API_VERSION
+            },
+            'host': host,
+            'basePath': basePath,
+            'tags': tags,
+            'paths': paths,
+            'definitions': definitions
         }
 
     def _compareRoutes(self, routeOp1, routeOp2):

--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -73,6 +73,7 @@ class Description(object):
         self._responses = {}
         self._consumes = []
         self._responseClass = None
+        self._responseClassArray = False
         self._notes = None
 
     def asDict(self):
@@ -88,15 +89,23 @@ class Description(object):
                 'description': 'Success'
             }
         if self._responseClass is not None:
-            self._responses['200']['schema'] = {
+            schema = {
                 '$ref': '#/definitions/%s' % self._responseClass
             }
+            if self._responseClassArray:
+                schema = {
+                    'type': 'array',
+                    'items': schema
+                }
+            self._responses['200']['schema'] = schema
 
         resp = {
             'summary': self._summary,
-            'parameters': self._params,
             'responses': self._responses
         }
+
+        if self._params:
+            resp['parameters'] = self._params
 
         if self._notes is not None:
             resp['description'] = self._notes
@@ -106,8 +115,9 @@ class Description(object):
 
         return resp
 
-    def responseClass(self, obj):
+    def responseClass(self, obj, array=False):
         self._responseClass = obj
+        self._responseClassArray = array
         return self
 
     def param(self, name, description, paramType='query', dataType='string',

--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -252,8 +252,18 @@ class Description(object):
         This helper will build an errorResponse declaration for you. Many
         endpoints will be able to use the default parameter values for one of
         their responses.
+
+        :param reason: The reason or list of reasons why the error occurred.
+        :type reason: str, list, or tuple
+        :param code: HTTP status code.
+        :type code: int
         """
         code = str(code)
+
+        # Combine list of reasons into a single string.
+        # swagger-ui renders the description using Markdown.
+        if not isinstance(reason, six.string_types):
+            reason = '\n\n'.join(reason)
 
         if code in self._responses:
             print(TerminalColor.warning(

--- a/girder/api/v1/assetstore.py
+++ b/girder/api/v1/assetstore.py
@@ -241,6 +241,6 @@ class Assetstore(Resource):
         Description('Delete an assetstore.')
         .notes('This will fail if there are any files in the assetstore.')
         .param('id', 'The ID of the assetstore.', paramType='path')
-        .errorResponse()
-        .errorResponse('The assetstore is not empty.')
+        .errorResponse(('A parameter was invalid.',
+                        'The assetstore is not empty.'))
         .errorResponse('You are not an administrator.', 403))

--- a/girder/api/v1/collection.py
+++ b/girder/api/v1/collection.py
@@ -47,7 +47,7 @@ class Collection(Resource):
     @filtermodel(model='collection')
     @describeRoute(
         Description('List or search for collections.')
-        .responseClass('Collection')
+        .responseClass('Collection', array=True)
         .param('text', "Pass this to perform a text search for collections.",
                required=False)
         .pagingParams(defaultSort='name')

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -126,7 +126,7 @@ class File(Resource):
         .notes('This is only required in certain non-standard upload '
                'behaviors. Clients should know which behavior models require '
                'the finalize step to be called in their behavior handlers.')
-        .param('uploadId', 'The ID of the upload record.', paramType='form')
+        .param('uploadId', 'The ID of the upload record.', paramType='formData')
         .errorResponse(('ID was invalid.',
                         'The upload does not require finalization.',
                         'Not enough bytes have been uploaded.'))
@@ -182,13 +182,13 @@ class File(Resource):
     @describeRoute(
         Description('Upload a chunk of a file with multipart/form-data.')
         .consumes('multipart/form-data')
-        .param('uploadId', 'The ID of the upload record.', paramType='form')
+        .param('uploadId', 'The ID of the upload record.', paramType='formData')
         .param('offset', 'Offset of the chunk in the file.', dataType='integer',
-               paramType='form')
+               paramType='formData')
         .param('chunk', 'The actual bytes of the chunk. For external upload '
                'behaviors, this may be set to an opaque string that will be '
                'handled by the assetstore adapter.',
-               dataType='file', paramType='body')
+               dataType='file', paramType='formData')
         .errorResponse(('ID was invalid.',
                         'Received too many bytes.',
                         'Chunk is smaller than the minimum size.'))

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -127,9 +127,9 @@ class File(Resource):
                'behaviors. Clients should know which behavior models require '
                'the finalize step to be called in their behavior handlers.')
         .param('uploadId', 'The ID of the upload record.', paramType='form')
-        .errorResponse('ID was invalid.')
-        .errorResponse('The upload does not require finalization.')
-        .errorResponse('Not enough bytes have been uploaded.')
+        .errorResponse(('ID was invalid.',
+                        'The upload does not require finalization.',
+                        'Not enough bytes have been uploaded.'))
         .errorResponse('You are not the user who initiated the upload.', 403)
     )
     def finalizeUpload(self, params):
@@ -188,10 +188,10 @@ class File(Resource):
         .param('chunk', 'The actual bytes of the chunk. For external upload '
                'behaviors, this may be set to an opaque string that will be '
                'handled by the assetstore adapter.',
-               dataType='File', paramType='body')
-        .errorResponse('ID was invalid.')
-        .errorResponse('Received too many bytes.')
-        .errorResponse('Chunk is smaller than the minimum size.')
+               dataType='file', paramType='body')
+        .errorResponse(('ID was invalid.',
+                        'Received too many bytes.',
+                        'Chunk is smaller than the minimum size.'))
         .errorResponse('You are not the user who initiated the upload.', 403)
         .errorResponse('Failed to store upload.', 500)
     )

--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -239,9 +239,9 @@ class Folder(Resource):
         .param('parentId', "The ID of the folder's parent.")
         .param('name', "Name of the folder.")
         .param('description', "Description for the folder.", required=False)
-        .param('public', """Whether the folder should be publicly visible. By
-               default, inherits the value from parent folder, or in the
-               case of user or collection parentType, defaults to False.""",
+        .param('public', "Whether the folder should be publicly visible. By "
+               "default, inherits the value from parent folder, or in the "
+               "case of user or collection parentType, defaults to False.",
                required=False, dataType='boolean')
         .errorResponse()
         .errorResponse('Write access was denied on the parent', 403)
@@ -364,10 +364,10 @@ class Folder(Resource):
         .param('parentId', 'The ID of the parent document.', required=False)
         .param('name', 'Name for the new folder.', required=False)
         .param('description', "Description for the new folder.", required=False)
-        .param('public', """Whether the folder should be publicly visible.  By
-               default, inherits the value from parent folder, or in the case
-               of user or collection parentType, defaults to False.  If
-               'original', use the value of the original folder.""",
+        .param('public', "Whether the folder should be publicly visible. By "
+               "default, inherits the value from parent folder, or in the case "
+               "of user or collection parentType, defaults to False. If "
+               "'original', use the value of the original folder.",
                required=False, enum=[True, False, 'original'])
         .param('progress', 'Whether to record progress on this task. Default '
                'is false.', required=False, dataType='boolean')

--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -51,7 +51,7 @@ class Folder(Resource):
     @filtermodel(model='folder')
     @describeRoute(
         Description('Search for folders by certain properties.')
-        .responseClass('Folder')
+        .responseClass('Folder', array=True)
         .param('parentType', "Type of the folder's parent", required=False,
                enum=['folder', 'user', 'collection'])
         .param('parentId', "The ID of the folder's parent.", required=False)

--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -336,9 +336,9 @@ class Folder(Resource):
         .param('id', 'The ID of the folder.', paramType='path')
         .param('body', 'A JSON object containing the metadata keys to add',
                paramType='body')
-        .errorResponse('ID was invalid.')
-        .errorResponse('Invalid JSON passed in request body.')
-        .errorResponse('Metadata key name was invalid.')
+        .errorResponse(('ID was invalid.',
+                        'Invalid JSON passed in request body.',
+                        'Metadata key name was invalid.'))
         .errorResponse('Write access was denied for the folder.', 403)
     )
     def setMetadata(self, folder, params):
@@ -371,10 +371,10 @@ class Folder(Resource):
                required=False, enum=[True, False, 'original'])
         .param('progress', 'Whether to record progress on this task. Default '
                'is false.', required=False, dataType='boolean')
-        .errorResponse()
-        .errorResponse('ID was invalid.')
-        .errorResponse('Read access was denied on the original folder.', 403)
-        .errorResponse('Write access was denied on the parent.', 403)
+        .errorResponse(('A parameter was invalid.',
+                        'ID was invalid.'))
+        .errorResponse('Read access was denied on the original folder.\n\n'
+                       'Write access was denied on the parent.', 403)
     )
     def copyFolder(self, folder, params):
         user = self.getCurrentUser()

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -170,9 +170,9 @@ class Item(Resource):
         .param('id', 'The ID of the item.', paramType='path')
         .param('body', 'A JSON object containing the metadata keys to add',
                paramType='body')
-        .errorResponse('ID was invalid.')
-        .errorResponse('Invalid JSON passed in request body.')
-        .errorResponse('Metadata key name was invalid.')
+        .errorResponse(('ID was invalid.',
+                        'Invalid JSON passed in request body.',
+                        'Metadata key name was invalid.'))
         .errorResponse('Write access was denied for the item.', 403)
     )
     def setMetadata(self, item, params):
@@ -287,10 +287,10 @@ class Item(Resource):
         .param('folderId', 'The ID of the parent folder.', required=False)
         .param('name', 'Name for the new item.', required=False)
         .param('description', "Description for the new item.", required=False)
-        .errorResponse()
-        .errorResponse('ID was invalid.')
-        .errorResponse('Read access was denied on the original item.', 403)
-        .errorResponse('Write access was denied on the parent folder.', 403)
+        .errorResponse(('A parameter was invalid.',
+                        'ID was invalid.'))
+        .errorResponse('Read access was denied on the original item.\n\n'
+                       'Write access was denied on the parent folder.', 403)
     )
     def copyItem(self, item, params):
         """

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -46,7 +46,7 @@ class Item(Resource):
     @filtermodel(model='item')
     @describeRoute(
         Description('Search for an item by certain properties.')
-        .responseClass('Item')
+        .responseClass('Item', array=True)
         .param('folderId', "Pass this to list all items in a folder.",
                required=False)
         .param('text', "Pass this to perform a full text search for items.",
@@ -208,7 +208,7 @@ class Item(Resource):
     @filtermodel(model='file')
     @describeRoute(
         Description('Get the files within an item.')
-        .responseClass('File')
+        .responseClass('File', array=True)
         .param('id', 'The ID of the item.', paramType='path')
         .pagingParams(defaultSort='name')
         .errorResponse('ID was invalid.')

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -227,8 +227,8 @@ class Resource(BaseResource):
                'path starting with either "/user/[user name]", for a user\'s '
                'resources or "/collection/[collection name]", for resources '
                'under a collection.')
-        .errorResponse('Path is invalid.')
-        .errorResponse('Path refers to a resource that does not exist.')
+        .errorResponse(('Path is invalid.',
+                        'Path refers to a resource that does not exist.'))
         .errorResponse('Read access was denied for the resource.', 403))
 
     @access.cookie(force=True)
@@ -279,10 +279,10 @@ class Resource(BaseResource):
                '(item id 2)], "folder": [(folder id 1)]}.')
         .param('includeMetadata', 'Include any metadata in JSON files in the '
                'archive.', required=False, dataType='boolean', default=False)
-        .errorResponse('Unsupport or unknown resource type.')
-        .errorResponse('Invalid resources format.')
-        .errorResponse('No resources specified.')
-        .errorResponse('Resource not found.')
+        .errorResponse(('Unsupported or unknown resource type.',
+                        'Invalid resources format.',
+                        'No resources specified.',
+                        'Resource not found.'))
         .errorResponse('Read access was denied for a resource.', 403))
 
     @access.user
@@ -330,10 +330,10 @@ class Resource(BaseResource):
                '(item id2)], "folder": [(folder id 1)]}.')
         .param('progress', 'Whether to record progress on this task.',
                default=False, required=False, dataType='boolean')
-        .errorResponse('Unsupport or unknown resource type.')
-        .errorResponse('Invalid resources format.')
-        .errorResponse('No resources specified.')
-        .errorResponse('Resource not found.')
+        .errorResponse(('Unsupported or unknown resource type.',
+                        'Invalid resources format.',
+                        'No resources specified.',
+                        'Resource not found.'))
         .errorResponse('Admin access was denied for a resource.', 403))
 
     @access.admin
@@ -406,12 +406,12 @@ class Resource(BaseResource):
         .param('parentId', 'Parent ID for the new parent of these resources.')
         .param('progress', 'Whether to record progress on this task. Default '
                'is false.', required=False, dataType='boolean')
-        .errorResponse('Unsupport or unknown resource type.')
-        .errorResponse('Invalid resources format.')
-        .errorResponse('Resource type not supported.')
-        .errorResponse('No resources specified.')
-        .errorResponse('Resource not found.')
-        .errorResponse('ID was invalid.'))
+        .errorResponse(('Unsupported or unknown resource type.',
+                        'Invalid resources format.',
+                        'Resource type not supported.',
+                        'No resources specified.',
+                        'Resource not found.',
+                        'ID was invalid.')))
 
     @access.user
     def copyResources(self, params):
@@ -460,9 +460,9 @@ class Resource(BaseResource):
         .param('parentId', 'Parent ID for the new parent of these resources.')
         .param('progress', 'Whether to record progress on this task. Default '
                'is false.', required=False, dataType='boolean')
-        .errorResponse('Unsupport or unknown resource type.')
-        .errorResponse('Invalid resources format.')
-        .errorResponse('Resource type not supported.')
-        .errorResponse('No resources specified.')
-        .errorResponse('Resource not found.')
-        .errorResponse('ID was invalid.'))
+        .errorResponse(('Unsupported or unknown resource type.',
+                        'Invalid resources format.',
+                        'Resource type not supported.',
+                        'No resources specified.',
+                        'Resource not found.',
+                        'ID was invalid.')))

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -232,8 +232,8 @@ class User(Resource):
         .param('admin', 'Is the user a site admin (admin access required)',
                required=False, dataType='boolean')
         .errorResponse()
-        .errorResponse('You do not have write access for this user.', 403)
-        .errorResponse('Must be an admin to create an admin.', 403)
+        .errorResponse(('You do not have write access for this user.',
+                        'Must be an admin to create an admin.'), 403)
     )
     def updateUser(self, user, params):
         self.requireParams(('firstName', 'lastName', 'email'), params)
@@ -273,8 +273,8 @@ class User(Resource):
         Description('Change your password.')
         .param('old', 'Your current password or a temporary access token.')
         .param('new', 'Your new password.')
-        .errorResponse('You are not logged in.', 401)
-        .errorResponse('Your old password is incorrect.', 401)
+        .errorResponse(('You are not logged in.',
+                        'Your old password is incorrect.'), 401)
         .errorResponse('Your new password is invalid.')
     )
     def changePassword(self, params):

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -57,7 +57,7 @@ class User(Resource):
     @filtermodel(model='user')
     @describeRoute(
         Description('List or search for users.')
-        .responseClass('User')
+        .responseClass('User', array=True)
         .param('text', "Pass this to perform a full text search for items.",
                required=False)
         .pagingParams(defaultSort='lastName')

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "jade": "1.3.1",
     "jquery": "2.1.1",
     "sprintf-js": "1.0.2",
-    "swagger-ui": "2.0.22",
+    "swagger-ui": "2.1.4",
     "underscore": "~1.5",
     "colors": "0.6.2",
     "event-source": "0.1.1",

--- a/plugins/geospatial/server/geospatial.py
+++ b/plugins/geospatial/server/geospatial.py
@@ -125,13 +125,13 @@ class GeospatialItem(Resource):
         .param('geoJSON', 'A GeoJSON object containing the features or feature'
                           ' collection to add.', required=True,
                paramType='query')
-        .errorResponse()
-        .errorResponse('Invalid GeoJSON was passed in request body.')
-        .errorResponse('GeoJSON feature or feature collection was not passed in'
-                       ' request body.')
-        .errorResponse("GeoJSON feature did not contain a property named"
-                       " 'name'.")
-        .errorResponse('Property name was invalid.')
+        .errorResponse(("A parameter was invalid.",
+                        "Invalid GeoJSON was passed in request body.",
+                        "GeoJSON feature or feature collection was not passed "
+                        "in request body.",
+                        "GeoJSON feature did not contain a property named"
+                        " 'name'.",
+                        "Property name was invalid."))
         .errorResponse('Write access was denied on the parent folder.', 403)
         .notes("All GeoJSON features must contain a property named 'name' from"
                " which the name of each created item is taken."))
@@ -317,8 +317,8 @@ class GeospatialItem(Resource):
                dataType='integer')
         .param('offset', 'Offset into result set (default=0).', required=False,
                dataType='integer')
-        .errorResponse()
-        .errorResponse('Field on which to search was not indexed.')
+        .errorResponse(('A parameter was invalid.',
+                        'Field on which to search was not indexed.'))
         .errorResponse('Index creation was denied.', 403)
         .notes("Field on which to search be indexed by a 2dsphere index."
                " Anonymous users may not use 'ensureIndex' to create such an"
@@ -492,10 +492,10 @@ class GeospatialItem(Resource):
         .param('id', 'The ID of the item.', paramType='path')
         .param('body', 'A JSON object containing the geospatial fields to add.',
                paramType='body')
-        .errorResponse('ID was invalid.')
-        .errorResponse('Invalid JSON was passed in request body.')
-        .errorResponse('Geospatial key name was invalid.')
-        .errorResponse('Geospatial field did not contain valid GeoJSON.')
+        .errorResponse(('ID was invalid.',
+                        'Invalid JSON was passed in request body.',
+                        'Geospatial key name was invalid.',
+                        'Geospatial field did not contain valid GeoJSON.'))
         .errorResponse('Write access was denied for the item.', 403))
 
     def _filter(self, item):

--- a/plugins/thumbnails/server/rest.py
+++ b/plugins/thumbnails/server/rest.py
@@ -47,9 +47,8 @@ class Thumbnail(Resource):
         .param('attachToType', 'The type of resource to which this thumbnail is'
                ' attached.', enum=['folder', 'user', 'collection', 'item'])
         .errorResponse()
-        .errorResponse('Write access was denied on the attach destination.',
-                       403)
-        .errorResponse('Read access was denied on the file.', 403)
+        .errorResponse(('Write access was denied on the attach destination.',
+                        'Read access was denied on the file.'), 403)
     )
     def createThumbnail(self, file, params):
         self.requireParams(('attachToId', 'attachToType'), params)

--- a/tests/cases/api_describe_test.py
+++ b/tests/cases/api_describe_test.py
@@ -22,7 +22,7 @@ from .. import base
 from girder.api import access, describe, docs
 from girder.api.rest import Resource
 
-OrderedRoutes = [
+Routes = [
     ('GET', (), ''),
     ('GET', (':id',), '/{id}'),
     ('UNKNOWN', (':id',), '/{id}'),
@@ -43,7 +43,7 @@ class DummyResource(Resource):
     def __init__(self):
         super(DummyResource, self).__init__()
         self.resourceName = 'foo'
-        for method, pathElements, testPath in OrderedRoutes:
+        for method, pathElements, testPath in Routes:
             self.route(method, pathElements, self.handler)
 
     @access.public
@@ -123,43 +123,80 @@ class ApiDescribeTestCase(base.TestCase):
         # Test top level describe endpoint
         resp = self.request(path='/describe', method='GET')
         self.assertStatusOk(resp)
-        self.assertEqual(resp.json['swaggerVersion'], describe.SWAGGER_VERSION)
-        self.assertEqual(resp.json['apiVersion'], describe.API_VERSION)
-        self.assertTrue({'path': '/group'} in resp.json['apis'])
+        self.assertHasKeys(resp.json, ('basePath', 'host', 'definitions',
+                                       'info', 'paths', 'swagger', 'tags'))
+        self.assertHasKeys(resp.json['info'], ('title', 'version'))
+        self.assertEqual(resp.json['swagger'], describe.SWAGGER_VERSION)
+        self.assertEqual(resp.json['info']['version'], describe.API_VERSION)
+        self.assertIn('/group', resp.json['paths'])
+        self.assertIn({'name': 'group'}, resp.json['tags'])
+        self.assertHasKeys(
+            resp.json['paths']['/group'], ('get', 'post'))
+        self.assertHasKeys(
+            resp.json['paths']['/group']['get'],
+            ('operationId', 'parameters', 'responses'))
+        self.assertHasKeys(
+            resp.json['paths']['/group']['post'],
+            ('operationId', 'parameters', 'responses'))
+        self.assertGreater(len(
+            resp.json['paths']['/group']['get']['operationId']), 0)
+        self.assertGreater(len(
+            resp.json['paths']['/group']['get']['parameters']), 0)
+        self.assertGreater(len(
+            resp.json['paths']['/group']['get']['responses']), 0)
+        param = resp.json['paths']['/group']['get']['parameters'][0]
+        self.assertHasKeys(
+            param,
+            ('description', 'in', 'name', 'required', 'type'))
+        self.assertGreater(len(param['description']), 0)
+        self.assertGreater(len(param['in']), 0)
+        self.assertGreater(len(param['name']), 0)
+        self.assertGreater(len(param['type']), 0)
+        self.assertTrue(isinstance(param['required'], bool))
+        self.assertIn(
+            '200',
+            resp.json['paths']['/group']['get']['responses'])
+        self.assertIn(
+            'description',
+            resp.json['paths']['/group']['get']['responses']['200'])
 
-        # Request a specific resource's description, sanity check
-        resp = self.request(path='/describe/user', method='GET')
+    def testRoutesExist(self):
+        # Check that the resources and operations exist
+        resp = self.request(path='/describe', method='GET')
         self.assertStatusOk(resp)
-        for routeDoc in resp.json['apis']:
-            self.assertHasKeys(('path', 'operations'), routeDoc)
-            self.assertTrue(len(routeDoc['operations']) > 0)
-
-        # Request an unknown resource's description to get an error
-        resp = self.request(path='/describe/unknown', method='GET')
-        self.assertStatus(resp, 400)
-        self.assertEqual(resp.json['message'], 'Invalid resource: unknown')
-
-    def testRouteOrder(self):
-        # Check that the resources and operations are listed in the order we
-        # expect
-        resp = self.request(path='/describe/foo', method='GET')
-        self.assertStatusOk(resp)
-        listedRoutes = [(method['httpMethod'], route['path'])
-                        for route in resp.json['apis']
-                        for method in route['operations']]
-        expectedRoutes = [(method, '/foo'+testPath)
-                          for method, pathElements, testPath in OrderedRoutes]
-        self.assertEqual(listedRoutes, expectedRoutes)
+        self.assertHasKeys(
+            resp.json['paths'],
+            ('/foo', '/foo/{id}', '/foo/{id}/action', '/foo/action',
+             '/foo/action/{id}', '/foo/noaction'))
+        self.assertHasKeys(
+            resp.json['paths']['/foo'],
+            ('get',))
+        self.assertEqual(len(resp.json['paths']['/foo']), 1)
+        self.assertHasKeys(
+            resp.json['paths']['/foo/{id}'],
+            ('get', 'unknown'))
+        self.assertEqual(len(resp.json['paths']['/foo/{id}']), 2)
+        self.assertHasKeys(
+            resp.json['paths']['/foo/{id}/action'],
+            ('get',))
+        self.assertEqual(len(resp.json['paths']['/foo/{id}/action']), 1)
+        self.assertHasKeys(
+            resp.json['paths']['/foo/action'],
+            ('get', 'put', 'post', 'patch', 'delete', 'newmethod', 'unknown'))
+        self.assertEqual(len(resp.json['paths']['/foo/action']), 7)
+        self.assertHasKeys(
+            resp.json['paths']['/foo/action/{id}'],
+            ('get',))
+        self.assertEqual(len(resp.json['paths']['/foo/action/{id}']), 1)
+        self.assertHasKeys(
+            resp.json['paths']['/foo/noaction'],
+            ('get',))
+        self.assertEqual(len(resp.json['paths']['/foo/noaction']), 1)
 
     def testAddModel(self):
-        resp = self.request(path='/describe/model')
+        resp = self.request(path='/describe')
         self.assertStatusOk(resp)
-        self.assertEqual(resp.json['models'], {
-            'Body': testModel,
-            'Global': globalModel
-        })
-
-        resp = self.request(path='/describe/folder')
-        self.assertStatusOk(resp)
-        self.assertEqual(resp.json['models'],
-                         dict(Global=globalModel, **docs.models['folder']))
+        self.assertTrue('definitions' in resp.json)
+        self.assertHasKeys(('Body', 'Global'), resp.json['definitions'])
+        self.assertEqual(resp.json['definitions']['Body'], testModel)
+        self.assertEqual(resp.json['definitions']['Global'], globalModel)

--- a/tests/cases/custom_root_test.py
+++ b/tests/cases/custom_root_test.py
@@ -74,13 +74,8 @@ class CustomRootTestCase(base.TestCase):
         # Our custom API augmentations should still work
         resp = self.request('/describe')
         self.assertStatusOk(resp)
-        self.assertTrue('apis' in resp.json)
-        otherDocs = [x for x in resp.json['apis'] if x['path'] == '/other']
-        self.assertEqual(len(otherDocs), 1)
-
-        resp = self.request('/describe/other')
-        self.assertStatusOk(resp)
-        self.assertEqual(len(resp.json['apis']), 1)
+        self.assertIn('paths', resp.json)
+        self.assertIn('/other', resp.json['paths'])
 
         resp = self.request('/other')
         self.assertStatusOk(resp)


### PR DESCRIPTION
The /describe endpoint now returns an API description that implements Swagger Spec 2.0:
https://github.com/OAI/OpenAPI-Specification/blob/0122c22e7fb93b571740dd3c6e141c65563a18be/versions/2.0.md

Previously, the /describe endpoint returned the Resource Listing and the
/describe/{resource} endpoint returned the API Declaration for a particular
resource. In Swagger Spec 2.0, the resource listing and API declaration are combined. Therefore, the /describe/{resource} endpoint is removed.

Also upgrades to swagger-ui 2.1.4 to support generating the front-end for a Swagger Spec 2.0 description.

Fixes https://github.com/girder/girder/issues/371
