### PR TITLE
Add license field to Item

### DIFF
--- a/clients/web/src/models/ItemModel.js
+++ b/clients/web/src/models/ItemModel.js
@@ -39,6 +39,19 @@ girder.models.ItemModel = girder.Model.extend({
         }, this)).error(_.bind(function (err) {
             this.trigger('g:error', err);
         }, this));
+    },
+
+    /**
+     * Get the list of licenses.
+     */
+    getLicenses: function (callback) {
+        girder.restRequest({
+            path: this.resourceName + '/licenses'
+        }).done(_.bind(function (resp) {
+            callback(resp);
+        }, this)).error(_.bind(function (err) {
+            this.trigger('g:error', err);
+        }, this));
     }
 });
 

--- a/clients/web/src/stylesheets/body/systemConfig.styl
+++ b/clients/web/src/stylesheets/body/systemConfig.styl
@@ -6,6 +6,11 @@
   margin-bottom 3px
   height 120px
 
+#g-core-licenses
+  font-family monospace
+  margin-bottom 3px
+  height 180px
+
 .g-settings-form-container
   $bgColor = #fcfaf3
   border 1px solid #d7d7d7

--- a/clients/web/src/templates/body/itemPage.jade
+++ b/clients/web/src/templates/body/itemPage.jade
@@ -44,6 +44,13 @@
   .g-item-updated.g-info-list-entry
     i.icon-clock
     | Updated on #{girder.formatDate(item.get('updated'), girder.DATE_SECOND)}
+  .g-item-license.g-info-list-entry
+      i.icon-shield
+      | License:&nbsp;
+      if item.has('license') && item.get('license').length
+        = item.get('license')
+      else
+        | Unspecified
 
 .g-item-metadata
 

--- a/clients/web/src/templates/body/systemConfiguration.jade
+++ b/clients/web/src/templates/body/systemConfiguration.jade
@@ -58,6 +58,10 @@ form.g-settings-form(role="form")
           selected=((settings['core.user_default_folders'] ||
           defaults['core.user_default_folders']) === "public_private")
           ) Yes, "Public" and "Private"
+    .form-group
+      label(for="g-core-licenses") Licenses
+      textarea#g-core-licenses.form-control
+        = JSON.stringify(settings['core.licenses'] || defaults['core.licenses'], null, 4)
   .g-settings-form-container
     h4 Email Creation
     .form-group

--- a/clients/web/src/templates/widgets/editItemWidget.jade
+++ b/clients/web/src/templates/widgets/editItemWidget.jade
@@ -1,3 +1,5 @@
+include selectLicenseMixin
+
 .modal-dialog
   .modal-content
     form#g-item-edit-form.modal-form(role="form")
@@ -15,6 +17,7 @@
         .form-group
           label.control-label(for="g-description") Description (optional)
           textarea.input-sm#g-description.form-control(placeholder="Enter item description")
+        +g-select-license(licenses)
         .g-validation-failed-message
       .modal-footer
         a.btn.btn-small.btn-default(data-dismiss="modal") Cancel

--- a/clients/web/src/templates/widgets/selectLicenseMixin.jade
+++ b/clients/web/src/templates/widgets/selectLicenseMixin.jade
@@ -1,0 +1,10 @@
+mixin g-select-license(licenses)
+  .g-select-license.form-group
+    label(for="g-license") License
+    select#g-license.form-control.input-sm
+      option(value="", selected="selected") Unspecified
+      if licenses
+        each item in licenses
+          optgroup(label=item.category)
+            each license in item.licenses
+              option(value=license.name)= license.name

--- a/clients/web/src/templates/widgets/uploadWidget.jade
+++ b/clients/web/src/templates/widgets/uploadWidget.jade
@@ -1,4 +1,5 @@
 include uploadWidgetMixins
+include selectLicenseMixin
 
 .modal-dialog
   .modal-content
