### PR TITLE
Add optional reference to uploads.

### DIFF
--- a/clients/ansible/README.md
+++ b/clients/ansible/README.md
@@ -8,7 +8,7 @@ The girder ansible module relies on the girder-client to do most of the heavy li
 
 ```yaml
 - name: install girder-client pip package
-  pip: name=girder-client version=1.1.1
+  pip: name=girder-client version=1.1.2
   sudo: yes
 
   # Code that uses girder module

--- a/clients/ansible/test/roles/girder-install/tasks/main.yml
+++ b/clients/ansible/test/roles/girder-install/tasks/main.yml
@@ -130,7 +130,7 @@
   - name: girder | pip | girder_client
     pip:
       name: girder-client
-      version: 1.1.1
+      version: 1.1.2
     when: do_install|bool
 
 

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -413,7 +413,7 @@ class GirderClient(object):
         # to upload anyway in this case also.
         return (None, False)
 
-    def uploadFileToItem(self, itemId, filepath):
+    def uploadFileToItem(self, itemId, filepath, reference=None):
         """
         Uploads a file to an item, in chunks.
         If ((the file already exists in the item with the same name and size)
@@ -421,6 +421,8 @@ class GirderClient(object):
 
         :param itemId: ID of parent item for file.
         :param filepath: path to file on disk.
+        :param reference: optional reference to send along with the upload.
+        :type reference: str
         """
         filename = os.path.basename(filepath)
         filepath = os.path.abspath(filepath)
@@ -441,6 +443,8 @@ class GirderClient(object):
             params = {
                 'size': filesize
             }
+            if reference:
+                params['reference'] = reference
             obj = self.put(path, params)
             if '_id' in obj:
                 uploadId = obj['_id']
@@ -456,6 +460,8 @@ class GirderClient(object):
                 'name': filename,
                 'size': filesize
             }
+            if reference:
+                params['reference'] = reference
             obj = self.post('file', params)
             if '_id' in obj:
                 uploadId = obj['_id']
@@ -481,7 +487,7 @@ class GirderClient(object):
                                 json.dumps(obj))
 
     def uploadFile(self, parentId, stream, name, size, parentType='item',
-                   progressCallback=None):
+                   progressCallback=None, reference=None):
         """
         Uploads a file into an item or folder.
 
@@ -501,14 +507,19 @@ class GirderClient(object):
             with progress information. It passes a single positional argument
             to the callable which is a dict of information about progress.
         :type progressCallback: callable
+        :param reference: optional reference to send along with the upload.
+        :type reference: str
         :returns: The file that was created on the server.
         """
-        obj = self.post('file', {
+        params = {
             'parentType': parentType,
             'parentId': parentId,
             'name': name,
-            'size': size
-        })
+            'size': size,
+        }
+        if reference is not None:
+            params['reference'] = reference
+        obj = self.post('file', params)
         if '_id' in obj:
             uploadId = obj['_id']
         else:

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -21,7 +21,7 @@
 from setuptools import setup, find_packages
 
 
-CLIENT_VERSION = '1.1.1'
+CLIENT_VERSION = '1.1.2'
 
 install_reqs = [
     'requests',

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -73,6 +73,9 @@ class File(Resource):
         .param('mimeType', 'The MIME type of the file.', required=False)
         .param('linkUrl', 'If this is a link file, pass its URL instead '
                'of size and mimeType using this parameter.', required=False)
+        .param('reference', 'If included, this information is passed to the '
+               'data.process event when the upload is complete.',
+               required=False)
         .errorResponse()
         .errorResponse('Write access was denied on the parent folder.', 403)
         .errorResponse('Failed to create upload.', 500)
@@ -107,7 +110,8 @@ class File(Resource):
             try:
                 upload = self.model('upload').createUpload(
                     user=user, name=params['name'], parentType=parentType,
-                    parent=parent, size=int(params['size']), mimeType=mimeType)
+                    parent=parent, size=int(params['size']), mimeType=mimeType,
+                    reference=params.get('reference'))
             except OSError as exc:
                 if exc.errno == errno.EACCES:
                     raise GirderException(
@@ -347,6 +351,9 @@ class File(Resource):
         Description('Change the contents of an existing file.')
         .param('id', 'The ID of the file.', paramType='path')
         .param('size', 'Size in bytes of the new file.', dataType='integer')
+        .param('reference', 'If included, this information is passed to the '
+               'data.process event when the upload is complete.',
+               required=False)
         .notes('After calling this, send the chunks just like you would with a '
                'normal file upload.')
     )
@@ -356,7 +363,8 @@ class File(Resource):
 
         # Create a new upload record into the existing file
         upload = self.model('upload').createUploadToFile(
-            file=file, user=user, size=int(params['size']))
+            file=file, user=user, size=int(params['size']),
+            reference=params.get('reference'))
 
         if upload['size'] > 0:
             return upload

--- a/plugins/worker/server/utils.py
+++ b/plugins/worker/server/utils.py
@@ -96,6 +96,7 @@ def jobInfoSpec(job, token=None, logPrint=True):
     return {
         'method': 'PUT',
         'url': '/'.join((getApiUrl(), 'job', str(job['_id']))),
+        'reference': str(job['_id']),
         'headers': {'Girder-Token': token},
         'logPrint': logPrint
     }

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -289,7 +289,7 @@ class PythonClientTestCase(base.TestCase):
         self.assertNotEqual(eventList[0]['file']['_id'],
                             eventList[1]['file']['_id'])
 
-        open(path, 'ab').write('test')
+        open(path, 'ab').write(b'test')
         size = os.path.getsize(path)
         client.uploadFileToItem(str(eventList[0]['file']['itemId']), path,
                                 reference='test3_reference')

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -24,7 +24,7 @@ import os
 import shutil
 import six
 
-from girder import config
+from girder import config, events
 from tests import base
 
 os.environ['GIRDER_PORT'] = os.environ.get('GIRDER_TEST_PORT', '20200')
@@ -252,3 +252,50 @@ class PythonClientTestCase(base.TestCase):
 
         files = list(self.model('item').childFiles(items[0]))
         self.assertEqual(len(files), 1)
+
+    def testUploadReference(self):
+        eventList = []
+        client = girder_client.GirderClient(port=os.environ['GIRDER_PORT'])
+        # Register a user
+        user = client.createResource('user', params={
+            'firstName': 'First',
+            'lastName': 'Last',
+            'login': 'mylogin',
+            'password': 'password',
+            'email': 'email@email.com'
+        })
+        client.authenticate('mylogin', 'password')
+        folders = client.listFolder(
+            parentId=user['_id'], parentFolderType='user', name='Public')
+        publicFolder = folders[0]
+
+        def processEvent(event):
+            eventList.append(event.info)
+
+        events.bind('data.process', 'lib_test', processEvent)
+
+        path = os.path.join(self.libTestDir, 'sub0', 'f')
+        size = os.path.getsize(path)
+        client.uploadFile(publicFolder['_id'], open(path), name='test1',
+                          size=size, parentType='folder',
+                          reference='test1_reference')
+        self.assertEqual(len(eventList), 1)
+        self.assertEqual(eventList[0]['reference'], 'test1_reference')
+
+        client.uploadFileToItem(str(eventList[0]['file']['itemId']), path,
+                                reference='test2_reference')
+        self.assertEqual(len(eventList), 2)
+        self.assertEqual(eventList[1]['reference'], 'test2_reference')
+        self.assertNotEqual(eventList[0]['file']['_id'],
+                            eventList[1]['file']['_id'])
+
+        open(path, 'ab').write('test')
+        size = os.path.getsize(path)
+        client.uploadFileToItem(str(eventList[0]['file']['itemId']), path,
+                                reference='test3_reference')
+        self.assertEqual(len(eventList), 3)
+        self.assertEqual(eventList[2]['reference'], 'test3_reference')
+        self.assertNotEqual(eventList[0]['file']['_id'],
+                            eventList[2]['file']['_id'])
+        self.assertEqual(eventList[1]['file']['_id'],
+                         eventList[2]['file']['_id'])


### PR DESCRIPTION
This is sent to the data.process event.

This is tested in the python client.

The worker plugin defaults to placing the job id in the reference.