### PR TITLE
Workaround for the grunt-fontello task.

### DIFF
--- a/clients/web/fontello.config.json
+++ b/clients/web/fontello.config.json
@@ -1,5 +1,5 @@
 {
-	"name": "3643f1665274345f0d7b88fbdb539555",
+	"name": "",
 	"css_prefix_text": "icon-",
 	"css_use_suffix": false,
 	"hinting": true,

--- a/grunt_tasks/build.js
+++ b/grunt_tasks/build.js
@@ -76,6 +76,12 @@ module.exports = function (grunt) {
                     src: ['img/**'],
                     dest: 'clients/web/static/built/jsoneditor'
                 }]
+            },
+            fontello_config: {
+                files: [{
+                    src: 'clients/web/fontello.config.json',
+                    dest: 'clients/web/static/built/fontello.config.json'
+                }]
             }
         },
 
@@ -96,7 +102,7 @@ module.exports = function (grunt) {
         fontello: {
             ext_font: {
                 options: {
-                    config: 'clients/web/fontello.config.json',
+                    config: 'clients/web/static/built/fontello.config.json',
                     fonts: 'clients/web/static/built/fontello/font',
                     styles: 'clients/web/static/built/fontello/css',
                     // Create output directories
@@ -234,6 +240,7 @@ module.exports = function (grunt) {
             'uglify:ext_js': {},
             'copy:swagger': {},
             'copy:jsoneditor': {},
+            'copy:fontello_config': {},
             'concat:ext_css': {},
             'fontello:ext_font': {}
         },


### PR DESCRIPTION
The grunt-fontello task mutates the fontello config file.  If this file has a name entry that is an invalid or expired fontello session ID, the task fails.  To work around this, copy the fontello config file to an other directory and have the grunt-fontello task use that.  This means that we always will get a new fontello session, and the task will avoid the condition of having a bad session.  This also avoids mutating the source file.