### PR TITLE
Miscellaneous code quality improvements

### DIFF
--- a/clients/ansible/girder.py
+++ b/clients/ansible/girder.py
@@ -1074,7 +1074,7 @@ class GirderClientModule(GirderClient):
         # Final list of keyword arguments to the function
         kwargs = {}
 
-        if type(params) is dict:
+        if isinstance(params, dict):
             for arg_name in self.spec[method]['required']:
                 if arg_name not in params.keys():
                     self.fail("%s is required for %s" % (arg_name, method))
@@ -1084,7 +1084,7 @@ class GirderClientModule(GirderClient):
                 if kwarg_name in params.keys():
                     kwargs[kwarg_name] = params[kwarg_name]
 
-        elif type(params) is list:
+        elif isinstance(params, list):
             args = params
         else:
             args = [params]

--- a/clients/web/src/templates/layout/layoutFooter.jade
+++ b/clients/web/src/templates/layout/layoutFooter.jade
@@ -1,4 +1,3 @@
-
 .g-footer-links
   a#g-about-link(href="http://girder.readthedocs.org/en/latest/user-guide.html") About
   a#g-contact-link(href="mailto:kitware@kitware.com") Contact

--- a/docs/prerequisites.rst
+++ b/docs/prerequisites.rst
@@ -100,7 +100,7 @@ Install MongoDB server using YUM: ::
 
 Enable the Node.js YUM repository: ::
 
-    curl -sL https://rpm.nodesource.com/setup_4.x | sudo bash
+    curl -sL https://rpm.nodesource.com/setup_4.x | sudo bash -
 
 Install Node.js and NPM using YUM: ::
 

--- a/docs/prerequisites.rst
+++ b/docs/prerequisites.rst
@@ -100,7 +100,7 @@ Install MongoDB server using YUM: ::
 
 Enable the Node.js YUM repository: ::
 
-    curl -sL https://rpm.nodesource.com/setup | sudo bash -
+    curl -sL https://rpm.nodesource.com/setup_4.x | sudo bash
 
 Install Node.js and NPM using YUM: ::
 

--- a/girder/api/access.py
+++ b/girder/api/access.py
@@ -17,7 +17,7 @@
 #  limitations under the License.
 ###############################################################################
 
-import functools
+import six
 
 from girder.models.model_base import AccessException
 from girder.api import rest
@@ -28,7 +28,7 @@ def admin(fun):
     Functions that require administrator access should be wrapped in this
     decorator.
     """
-    @functools.wraps(fun)
+    @six.wraps(fun)
     def accessDecorator(*args, **kwargs):
         rest.requireAdmin(rest.getCurrentUser())
         return fun(*args, **kwargs)
@@ -42,7 +42,7 @@ def user(fun):
     in this decorator. That is, a token must be passed that has the
     "core.user_auth" scope and a valid user ID.
     """
-    @functools.wraps(fun)
+    @six.wraps(fun)
     def accessDecorator(*args, **kwargs):
         user = rest.getCurrentUser()
         if not user:
