### PR TITLE
update the get-pip.py location as requested by get-pip.py itself

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -qy software-properties-common python-soft
     libpython-dev && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN wget https://raw.github.com/pypa/pip/master/contrib/get-pip.py && python get-pip.py
+RUN wget https://bootstrap.pypa.io/get-pip.py && python get-pip.py
 
 WORKDIR /girder
 COPY girder /girder/girder


### PR DESCRIPTION
Looks like the get-pip.py shell script needs updating; the latest URL is provided here.