### PR TITLE
Add test labels and use a Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
     - pip install -U pip virtualenv
 install:
     - if [ "$GIRDER_TEST_GROUP" == "server" -o "$GIRDER_TEST_GROUP" == "client" ] ; then pip install -r requirements.txt -r requirements-dev.txt -e . ; fi
-    - if [ "$GIRDER_TEST_GROUP" == "packaging" -o "$GIRDER_TEST_GROUP" == "client" -o "$GIRDER_TEST_GROUP" == "other" ] ; then npm install ; fi
+    - npm install
 script:
     - mkdir _build
     - cd _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,12 @@ before_install:
     - npm --version
     - pip install -U pip virtualenv
 install:
-    - pip install -r requirements.txt -r requirements-dev.txt -e .
-    - npm install
+    - if [ "$GIRDER_TEST_GROUP" -eq "server" -o "$GIRDER_TEST_GROUP" -eq "client" ] ; then
+    -   pip install -r requirements.txt -r requirements-dev.txt -e .
+    - fi
+    - if [ "$GIRDER_TEST_GROUP" -eq "packaging" -o "$GIRDER_TEST_GROUP" -eq "client" -o "$GIRDER_TEST_GROUP" -eq "other" ] ; then
+    -   npm install
+    - fi
 script:
     - mkdir _build
     - cd _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ python:
     - "2.7"
     - "3.4"
 
+env:
+    - GIRDER_TEST_GROUP=server
+    - GIRDER_TEST_GROUP=client
+    - GIRDER_TEST_GROUP=packaging
+    - GIRDER_TEST_GROUP=other
+
 cache:
     directories:
         - $HOME/.cache
@@ -18,22 +24,18 @@ before_install:
     - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]; then export PY3="true"; else export PY2="true"; fi
     - if [ -n "${PY3}" ]; then export MONGO_VERSION=3.0.7; export PY_COVG="OFF"; else export MONGO_VERSION=2.6.11; export PY_COVG="ON"; export DEPLOY=true; fi
     - if [ -n "${PY3}" ]; then export IGNORE_PLUGINS=hdfs_assetstore,metadata_extractor; fi
-    - CACHE=$HOME/.cache source ./scripts/install_mongo.sh
+    - if [ "$GIRDER_TEST_GROUP" != "other" ] ; then CACHE=$HOME/.cache source ./scripts/install_mongo.sh ; fi
     - mkdir /tmp/db
-    - mongod --dbpath=/tmp/db >/dev/null 2>/dev/null &
-    - mongod --version
+    - (mongod --dbpath=/tmp/db >/dev/null 2>/dev/null || true ) &
+    - mongod --version || true
     - CACHE=$HOME/.cache CMAKE_VERSION=3.1.0 CMAKE_SHORT_VERSION=3.1 source ./scripts/install_cmake.sh
     - cmake --version
     - npm install -g npm
     - npm --version
     - pip install -U pip virtualenv
 install:
-    - if [ "$GIRDER_TEST_GROUP" -eq "server" -o "$GIRDER_TEST_GROUP" -eq "client" ] ; then
-    -   pip install -r requirements.txt -r requirements-dev.txt -e .
-    - fi
-    - if [ "$GIRDER_TEST_GROUP" -eq "packaging" -o "$GIRDER_TEST_GROUP" -eq "client" -o "$GIRDER_TEST_GROUP" -eq "other" ] ; then
-    -   npm install
-    - fi
+    - if [ "$GIRDER_TEST_GROUP" == "server" -o "$GIRDER_TEST_GROUP" == "client" ] ; then pip install -r requirements.txt -r requirements-dev.txt -e . ; fi
+    - if [ "$GIRDER_TEST_GROUP" == "packaging" -o "$GIRDER_TEST_GROUP" == "client" -o "$GIRDER_TEST_GROUP" == "other" ] ; then npm install ; fi
 script:
     - mkdir _build
     - cd _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,11 @@ before_install:
     - mongod --version || true
     - CACHE=$HOME/.cache CMAKE_VERSION=3.4.3 CMAKE_SHORT_VERSION=3.4 source ./scripts/install_cmake.sh
     - cmake --version