@@ -68,7 +68,7 @@ def token(fun):
     was passed, but checking of the scopes is left to the handler and is not
     part of this decorator.
     """
-    @functools.wraps(fun)
+    @six.wraps(fun)
     def accessDecorator(*args, **kwargs):
         token = rest.getCurrentToken()
         if not token:

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -84,7 +84,7 @@ def _cacheAuthUser(fun):
             return cherrypy.request.girderUser
 
         user = fun(returnToken, *args, **kwargs)
-        if type(user) is tuple:
+        if isinstance(user, tuple):
             setattr(cherrypy.request, 'girderUser', user[0])
         else:
             setattr(cherrypy.request, 'girderUser', user)
@@ -801,7 +801,7 @@ class Resource(ModelImporter):
 
         val = params[key]
 
-        if type(val) is bool:
+        if isinstance(val, bool):
             return val
 
         return val.lower().strip() in ('true', 'on', '1', 'yes')
@@ -850,7 +850,7 @@ class Resource(ModelImporter):
 
         if 'sort' in params:
             sort = [(params['sort'].strip(), sortdir)]
-        elif type(defaultSortField) is str:
+        elif isinstance(defaultSortField, six.string_types):
             sort = [(defaultSortField, sortdir)]
         else:
             sort = None

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -223,7 +223,7 @@ class File(Resource):
                 'Server has received %s bytes, but client sent offset %s.' % (
                     upload['received'], offset))
         try:
-            if type(chunk) == cherrypy._cpreqbody.Part:
+            if isinstance(chunk, cherrypy._cpreqbody.Part):
                 return self.model('upload').handleChunk(upload, chunk.file)
             else:
                 return self.model('upload').handleChunk(upload, chunk)

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -120,7 +120,7 @@ class Resource(BaseResource):
             resources = json.loads(params['resources'])
         except ValueError:
             raise RestException('The resources parameter must be JSON.')
-        if type(resources) is not dict:
+        if not isinstance(resources, dict):
             raise RestException('Invalid resources format.')
         if allowedModels:
             for key in resources:

--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -82,7 +82,7 @@ class System(Resource):
             try:
                 settings = json.loads(params['list'])
 
-                if type(settings) is not list:
+                if not isinstance(settings, list):
                     raise ValueError()
             except ValueError:
                 raise RestException('List was not a valid JSON list.')
@@ -137,7 +137,7 @@ class System(Resource):
             try:
                 keys = json.loads(params['list'])
 
-                if type(keys) is not list:
+                if not isinstance(keys, list):
                     raise ValueError()
             except ValueError:
                 raise RestException('List was not a valid JSON list.')

--- a/girder/models/collection.py
+++ b/girder/models/collection.py
@@ -102,15 +102,6 @@ class Collection(AccessControlledModel):
             progress.update(increment=1, message='Deleted collection ' +
                             collection['name'])
 
-    def list(self, user=None, limit=0, offset=0, sort=None):
-        """
-        Search for collections with full text search.
-        """
-        cursor = self.find({}, sort=sort)
-        return self.filterResultsByPermission(
-            cursor=cursor, user=user, level=AccessType.READ, limit=limit,
-            offset=offset)
-
     def createCollection(self, name, creator, description='', public=True):
         """
         Create a new collection.

--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -129,7 +129,7 @@ class File(acl_mixin.AccessControlMixin, Model):
 
     def createLinkFile(self, name, parent, parentType, url, creator):
         """
-        Create a file that is a link to a URL rather than something we maintain
+        Create a file that is a link to a URL, rather than something we maintain
         in an assetstore.
 
         :param name: The local name for the file.

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -497,7 +497,7 @@ class Folder(AccessControlledModel):
                                save=False)
 
         # Allow explicit public flag override if it's set.
-        if public is not None and type(public) is bool:
+        if public is not None and isinstance(public, bool):
             self.setPublic(folder, public, save=False)
 
         if allowRename:

--- a/girder/models/group.py
+++ b/girder/models/group.py
@@ -316,7 +316,7 @@ class Group(AccessControlledModel):
         :type creator: dict
         :returns: The group document that was created.
         """
-        assert type(public) is bool
+        assert isinstance(public, bool)
 
         now = datetime.datetime.utcnow()
 

--- a/girder/models/group.py
+++ b/girder/models/group.py
@@ -117,24 +117,6 @@ class Group(AccessControlledModel):
 
         return doc
 
-    def list(self, user=None, limit=0, offset=0, sort=None):
-        """
-        Search for groups or simply list all visible groups.
-
-        :param text: Pass this to perform a text search of all groups.
-        :param user: The user to search as.
-        :param limit: Result set size limit.
-        :param offset: Offset into the results.
-        :param sort: The sort direction.
-        """
-        # Perform the find; we'll do access-based filtering of the result
-        # set afterward.
-        cursor = self.find({}, sort=sort)
-
-        return self.filterResultsByPermission(
-            cursor=cursor, user=user, level=AccessType.READ, limit=limit,
-            offset=offset)
-
     def listMembers(self, group, offset=0, limit=0, sort=None):
         """
         List members of the group.
@@ -187,6 +169,7 @@ class Group(AccessControlledModel):
 
         if not group['_id'] in user['groups']:
             user['groups'].append(group['_id'])
+            # saved again in setUserAccess...
             self.model('user').save(user, validate=False)
 
         # Delete outstanding request if one exists
@@ -455,6 +438,7 @@ class Group(AccessControlledModel):
         field in the case of WRITE access and above since READ access is
         implied by membership or invitation.
         """
