### PR TITLE
Upgrade Girder package requirements

### DIFF
--- a/clients/ansible/girder.py
+++ b/clients/ansible/girder.py
@@ -17,12 +17,15 @@
 #  limitations under the License.
 ###############################################################################
 
+import json
+import os
+from inspect import getmembers, ismethod, getargspec
+
 # Ansible's module magic requires this to be
 # 'from ansible.module_utils.basic import *' otherwise it will error out. See:
 # https://github.com/ansible/ansible/blob/v1.9.4-1/lib/ansible/module_common.py#L41-L59
 # For more information on this magic. For now we noqa to prevent flake8 errors
 from ansible.module_utils.basic import *  # noqa
-from inspect import getmembers, ismethod, getargspec
 
 try:
     from girder_client import GirderClient, AuthenticationError, HttpError
@@ -31,7 +34,7 @@ except ImportError:
     HAS_GIRDER_CLIENT = False
 
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 DOCUMENTATION = '''
 ---
@@ -899,7 +902,7 @@ class Resource(object):
             try:
                 # If we can't create the item,  try and return
                 # The item with the same name
-                ret = self.resource_by_name[args['name']]
+                ret = self.resource_by_name[kwargs['name']]
             except KeyError:
                 raise htErr
         return ret
@@ -1733,7 +1736,7 @@ def main():
     for method in gcm.required_one_of:
         argument_spec[method] = dict(type=gcm.spec[method]['type'])
 
-    module = AnsibleModule(
+    module = AnsibleModule(  # noqa
         argument_spec=argument_spec,
         required_one_of=[gcm.required_one_of,
                          ["token", "username", "user"]],

--- a/clients/python/requirements.txt
+++ b/clients/python/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.9.1
+requests==2.10.0
 six==1.10.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,39 +1,41 @@
 # girder core
-coverage==4.0.3
-flake8==2.5.2
+coverage==4.1.0
+flake8==2.5.4
 flake8-blind-except==0.1.0
-flake8-docstrings==0.2.4
-httmock==1.2.4
-mock==1.3.0
+flake8-docstrings==0.2.6
+httmock==1.2.5
+mock==2.0.0
+# Versions >0.4.0 of moto cause test failures
 moto==0.4.0
-Sphinx==1.3.5
+Sphinx==1.4.2
 sphinx_rtd_theme==0.1.9
-virtualenv==14.0.5
+virtualenv==15.0.2
 
 # dependencies of flake8
 mccabe==0.4.0
 pep8==1.7.0
-pyflakes==1.0.0
+pyflakes==1.2.3
 
 # dependencies of flake8-docstrings
 pep257==0.7.0
 
 # dependencies of mock
-funcsigs==0.4
-pbr==1.8.1
+funcsigs==1.0.2
+pbr==1.10.0
 
 # dependencies of moto
-Flask==0.10.1
+Flask==0.11
+# Versions >0.8.10 and <=0.8.14 of httpretty cause test failures
 httpretty==0.8.10
 itsdangerous==0.24
-Werkzeug==0.11.3
-xmltodict==0.9.2
+Werkzeug==0.11.10
+xmltodict==0.10.1
 
 # dependencies of Sphinx
-alabaster==0.7.7
-Babel==2.2.0
+alabaster==0.7.8
+Babel==2.3.4
 docutils==0.12
-Pygments==2.1
+Pygments==2.1.3
 snowballstemmer==1.2.1
 
 # dependencies of moto + Sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,24 +1,24 @@
 # girder core
 bcrypt==2.0.0
-boto==2.39.0
-cffi==1.5.0
-CherryPy==4.0.0
-Mako==1.0.3
-pymongo==3.2
+boto==2.40.0
+cffi==1.6.0
+CherryPy==5.4.0
+Mako==1.0.4
+pymongo==3.2.2
 PyYAML==3.11
-requests==2.9.1
-psutil==3.4.2
-pytz==2015.7
+psutil==4.2.0
+pytz==2016.4
+requests==2.10.0
 six==1.10.0
 
 # celery_jobs
-celery==3.1.20
+celery==3.1.23
 
 # geospatial
 geojson==1.3.2
 
 # hdfs_assetstore
-snakebite==2.7.3 ; python_version < '3.0'
+snakebite==2.9.0 ; python_version < '3.0'
 
 # metadata_extractor
 hachoir-core==1.3.3     ; python_version < '3.0'
@@ -26,13 +26,13 @@ hachoir-metadata==1.3.3 ; python_version < '3.0'
 hachoir-parser==1.3.4   ; python_version < '3.0'
 
 # thumbnails
-Pillow==3.1.2
+Pillow==3.2.0
 
 # dependencies of celery
 amqp==1.4.9
 anyjson==0.3.3
-billiard==3.3.0.22
-kombu==3.0.33
+billiard==3.3.0.23
+kombu==3.0.34
 
 # dependencies of cffi
 pycparser==2.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@
 bcrypt==2.0.0
 boto==2.40.0
 cffi==1.6.0
-CherryPy==5.4.0
+# Version 5.4.0 of CherryPy contains a bug with Python 3
+CherryPy==5.3.0
 Mako==1.0.4
 pymongo==3.2.2
 PyYAML==3.11

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ with open('package.json') as f:
 install_reqs = [
     'bcrypt',
     'boto',
-    'CherryPy',
+    'CherryPy<5.4.0',
     'Mako',
     'pymongo>=3',
     'PyYAML',


### PR DESCRIPTION
Boto changes at:
http://docs.pythonboto.org/en/latest/releasenotes/v2.40.0.html

cffi changes at:
https://cffi.readthedocs.io/en/latest/whatsnew.html#v1-6

CherryPy changes at:
https://github.com/cherrypy/cherrypy/blob/master/CHANGES.txt

Mako changes at:
http://docs.makotemplates.org/en/latest/changelog.html#change-1.0.4

PyMongo changes at:
http://api.mongodb.com/python/current/changelog.html#changes-in-version-3-2-2

psutil changes at:
https://github.com/giampaolo/psutil/blob/master/HISTORY.rst#410---2016-03-12

pytz changes not available.

Requests changes at:
http://docs.python-requests.org/en/master/community/updates/

Celery changes at:
http://docs.celeryproject.org/en/latest/changelog.html#version-3-1-23

Snakebite changes at (raw form):
https://github.com/spotify/snakebite/compare/2.7.3...2.8.2

Pillow changes at:
https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst#320-2016-04-01

Flake8 changes at:
https://flake8.readthedocs.io/en/latest/changes.html

Flake8-Docstrings changes at:
https://gitlab.com/pycqa/flake8-docstrings/blob/master/HISTORY.rst

HTTMock changes at (raw form):
https://github.com/patrys/httmock/compare/1.2.4...1.2.5

Mock changes at:
https://mock.readthedocs.io/en/latest/changelog.html

Sphinx changes at:
http://www.sphinx-doc.org/en/stable/changes.html

virtualenv changes at:
https://virtualenv.pypa.io/en/latest/changes.html