### PR TITLE
Trigger g:changed event *after* rerendering

### DIFF
--- a/clients/web/src/views/widgets/FileListWidget.js
+++ b/clients/web/src/views/widgets/FileListWidget.js
@@ -58,8 +58,8 @@ girder.views.FileListWidget = girder.View.extend({
             (settings.itemId || settings.item.get('_id')) + '/files';
         this.collection.append = true; // Append, don't replace pages
         this.collection.on('g:changed', function () {
-            this.trigger('g:changed');
             this.render();
+            this.trigger('g:changed');
         }, this).fetch();
 
         this.parentItem = settings.item;
@@ -124,7 +124,7 @@ girder.views.FileListWidget = girder.View.extend({
      */
     insertFile: function (file) {
         this.collection.add(file);
-        this.trigger('g:changed');
         this.render();
+        this.trigger('g:changed');
     }
 });

--- a/clients/web/src/views/widgets/ItemListWidget.js
+++ b/clients/web/src/views/widgets/ItemListWidget.js
@@ -24,8 +24,8 @@ girder.views.ItemListWidget = girder.View.extend({
         this.collection = new girder.collections.ItemCollection();
         this.collection.append = true; // Append, don't replace pages
         this.collection.on('g:changed', function () {
-            this.trigger('g:changed');
             this.render();
+            this.trigger('g:changed');
         }, this).fetch({
             folderId: settings.folderId
         });


### PR DESCRIPTION
I'm not sure if there is a reason the `g:changed` event was being triggered before rendering, but this change makes the `FileListWidget` and `ItemListWidget` consistent with the behavior [`FolderListWidget`](https://github.com/girder/girder/blob/master/clients/web/src/views/widgets/FolderListWidget.js#L29-L30).