### PR TITLE
Fix race conditions in client side testing

### DIFF
--- a/clients/web/test/spec/adminSpec.js
+++ b/clients/web/test/spec/adminSpec.js
@@ -1,14 +1,7 @@
 /**
  * Start the girder backbone app.
  */
-$(function () {
-    girder.events.trigger('g:appload.before');
-    var app = new girder.App({
-        el: 'body',
-        parentView: null
-    });
-    girder.events.trigger('g:appload.after');
-});
+girderTest.startApp();
 
 describe('Create an admin and non-admin user', function () {
 

--- a/clients/web/test/spec/collectionSpec.js
+++ b/clients/web/test/spec/collectionSpec.js
@@ -1,14 +1,7 @@
 /**
  * Start the girder backbone app.
  */
-$(function () {
-    girder.events.trigger('g:appload.before');
-    var app = new girder.App({
-        el: 'body',
-        parentView: null
-    });
-    girder.events.trigger('g:appload.after');
-});
+girderTest.startApp();
 
 describe('Test collection actions', function () {
 

--- a/clients/web/test/spec/dataSpec.js
+++ b/clients/web/test/spec/dataSpec.js
@@ -56,15 +56,7 @@ function _setMinimumChunkSize(minSize) {
 /**
  * Start the girder backbone app.
  */
-$(function () {
-    girder.events.trigger('g:appload.before');
-    var app = new girder.App({
-        el: 'body',
-        parentView: null
-    });
-    app = app;
-    girder.events.trigger('g:appload.after');
-});
+girderTest.startApp();
 
 describe('Create a data hierarchy', function () {
     it('register a user',

--- a/clients/web/test/spec/emptyLayoutSpec.js
+++ b/clients/web/test/spec/emptyLayoutSpec.js
@@ -1,14 +1,7 @@
 /**
  * Start the girder backbone app.
  */
-$(function () {
-    girder.events.trigger('g:appload.before');
-    var app = new girder.App({
-        el: 'body',
-        parentView: null
-    });
-    girder.events.trigger('g:appload.after');
-});
+girderTest.startApp();
 
 describe('Test empty and default layouts', function () {
 

--- a/clients/web/test/spec/folderSpec.js
+++ b/clients/web/test/spec/folderSpec.js
@@ -2,16 +2,7 @@
  * Start the girder backbone app.
  */
 /* globals waitsFor, runs, girderTest, expect, describe, it */
-
-$(function () {
-    girder.events.trigger('g:appload.before');
-    var app = new girder.App({
-        el: 'body',
-        parentView: null
-    });
-    app = app;
-    girder.events.trigger('g:appload.after');
-});
+girderTest.startApp();
 
 /* Show the folder edit dialog and click a button.
  * :param button: the jquery selector for the button.

--- a/clients/web/test/spec/groupSpec.js
+++ b/clients/web/test/spec/groupSpec.js
@@ -1,14 +1,7 @@
 /**
  * Start the girder backbone app.
  */
-$(function () {
-    girder.events.trigger('g:appload.before');
-    var app = new girder.App({
-        el: 'body',
-        parentView: null
-    });
-    girder.events.trigger('g:appload.after');
-});
+girderTest.startApp();
 
 /* Search for a name on the members search panel, and invite or add the first
  * found user as a member, moderator, or admin.

--- a/clients/web/test/spec/itemSpec.js
+++ b/clients/web/test/spec/itemSpec.js
@@ -1,14 +1,7 @@
 /**
  * Start the girder backbone app.
  */
-$(function () {
-    girder.events.trigger('g:appload.before');
-    var app = new girder.App({
-        el: 'body',
-        parentView: null
-    });
-    girder.events.trigger('g:appload.after');
-});
+girderTest.startApp();
 
 function _editItem(button, buttonText)
 /* Show the item edit dialog and click a button.

--- a/clients/web/test/spec/routingSpec.js
+++ b/clients/web/test/spec/routingSpec.js
@@ -1,14 +1,7 @@
 /**
  * Start the girder backbone app.
  */
-$(function () {
-    girder.events.trigger('g:appload.before');
-    var app = new girder.App({
-        el: 'body',
-        parentView: null
-    });
-    girder.events.trigger('g:appload.after');
-});
+girderTest.startApp();
 
 function _getFirstId(collection, ids, key, fetchParamsFunc) {
     var coll;

--- a/clients/web/test/spec/userSpec.js
+++ b/clients/web/test/spec/userSpec.js
@@ -1,14 +1,7 @@
 /**
  * Start the girder backbone app.
  */
-$(function () {
-    girder.events.trigger('g:appload.before');
-    var app = new girder.App({
-        el: 'body',
-        parentView: null
-    });
-    girder.events.trigger('g:appload.after');
-});
+girderTest.startApp();
 
 describe('Create an admin and non-admin user', function () {
     var link, registeredUsers = [];

--- a/clients/web/test/spec/versionSpec.js
+++ b/clients/web/test/spec/versionSpec.js
@@ -1,14 +1,7 @@
 /**
  * Start the girder backbone app.
  */
-$(function () {
-    girder.events.trigger('g:appload.before');
-    var app = new girder.App({
-        el: 'body',
-        parentView: null
-    });
-    girder.events.trigger('g:appload.after');
-});
+girderTest.startApp();
 
 describe('Test version reporting', function () {
     it('check front page git SHA', function () {

--- a/clients/web/test/spec/widgetsSpec.js
+++ b/clients/web/test/spec/widgetsSpec.js
@@ -1,14 +1,7 @@
 /**
  * Start the girder backbone app.
  */
-$(function () {
-    girder.events.trigger('g:appload.before');
-    var app = new girder.App({
-        el: 'body',
-        parentView: null
-    });
-    girder.events.trigger('g:appload.after');
-});
+girderTest.startApp();
 
 function _setProgress(test, duration) {
     /* Set or update a current progress notification.

--- a/clients/web/test/testEnv.jadehtml
+++ b/clients/web/test/testEnv.jadehtml
@@ -16,32 +16,24 @@ html(lang="en")
       script(src="#{js}")
 
     each js in jsFilesCovered
-      script(src="#{js}", data-cover)
+      script(type="text/javascript")
+        | girderTest.addCoveredScript("#{js}")
 
     script(type="text/javascript").
       (function () {
         var jasmineEnv = jasmine.getEnv();
         var consoleReporter = new jasmine.ConsoleReporter();
+
         window.jasmine_phantom_reporter = consoleReporter;
         jasmineEnv.addReporter(consoleReporter);
-        girder.sseTimeout = 10;
+
         if (window.blanket) {
             window.blanket.options('timeout', 3000);
-        }
-        function waitAndExecute() {
-            if (!jasmineEnv.currentRunner().suites_.length) {
-                window.setTimeout(waitAndExecute, 10);
-                return;
-            }
-            jasmineEnv.execute();
         }
 
         var currentWindowOnload = window.onload;
 
-        window.onload = function () {
-            if (currentWindowOnload) {
-                currentWindowOnload();
-            }
-            waitAndExecute();
-        };
+        girderTest.promise.then(function () {
+            girder.sseTimeout = 10;
+        });
       })();

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -1270,3 +1270,24 @@ $(function () {
         }
     });
 });
+
+/**
+ * Wait for all of the sources to load and then start the main girder application.
+ * This will also delay the invocation of the jasmine test suite until after the
+ * application is running.  This method returns a promise that resolves with the
+ * application object.
+ */
+girderTest.startApp = function () {
+    var defer = new $.Deferred();
+    girderTest.promise.then(function () {
+        girder.events.trigger('g:appload.before');
+        var app = new girder.App({
+            el: 'body',
+            parentView: null
+        });
+        girder.events.trigger('g:appload.after');
+        defer.resolve(app);
+    });
+    girderTest.promise = defer.promise();
+    return girderTest.promise;
+}

--- a/plugins/geospatial/plugin_tests/geospatialSpec.js
+++ b/plugins/geospatial/plugin_tests/geospatialSpec.js
@@ -1,21 +1,12 @@
-$(function () {
-    /* Include the built version of the our templates.  This means that grunt
-    * must be run to generate these before the test. */
-    girderTest.addCoveredScripts([
-        '/static/built/plugins/geospatial/templates.js',
-        '/plugins/geospatial/web_client/js/ItemWidget.js'
-    ]);
-    girderTest.importStylesheet(
-        '/static/built/plugins/geospatial/plugin.min.css'
-    );
 
-    girder.events.trigger('g:appload.before');
-    var app = new girder.App({
-        el: 'body',
-        parentView: null
-    });
-    girder.events.trigger('g:appload.after');
-});
+girderTest.addCoveredScripts([
+    '/static/built/plugins/geospatial/templates.js',
+    '/plugins/geospatial/web_client/js/ItemWidget.js'
+]);
+girderTest.importStylesheet(
+    '/static/built/plugins/geospatial/plugin.min.css'
+);
+girderTest.startApp();
 
 describe('a test for the geospatial plugin', function () {
     it('creates the admin user', girderTest.createUser('geospatial',

--- a/plugins/thumbnails/plugin_tests/thumbnailsSpec.js
+++ b/plugins/thumbnails/plugin_tests/thumbnailsSpec.js
@@ -10,12 +10,7 @@ girderTest.importStylesheet(
     '/static/built/plugins/thumbnails/plugin.min.css'
 );
 
-girder.events.trigger('g:appload.before');
-new girder.App({
-    el: 'body',
-    parentView: null
-});
-girder.events.trigger('g:appload.after');
+girderTest.startApp();
 
 describe('Test the thumbnail creation UI.', function () {
     it('register a user', girderTest.createUser(

--- a/plugins/user_quota/plugin_tests/userQuotaSpec.js
+++ b/plugins/user_quota/plugin_tests/userQuotaSpec.js
@@ -1,25 +1,17 @@
 /* globals girderTest, runs, waitsFor, expect, describe, it */
 
-$(function () {
-    var app;
-    /* Include the built version of the our templates.  This means that grunt
-     * must be run to generate these before the test. */
-    girderTest.addCoveredScripts([
-        '/static/built/plugins/user_quota/templates.js',
-        '/plugins/user_quota/web_client/js/userQuota.js',
-        '/plugins/user_quota/web_client/js/configView.js'
-    ]);
-    girderTest.importStylesheet(
-        '/static/built/plugins/user_quota/plugin.min.css'
-    );
+/* Include the built version of the our templates.  This means that grunt
+ * must be run to generate these before the test. */
+girderTest.addCoveredScripts([
+    '/static/built/plugins/user_quota/templates.js',
+    '/plugins/user_quota/web_client/js/userQuota.js',
+    '/plugins/user_quota/web_client/js/configView.js'
+]);
+girderTest.importStylesheet(
+    '/static/built/plugins/user_quota/plugin.min.css'
+);
 
-    girder.events.trigger('g:appload.before');
-    app = new girder.App({
-        el: 'body',
-        parentView: null
-    });
-    girder.events.trigger('g:appload.after');
-});
+girderTest.startApp();
 
 /* Go to the collections page.  If a collection is specified, go to that
  * collection's page.


### PR DESCRIPTION
I *think* this should resolve the race conditions that I have seen recently while writing plugin tests.  I found a few problems with the test runner:

* Blanket instruments and loads code asynchronously, so occasionally it would load a source files out of order.
* Scripts add by `addCoveredScripts` were also loaded asynchronously so their order was **not** respected as advertised.
* The jasmine test suite was being executed before plugin sources were loaded.
* `window.onload` isn't sufficient to guarantee that the instrumented scripts have been loaded.

To fix this, I created a promise chain as `girderTest.promise` that loads each script in sequence and is fully resolved when all of the scripts are loaded.  I also added a standard `girderTest.startApp` method that will load the application after all of the sources have been loaded.

I also removed the manual invocation of jasmine's test runner.  It was necessary before because we weren't using the `blanket.requiringFile` method correctly.