### PR TITLE
Disable default error behavior on girder.login request

### DIFF
--- a/clients/web/src/init.js
+++ b/clients/web/src/init.js
@@ -171,7 +171,8 @@ _.extend(girder, {
             path: '/user/authentication',
             headers: {
                 'Girder-Authorization': auth
-            }
+            },
+            error: null
         }).then(function (response) {
             response.user.token = response.authToken;
 


### PR DESCRIPTION
Request failure on a login attempt is an error by the user, not
the system.

@cpatrick this meets your under 7 lines threshold, PTAL.