### PR TITLE
Introduce new command: localsync

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -871,7 +871,7 @@ class GirderClient(object):
         :param dest: The local download destination.
         """
 
-        with open(os.path.join(dest, ".girder_metadata"), "w") as fh:
+        with open(os.path.join(dest, '.girder_metadata'), 'w') as fh:
             fh.write(json.dumps(self.incomingMetadata))
 
     def loadLocalMetadata(self, dest):
@@ -882,10 +882,10 @@ class GirderClient(object):
         """
 
         try:
-            with open(os.path.join(dest, ".girder_metadata"), "r") as fh:
+            with open(os.path.join(dest, '.girder_metadata'), 'r') as fh:
                 self.localMetadata = json.loads(fh.read())
-        except OSError:
-            print("Local metadata does not exists. Falling back to download.")
+        except (IOError, OSError):
+            print('Local metadata does not exists. Falling back to download.')
 
     def inheritAccessControlRecursive(self, ancestorFolderId, access=None,
                                       public=None):

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -31,7 +31,7 @@ import six
 _safeNameRegex = re.compile(r'^[/\\]+')
 
 
-def _compare_items(x, y):
+def _compareDicts(x, y):
     """
     Compare two dictionaries with metadata.
 
@@ -157,8 +157,8 @@ class GirderClient(object):
             self.blacklist = []
         self.folder_upload_callbacks = []
         self.item_upload_callbacks = []
-        self.incoming_metadata = {}
-        self.local_metadata = {}
+        self.incomingMetadata = {}
+        self.localMetadata = {}
 
     def authenticate(self, username=None, password=None, interactive=False,
                      apiKey=None):
@@ -854,9 +854,9 @@ class GirderClient(object):
 
             for item in items:
                 _id = item['_id']
-                self.incoming_metadata[_id] = item
-                if sync and _id in self.local_metadata and \
-                        _compare_items(item, self.local_metadata[_id]):
+                self.incomingMetadata[_id] = item
+                if sync and _id in self.localMetadata and \
+                        _compareDicts(item, self.localMetadata[_id]):
                     continue
                 self.downloadItem(item['_id'], dest, name=item['name'])
 
@@ -872,7 +872,7 @@ class GirderClient(object):
         """
 
         with open(os.path.join(dest, ".girder_metadata"), "w") as fh:
