### PR TITLE
Register plugins via a setuptools entry_point

### DIFF
--- a/girder/__init__.py
+++ b/girder/__init__.py
@@ -23,7 +23,10 @@ import os
 
 
 from girder.constants import LOG_ROOT, MAX_LOG_SIZE, LOG_BACKUP_COUNT
-from girder.utility import config, mkdir
+from girder.utility import config, mkdir, plugin_utilities
+
+# alias girder.plugin => girder.utility.plugin_utilities
+plugin = plugin_utilities
 
 
 class LogLevelFilter(object):

--- a/girder/__init__.py
+++ b/girder/__init__.py
@@ -23,10 +23,7 @@ import os
 
 
 from girder.constants import LOG_ROOT, MAX_LOG_SIZE, LOG_BACKUP_COUNT
-from girder.utility import config, mkdir, plugin_utilities
-
-# alias girder.plugin => girder.utility.plugin_utilities
-plugin = plugin_utilities
+from girder.utility import config, mkdir
 
 
 class LogLevelFilter(object):
@@ -112,3 +109,6 @@ def _setupLogger():
     return logger
 
 logger = _setupLogger()
+
+# alias girder.plugin => girder.utility.plugin_utilities
+from girder.utility import plugin_utilities as plugin  # noqa

--- a/tests/packaging/entry_point_plugin/entry_point_plugin.py
+++ b/tests/packaging/entry_point_plugin/entry_point_plugin.py
@@ -1,0 +1,8 @@
+
+def load(info):
+    pass
+
+
+load.config = {
+    "name": "Plugin using entry_point"
+}

--- a/tests/packaging/entry_point_plugin/entry_point_plugin.py
+++ b/tests/packaging/entry_point_plugin/entry_point_plugin.py
@@ -1,8 +1,6 @@
+from girder.utility.plugin_utilities import config
 
+
+@config(name='Plugin using entry_point')
 def load(info):
     pass
-
-
-load.config = {
-    "name": "Plugin using entry_point"
-}

--- a/tests/packaging/entry_point_plugin/entry_point_plugin.py
+++ b/tests/packaging/entry_point_plugin/entry_point_plugin.py
@@ -1,6 +1,6 @@
-from girder.utility.plugin_utilities import config
+from girder import plugin
 
 
-@config(name='Plugin using entry_point')
+@plugin.config(name='Plugin using entry_point')
 def load(info):
     pass

--- a/tests/packaging/entry_point_plugin/setup.py
+++ b/tests/packaging/entry_point_plugin/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup
+
+
+setup(
+    name='girder-entry-point-plugin',
+    py_modules=['entry_point_plugin'],
+    entry_points={
+        'girder.plugin': 'test_entry_point = entry_point_plugin:load'
+    }
+)

--- a/tests/packaging/pip_install_girder.sh
+++ b/tests/packaging/pip_install_girder.sh
@@ -31,6 +31,14 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+# Install a standalone plugin the registers itself against the
+# girder.plugin entrypoint
+"${virtualenv_pip}" install -e "${PROJECT_SOURCE_DIR}/tests/packaging/entry_point_plugin"
+if ! python -c 'from girder.utility.plugin_utilities import findAllPlugins; assert findAllPlugins().get("test_entry_point", {}).get("name") == "Plugin using entry_point"' ; then
+    echo "Error: failed to register a plugin with the girder.plugin entry point"
+    exit 1
+fi
+
 # Start the server
 export GIRDER_PORT=31200
 python -m girder &> /dev/null &


### PR DESCRIPTION
I came up with a way to do this without breaking backward compatibility so it doesn't necessarily have to wait until version 2.0.  You can test drive it with a standalone version of the geospatial plugin [here](https://github.com/jbeezley/girder-geospatial).  Just `python setup.py develop` or `python setup.py install` this branch of girder (unnecessary once this branch is on PyPI) then
```
pip install git+https://github.com/jbeezley/girder-geospatial.git
```
The plugin `Geospatial (standalone)` should now be listed on the plugins page.

Note: this won't work for client side plugins, so I'll understand if we decide to hold off on this PR until that is resolved.