### PR TITLE
Fix some namespace issues when importing a plugin via entry_point.

### DIFF
--- a/girder/utility/install.py
+++ b/girder/utility/install.py
@@ -143,7 +143,8 @@ def install_plugin(opts):
 
             else:
                 raise Exception('Plugin already exists at %s, use "-f" to '
-                                'overwrite the existing directory.')
+                                'overwrite the existing directory.' % (
+                                    targetPath, ))
         if opts.symlink:
             os.symlink(pluginPath, targetPath)
         else:

--- a/girder/utility/plugin_utilities.py
+++ b/girder/utility/plugin_utilities.py
@@ -37,6 +37,7 @@ import traceback
 import yaml
 import importlib
 
+import pkg_resources
 from pkg_resources import iter_entry_points
 
 from girder.constants import PACKAGE_DIR, ROOT_DIR, ROOT_PLUGINS_PACKAGE, \
@@ -188,9 +189,10 @@ def loadPlugin(name, root, appconf, apiRoot=None, curConfig=None):
         # Try to load the plugin as an entry_point
         for entry_point in iter_entry_points(group='girder.plugin', name=name):
             pluginLoadMethod = entry_point.load()
-            pluginDir = os.path.dirname(
-                importlib.import_module(entry_point.module_name).__file__
-            )
+            module = importlib.import_module(entry_point.module_name)
+            pluginDir = os.path.dirname(module.__file__)
+            module.PLUGIN_ROOT_DIR = pluginDir
+            girder.plugins.__dict__[name] = module
             isPluginDir = True
 
     if not os.path.exists(pluginDir):
@@ -227,6 +229,7 @@ def loadPlugin(name, root, appconf, apiRoot=None, curConfig=None):
                 pluginLoadMethod = getattr(module, 'load', None)
 
             if pluginLoadMethod is not None:
+                sys.modules[moduleName] = module
                 pluginLoadMethod(info)
 
             root, appconf, apiRoot = (
@@ -311,13 +314,7 @@ def getPluginDir(curConfig=None):
     return pluginDir
 
 
-def findAllPlugins(curConfig=None):
-    """
-    Walks the plugins directories to find all of the plugins. If the plugin has
-    a plugin.json file, this reads that file to determine dependencies.
-    """
-    allPlugins = {}
-
+def findEntryPointPlugins(allPlugins):
     # look for plugins enabled via setuptools `entry_points`
     for entry_point in iter_entry_points(group='girder.plugin'):
         # set defaults
@@ -327,10 +324,49 @@ def findAllPlugins(curConfig=None):
             'version': '',
             'dependencies': set()
         }
-        allPlugins[entry_point.name].update(
-            getattr(entry_point.load(), 'config', {})
-        )
+        configJson = os.path.join('girder', 'plugin.json')
+        configYml = os.path.join('girder', 'plugin.yml')
+        data = {}
+        try:
+            if pkg_resources.resource_exists(entry_point.name, configJson):
+                with pkg_resources.resource_stream(
+                        entry_point.name, configJson) as conf:
+                    try:
+                        data = json.load(conf)
+                    except ValueError as e:
+                        print(
+                            TerminalColor.error(
+                                'ERROR: Plugin "%s": plugin.json is not valid '
+                                'JSON.' % entry_point.name))
+                        print(e)
+            elif pkg_resources.resource_exists(entry_point.name, configYml):
+                with pkg_resources.resource_stream(
+                        entry_point.name, configYml) as conf:
+                    try:
+                        data = yaml.safe_load(conf)
+                    except yaml.YAMLError as e:
+                        print(
+                            TerminalColor.error(
+                                'ERROR: Plugin "%s": plugin.yml is not valid '
+                                'YAML.' % entry_point.name))
+                        print(e)
+        except ImportError:
+            pass
+        if data == {}:
+            data = getattr(entry_point.load(), 'config', {})
+        allPlugins[entry_point.name].update(data)
+        allPlugins[entry_point.name]['dependencies'] = set(
+            allPlugins[entry_point.name]['dependencies'])
 
+
+def findAllPlugins(curConfig=None):
+    """
+    Walks the plugins directories to find all of the plugins. If the plugin has
+    a plugin.json file, this reads that file to determine dependencies.
+    """
+    allPlugins = {}
+
+    findEntryPointPlugins(allPlugins)
     pluginDirs = getPluginDirs(curConfig)
     if not pluginDirs:
         print(TerminalColor.warning('Plugin directory not found.'))
