### PR TITLE
Add a button to enable wrapping of item previews

### DIFF
--- a/plugins/item_previews/web_client/js/item_previews.js
+++ b/plugins/item_previews/web_client/js/item_previews.js
@@ -9,6 +9,15 @@ girder.views.ItemPreviewWidget = girder.View.extend({
         'click a.g-item-preview-link': function (event) {
             var id = this.$(event.currentTarget).data('id');
             this.parentView.itemListView.trigger('g:itemClicked', this.collection.get(id));
+        },
+        'click .g-widget-item-previews-wrap': function (event) {
+            this.wrapPreviews = !this.wrapPreviews;
+            this.render();
+            if (this.wrapPreviews) {
+                this.$('.g-widget-item-previews-container')[0].style.whiteSpace = 'normal';
+            } else {
+                this.$('.g-widget-item-previews-container')[0].style.whiteSpace = 'nowrap';
+            }
         }
     },
 
@@ -21,6 +30,8 @@ girder.views.ItemPreviewWidget = girder.View.extend({
         }, this).fetch({
             folderId: settings.folderId
         });
+
+        this.wrapPreviews = false;
     },
 
     _MAX_JSON_SIZE: 2e6 /* bytes */,
@@ -44,6 +55,7 @@ girder.views.ItemPreviewWidget = girder.View.extend({
 
         view.$el.html(girder.templates.itemPreviews({
             items: supportedItems,
+            wrapPreviews: view.wrapPreviews,
             hasMore: this.collection.hasNextPage(),
             isImageItem: this._isImageItem,
             isJSONItem: this._isJSONItem,
@@ -70,6 +82,13 @@ girder.views.ItemPreviewWidget = girder.View.extend({
             }).error(function (err) {
                 console.error('Could not preview item', err);
             });
+        });
+
+        this.$('.g-widget-item-previews-wrap').tooltip({
+            container: this.$el,
+            placement: 'left',
+            animation: false,
+            delay: {show: 100}
         });
 
         return this;

--- a/plugins/item_previews/web_client/js/item_previews.js
+++ b/plugins/item_previews/web_client/js/item_previews.js
@@ -14,9 +14,9 @@ girder.views.ItemPreviewWidget = girder.View.extend({
             this.wrapPreviews = !this.wrapPreviews;
             this.render();
             if (this.wrapPreviews) {
-                this.$('.g-widget-item-previews-container')[0].style.whiteSpace = 'normal';
+                this.$('.g-widget-item-previews-container').addClass('g-wrap');
             } else {
-                this.$('.g-widget-item-previews-container')[0].style.whiteSpace = 'nowrap';
+                this.$('.g-widget-item-previews-container').removeClass('g-wrap');
             }
         }
     },

--- a/plugins/item_previews/web_client/stylesheets/item_previews.styl
+++ b/plugins/item_previews/web_client/stylesheets/item_previews.styl
@@ -1,5 +1,11 @@
 $maxPreviewHeight = 400px
 
+.g-widget-item-previews-wrap
+  font-size 12x
+  float right
+  margin-right 4px
+  padding 2px 3px
+
 .g-widget-item-previews-header
   background-color #f0f0f0
   color #555

--- a/plugins/item_previews/web_client/stylesheets/item_previews.styl
+++ b/plugins/item_previews/web_client/stylesheets/item_previews.styl
@@ -19,6 +19,8 @@ $maxPreviewHeight = 400px
   max-height $maxPreviewHeight
   overflow-x auto
   white-space nowrap
+  &.g-wrap
+    white-space normal
 
 .g-widget-item-preview
   display inline

--- a/plugins/item_previews/web_client/templates/itemPreviews.jade
+++ b/plugins/item_previews/web_client/templates/itemPreviews.jade
@@ -1,6 +1,12 @@
 .g-widget-item-previews-header
   i.icon-eye
   |  Item Previews
+  .btn-group.pull-right
+    button.g-widget-item-previews-wrap.btn.btn-sm.btn-primary.btn-default(title="Wrap Previews")
+      if (wrapPreviews)
+        i.icon-left
+      else
+        i.icon-down
 
 .g-widget-item-previews-container
 


### PR DESCRIPTION
Allows to switch between a horizontal and a vertical scrolling for the item preview. An example can be found [here](https://hub.yt/girder/#collection/573df8329a6bd20001508d26/folder/573df83c9a6bd20001508d27)