### PR TITLE
Exclude test directories from python packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ include girder/girder-version.json
 include package.json
 include README.rst
 include girder/conf/girder.dist.cfg
+recursive-exclude tests *
 recursive-include clients/web *
 recursive-include girder/mail_templates *
 recursive-include grunt_tasks *
@@ -13,3 +14,4 @@ global-exclude *.pyc *.pyo *.cmake
 prune clients/web/static/built
 prune clients/web/dev
 prune clients/web/test
+prune plugins/*/plugin_tests

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,9 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4'
     ],
-    packages=find_packages(exclude=('tests.*', 'tests')),
+    packages=find_packages(
+        exclude=('tests.*', 'tests', '*.plugin_tests.*', '*.plugin_tests')
+    ),
     package_data={
         'girder': [
             'girder-version.json',


### PR DESCRIPTION
Having the test directories included in the python packaging will cause race conditions such as what happened here: http://my.cdash.org/testDetails.php?test=23360663&build=913481.  This is an attempt to fix it by limiting the files that are copied to the staging area during the packaging step.