### PR TITLE
Upgrade CherryPy, fixing a Python3 incompatibility

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ httmock==1.2.5
 mock==2.0.0
 # Versions >0.4.0 of moto cause test failures
 moto==0.4.0
-Sphinx==1.4.2
+Sphinx==1.4.3
 sphinx_rtd_theme==0.1.9
 virtualenv==15.0.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,7 @@
 bcrypt==2.0.0
 boto==2.40.0
 cffi==1.6.0
-# Version 5.4.0 of CherryPy contains a bug with Python 3
-CherryPy==5.3.0
+CherryPy==6.0.1
 Mako==1.0.4
 pymongo==3.2.2
 PyYAML==3.11

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ with open('package.json') as f:
 install_reqs = [
     'bcrypt',
     'boto',
-    'CherryPy<5.4.0',
+    'CherryPy',
     'Mako',
     'pymongo>=3',
     'PyYAML',


### PR DESCRIPTION
* Upgrade CherryPy to 6.0.1
 * CherryPy changes at: https://github.com/cherrypy/cherrypy/blob/master/CHANGES.txt
 * This resolves an bug with Python3 and CherryPy 5.4.0: cherrypy/cherrypy@0d48639
 * Closes #1362
* Upgrade Girder development package requirements
 * Sphinx changes at: http://www.sphinx-doc.org/en/stable/changes.htm