+    - mkdir -p $HOME/.cache/node_modules || true
+    - ln -sf $HOME/.cache/node_modules .
     - npm install -g npm
     - npm --version
+    - npm prune
     - pip install -U pip virtualenv
 install:
     - if [ "$GIRDER_TEST_GROUP" == "server" -o "$GIRDER_TEST_GROUP" == "client" ] ; then pip install -r requirements.txt -r requirements-dev.txt -e . ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
     - mkdir /tmp/db
     - (mongod --dbpath=/tmp/db >/dev/null 2>/dev/null || true ) &
     - mongod --version || true
-    - CACHE=$HOME/.cache CMAKE_VERSION=3.1.0 CMAKE_SHORT_VERSION=3.1 source ./scripts/install_cmake.sh
+    - CACHE=$HOME/.cache CMAKE_VERSION=3.4.3 CMAKE_SHORT_VERSION=3.4 source ./scripts/install_cmake.sh
     - cmake --version
     - npm install -g npm
     - npm --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
     - npm prune
     - pip install -U pip virtualenv
 install:
-    - if [ "$GIRDER_TEST_GROUP" == "server" -o "$GIRDER_TEST_GROUP" == "client" ] ; then pip install -r requirements.txt -r requirements-dev.txt -e . ; fi
+    - if [ "$GIRDER_TEST_GROUP" == "server" -o "$GIRDER_TEST_GROUP" == "client" -o "$GIRDER_TEST_GROUP" == "other" ] ; then pip install -r requirements.txt -r requirements-dev.txt -e . ; fi
     - npm install
 script:
     - mkdir _build

--- a/cmake/travis_continuous.cmake
+++ b/cmake/travis_continuous.cmake
@@ -3,13 +3,37 @@ set(CTEST_BINARY_DIRECTORY "$ENV{TRAVIS_BUILD_DIR}/_build")
 
 include(${CTEST_SOURCE_DIRECTORY}/CTestConfig.cmake)
 set(CTEST_SITE "Travis")