+        # save parameter not used?
         if level is not None and level > AccessType.READ:
             doc = AccessControlledModel.setUserAccess(
                 self, doc, user, level, save=True)

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -260,7 +260,7 @@ class Item(acl_mixin.AccessControlMixin, Model):
 
         now = datetime.datetime.utcnow()
 
-        if not type(creator) is dict or '_id' not in creator:
+        if not isinstance(creator, dict) or '_id' not in creator:
             # Internal error -- this shouldn't be called without a user.
             raise GirderException('Creator must be a user.',
                                   'girder.models.item.creator-not-user')

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -79,7 +79,7 @@ class Model(ModelImporter):
             else:
                 self.collection.create_index(index)
 
-        if type(self._textIndex) is dict:
+        if isinstance(self._textIndex, dict):
             textIdx = [(k, 'text') for k in six.viewkeys(self._textIndex)]
             try:
                 self.collection.create_index(
@@ -454,7 +454,7 @@ class Model(ModelImporter):
         if not id:
             raise ValidationException('Attempt to load null ObjectId: %s' % id)
 
-        if objectId and type(id) is not ObjectId:
+        if objectId and not isinstance(id, ObjectId):
             try:
                 id = ObjectId(id)
             except InvalidId:
@@ -633,7 +633,7 @@ class AccessControlledModel(Model):
         Private helper for setting access on a resource.
         """
         assert entity == 'users' or entity == 'groups'
-        if type(id) is not ObjectId:
+        if not isinstance(id, ObjectId):
             id = ObjectId(id)
 
         if 'access' not in doc:
@@ -671,7 +671,7 @@ class AccessControlledModel(Model):
         :type save: bool
         :returns: The updated resource document.
         """
-        assert type(public) is bool
+        assert isinstance(public, bool)
 
         doc['public'] = public
 

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -958,6 +958,20 @@ class AccessControlledModel(Model):
 
         return doc
 
+    def list(self, user=None, limit=0, offset=0, sort=None):
+        """
+        Return a list of documents that are visible to a user.
+
+        :param user: The user to filter for.
+        :param limit: Result set size limit.
+        :param offset: Offset into the results.
+        :param sort: The sort direction.
+        """
+        cursor = self.find({}, sort=sort)
+        return self.filterResultsByPermission(
+            cursor=cursor, user=user, level=AccessType.READ, limit=limit,
+            offset=offset)
+
     def copyAccessPolicies(self, src, dest, save=False):
         """
         Copies the set of access control policies from one document to another.

--- a/girder/models/setting.py
+++ b/girder/models/setting.py
@@ -59,7 +59,7 @@ class Setting(Model):
         names. Removes any invalid plugin names, removes duplicates, and adds
         all transitive dependencies to the enabled list.
         """
-        if not type(doc['value']) is list:
+        if not isinstance(doc['value'], list):
             raise ValidationException(
                 'Plugins enabled setting must be a list.', 'value')
 
@@ -77,7 +77,7 @@ class Setting(Model):
     def validateCoreCollectionCreatePolicy(self, doc):
         value = doc['value']
 
-        if type(value) is not dict:
+        if not isinstance(value, dict):
             raise ValidationException('Collection creation policy must be a '
                                       'JSON object.')
 

--- a/girder/models/upload.py
+++ b/girder/models/upload.py
@@ -314,7 +314,7 @@ class Upload(Model):
             for key in ('uploadId', 'userId', 'parentId', 'assetstoreId'):
                 if key in filters:
                     id = filters[key]
-                    if id and type(id) is not ObjectId:
+                    if id and not isinstance(id, ObjectId):
                         id = ObjectId(id)
                     if id:
                         if key == 'uploadId':

--- a/girder/utility/filesystem_assetstore_adapter.py
+++ b/girder/utility/filesystem_assetstore_adapter.py
@@ -79,7 +79,7 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
         return ['sha512', 'imported']
 
     def __init__(self, assetstore):
-        self.assetstore = assetstore
+        super(FilesystemAssetstoreAdapter, self).__init__(assetstore)
         # If we can't create the temp directory, the assetstore still needs to
         # be initialized so that it can be deleted or modified.  The validation
         # prevents invalid new assetstores from being created, so this only

--- a/girder/utility/filesystem_assetstore_adapter.py
+++ b/girder/utility/filesystem_assetstore_adapter.py
@@ -85,17 +85,17 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
         # prevents invalid new assetstores from being created, so this only
         # happens to existing assetstores that no longer can access their temp
         # directories.
-        self.tempDir = os.path.join(assetstore['root'], 'temp')
+        self.tempDir = os.path.join(self.assetstore['root'], 'temp')
         try:
             mkdir(self.tempDir)
         except OSError:
             self.unavailable = True
             logger.exception('Failed to create filesystem assetstore '
                              'directories %s' % self.tempDir)
-        if not os.access(assetstore['root'], os.W_OK):
+        if not os.access(self.assetstore['root'], os.W_OK):
             self.unavailable = True
             logger.error('Could not write to assetstore root: %s',
-                         assetstore['root'])
+                         self.assetstore['root'])
 
     def capacityInfo(self):
         """

--- a/girder/utility/gridfs_assetstore_adapter.py
+++ b/girder/utility/gridfs_assetstore_adapter.py
@@ -79,7 +79,7 @@ class GridFsAssetstoreAdapter(AbstractAssetstoreAdapter):
         """
         :param assetstore: The assetstore to act on.
         """
-        self.assetstore = assetstore
+        super(GridFsAssetstoreAdapter, self).__init__(assetstore)
         try:
             self.chunkColl = getDbConnection(
                 assetstore.get('mongohost', None),

--- a/girder/utility/gridfs_assetstore_adapter.py
+++ b/girder/utility/gridfs_assetstore_adapter.py
@@ -82,17 +82,18 @@ class GridFsAssetstoreAdapter(AbstractAssetstoreAdapter):
         super(GridFsAssetstoreAdapter, self).__init__(assetstore)
         try:
             self.chunkColl = getDbConnection(
-                assetstore.get('mongohost', None),
-                assetstore.get('replicaset', None))[assetstore['db']].chunk
+                self.assetstore.get('mongohost', None),
+                self.assetstore.get('replicaset', None)
+            )[self.assetstore['db']].chunk
         except pymongo.errors.ConnectionFailure:
             logger.error('Failed to connect to GridFS assetstore %s',
-                         assetstore['db'])
+                         self.assetstore['db'])
             self.chunkColl = 'Failed to connect'
             self.unavailable = True
             return
         except pymongo.errors.ConfigurationError:
             logger.exception('Failed to configure GridFS assetstore %s',
-                             assetstore['db'])
+                             self.assetstore['db'])
             self.chunkColl = 'Failed to configure'
             self.unavailable = True
             return

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -165,12 +165,12 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
         """
         :param assetstore: The assetstore to act on.
         """
+        super(S3AssetstoreAdapter, self).__init__(assetstore)
         if ('accessKeyId' in assetstore and 'secret' in assetstore and
                 'service' in assetstore):
             assetstore['botoConnect'] = makeBotoConnectParams(
                 assetstore['accessKeyId'], assetstore['secret'],
                 assetstore['service'])
-        self.assetstore = assetstore
 
     def _getRequestHeaders(self, upload):
         return {

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -166,11 +166,11 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
         :param assetstore: The assetstore to act on.
         """
         super(S3AssetstoreAdapter, self).__init__(assetstore)
