### PR TITLE
Provision improvements persistent girder server

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,8 +1,33 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/trusty64"
+
+  config.vm.hostname = "girder"
+
   config.vm.network "forwarded_port", guest: 80, host: 9080
-  config.vm.provision "ansible" do |ansible|
+  config.vm.post_up_message = "Girder is running at http://localhost:9080"
+
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.synced_folder ".", "/home/vagrant/girder"
+
+  provisioner_type = if
+      Gem::Version.new(Vagrant::VERSION) > Gem::Version.new('1.8.1')
+    then
+      # Vagrant > 1.8.1 is required due to
+      # https://github.com/mitchellh/vagrant/issues/6793
+      "ansible_local"
+    else
+      "ansible"
+    end
+  config.vm.provision provisioner_type do |ansible|
     ansible.playbook = "devops/ansible/playbook.yml"
-    ansible.verbose = "v"
+    #ansible.verbose = "v"
+    if provisioner_type == "ansible_local"
+      ansible.provisioning_path = "/home/vagrant/girder"
+    end
+  end
+
+  config.vm.provider "virtualbox" do |virtualbox|
+    virtualbox.name = "girder"
+    virtualbox.memory = 768
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,8 +3,8 @@ Vagrant.configure("2") do |config|
 
   config.vm.hostname = "girder"
 
-  config.vm.network "forwarded_port", guest: 80, host: 9080
-  config.vm.post_up_message = "Girder is running at http://localhost:9080"
+  config.vm.network "forwarded_port", guest: 8080, host: 8080
+  config.vm.post_up_message = "Girder is running at http://localhost:8080"
 
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder ".", "/home/vagrant/girder"

--- a/devops/ansible/playbook.yml
+++ b/devops/ansible/playbook.yml
@@ -1,86 +1,97 @@
-
+---
 
 - hosts: all
 
-  handlers:
-  - name: restart nginx
-    service: name=nginx pattern=/etc/init.d/nginx state=restarted enabled=yes
-    sudo: yes
-
-  - name: restart mongodb
-    service: name=mongodb pattern=/etc/init.d/mongodb state=restarted enabled=yes
-    sudo: yes
-
   tasks:
 
-  - name: add nodejs ppa
-    apt_repository: repo='ppa:chris-lea/node.js'
-    sudo: yes
+  - name: Ensure minimum Ansible version
+    fail:
+      msg: "This playbook requires Ansible 2.0.0 or greater."
+    when: "{{ ansible_version.full | version_compare('2.0.0', '<') }}"
 
-  - name: update apt cache
-    apt: update_cache=yes
-    sudo: yes
-
-  - name: install package dependencies
-    apt: name={{ item }} state=present
+  - name: System | Install dependencies
+    apt: name={{ item }}
     sudo: yes
     with_items:
-      - python-pip
-      - python2.7-dev
       - build-essential
-      - mongodb
-      - python-software-properties
-      - libffi-dev
-      - nodejs
-      - screen
-      - nginx
-      - cmake
-      - cmake-curses-gui
       - git
+      - python2.7-dev
+      - libffi-dev
+      - libjpeg-dev
+      - zlib1g-dev
+      - python-pip
 
-  - name: Enable mongo full-text search
-    lineinfile: dest=/etc/mongodb.conf regexp=^setParameter= line=setParameter=textSearchEnabled=true
+  - name: MongoDB | Add PPA key
+    apt_key:
+      id: "EA312927"
+      keyserver: "keyserver.ubuntu.com"
     sudo: yes
-    notify:
-      - restart mongodb
 
-  - name: install girder
-    pip: name='file:///vagrant/girder[plugins]' editable=yes
+  - name: MongoDB | Add PPA
+    apt_repository:
+      repo: "deb https://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/3.2 multiverse"
     sudo: yes
 
-  - name: install grunt and globally
-    npm: name={{ item }} global=yes
+  - name: MongoDB | Install package
+    apt:
+      name: mongodb-org
+    sudo: yes
+
+  - name: NodeJS | Add PPA key
+    apt_key:
+      id: "68576280"
+      url: "https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
+    sudo: yes
+
+  - name: NodeJS | Add PPA
+    apt_repository:
+      repo: "deb https://deb.nodesource.com/node_4.x {{ ansible_distribution_release }} main"
+    sudo: yes
+
+  - name: NodeJS | Install package
+    apt:
+      name: nodejs
+    sudo: yes
+
+  - name: Girder | Upgrade pip
+    pip:
+      name: pip
+      state: latest
+    sudo: yes
+
+  - name: Girder | Install requirements
+    pip:
+      requirements: "requirements.txt"
+      chdir: "/home/vagrant/girder"
+    sudo: yes
+
+  - name: Girder | Install Girder
+    pip:
+      name: ".[plugins]"
+      # 'editable' requires Ansible >= 2.0.0
+      editable: yes
+      chdir: "/home/vagrant/girder"
+    sudo: yes
+
+  - name: Girder | Install Grunt globally
+    npm:
+      name: "{{ item }}"
+      global: yes
     with_items:
       - grunt
       - grunt-cli
     sudo: yes
 
