### PR TITLE
Fix several bugs associated with data copying

### DIFF
--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -254,7 +254,6 @@ class File(acl_mixin.AccessControlMixin, Model):
         # certain that the file will actually be saved. It is also possible for
         # "model.file.save" to set "defaultPrevented", which would prevent the
         # item from being saved initially.
-
         fileDoc = event.info
         itemId = fileDoc.get('itemId')
         if itemId and fileDoc.get('size'):
@@ -303,8 +302,5 @@ class File(acl_mixin.AccessControlMixin, Model):
             adapter.copyFile(srcFile, file)
         elif file.get('linkUrl'):
             file['linkUrl'] = srcFile['linkUrl']
-        item = self.model('item').load(id=file['itemId'], user=creator,
-                                       level=AccessType.WRITE, exc=True)
-        if 'size' in file:
-            self.propagateSizeChange(item, file['size'])
+
         return self.save(file)

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -390,6 +390,9 @@ class Item(acl_mixin.AccessControlMixin, Model):
         # copy files
         for file in self.childFiles(item=srcItem):
             self.model('file').copyFile(file, creator=creator, item=newItem)
+
+        # Reload to get updated size value
+        newItem = self.load(newItem['_id'], force=True)
         events.trigger('model.item.copy.after', newItem)
         return newItem
 

--- a/tests/cases/item_test.py
+++ b/tests/cases/item_test.py
@@ -578,6 +578,7 @@ class ItemTestCase(base.TestCase):
         }
         resp = self.request(path='/file', method='POST', user=self.users[0],
                             params=params)
+
         self.assertStatusOk(resp)
         # Copy to a new item.  It will be in the same folder, but we want a
         # different name.
@@ -587,6 +588,8 @@ class ItemTestCase(base.TestCase):
         resp = self.request(path='/item/%s/copy' % origItem['_id'],
                             method='POST', user=self.users[0], params=params)
         self.assertStatusOk(resp)
+        # Make sure size was returned correctly
+        self.assertEqual(resp.json['size'], 11)
         # Now ask for the new item explicitly and check its metadata
         self.request(path='/item/%s' % resp.json['_id'],
                      user=self.users[0], type='application/json')


### PR DESCRIPTION
* Fixes #1318. When copying any file, the propagated size was
  doubled in the destination tree.
* The endpoints for copying always returned the new documents
  showing size "0" because we didn't reload the document after
  the copy operation.