### PR TITLE
Update jade to version 1.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "grunt-fontello": "~0.3.1",
     "grunt-npm-install": "~0.2.0",
     "remarkable": "1.6.2",
-    "jade": "1.3.1",
+    "jade": "1.11.0",
     "jquery": "2.1.1",
     "sprintf-js": "1.0.2",
     "swagger-ui": "2.0.22",


### PR DESCRIPTION
Needed to work with webpack's `jade-loader` which requires >= 1.7.