@@ -10,6 +11,8 @@ include uploadWidgetMixins
       .modal-body
         +g-upload-widget-browse-or-drop
         +g-upload-widget-progress
+        if licenses
+          +g-select-license(licenses)
       .modal-footer
         a.btn.btn-small.btn-default(data-dismiss="modal") Close
         +g-upload-widget-start-button

--- a/clients/web/src/templates/widgets/uploadWidgetNonModal.jade
+++ b/clients/web/src/templates/widgets/uploadWidgetNonModal.jade
@@ -1,4 +1,5 @@
 include uploadWidgetMixins
+include selectLicenseMixin
 
 form#g-upload-form
   if title
@@ -6,5 +7,7 @@ form#g-upload-form
   +g-upload-widget-subtitle
   +g-upload-widget-browse-or-drop
   +g-upload-widget-progress
+  if licenses
+    +g-select-license(licenses)
   .g-nonmodal-upload-buttons-container
     +g-upload-widget-start-button

--- a/clients/web/src/views/body/ItemView.js
+++ b/clients/web/src/views/body/ItemView.js
@@ -48,16 +48,21 @@
         editItem: function () {
             var container = $('#g-dialog-container');
 
-            if (!this.editItemWidget) {
-                this.editItemWidget = new girder.views.EditItemWidget({
-                    el: container,
-                    item: this.model,
-                    parentView: this
-                }).off('g:saved').on('g:saved', function () {
-                    this.render();
-                }, this);
-            }
-            this.editItemWidget.render();
+            var item = new girder.models.ItemModel();
+            item.getLicenses(_.bind(function (licenses) {
+                if (!this.editItemWidget) {
+                    this.editItemWidget = new girder.views.EditItemWidget({
+                        el: container,
+                        item: this.model,
+                        licenses: licenses,
+                        parentView: this
+                    }).off('g:saved').on('g:saved', function () {
+                        this.render();
+                    }, this);
+                }
+                this.editItemWidget.licenses = licenses;
+                this.editItemWidget.render();
+            }, this));
         },
 
         deleteItem: function () {

--- a/clients/web/src/views/body/SystemConfigurationView.js
+++ b/clients/web/src/views/body/SystemConfigurationView.js
@@ -59,7 +59,8 @@ girder.views.SystemConfigurationView = girder.View.extend({
             'core.cors.allow_headers',
             'core.add_to_group_policy',
             'core.collection_create_policy',
-            'core.user_default_folders'
+            'core.user_default_folders',
+            'core.licenses'
         ];
         this.settingsKeys = keys;
         girder.restRequest({

--- a/clients/web/src/views/widgets/EditItemWidget.js
+++ b/clients/web/src/views/widgets/EditItemWidget.js
@@ -6,7 +6,8 @@ girder.views.EditItemWidget = girder.View.extend({
         'submit #g-item-edit-form': function () {
             var fields = {
                 name: this.$('#g-name').val(),
-                description: this.$('#g-description').val()
+                description: this.$('#g-description').val(),
+                license: this.$('#g-license').val()
             };
 
             if (this.item) {
@@ -25,12 +26,14 @@ girder.views.EditItemWidget = girder.View.extend({
     initialize: function (settings) {
         this.item = settings.item || null;
         this.parentModel = settings.parentModel;
+        this.licenses = settings.licenses || null;
     },
 
     render: function () {
         var view = this;
         var modal = this.$el.html(girder.templates.editItemWidget({
-            item: this.item}))
+            item: this.item,
+            licenses: this.licenses}))
             .girderModal(this).on('shown.bs.modal', function () {
                 view.$('#g-name').focus();
                 if (view.item) {
@@ -48,6 +51,10 @@ girder.views.EditItemWidget = girder.View.extend({
                 if (view.item) {
                     view.$('#g-name').val(view.item.get('name'));
                     view.$('#g-description').val(view.item.get('description'));
+                    if (view.item.has('license')) {
+                        // XXX: handle nonexistent license?
+                        view.$('#g-license').val(view.item.get('license'));
+                    }
                     view.create = false;
                 } else {
                     view.create = true;

--- a/clients/web/src/views/widgets/HierarchyWidget.js
+++ b/clients/web/src/views/widgets/HierarchyWidget.js
@@ -276,17 +276,22 @@ girder.views.HierarchyWidget = girder.View.extend({
      * Prompt the user to create a new item in the current folder
      */
     createItemDialog: function () {
-        new girder.views.EditItemWidget({
-            el: $('#g-dialog-container'),
-            parentModel: this.parentModel,
-            parentView: this
-        }).on('g:saved', function (item) {
-            this.itemListView.insertItem(item);
-            if (this.parentModel.has('nItems')) {
-                this.parentModel.increment('nItems');
-            }
-            this.updateChecked();
-        }, this).render();
+        // Get the list of licenses
+        var item = new girder.models.ItemModel();
+        item.getLicenses(_.bind(function (licenses) {
+            new girder.views.EditItemWidget({
+                el: $('#g-dialog-container'),
+                parentModel: this.parentModel,
+                licenses: licenses,
+                parentView: this
+            }).on('g:saved', function (item) {
+                this.itemListView.insertItem(item);
+                if (this.parentModel.has('nItems')) {
+                    this.parentModel.increment('nItems');
+                }
+                this.updateChecked();
+            }, this).render();
+        }, this));
     },
 
     /**

--- a/clients/web/src/views/widgets/HierarchyWidget.js
+++ b/clients/web/src/views/widgets/HierarchyWidget.js
@@ -533,24 +533,29 @@ girder.views.HierarchyWidget = girder.View.extend({
      * Show and handle the upload dialog
      */
     uploadDialog: function () {
-        var container = $('#g-dialog-container');
+        // Get the list of licenses
+        var item = new girder.models.ItemModel();
+        item.getLicenses(_.bind(function (licenses) {
+            var container = $('#g-dialog-container');
 
-        new girder.views.UploadWidget({
-            el: container,
-            parent: this.parentModel,
-            parentType: this.parentType,
-            parentView: this
-        }).on('g:uploadFinished', function (info) {
-            girder.dialogs.handleClose('upload');
-            this.upload = false;
-            if (this.parentModel.has('nItems')) {
-                this.parentModel.increment('nItems', info.files.length);
-            }
-            if (this.parentModel.has('size')) {
-                this.parentModel.increment('size', info.totalSize);
-            }
-            this.setCurrentModel(this.parentModel, {setRoute: false});
-        }, this).render();
+            new girder.views.UploadWidget({
+                el: container,
+                parent: this.parentModel,
+                parentType: this.parentType,
+                licenses: licenses,
+                parentView: this
+            }).on('g:uploadFinished', function (info) {
+                girder.dialogs.handleClose('upload');
+                this.upload = false;
+                if (this.parentModel.has('nItems')) {
+                    this.parentModel.increment('nItems', info.files.length);
+                }
+                if (this.parentModel.has('size')) {
+                    this.parentModel.increment('size', info.totalSize);
+                }
+                this.setCurrentModel(this.parentModel, {setRoute: false});
+            }, this).render();
+        }, this));
     },
 
     /**

--- a/clients/web/src/views/widgets/UploadWidget.js
+++ b/clients/web/src/views/widgets/UploadWidget.js
@@ -97,6 +97,7 @@ girder.views.UploadWidget = girder.View.extend({
         this.title = _.has(settings, 'title') ? settings.title : 'Upload files';
         this.modal = _.has(settings, 'modal') ? settings.modal : true;
         this.overrideStart = settings.overrideStart || false;
+        this.licenses = _.has(settings, 'licenses') ? settings.licenses : null;
     },
 
     render: function () {
@@ -104,7 +105,8 @@ girder.views.UploadWidget = girder.View.extend({
             this.$el.html(girder.templates.uploadWidget({
                 parent: this.parent,
                 parentType: this.parentType,
-                title: this.title
+                title: this.title,
+                licenses: this.licenses
             }));
 
             var base = this;
@@ -128,7 +130,8 @@ girder.views.UploadWidget = girder.View.extend({
             this.$el.html(girder.templates.uploadWidgetNonModal({
                 parent: this.parent,
                 parentType: this.parentType,
-                title: this.title
+                title: this.title,
+                licenses: this.licenses
             }));
         }
         return this;
@@ -223,6 +226,7 @@ girder.views.UploadWidget = girder.View.extend({
                 ? this.parent : new girder.models.FileModel();
 
         this.currentFile.on('g:upload.complete', function () {
+            this._setItemLicense(this.currentFile);
             this.currentIndex += 1;
             this.uploadNextFile();
         }, this).on('g:upload.chunkSent', function (info) {
@@ -258,6 +262,22 @@ girder.views.UploadWidget = girder.View.extend({
             this.currentFile.updateContents(this.files[this.currentIndex]);
         } else {
             this.currentFile.upload(this.parent, this.files[this.currentIndex]);
+        }
+    },
+
+    /**
+     * Set a file's item to the currently selected license.
+     */
+    _setItemLicense: function (file) {
+        if (!_.isNull(this.licenses)) {
+            var license = this.$('#g-license').val();
+            if (!_.isEmpty(license)) {
+                var item = new girder.models.ItemModel({
+                    _id: file.get('itemId'),
+                    license: license
+                });
+                item.save();
+            }
         }
     }
 });

--- a/clients/web/test/spec/customWidgetsSpec.js
+++ b/clients/web/test/spec/customWidgetsSpec.js
@@ -11,6 +11,7 @@
                     modal: false,
                     title: null,
                     el: 'body',
+                    licenses: [{category: 'A', licenses: [{name: '1'}]}],
                     parentView: null
                 }).render();
 
@@ -20,6 +21,8 @@
                 expect($('.g-drop-zone:visible').length).toBe(1);
                 expect($('.g-start-upload.btn.disabled:visible').length).toBe(1);
                 expect($('.g-overall-progress-message').text()).toBe('No files selected');
+                expect($('#g-license optgroup').length).toBe(1);
+                expect($('#g-license option').length).toBe(2);
             });
         });
     });

--- a/clients/web/test/spec/itemSpec.js
+++ b/clients/web/test/spec/itemSpec.js
@@ -130,6 +130,7 @@ describe('Test item creation, editing, and deletion', function () {
         runs(function () {
             $('#g-name').val('Test Item Name');
             $('#g-description').val('Test Item Description');
+            $('#g-license').val('CC0');
             $('.g-save-item').click();
         });
 
@@ -149,6 +150,7 @@ describe('Test item creation, editing, and deletion', function () {
         runs(function () {
             expect($('.g-item-name').text()).toBe("Test Item Name");
             expect($('.g-item-description').text()).toBe("Test Item Description");
+            expect($('.g-item-license').text()).toContain('CC0');
         });
     });
 

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -114,6 +114,7 @@ class Item(Resource):
         .param('folderId', 'The ID of the parent folder.')
         .param('name', 'Name for the item.')
         .param('description', "Description for the item.", required=False)
+        .param('license', "License for the item.", required=False)
         .errorResponse()
         .errorResponse('Write access was denied on the parent folder.', 403)
     )
@@ -123,12 +124,14 @@ class Item(Resource):
         user = self.getCurrentUser()
         name = params['name'].strip()
         description = params.get('description', '').strip()
+        license = params.get('license', '').strip()
 
         folder = self.model('folder').load(id=params['folderId'], user=user,
                                            level=AccessType.WRITE, exc=True)
 
         return self.model('item').createItem(
-            folder=folder, name=name, creator=user, description=description)
+            folder=folder, name=name, creator=user, description=description,
+            license=license)
 
     @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='item', level=AccessType.WRITE)
@@ -139,6 +142,7 @@ class Item(Resource):
         .param('id', 'The ID of the item.', paramType='path')
         .param('name', 'Name for the item.', required=False)
         .param('description', 'Description for the item.', required=False)
+        .param('license', 'License for the item.', required=False)
         .param('folderId', 'Pass this to move the item to a new folder.',
                required=False)
         .errorResponse('ID was invalid.')
@@ -148,6 +152,8 @@ class Item(Resource):
         item['name'] = params.get('name', item['name']).strip()
         item['description'] = params.get(
             'description', item['description']).strip()
+        item['license'] = params.get(
+            'license', item.get('license', '')).strip()
 
         self.model('item').updateItem(item)
 
@@ -287,6 +293,7 @@ class Item(Resource):
         .param('folderId', 'The ID of the parent folder.', required=False)
         .param('name', 'Name for the new item.', required=False)
         .param('description', "Description for the new item.", required=False)
+        .param('license', "License for the new item.", required=False)
         .errorResponse()
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied on the original item.', 403)
@@ -307,6 +314,7 @@ class Item(Resource):
         folder = self.model('folder').load(
             id=folderId, user=user, level=AccessType.WRITE, exc=True)
         description = params.get('description', None)
+        license = params.get('license', None)
         return self.model('item').copyItem(
             item, creator=user, name=name, folder=folder,
-            description=description)
+            description=description, license=license)

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -22,7 +22,7 @@ import cherrypy
 from ..describe import Description, describeRoute
 from ..rest import Resource, RestException, filtermodel, loadmodel
 from girder.utility import ziputil
-from girder.constants import AccessType, TokenScope
+from girder.constants import AccessType, SettingKey, TokenScope
 from girder.api import access
 
 
@@ -33,6 +33,7 @@ class Item(Resource):
         self.resourceName = 'item'
         self.route('DELETE', (':id',), self.deleteItem)
         self.route('GET', (), self.find)
+        self.route('GET', ('licenses',), self.getLicenses)
         self.route('GET', (':id',), self.getItem)
         self.route('GET', (':id', 'files'), self.getFiles)
         self.route('GET', (':id', 'download'), self.download)
@@ -92,6 +93,13 @@ class Item(Resource):
                 sort=sort))
         else:
             raise RestException('Invalid search mode.')
+
+    @access.public
+    @describeRoute(
+        Description('Get list of item licenses.')
+    )
+    def getLicenses(self, params):
+        return self.model('setting').get(SettingKey.LICENSES)
 
     @access.public(scope=TokenScope.DATA_READ)
     @loadmodel(model='item', level=AccessType.READ)

--- a/girder/constants.py
+++ b/girder/constants.py
@@ -147,6 +147,7 @@ class SettingKey:
     ADD_TO_GROUP_POLICY = 'core.add_to_group_policy'
     COLLECTION_CREATE_POLICY = 'core.collection_create_policy'
     USER_DEFAULT_FOLDERS = 'core.user_default_folders'
+    LICENSES = 'core.licenses'
 
 
 class SettingDefault:
@@ -177,7 +178,78 @@ class SettingDefault:
             'groups': [],
             'users': []
         },
-        SettingKey.USER_DEFAULT_FOLDERS: 'public_private'
+        SettingKey.USER_DEFAULT_FOLDERS: 'public_private',
+        SettingKey.LICENSES: [
+            {
+                # "Popular" licenses from
+                # https://opensource.org/licenses/category
+                'category': 'Code Licenses',
+                'licenses': [
+                    {
+                        'name': 'Apache License 2.0'
+                    },
+                    {
+                        'name': 'BSD 3-Clause "New" or "Revised" License'
+                    },
+                    {
+                        'name': 'BSD 2-Clause "Simplified" or "FreeBSD" License'
+                    },
+                    {
+                        'name': 'GNU General Public License (GPL) 2.0'
+                    },
+                    {
+                        'name': 'GNU General Public License (GPL) 3.0'
+                    },
+                    {
+                        'name': 'GNU Lesser General Public License (LGPL) 2.1'
+                    },
+                    {
+                        'name': 'GNU Lesser General Public License (LGPL) 3.0'
+                    },
+                    {
+                        'name': 'MIT License'
+                    },
+                    {
+                        'name': 'Mozilla Public License 2.0'
+                    }
+                ]
+            },
+            {
+                # See http://creativecommons.org/licenses/
+                'category': 'Content Licenses',
+                'licenses': [
+                    {
+                        'name': 'CC0'
+                    },
+                    {
+                        'name': 'CC Attribution (BY)'
+                    },
+                    {
+                        'name': 'CC Attribution-ShareAlike (BY-SA)'
+                    },
+                    {
+                        'name': 'CC Attribution-NoDerivs (BY-ND)'
+                    },
+                    {
+                        'name': 'CC Attribution-NonCommercial (BY-NC)'
+                    },
+                    {
+                        'name': 'CC Attribution-NonCommercial-ShareAlike '
+                                '(BY-NC-SA)'
+                    },
+                    {
+                        'name': 'CC Attribution-NonCommercial-NoDerivs '
+                                '(BY-NC-ND)'
+                    },
+                    {
+                        'name': 'Public Domain'
+                    },
+                    {
+                        'name': 'All Rights Reserved'
+                    },
+                ]
+            }
+        ]
     }
 
 

