### PR TITLE
Dump a log of ajax requests on client test failure

### DIFF
--- a/clients/web/test/specRunner.js
+++ b/clients/web/test/specRunner.js
@@ -63,6 +63,11 @@ page.onConsoleMessage = function (msg) {
 
         console.log('<DartMeasurementFile name="PhantomScreenshot" type="image/png">' +
             fs.workingDirectory + fs.separator + imageFile + '</DartMeasurementFile>');
+
+        console.log('Dumping ajax trace:')
+        console.log(page.evaluate(function () {
+            return JSON.stringify(girderTest.ajaxLog(true), null, '  ');
+        }));
         return;
     }
 


### PR DESCRIPTION
I wrote this to debug a minerva test, and it might be useful in general.  Along with saving a screenshot of the page on console output, it will also dump a list of ajax calls made along with their responses.  The output looks like this:

```
400 Bad Request {"field": "id", "message": "Invalid ObjectId: undefined", "type": "validation"}
[object Object]
F Main view -> create a new session
Created screenshot: phantom-2016-02-23T19.18.20.780Z.png
<DartMeasurementFile name="PhantomScreenshot" type="image/png">/Users/jbeezley/test/girder/phantom-2016-02-23T19.18.20.780Z.png</DartMeasurementFile>
Dumping ajax trace:
[
  {
    "opts": {
      "dataType": "json",
      "type": "POST",
      "path": "/file",
      "data": {
        "parentType": "item",
        "parentId": "56ccb07762a8f85656f373ef",
        "name": "session.json",
        "size": 261,
        "mimeType": ""
      },
      "url": "http://localhost:30020//api/v1/file",
      "headers": {
        "Girder-Token": "TdUEbtYoz0PpJXgoGRS2wUObtsMW3qXal2BaMP9Qt0YHuUTSyGbf2eO1075OFdk0"
      }
    },
    "status": "success",
    "result": {
      "_id": "56ccb07762a8f85656f373f0",
      "assetstoreId": "56ccb07262a8f85656f373e6",
      "created": "2016-02-23T19:18:15.679459+00:00",
      "mimeType": "application/octet-stream",
      "name": "session.json",
      "parentId": "56ccb07762a8f85656f373ef",
      "parentType": "item",
      "received": 0,
      "sha512state": "08c9bcf367e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000",
      "size": 261,
      "tempFile": "/Users/jbeezley/test/girder/tests/assetstore/web_client_minerva/temp/tmpIYIQbQ",
      "updated": "2016-02-23T19:18:15.680375+00:00",
      "userId": "56ccb07262a8f85656f373ea"
    }
  },
  {
    "opts": {
      "dataType": "json",
      "type": "POST",
      "path": "/file/chunk",
      "data": {},
      "contentType": false,
      "processData": false,
      "url": "http://localhost:30020//api/v1/file/chunk",
      "headers": {
        "Girder-Token": "TdUEbtYoz0PpJXgoGRS2wUObtsMW3qXal2BaMP9Qt0YHuUTSyGbf2eO1075OFdk0"
      }
    },
    "status": "success",
    "result": {
      "_id": "56ccb07762a8f85656f373f0",
      "assetstoreId": "56ccb07262a8f85656f373e6",
      "created": "2016-02-23T19:18:15.679000+00:00",
      "mimeType": "application/octet-stream",
      "name": "session.json",
      "parentId": "56ccb07762a8f85656f373ef",
      "parentType": "item",
      "received": 0,
      "sha512state": "08c9bcf367e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000",
      "size": 261,
      "tempFile": "/Users/jbeezley/test/girder/tests/assetstore/web_client_minerva/temp/tmpIYIQbQ",
      "updated": "2016-02-23T19:18:15.690112+00:00",
      "userId": "56ccb07262a8f85656f373ea"
    }
  },
  {
    "opts": {
      "dataType": "json",
      "type": "GET",
      "path": "/item/56ccb07762a8f85656f373ef",
      "url": "http://localhost:30020//api/v1/item/56ccb07762a8f85656f373ef",
      "headers": {
        "Girder-Token": "TdUEbtYoz0PpJXgoGRS2wUObtsMW3qXal2BaMP9Qt0YHuUTSyGbf2eO1075OFdk0"
      }
    },
    "status": "success",
    "result": {
      "_id": "56ccb07762a8f85656f373ef",
      "_modelType": "item",
      "baseParentId": "56ccb07262a8f85656f373ea",
      "baseParentType": "user",
      "created": "2016-02-23T19:18:15.671000+00:00",
      "creatorId": "56ccb07262a8f85656f373ea",
      "description": "A session created during a client test.",
      "folderId": "56ccb07662a8f85656f373ee",
      "name": "Test session",
      "size": 0,
      "updated": "2016-02-23T19:18:15.671000+00:00"
    }
  },
  {
    "opts": {
      "dataType": "json",
      "type": "GET",
      "path": "/minerva_session/56ccb07762a8f85656f373ef/session",
      "url": "http://localhost:30020//api/v1/minerva_session/56ccb07762a8f85656f373ef/session",
      "headers": {
        "Girder-Token": "TdUEbtYoz0PpJXgoGRS2wUObtsMW3qXal2BaMP9Qt0YHuUTSyGbf2eO1075OFdk0"
      }
    },
    "status": "success",
    "result": {}
  },
  {
    "opts": {
      "dataType": "json",
      "type": "GET",
      "path": "/file/undefined/download",
      "url": "http://localhost:30020//api/v1/file/undefined/download",
      "headers": {
        "Girder-Token": "TdUEbtYoz0PpJXgoGRS2wUObtsMW3qXal2BaMP9Qt0YHuUTSyGbf2eO1075OFdk0"
      }
    },
    "status": "error",
    "errorThrown": "Bad Request"
  }
]
  Error: timeout: timed out after 5000 msec waiting for something to happen

Main view: 1 of 2 passed.
----------------
Testing Finished
----------------
2 specs, 1 failure in 8.156s.
```