-set(CTEST_BUILD_NAME "Linux-$ENV{TRAVIS_BRANCH}-Mongo-$ENV{MONGO_VERSION}")
+set(CTEST_BUILD_NAME "Linux-$ENV{TRAVIS_BRANCH}-Mongo-$ENV{MONGO_VERSION}-$ENV{GIRDER_TEST_GROUP}")
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
+set(include_label ".*")
+set(exclude_label "")
+
+if(ENV{GIRDER_TEST_GROUP} STREQUAL server)
+  set(include_label "girder_server")
+elseif(ENV{GIRDER_TEST_GROUP STREQUAL client)
+  set(include_label "girder_client")
+elseif(ENV{GIRDER_TEST_GROUP STREQUAL packaging)
+  set(include_label "girder_packaging")
+elseif(ENV{GIRDER_TEST_GROUP STREQUAL other)
+  set(exclude_label "(girder_server|girder_client|girder_packaging)")
+endif()
 
 ctest_start("Continuous")
-ctest_configure()
+ctest_configure(OPTIONS "${config_opts}")
 ctest_build()
-ctest_test(PARALLEL_LEVEL 4 RETURN_VALUE res)
+
+if(ENV{GIRDER_TEST_GROUP STREQUAL other)
+  ctest_test(
+    PARALLEL_LEVEL 4 RETURN_VALUE res
+    EXCLUDE_LABEL "${exclude_label}"
+  )
+else()
+  ctest_test(
+    PARALLEL_LEVEL 4 RETURN_VALUE res
+    INCLUDE_LABEL "${include_label}"
+  )
+endif()
+
 ctest_coverage()
 file(REMOVE "${CTEST_BINARY_DIRECTORY}/coverage.xml")
 ctest_submit()

--- a/cmake/travis_continuous.cmake
+++ b/cmake/travis_continuous.cmake
@@ -35,7 +35,13 @@ else()
   )
 endif()
 
-ctest_coverage()
+if(test_group STREQUAL "server")
+  ctest_coverage()
+elseif(test_group STREQUAL "client")
+  file(RENAME "${CTEST_BINARY_DIRECTORY}/js_coverage.xml" "${CTEST_BINARY_DIRECTORY}/coverage.xml")
+  ctest_coverage()
+endif()
+
 file(REMOVE "${CTEST_BINARY_DIRECTORY}/coverage.xml")
 ctest_submit()
 

--- a/cmake/travis_continuous.cmake
+++ b/cmake/travis_continuous.cmake
@@ -2,27 +2,28 @@ set(CTEST_SOURCE_DIRECTORY "$ENV{TRAVIS_BUILD_DIR}")
 set(CTEST_BINARY_DIRECTORY "$ENV{TRAVIS_BUILD_DIR}/_build")
 
 include(${CTEST_SOURCE_DIRECTORY}/CTestConfig.cmake)
+set(test_group "$ENV{GIRDER_TEST_GROUP}")
 set(CTEST_SITE "Travis")
-set(CTEST_BUILD_NAME "Linux-$ENV{TRAVIS_BRANCH}-Mongo-$ENV{MONGO_VERSION}-$ENV{GIRDER_TEST_GROUP}")
+set(CTEST_BUILD_NAME "Linux-$ENV{TRAVIS_BRANCH}-Mongo-$ENV{MONGO_VERSION}-${test_group}")
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 set(include_label ".*")
 set(exclude_label "")
 
-if(ENV{GIRDER_TEST_GROUP} STREQUAL server)
+if(test_group STREQUAL server)
   set(include_label "girder_server")
-elseif(ENV{GIRDER_TEST_GROUP STREQUAL client)
+elseif(test_group STREQUAL client)
   set(include_label "girder_client")
-elseif(ENV{GIRDER_TEST_GROUP STREQUAL packaging)
+elseif(test_group STREQUAL packaging)
   set(include_label "girder_packaging")
-elseif(ENV{GIRDER_TEST_GROUP STREQUAL other)
+elseif(test_group STREQUAL other)
   set(exclude_label "(girder_server|girder_client|girder_packaging)")
 endif()
 
 ctest_start("Continuous")
-ctest_configure(OPTIONS "${config_opts}")
+ctest_configure()
 ctest_build()
 
-if(ENV{GIRDER_TEST_GROUP STREQUAL other)
+if(test_group STREQUAL other)
   ctest_test(
     PARALLEL_LEVEL 4 RETURN_VALUE res
     EXCLUDE_LABEL "${exclude_label}"

--- a/scripts/tests/test_json_config_expand_relpaths_script/CMakeLists.txt
+++ b/scripts/tests/test_json_config_expand_relpaths_script/CMakeLists.txt
@@ -10,6 +10,7 @@ function(add_json_config_expand_relpaths_test name)
     COMMAND ${NODEJS_EXECUTABLE} ${JSON_CONFIG_EXPAND_RELPATHS_SCRIPT} ${ARGN}
     )
   set(testname ${testname} PARENT_SCOPE)
+  set_property(TEST "${testname}" PROPERTY LABELS girder_devel)
 endfunction()
 
 #
@@ -100,6 +101,7 @@ set_tests_properties(${testname}_check_result
   PROPERTIES
     DEPENDS ${testname}
     REQUIRED_FILES "${baseline_case1};${output_case1}"
+    LABELS girder_devel
   )
 
 #
@@ -120,4 +122,5 @@ set_tests_properties(${testname}_check_result
   PROPERTIES
     DEPENDS ${testname}
     REQUIRED_FILES "${baseline_case2};${output_case2}"
+    LABELS girder_devel
   )

--- a/scripts/tests/test_json_config_merge_script/CMakeLists.txt
+++ b/scripts/tests/test_json_config_merge_script/CMakeLists.txt
@@ -10,6 +10,7 @@ function(add_json_config_merge_test name)
     COMMAND ${NODEJS_EXECUTABLE} ${JSON_CONFIG_MERGE_SCRIPT} ${ARGN}
     )
   set(testname ${testname} PARENT_SCOPE)
+  set_property(TEST "${testname}" PROPERTY LABELS girder_devel)
 endfunction()
 
 #
@@ -97,6 +98,7 @@ set_tests_properties(${testname}_check_result
   PROPERTIES
     DEPENDS ${testname}
     REQUIRED_FILES "${baseline_case1};${output_case1}"
+    LABELS girder_devel
   )
 
 #
@@ -116,4 +118,5 @@ set_tests_properties(${testname}_check_result
   PROPERTIES
     DEPENDS ${testname}
     REQUIRED_FILES "${baseline_case2};${output_case2}"
+    LABELS girder_devel
   )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,18 +64,20 @@ if(RUN_CORE_TESTS)
   add_web_client_test(empty_layout "${PROJECT_SOURCE_DIR}/clients/web/test/spec/emptyLayoutSpec.js")
   add_web_client_test(swagger "${PROJECT_SOURCE_DIR}/clients/web/test/spec/swaggerSpec.js" BASEURL "/api/v1" NOCOVERAGE)
 
+  # Add tests for the local TestData module
+  add_plugin_data_path("has_external_data" "${PROJECT_SOURCE_DIR}/tests/test_plugins/has_external_data")
+  add_python_test(external_data_core
+    EXTERNAL_DATA "test_file.txt"
+  )
+  add_python_test(external_data_plugin
+    EXTERNAL_DATA "test_file.txt" "plugins/has_external_data/test_file.txt"
+  )
+  set_property(TEST server_external_data_core PROPERTY LABELS girder_devel)
+  set_property(TEST server_external_data_plugin PROPERTY LABELS girder_devel)
+
   add_subdirectory(clients)
   add_subdirectory(packaging)
 endif()
-
-# Add tests for the local TestData module
-add_plugin_data_path("has_external_data" "${PROJECT_SOURCE_DIR}/tests/test_plugins/has_external_data")
-add_python_test(external_data_core
-  EXTERNAL_DATA "test_file.txt"
-)
-add_python_test(external_data_plugin
-  EXTERNAL_DATA "test_file.txt" "plugins/has_external_data/test_file.txt"
-)
 
 
 # Use a macro instead of a function because web client tests actually write

--- a/tests/JavascriptTests.cmake
+++ b/tests/JavascriptTests.cmake
@@ -29,6 +29,8 @@ function(javascript_tests_init)
             combine_report
             "${PROJECT_BINARY_DIR}/js_coverage"
   )
+  set_property(TEST js_coverage_reset PROPERTY LABELS girder_client)
+  set_property(TEST js_coverage_combine_report PROPERTY LABELS girder_client)
 endfunction()
 
 include(${PROJECT_SOURCE_DIR}/scripts/JsonConfigExpandRelpaths.cmake)
@@ -59,6 +61,7 @@ function(add_eslint_test name input)
     WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
     COMMAND "${ESLINT_EXECUTABLE}" --ignore-path "${ignore_file}" --config "${config_file}" "${input}"
   )
+  set_property(TEST "eslint_${name}" PROPERTY LABELS girder_client girder_static_analysis)
 endfunction()
 
 function(add_javascript_style_test name input)
@@ -134,6 +137,8 @@ function(add_javascript_style_test name input)
     WORKING_DIRECTORY "${test_directory}"
     COMMAND "${JSSTYLE_EXECUTABLE}"  --config "${jsstyle_config}" "${input}"
   )
+  set_property(TEST "jshint_${name}" PROPERTY LABELS girder_client girder_static_analysis)
+  set_property(TEST "jsstyle_${name}" PROPERTY LABELS girder_client girder_static_analysis)
 endfunction()
 
 function(add_web_client_test case specFile)
@@ -254,4 +259,6 @@ function(add_web_client_test case specFile)
     set_property(TEST ${testname} APPEND PROPERTY DEPENDS js_coverage_reset)
     set_property(TEST js_coverage_combine_report APPEND PROPERTY DEPENDS ${testname})
   endif()
+
+  set_property(TEST ${testname} PROPERTY LABELS girder_client)
 endfunction()

--- a/tests/PythonTests.cmake
+++ b/tests/PythonTests.cmake
@@ -59,6 +59,12 @@ function(python_tests_init)
     set_property(TEST py_coverage PROPERTY DEPENDS py_coverage_combine)
     set_property(TEST py_coverage_html PROPERTY DEPENDS py_coverage)
     set_property(TEST py_coverage_xml PROPERTY DEPENDS py_coverage)
+
+    set_property(TEST py_coverage PROPERTY LABELS girder_server)
+    set_property(TEST py_coverage_reset PROPERTY LABELS girder_server)
+    set_property(TEST py_coverage_combine PROPERTY LABELS girder_server)
+    set_property(TEST py_coverage_html PROPERTY LABELS girder_server)
+    set_property(TEST py_coverage_xml PROPERTY LABELS girder_server)
   endif()
 endfunction()
 
@@ -69,6 +75,7 @@ function(add_python_style_test name input)
       WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
       COMMAND "${FLAKE8_EXECUTABLE}" "--config=${flake8_config}" "${input}"
     )
+    set_property(TEST "${name}" PROPERTY LABELS girder_static_analysis girder_server)
   endif()
 endfunction()
 
@@ -146,4 +153,6 @@ function(add_python_test case)
     girder_ExternalData_expand_arguments("${name}_data" _tmp ${_data_files})
     girder_ExternalData_add_target("${name}_data")
   endif()
+
+  set_property(TEST ${name} PROPERTY LABELS girder_server)
 endfunction()

--- a/tests/packaging/CMakeLists.txt
+++ b/tests/packaging/CMakeLists.txt
@@ -34,12 +34,19 @@ add_test(
   COMMAND "${PROJECT_SOURCE_DIR}/node_modules/.bin/grunt" package
 )
 
+set_property(TEST packaging_generate
+  PROPERTY LABELS girder_packaging
+)
+
 add_test(
   NAME packaging_verify_contents
   WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
   COMMAND "${PYTHON_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/tests/packaging/test_package_contents.py"
 )
 
+set_property(TEST packaging_verify_contents
+  PROPERTY LABELS girder_packaging
+)
 set_property(TEST packaging_verify_contents
   PROPERTY DEPENDS packaging_generate
 )
@@ -57,6 +64,9 @@ add_test(
 )
 
 set_property(TEST packaging_install
+  PROPERTY LABELS girder_packaging
+)
+set_property(TEST packaging_install
   PROPERTY DEPENDS "packaging_generate"
 )
 set_property(TEST packaging_install
@@ -72,6 +82,9 @@ add_test(
           "${virtualenv_pip}"
 )
 
+set_property(TEST packaging_plugin_install
+  PROPERTY LABELS girder_packaging
+)
 set_property(TEST packaging_plugin_install
   PROPERTY DEPENDS "packaging_install"
 )


### PR DESCRIPTION
This splits the tests into 4 groups (server, client, packaging, and other) that will run in independent containers on Travis.  This has a few benefits:
* tests are less likely to interfere with each other
* rerunning a single test group is faster (5 minutes vs 10 minutes)
* you can use up to 5 containers in parallel on Travis
* javascript coverage reports now show up on cdash

There are a couple of other tangentially related changes here as well:
* The external data tests are now turned off with the `RUN_CORE_TESTS` option
* Updated cmake to 3.4.3 because I thought I was encountering bugs related to test labels
* The `node_modules` directory is now cached between runs (the `npm prune` line ensures that it remains pristine)