@@ -371,7 +407,6 @@ def findAllPlugins(curConfig=None):
                 'version': data.get('version', ''),
                 'dependencies': set(data.get('dependencies', []))
             }
-
     return allPlugins
 
 

--- a/girder/utility/plugin_utilities.py
+++ b/girder/utility/plugin_utilities.py
@@ -26,6 +26,7 @@ in this class are general utility functions designed to be used within the
 plugins themselves to help them register with the application.
 """
 
+import codecs
 import functools
 import girder
 import imp
@@ -332,7 +333,7 @@ def findEntryPointPlugins(allPlugins):
                 with pkg_resources.resource_stream(
                         entry_point.name, configJson) as conf:
                     try:
-                        data = json.load(conf)
+                        data = json.load(codecs.getreader('utf8')(conf))
                     except ValueError as e:
                         print(
                             TerminalColor.error(

--- a/tests/packaging/entry_point_json_plugin/entry_point_json_plugin.py
+++ b/tests/packaging/entry_point_json_plugin/entry_point_json_plugin.py
@@ -1,0 +1,3 @@
+def load(info):
+    import plugin_module
+    plugin_module.test()

--- a/tests/packaging/entry_point_json_plugin/plugin.json
+++ b/tests/packaging/entry_point_json_plugin/plugin.json
@@ -1,0 +1,4 @@
+{
+    "name": "Plugin using entry_point and a JSON file",
+    "description": "Set plugin information from a file rather than a decorator"
+}

--- a/tests/packaging/entry_point_json_plugin/plugin_module.py
+++ b/tests/packaging/entry_point_json_plugin/plugin_module.py
@@ -1,0 +1,2 @@
+def test():
+    return 'okay'

--- a/tests/packaging/entry_point_json_plugin/setup.py
+++ b/tests/packaging/entry_point_json_plugin/setup.py
@@ -1,0 +1,19 @@
+import os
+from setuptools import setup
+
+setupPath = os.path.dirname(os.path.realpath(__file__))
+os.chdir(setupPath)
+
+setup(
+    name='entry_point_json_plugin',
+    py_modules=['entry_point_json_plugin'],
+    entry_points={
+        'girder.plugin':
+            'entry_point_json_plugin = entry_point_json_plugin:load'
+    },
+    data_files=[
+        ('girder', ['plugin.json']),
+    ],
+    include_package_data=True,
+    zip_safe=True,
+)

--- a/tests/packaging/pip_install_girder.sh
+++ b/tests/packaging/pip_install_girder.sh
@@ -31,11 +31,16 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-# Install a standalone plugin the registers itself against the
+# Install some standalone plugins the registers themselves against the
 # girder.plugin entrypoint
 "${virtualenv_pip}" install -e "${PROJECT_SOURCE_DIR}/tests/packaging/entry_point_plugin"
+"python" "${PROJECT_SOURCE_DIR}/tests/packaging/entry_point_json_plugin/setup.py" install
 if ! python -c 'from girder.utility.plugin_utilities import findAllPlugins; assert findAllPlugins().get("test_entry_point", {}).get("name") == "Plugin using entry_point"' ; then
     echo "Error: failed to register a plugin with the girder.plugin entry point"
+    exit 1
+fi
+if ! python -c 'from girder.utility.plugin_utilities import findAllPlugins; assert findAllPlugins().get("entry_point_json_plugin", {}).get("name") == "Plugin using entry_point and a JSON file"' ; then
+    echo "Error: failed to register a plugin with the girder.plugin entry point and a JSON file"
     exit 1
 fi
 


### PR DESCRIPTION
When importing a module by entry point, make sure it is available via girder.plugins[modulename] so that its submodules are always reachable in a consistent fashion.

Read a plugin.json or plugin.yml file from the packaged plugin rather than requiring this information to be duplicated at the entry point with the @plugin decorator.  This expects the plugins file within the module to be a girder/plugin.json or girder/plugin.yml.

Note that plugins must not import other plugins at the time that the module with the entry point is imported, as checking the @plugin decorator OR reading module files (such as plugin.json) import the module BEFORE module dependencies have been sorted and loaded.

The most useful feature of this branch is making sure the plugin is in the appropriate spot of the sys.modules namespace so that it can import its own modules.  This isn't currently tested, as it will require installing and enabling a plugin that isn't in the plugins directory.