### PR TITLE
Use absolute path for database volume in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ mongodb:
     ports:
         - "27017"
     volumes:
-        - "data/db"
+        - "/data/db"
 
 girder:
     build: .


### PR DESCRIPTION
Using the latest version of docker-compose you get this error:
```
ERROR: Invalid volume spec "data/db": volumeabs: Invalid volume destination path: 'data/db' mount path must be absolute.
```