-        if ('accessKeyId' in assetstore and 'secret' in assetstore and
-                'service' in assetstore):
-            assetstore['botoConnect'] = makeBotoConnectParams(
-                assetstore['accessKeyId'], assetstore['secret'],
-                assetstore['service'])
+        if ('accessKeyId' in self.assetstore and 'secret' in self.assetstore and
+                'service' in self.assetstore):
+            self.assetstore['botoConnect'] = makeBotoConnectParams(
+                self.assetstore['accessKeyId'], self.assetstore['secret'],
+                self.assetstore['service'])
 
     def _getRequestHeaders(self, upload):
         return {

--- a/plugins/hdfs_assetstore/server/assetstore.py
+++ b/plugins/hdfs_assetstore/server/assetstore.py
@@ -33,7 +33,7 @@ from snakebite.client import Client as HdfsClient
 class HdfsAssetstoreAdapter(AbstractAssetstoreAdapter):
     def __init__(self, assetstore):
         super(HdfsAssetstoreAdapter, self).__init__(assetstore)
-        self.client = self._getClient(assetstore)
+        self.client = self._getClient(self.assetstore)
 
     @staticmethod
     def _getHdfsUser(assetstore):

--- a/plugins/hdfs_assetstore/server/assetstore.py
+++ b/plugins/hdfs_assetstore/server/assetstore.py
@@ -32,7 +32,7 @@ from snakebite.client import Client as HdfsClient
 
 class HdfsAssetstoreAdapter(AbstractAssetstoreAdapter):
     def __init__(self, assetstore):
-        self.assetstore = assetstore
+        super(HdfsAssetstoreAdapter, self).__init__(assetstore)
         self.client = self._getClient(assetstore)
 
     @staticmethod

--- a/plugins/worker/server/utils.py
+++ b/plugins/worker/server/utils.py
@@ -24,7 +24,7 @@ def girderInputSpec(resource, resourceType='file', name=None, token=None,
     :param dataFormat: The worker `format` field.
     :type dataFormat: str
     """
-    if type(token) is dict:
+    if isinstance(token, dict):
         token = token['_id']
 
     return {
@@ -61,7 +61,7 @@ def girderOutputSpec(parent, token, parentType='folder', name=None,
     :param dataFormat: The worker `format` field.
     :type dataFormat: str
     """
-    if type(token) is dict:
+    if isinstance(token, dict):
         token = token['_id']
 
     return {
@@ -90,7 +90,7 @@ def jobInfoSpec(job, token=None, logPrint=True):
     if token is None:
         token = ModelImporter.model('job', 'jobs').createJobToken(job)
 
-    if type(token) is dict:
+    if isinstance(token, dict):
         token = token['_id']
 
     return {

--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -449,7 +449,7 @@ class AssetstoreTestCase(base.TestCase):
         singleChunkUpload = resp.json
         s3Info = singleChunkUpload['s3']
         self.assertEqual(s3Info['chunked'], False)
-        self.assertEqual(type(s3Info['chunkLength']), int)
+        self.assertIsInstance(s3Info['chunkLength'], int)
         self.assertEqual(s3Info['request']['method'], 'PUT')
         six.assertRegex(self, s3Info['request']['url'], s3Regex)
         self.assertEqual(s3Info['request']['headers']['x-amz-acl'], 'private')
@@ -485,7 +485,7 @@ class AssetstoreTestCase(base.TestCase):
         multiChunkUpload = resp.json
         s3Info = multiChunkUpload['s3']
         self.assertEqual(s3Info['chunked'], True)
-        self.assertEqual(type(s3Info['chunkLength']), int)
+        self.assertIsInstance(s3Info['chunkLength'], int)
         self.assertEqual(s3Info['request']['method'], 'POST')
         six.assertRegex(self, s3Info['request']['url'], s3Regex)
 

--- a/tests/cases/collection_test.py
+++ b/tests/cases/collection_test.py
@@ -147,7 +147,7 @@ class CollectionTestCase(base.TestCase):
         self.assertEqual(coll, None)
 
     def testCollectionAccess(self):
-        # Asking to change to  an invalid access list should fail
+        # Asking to change to an invalid access list should fail
         resp = self.request(path='/collection/%s/access' %
                             self.collection['_id'], method='PUT', params={
                                 'access': 'not an access list',

--- a/tests/cases/custom_root_test.py
+++ b/tests/cases/custom_root_test.py
@@ -40,7 +40,7 @@ class CustomRootTestCase(base.TestCase):
 
         # Make sure our import semantics work as expected for plugins
         from girder.plugins import test_plugin
-        self.assertEqual(type(test_plugin), types.ModuleType)
+        self.assertIsInstance(test_plugin, types.ModuleType)
 
     def tearDown(self):
         base.stopServer()

--- a/tests/cases/folder_test.py
+++ b/tests/cases/folder_test.py
@@ -82,7 +82,7 @@ class FolderTestCase(base.TestCase):
         resp = self.request(
             path='/folder/%s' % str(resp.json[0]['_id']))
         self.assertStatusOk(resp)
-        self.assertEqual(type(resp.json), dict)
+        self.assertIsInstance(resp.json, dict)
         self.assertFalse('access' in resp.json)
 
         # If we log in as the user, we should also be able to see the

--- a/tests/cases/group_test.py
+++ b/tests/cases/group_test.py
@@ -155,26 +155,26 @@ class GroupTestCase(base.TestCase):
             'private group', self.users[0], public=False)
         resp = self.request(path='/group', method='GET', user=self.users[0])
         self.assertStatusOk(resp)
-        self.assertEqual(type(resp.json), list)
+        self.assertIsInstance(resp.json, list)
         self.assertEqual(len(resp.json), 3)
 
         resp = self.request(path='/group', method='GET', user=self.users[1])
         self.assertStatusOk(resp)
-        self.assertEqual(type(resp.json), list)
+        self.assertIsInstance(resp.json, list)
         self.assertEqual(len(resp.json), 1)
         self.assertEqual(resp.json[0]['_id'], str(publicGroup['_id']))
         # Test searching by name
         resp = self.request(path='/group', method='GET', user=self.users[0],
                             params={'text': 'private'})
         self.assertStatusOk(resp)
-        self.assertEqual(type(resp.json), list)
+        self.assertIsInstance(resp.json, list)
         self.assertEqual(len(resp.json), 2)
         self.assertEqual(resp.json[0]['_id'], str(privateGroup['_id']))
         self.assertEqual(resp.json[1]['_id'], str(privateGroup2['_id']))
         resp = self.request(path='/group', method='GET', user=self.users[0],
                             params={'text': 'private', 'exact': True})
         self.assertStatusOk(resp)
-        self.assertEqual(type(resp.json), list)
+        self.assertIsInstance(resp.json, list)
         self.assertEqual(len(resp.json), 1)
         self.assertEqual(resp.json[0]['_id'], str(privateGroup['_id']))
 


### PR DESCRIPTION
This a PR full of assorted small changes that I've accumulated locally over the past few months. None were significant to make a dedicated PR for, but I'd like to get them in.

This will probably be easiest to review on a commit-by-commit basis. None of the changes should have any immediate impact on behavior, but are still desirable for code quality.
 
If desired, I can split out some commits into their own PR(s).

* Use six.wraps instead of functools.wraps
 * Python 3 didn't have a "functools.wraps" until 3.4.
* Call superclass constructor in AssetstoreAdapter classes
 * This doesn't change behavior now, but is more semantically correct and could be useful in the future.
* Clean some whitespace
* Use isinstance to determine Python types
 * Python is a language for consenting adults. Using direct type comparison via "type(...) ==" or "type(...) is" prevents downstream developers from ever subclassing. Unless subclassing needs to be explicitly forbidden, type checking should always use "isinstance".
* Fix install docs to recommend using Node 4.x on RPM distros
 * This is equivalent to what is already recommended for DEB distros.
* Refactor a portion of test code to eliminate duplication
* Generalize the AccessControlledModel.list method
 * Previously, Group and Collection had identical implementations of the "list" method. This code can be generalized to all AccessControlledModel without affecting any behavior.
 * Note that Job.list has different semantics than the AccessControlledModel.list which it now directly overrides.
