### PR TITLE
Allow girder.EventStream to take arbitrary paths

### DIFF
--- a/clients/web/src/utilities/EventStream.js
+++ b/clients/web/src/utilities/EventStream.js
@@ -8,7 +8,8 @@
      */
     girder.EventStream = function (settings) {
         var defaults = {
-            timeout: null
+            timeout: null,
+            streamPath: '/notification/stream'
         };
 
         this.settings = _.extend(defaults, settings);
@@ -21,7 +22,7 @@
     prototype.open = function () {
         if (window.EventSource) {
             var stream = this,
-                url = girder.apiRoot + '/notification/stream';
+                url = girder.apiRoot + this.settings.streamPath;
 
             if (this.settings.timeout) {
                 url += '?timeout=' + this.settings.timeout;


### PR DESCRIPTION
This allows Girder plugins to start their own event streams while still benefiting from the Backbone event triggering that Girder provides.

@aashish24 @kotfic This is what's being used for the Cumulus Minerva plugin (PR shortly) to stream log results.