-  - name: run npm install
-    npm: path=/vagrant
+  - name: Girder | Run npm install
+    npm:
+      path: "/home/vagrant/girder"
 
-  - name: run grunt init
-    command: grunt init chdir=/vagrant
+  - name: Girder | Run grunt init
+    command: grunt init
+    args:
+      chdir: "/home/vagrant/girder"
 
-  - name: run grunt
-    command: grunt chdir=/vagrant
-
-  - name: disable default nginx site
-    command: rm /etc/nginx/sites-enabled/default removes=/etc/nginx/sites-enabled/default
-    sudo: yes
-    notify:
-      - restart nginx
-
-  - name: add the girder nginx site
-    template: src=nginx.j2 dest=/etc/nginx/sites-available/girder
-    sudo: yes
-    notify:
-      - restart nginx
-
-  - name: enable girder nginx site
-    command: ln -s /etc/nginx/sites-available/girder /etc/nginx/sites-enabled/girder creates=/etc/nginx/sites-enabled/girder
-    sudo: yes
-    notify:
-      - restart nginx
-
-  - name: copy helper script
-    copy: src=start_girder_in_screen.sh dest=/home/vagrant mode=0744
+  - name: Girder | Run grunt
+    command: grunt
+    args:
+      chdir: "/home/vagrant/girder"

--- a/devops/ansible/playbook.yml
+++ b/devops/ansible/playbook.yml
@@ -99,7 +99,7 @@
   - name: Girder | Run grunt watch
     at: 
     args:
-        command: "cd /home/vagrant/girder && grunt watch" 
+        command: "cd /home/vagrant/girder && grunt watch >> /tmp/grunt_watch.log" 
         count: 1
         units: "minutes"
         unique: true
@@ -107,7 +107,7 @@
   - name: Girder | Run web server
     at:
     args:
-        command: "cd /home/vagrant/girder && python -m girder" 
+        command: "cd /home/vagrant/girder && python -m girder >> /tmp/girder_server.log" 
         count: 1
         units: "minutes"
         unique: true

--- a/devops/ansible/playbook.yml
+++ b/devops/ansible/playbook.yml
@@ -95,3 +95,19 @@
     command: grunt
     args:
       chdir: "/home/vagrant/girder"
+
+  - name: Girder | Run grunt watch
+    at: 
+    args:
+        command: "cd /home/vagrant/girder && grunt watch" 
+        count: 1
+        units: "minutes"
+        unique: true
+
+  - name: Girder | Run web server
+    at:
+    args:
+        command: "cd /home/vagrant/girder && python -m girder" 
+        count: 1
+        units: "minutes"
+        unique: true

--- a/docs/prerequisites.rst
+++ b/docs/prerequisites.rst
@@ -8,6 +8,8 @@ The following software packages are required to be installed on your system:
 * `MongoDB 2.6+ <http://www.mongodb.org/>`_
 * `Node.js <http://nodejs.org/>`_
 * `curl <http://curl.haxx.se/>`_
+* `zlib <http://www.zlib.net/>`_
+* `libjpeg <http://libjpeg.sourceforge.net/>`_
 
 Additionally, in order to send out emails to users, Girder will need to be able
 to communicate with an SMTP server. Proper installation and configuration of
@@ -38,7 +40,7 @@ Debian / Ubuntu
 
 Install the prerequisites using APT: ::
 
-    sudo apt-get install curl g++ git libffi-dev make python-dev python-pip
+    sudo apt-get install curl g++ git libffi-dev make python-dev python-pip libjpeg-dev zlib1g-dev
 
 MongoDB 2.6 requires a special incantation to install at this time. Install
 the APT key with the following: ::
@@ -81,7 +83,7 @@ YUM repository: ::
 
 Install the prerequisites using YUM: ::
 
-   sudo yum install curl gcc-c++ git libffi-devel make python-devel python-pip
+   sudo yum install curl gcc-c++ git libffi-devel make python-devel python-pip libjpeg-turbo-devel zlib-devel
 
 Create a file ``/etc/yum.repos.d/mongodb.repo`` that contains the following
 configuration information for the MongoDB YUM repository:
@@ -100,7 +102,7 @@ Install MongoDB server using YUM: ::
 
 Enable the Node.js YUM repository: ::
 
-    curl -sL https://rpm.nodesource.com/setup | sudo bash -
+    curl -sL https://rpm.nodesource.com/setup_4.x | sudo bash -
 
 Install Node.js and NPM using YUM: ::
 


### PR DESCRIPTION
Builds on @brianhelba's great job on updating the Vagrantfile.

Adds a way to persistently run a Girder server, with automatic `grunt watch` and Girder CherryPy server available on localhost:8080. Fixes https://github.com/girder/girder/pull/1263 WIP TODO #1