### PR TITLE
Allow to import leaf folders as items

### DIFF
--- a/clients/web/src/templates/body/filesystemImport.jade
+++ b/clients/web/src/templates/body/filesystemImport.jade
@@ -26,6 +26,11 @@ form.g-filesystem-import-form
     input.form-control.input-sm#g-filesystem-import-dest-id(
       type="text"
       placeholder="Existing folder, user, or collection ID to use as the destination")
+  .form-group
+    label(for="g-filesystem-import-leaf-items") Leaf Folders as Items
+    select.form-control#g-filesystem-import-leaf-items
+      option(value="true") True
+      option(value="false") False
   .g-validation-failed-message
   button.g-submit-assetstore-import.btn.btn-success(type="submit")
     i.icon-link-ext

--- a/clients/web/src/templates/body/filesystemImport.jade
+++ b/clients/web/src/templates/body/filesystemImport.jade
@@ -29,8 +29,8 @@ form.g-filesystem-import-form
   .form-group
     label(for="g-filesystem-import-leaf-items") Leaf Folders as Items
     select.form-control#g-filesystem-import-leaf-items
-      option(value="true") True
       option(value="false") False
+      option(value="true") True
   .g-validation-failed-message
   button.g-submit-assetstore-import.btn.btn-success(type="submit")
     i.icon-link-ext

--- a/clients/web/src/views/body/FilesystemImportView.js
+++ b/clients/web/src/views/body/FilesystemImportView.js
@@ -4,7 +4,8 @@ girder.views.FilesystemImportView = girder.View.extend({
             e.preventDefault();
 
             var destId = this.$('#g-filesystem-import-dest-id').val().trim(),
-                destType = this.$('#g-filesystem-import-dest-type').val();
+                destType = this.$('#g-filesystem-import-dest-type').val(),
+                foldersAsItems = this.$('#g-filesystem-import-leaf-items').val();
 
             this.$('.g-validation-failed-message').empty();
 
@@ -14,6 +15,7 @@ girder.views.FilesystemImportView = girder.View.extend({
                 this.$('.g-validation-failed-message').text(resp.responseJSON.message);
             }, this).import({
                 importPath: this.$('#g-filesystem-import-path').val().trim(),
+                leafFoldersAsItems: foldersAsItems,
                 destinationId: destId,
                 destinationType: destType,
                 progress: true

--- a/girder/api/v1/assetstore.py
+++ b/girder/api/v1/assetstore.py
@@ -164,11 +164,13 @@ class Assetstore(Resource):
             exc=True)
 
         progress = self.boolParam('progress', params, default=False)
+        leafFoldersAsItems = self.boolParam('leafFoldersAsItems', params,
+                                            default=False)
         with ProgressContext(
                 progress, user=user, title='Importing data') as ctx:
             return self.model('assetstore').importData(
                 assetstore, parent=parent, parentType=parentType, params=params,
-                progress=ctx, user=user)
+                progress=ctx, user=user, leafFoldersAsItems=leafFoldersAsItems)
 
     @access.admin
     @loadmodel(model='assetstore')

--- a/girder/utility/filesystem_assetstore_adapter.py
+++ b/girder/utility/filesystem_assetstore_adapter.py
@@ -144,8 +144,8 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
 
         if self.requestOffset(upload) > upload['received']:
             # This probably means the server died midway through writing last
-            # chunk to disk, and the database record was not updated. This means
-            # we need to update the sha512 state with the difference.
+            # chunk to disk, and the database record was not updated. This
+            # means we need to update the sha512 state with the difference.
             with open(upload['tempFile'], 'rb') as tempFile:
                 tempFile.seek(upload['received'])
                 while True:
@@ -320,31 +320,59 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
         file['imported'] = True
         return self.model('file').save(file)
 
-    def importData(self, parent, parentType, params, progress, user):
+    def _importDataAsItem(self, name, user, folder, path, files,
+                          reuseExisting=True):
+        item = self.model('item').createItem(
+            name=name, creator=user, folder=folder,
+            reuseExisting=reuseExisting)
+        for fname in files:
+            self.importFile(item, os.path.join(path, fname),
+                            user, name=fname)
+
+    def importData(self, parent, parentType, params, progress, user,
+                   leafFoldersAsItems):
         importPath = params['importPath']
 
         if not os.path.isdir(importPath):
             raise ValidationException('No such directory: %s.' % importPath)
 
-        for name in os.listdir(importPath):
+        def hasOnlyFiles(path, files):
+            return all(map(os.path.isfile, (os.path.join(path, fname)
+                                            for fname in files)))
+
+        listDir = os.listdir(importPath)
+        if leafFoldersAsItems and hasOnlyFiles(importPath, listDir):
+            self._importDataAsItem(os.path.basename(importPath.rstrip('/')),
+                                   user, parent, importPath, listDir)
+            return
+
+        for name in listDir:
             progress.update(message=name)
             path = os.path.join(importPath, name)
 
             if os.path.isdir(path):
-                folder = self.model('folder').createFolder(
-                    parent=parent, name=name, parentType=parentType,
-                    creator=user, reuseExisting=True)
-                self.importData(folder, 'folder', params={
-                    'importPath': os.path.join(importPath, name)
-                }, progress=progress, user=user)
+                localListDir = os.listdir(path)
+                if leafFoldersAsItems and hasOnlyFiles(path, localListDir):
+                    self._importDataAsItem(name, user, parent, path,
+                                           localListDir)
+                else:
+                    folder = self.model('folder').createFolder(
+                        parent=parent, name=name, parentType=parentType,
+                        creator=user, reuseExisting=True)
+                    self.importData(folder, 'folder', params={
+                        'importPath': os.path.join(importPath, name)},
+                        progress=progress, user=user,
+                        leafFoldersAsItems=leafFoldersAsItems)
             else:
                 if parentType != 'folder':
                     raise ValidationException(
-                        'Files cannot be imported directly underneath a %s.' %
+                        'Files cannot be imported directly'
+                        'underneath a %s.' %
                         parentType)
 
                 item = self.model('item').createItem(
-                    name=name, creator=user, folder=parent, reuseExisting=True)
+                    name=name, creator=user, folder=parent,
+                    reuseExisting=True)
                 self.importFile(item, path, user, name=name)
 
     def findInvalidFiles(self, progress=progress.noProgress, filters=None,

--- a/girder/utility/filesystem_assetstore_adapter.py
+++ b/girder/utility/filesystem_assetstore_adapter.py
@@ -342,7 +342,7 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
 
         listDir = os.listdir(importPath)
         if leafFoldersAsItems and hasOnlyFiles(importPath, listDir):
-            self._importDataAsItem(os.path.basename(importPath.rstrip('/')),
+            self._importDataAsItem(os.path.basename(importPath.rstrip(os.sep)),
                                    user, parent, importPath, listDir)
             return
 


### PR DESCRIPTION
Similarly to `girder_client` this change allows to import leaf folders as items during `importData` from fs assetstore.