### PR TITLE
Fix some CTest issues

### DIFF
--- a/devops/ansible/playbook.yml
+++ b/devops/ansible/playbook.yml
@@ -28,6 +28,27 @@
       - zlib1g-dev
       - python-pip
 
+  - name: Python | Add Python Updates PPA key
+    apt_key:
+      id: "DB82666C"
+      keyserver: "keyserver.ubuntu.com"
+    become: yes
+
+  - name: Python | Add Python Updates PPA
+    apt_repository:
+      repo: "deb http://ppa.launchpad.net/fkrull/deadsnakes-python2.7/ubuntu {{ ansible_distribution_release }} main"
+    become: yes
+
+  # Packaged Girder cannot be built with Python<2.7.9 on VirtualBox's filesystem (Python Issue #8876)
+  - name: Python | Install updated Python
+    apt:
+      name: "{{ item }}"
+      state: latest
+    become: yes
+    with_items:
+      - python2.7
+      - python2.7-dev
+
   - name: MongoDB | Add PPA key
     apt_key:
       id: "EA312927"

--- a/tests/JavascriptTests.cmake
+++ b/tests/JavascriptTests.cmake
@@ -41,6 +41,10 @@ function(add_eslint_test name input)
     return()
   endif()
 
+  if (NOT ESLINT_EXECUTABLE)
+    message(FATAL_ERROR "CMake variable ESLINT_EXECUTABLE is not set. Run 'npm install' or disable BUILD_JAVASCRIPT_TESTS.")
+  endif()
+
   set(_args ESLINT_IGNORE_FILE ESLINT_CONFIG_FILE)
   cmake_parse_arguments(fn "${_options}" "${_args}" "${_multival_args}" ${ARGN})
 

--- a/tests/mock_smtp.py
+++ b/tests/mock_smtp.py
@@ -21,6 +21,7 @@ import asyncore
 import email
 import os
 import smtpd
+import sys
 import threading
 import time
 
@@ -32,6 +33,16 @@ _maxTries = 100
 
 class MockSmtpServer(smtpd.SMTPServer):
     mailQueue = queue.Queue()
+
+    def __init__(self, localaddr, remoteaddr, decode_data=False):
+        kwargs = {}
+        if sys.version_info >= (3, 5):
+            # Python 3.5+ prints a warning if 'decode_data' isn't explicitly
+            # specified, but earlier versions don't accept the argument at all
+            kwargs['decode_data'] = decode_data
+        # smtpd.SMTPServer is an old-style class in Python2,
+        # so super() can't be used
+        smtpd.SMTPServer.__init__(self, localaddr, remoteaddr, **kwargs)
 
     def process_message(self, peer, mailfrom, rcpttos, data):
         self.mailQueue.put(data)


### PR DESCRIPTION
* Make CTest fail gracefully if eslint is not available
* Provision Vagrant with Python 2.7.11
 * This fixes an issue where the Girder package fails to build on Virtualbox.
* Silence a test output warning in Python 3.5
 * The "decode_data" parameter to SMTPServer should be explicitly provided
in Python 3.5+.

Fixes #1336 