### PR TITLE
Enforce more of PEP257 -- Docstring Conventions

### DIFF
--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -230,14 +230,16 @@ class AbstractAssetstoreAdapter(ModelImporter):
                 offset, endByte - 1, file['size'])
 
     def checkUploadSize(self, upload, chunkSize):
-        """Check if the upload is valid based on the chunk size.  If this
+        """
+        Check if the upload is valid based on the chunk size.  If this
         raises an exception, then the caller should clean up and reraise the
         exception.
 
         :param upload: the dictionary of upload information.  The received and
                        size values are used.
         :param chunkSize: the chunk size that needs to be validated.
-        :type chunkSize: a non-negative integer or None if unknown."""
+        :type chunkSize: a non-negative integer or None if unknown.
+        """
         if 'received' not in upload or 'size' not in upload:
             return
         if chunkSize is None:

--- a/plugins/provenance/server/resource.py
+++ b/plugins/provenance/server/resource.py
@@ -91,8 +91,10 @@ class ResourceExt(Resource):
                 self.boundResources[resource] = True
 
     def unbindModels(self, resources={}):
-        """Unbind any models that were bound and aren't listed as needed.
-        :param resources: resources that shouldn't be unbound."""
+        """
+        Unbind any models that were bound and aren't listed as needed.
+        :param resources: resources that shouldn't be unbound.
+        """
         # iterate over a list so that we can change the dictionary as we use it
         for oldresource in list(six.viewkeys(self.boundResources)):
             if oldresource not in resources:
@@ -323,8 +325,10 @@ class ResourceExt(Resource):
         return snap
 
     def fileSaveHandler(self, event):
-        """When a file is saved, update the provenance of the parent item.
-        :param event: the event with the file information."""
+        """
+        When a file is saved, update the provenance of the parent item.
+        :param event: the event with the file information.
+        """
         curFile = event.info
         if 'itemId' not in curFile or '_id' not in curFile:
             return
@@ -356,9 +360,11 @@ class ResourceExt(Resource):
         self.model('item').save(item, triggerEvents=False)
 
     def fileSaveCreatedHandler(self, event):
-        """When a file is created, we don't record it in the save handler
-        beacuse we want to know its id.  We record it here, instead.
-        :param event: the event with the file information."""
+        """
+        When a file is created, we don't record it in the save handler
+        because we want to know its id.  We record it here, instead.
+        :param event: the event with the file information.
+        """
         file = event.info
         if 'itemId' not in file or not file['itemId'] or '_id' not in file:
             return
@@ -380,8 +386,10 @@ class ResourceExt(Resource):
         self.model('item').save(item, triggerEvents=False)
 
     def fileRemoveHandler(self, event):
-        """When a file is removed, update the provenance of the parent item.
-        :param event: the event with the file information."""
+        """
+        When a file is removed, update the provenance of the parent item.
+        :param event: the event with the file information.
+        """
         file = event.info
         if 'itemId' not in file:
             return

--- a/tests/cases/upload_test.py
+++ b/tests/cases/upload_test.py
@@ -82,13 +82,15 @@ class UploadTestCase(base.TestCase):
                 self.folder = folder
 
     def _uploadFile(self, name, partial=False, largeFile=False):
-        """Upload a file either completely or partially.
+        """
+        Upload a file either completely or partially.
         :param name: the name of the file to upload.
         :param partial: the number of steps to complete in the uploads: 0
                         initializes the upload, 1 uploads 1 chunk, etc.  False
                         to complete the upload.
         :param largeFile: if True, upload a file that is > 32Mb
-        :returns: the upload record which includes the upload id."""
+        :returns: the upload record which includes the upload id.
+        """
         if not largeFile:
             chunk1 = Chunk1
             chunk2 = Chunk2
@@ -163,9 +165,11 @@ class UploadTestCase(base.TestCase):
         return upload
 
     def _testUpload(self):
-        """Upload a file to the server and several partial files.  Test that we
+        """
+        Upload a file to the server and several partial files.  Test that we
         can delete a partial upload but not a completed upload. Test that we
-        can delete partial uploads that are older than a certain date."""
+        can delete partial uploads that are older than a certain date.
+        """
         completeUpload = self._uploadFile('complete_upload')
         # test uploading large files
         self._uploadFile('complete_upload', largeFile=True)

--- a/tests/flake8.cfg
+++ b/tests/flake8.cfg
@@ -26,7 +26,7 @@ exclude: girder/external/*
 #   ~~~~~~~~~~~~~~~~
 #   By including the flake8-docstrings module, we also will fail on PEP257
 #   errors (D...).  For the moment, suppress all of the D... errors that would
-#   cause us to fail.  We may want to revisit this to make out code more PEP257
+#   cause us to fail.  We may want to revisit this to make our code more PEP257
 #   conformant.
 #     D100 - Public module   (100) docstring missing.
 #     D101 - Public class    (101) docstring missing.
@@ -40,9 +40,6 @@ exclude: girder/external/*
 #     D203 - 1 blank required before (203) class docstring.
 #     D204 - 1 blank required after  (204) class docstring.
 #     D205 - Blank line required between one-line summary and description.
-#     D208 - Docstring over-indented.
-#     D209 - Put multi-line docstring closing quotes on separate line.
-#     D300 - Use """triple double quotes""".
 #     D400 - First line should end with a period.
 #     D401 - First line should be in imperative mood.
 #     D402 - First line should not be the function's "signature".
@@ -56,4 +53,4 @@ exclude: girder/external/*
 #     N803 - Argument name should be lowercase.
 #     N806 - Variable in function should be lowercase.
 #     N812 - Lowercase imported as non lowercase.
-ignore: D100,D101,D102,D103,D104,D105,D200,D201,D202,D203,D204,D205,D208,D209,D300,D400,D401,D402,E123,E226,E241,N802,N803,N806,N812
+ignore: D100,D101,D102,D103,D104,D105,D200,D201,D202,D203,D204,D205,D400,D401,D402,E123,E226,E241,N802,N803,N806,N812

--- a/tests/mongo_replicaset.py
+++ b/tests/mongo_replicaset.py
@@ -192,7 +192,8 @@ def stopMongoReplicaSet(graceful=True, purgeFiles=True):
     :param graceful: if True, try to let the servers stop gracefully.
                      Otherwise, kill them quickly.
     :param purgeFiles: if True, then after stopping the server, delete the
-                       files it was using."""
+                       files it was using.
+    """
     if graceful:
         pauseList = [False for server in Config]
         pauseMongoReplicaSet(pauseList)


### PR DESCRIPTION
Enforce the following warnings from flake8-docstrings for [PEP257](https://www.python.org/dev/peps/pep-0257/):

    D208 - Docstring over-indented.
    D209 - Put multi-line docstring closing quotes on separate line.
    D300 - Use """triple double quotes""".