--- a/girder/models/setting.py
+++ b/girder/models/setting.py
@@ -208,6 +208,28 @@ class Setting(Model):
                 'User default folders must be either "public_private" or '
                 '"none".', 'value')
 
+    def validateCoreLicenses(self, doc):
+        if not isinstance(doc['value'], list):
+            raise ValidationException(
+                'Licenses setting must be a list.', 'value')
+
+        for item in doc['value']:
+            category = item.get('category', None)
+            if not category:
+                raise ValidationException(
+                    'License category must be specified and non-empty.',
+                    'category')
+            licenses = item.get('licenses', [])
+            if not isinstance(licenses, list):
+                raise ValidationException(
+                    'Licenses in category must be a list.', 'licenses')
+            for license in licenses:
+                name = license.get('name', None)
+                if not name:
+                    raise ValidationException(
+                        'License name must be specified and non-empty.',
+                        'name')
+
     def get(self, key, default='__default__'):
         """
         Retrieve a setting by its key.

--- a/tests/cases/item_test.py
+++ b/tests/cases/item_test.py
@@ -710,3 +710,18 @@ class ItemTestCase(base.TestCase):
         resp = self.request(path='/item/%s/download' % item['_id'],
                             cookie='girderToken=invalid_token')
         self.assertStatus(resp, 401)
+
+    def testGetLicenses(self):
+        """
+        Test getting list of licenses.
+        """
+        resp = self.request(path='/item/licenses')
+        self.assertStatusOk(resp)
+        self.assertGreater(len(resp.json), 0)
+        self.assertIn('category', resp.json[0])
+        self.assertIn('licenses', resp.json[0])
+        self.assertGreater(len(resp.json[0]['licenses']), 1)
+        self.assertIn('name', resp.json[0]['licenses'][0])
+        self.assertGreater(len(resp.json[0]['licenses'][0]['name']), 0)
+        self.assertIn('name', resp.json[0]['licenses'][1])
+        self.assertGreater(len(resp.json[0]['licenses'][1]['name']), 0)


### PR DESCRIPTION
Items gain a 'license' field.

In the web client, users can select a license from a dropdown when uploading an item, creating an item, or editing an item.

The list of licenses is a site-wide setting. The default licenses include the some of the "popular" open source licenses listed on https://opensource.org/licenses/category, the Creative Commons licenses listed on http://creativecommons.org/licenses/, as well as CC0, Public Domain, and All Rights Reserved.

Fixes #1320 