-            fh.write(json.dumps(self.incoming_metadata))
+            fh.write(json.dumps(self.incomingMetadata))
 
     def loadLocalMetadata(self, dest):
         """
@@ -883,7 +883,7 @@ class GirderClient(object):
 
         try:
             with open(os.path.join(dest, ".girder_metadata"), "r") as fh:
-                self.local_metadata = json.loads(fh.read())
+                self.localMetadata = json.loads(fh.read())
         except OSError:
             print("Local metadata does not exists. Falling back to download.")
 

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -101,7 +101,6 @@ def main():
             print('download command only accepts parent-type of folder')
         else:
             g.downloadFolderRecursive(args.parent_id, args.local_folder)
-            g.saveLocalMetadata(args.local_folder)
     elif args.c == 'localsync':
         if args.parent_type != 'folder':
             print('localsync command only accepts parent-type of folder')

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -74,7 +74,8 @@ def main():
     parser.add_argument('--port', required=False, default=None)
     parser.add_argument('--api-root', required=False, default=None,
                         help='relative path to the Girder REST API')
-    parser.add_argument('-c', default='upload', choices=['upload', 'download'],
+    parser.add_argument('-c', default='upload',
+                        choices=['upload', 'download', 'localsync'],
                         help='command to run')
     parser.add_argument('parent_id', help='id of Girder parent target')
     parser.add_argument('--parent-type', required=False, default='folder',
@@ -100,6 +101,15 @@ def main():
             print('download command only accepts parent-type of folder')
         else:
             g.downloadFolderRecursive(args.parent_id, args.local_folder)
+            g.saveLocalMetadata(args.local_folder)
+    elif args.c == 'localsync':
+        if args.parent_type != 'folder':
+            print('localsync command only accepts parent-type of folder')
+        else:
+            g.loadLocalMetadata(args.local_folder)
+            g.downloadFolderRecursive(args.parent_id, args.local_folder,
+                                      sync=True)
+            g.saveLocalMetadata(args.local_folder)
     else:
         print('No implementation for command %s' % args.c)
 

--- a/docs/python-client.rst
+++ b/docs/python-client.rst
@@ -120,6 +120,22 @@ To download a Girder Folder hierarchy rooted at Folder id
 
 Downloading is only supported from a parent type of Folder.
 
+Synchronize local folder with a Folder hierarchy
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If the `download_folder` is a local copy of a Girder Folder hierarchy rooted at
+Folder id `54b6d40b8926486c0cbca364`, any change made to the Girder Folder remotely
+can be synchronized locally by ::
+
+    girder-cli -c localsync 54b6d40b8926486c0cbca364 download_folder
+
+This will only download new Items or Items that have been modified since the
+last download/localsync. Local files that are no longer present in the remote
+Girder Folder will not be removed. This command relies on a presence of
+metadata file `.metadata-girder` within `download_folder`, which is created
+upon `girder-cli -c download`. If `.metadata-girder` is not present,
+`localsync` will fallback to `download`.
+
 The Python Client Library
 -------------------------
 

--- a/tests/cases/py_client/cli_test.py
+++ b/tests/cases/py_client/cli_test.py
@@ -179,7 +179,12 @@ class PythonCliTestCase(base.TestCase):
             'Creating Folder from .*tests/cases/py_client/testdata')
         self.assertIn('Uploading Item from hello.txt', ret['stdout'])
 
-        # Test localsync, it shouldn't touch files
+        # Test localsync, it shouldn't touch files on 2nd pass
+        ret = invokeCli(('-c', 'localsync', str(subfolder['_id']),
+                         downloadDir), username='mylogin',
+                        password='password')
+        self.assertEqual(ret['exitVal'], 0)
+
         old_mtimes = {}
         for fname in os.listdir(downloadDir):
             filename = os.path.join(downloadDir, fname)

--- a/tests/cases/py_client/cli_test.py
+++ b/tests/cases/py_client/cli_test.py
@@ -162,6 +162,8 @@ class PythonCliTestCase(base.TestCase):
                         username='mylogin', password='password')
         self.assertEqual(ret['exitVal'], 0)
         for downloaded in os.listdir(downloadDir):
+            if downloaded == '.girder_metadata':
+                continue
             self.assertIn(downloaded, toUpload)
 
         # Download again to same location, we should not get errors
@@ -176,6 +178,23 @@ class PythonCliTestCase(base.TestCase):
             self, ret['stdout'],
             'Creating Folder from .*tests/cases/py_client/testdata')
         self.assertIn('Uploading Item from hello.txt', ret['stdout'])
+
+        # Test localsync, it shouldn't touch files
+        old_mtimes = {}
+        for fname in os.listdir(downloadDir):
+            filename = os.path.join(downloadDir, fname)
+            old_mtimes[fname] = os.path.getmtime(filename)
+
+        ret = invokeCli(('-c', 'localsync', str(subfolder['_id']),
+                         downloadDir), username='mylogin',
+                        password='password')
+        self.assertEqual(ret['exitVal'], 0)
+
+        for fname in os.listdir(downloadDir):
+            if fname == '.girder_metadata':
+                continue
+            filename = os.path.join(downloadDir, fname)
+            self.assertEqual(os.path.getmtime(filename), old_mtimes[fname])
 
     def testLeafFoldersAsItems(self):
         localDir = os.path.join(os.path.dirname(__file__), 'testdata')


### PR DESCRIPTION
'localsync' can be used to update existing directory that was previously
downloaded using 'girder-cli download'. It compares items' metadata and
skips download if nothing has changed.

Useful for huge folders