### PR TITLE
Make it possible to execute jasmine test specs in the browser

### DIFF
--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -1177,3 +1177,23 @@ girderTest.anonymousLoadPage = function (logoutFirst, fragment, hasLoginDialog, 
         loginFunction();
     }
 };
+
+/*
+ * Provide an alternate path to injecting a test spec as a url query parameter.
+ *
+ * To use, start girder in testing mode: `python -m girder --testing` and
+ * browse to the test html with a spec provided:
+ *
+ *   http://localhost:8080/static/built/testEnv.html?spec=%2Fclients%2Fweb%2Ftest%2Fspec%2FversionSpec.js
+ *
+ * Note: the path to the spec file must be url encoded.
+ */
+$(function () {
+    var specs = [];
+    document.location.search.substring(1).split('&').forEach(function (query) {
+        query = query.split('=');
+        if (query.length > 1 && query[0] === 'spec') {
+            specs.push($.getScript(decodeURIComponent(query[1])));
+        }
+    });
+});

--- a/grunt_tasks/dev.js
+++ b/grunt_tasks/dev.js
@@ -68,8 +68,8 @@ module.exports = function (grunt) {
         var buffer = fs.readFileSync('clients/web/test/testEnv.jadehtml');
         var globs = grunt.config('uglify.app.files')['clients/web/static/built/girder.app.min.js'];
         var dependencies = [
-            '/clients/web/test/testUtils.js',
-            '/clients/web/static/built/girder.ext.min.js'
+            '/clients/web/static/built/girder.ext.min.js',
+            '/clients/web/test/testUtils.js'
         ];
         var inputs = [];
 


### PR DESCRIPTION
This won't work for tests that rely on `callPhantom`, but you can at least load up some of the specs in the browser to debug them.