### PR TITLE
Add Homepage Markdown Plugin

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -89,6 +89,7 @@ Python package, which may be installed using **pip**: ::
 
 Once the package is installed, the plugin may be enabled via the admin console.
 
+
 Google Analytics
 ----------------
 
@@ -100,6 +101,15 @@ it does not technically trigger routing events for hierarchy navigation).
 
 To use this plugin, simply copy your tracking ID from Google Analytics into the
 plugin configuration page.
+
+
+Homepage
+--------
+
+The Homepage plugin allows the default Girder front page to be replaced by
+content written in [Markdown](https://daringfireball.net/projects/markdown/)
+format. After enabling this plugin, visit the plugin configuration page
+to edit and preview the Markdown.
 
 
 Metadata Extractor

--- a/plugins/.gitignore
+++ b/plugins/.gitignore
@@ -6,6 +6,7 @@
 !gravatar/
 !hashsum_download/
 !hdfs_assetstore/
+!homepage/
 !item_previews/
 !jobs/
 !jquery_widgets/

--- a/plugins/homepage/plugin.cmake
+++ b/plugins/homepage/plugin.cmake
@@ -1,0 +1,10 @@
+add_python_test(homepage PLUGIN homepage)
+
+add_python_style_test(python_static_analysis_homepage
+    "${PROJECT_SOURCE_DIR}/plugins/homepage/server")
+
+add_python_style_test(python_static_analysis_homepage_tests
+    "${PROJECT_SOURCE_DIR}/plugins/homepage/plugin_tests")
+
+add_eslint_test(homepage
+    "${PROJECT_SOURCE_DIR}/plugins/homepage/web_client/js/src")

--- a/plugins/homepage/plugin.cmake
+++ b/plugins/homepage/plugin.cmake
@@ -7,4 +7,4 @@ add_python_style_test(python_static_analysis_homepage_tests
     "${PROJECT_SOURCE_DIR}/plugins/homepage/plugin_tests")
 
 add_eslint_test(homepage
-    "${PROJECT_SOURCE_DIR}/plugins/homepage/web_client/js/src")
+    "${PROJECT_SOURCE_DIR}/plugins/homepage/web_client/js")

--- a/plugins/homepage/plugin.json
+++ b/plugins/homepage/plugin.json
@@ -1,0 +1,5 @@
+{
+    "name": "Homepage",
+    "description": "Customize the homepage using Markdown.",
+    "version": "1.0.0"
+}

--- a/plugins/homepage/plugin_tests/homepage_test.py
+++ b/plugins/homepage/plugin_tests/homepage_test.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright 2014 Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+from tests import base
+
+
+def setUpModule():
+    base.enabledPlugins.append('homepage')
+    base.startServer()
+
+
+def tearDownModule():
+    base.stopServer()
+
+
+class HomepageTest(base.TestCase):
+
+    def testGetMarkdown(self):
+        key = 'homepage.markdown'
+
+        # test without set
+        resp = self.request('/homepage/markdown')
+        self.assertStatusOk(resp)
+        self.assertIs(resp.json[key], None)
+
+        # set markdown
+        self.model('setting').set(key, 'foo')
+
+        # verify we can get the markdown without being authenticated
+        resp = self.request('/homepage/markdown')
+        self.assertStatusOk(resp)
+        self.assertEquals(resp.json[key], 'foo')

--- a/plugins/homepage/plugin_tests/homepage_test.py
+++ b/plugins/homepage/plugin_tests/homepage_test.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 ###############################################################################
-#  Copyright 2014 Kitware Inc.
+#  Copyright 2016 Kitware Inc.
 #
 #  Licensed under the Apache License, Version 2.0 ( the "License" );
 #  you may not use this file except in compliance with the License.

--- a/plugins/homepage/server/__init__.py
+++ b/plugins/homepage/server/__init__.py
@@ -18,14 +18,30 @@
 ###############################################################################
 
 from girder import events
+from girder.api import access
+from girder.api.describe import Description, describeRoute
+from girder.api.rest import Resource
 
+KEY = 'homepage.markdown'
+
+class Homepage(Resource):
+    def __init__(self):
+        super(Homepage, self).__init__()
+        self.resourceName = 'homepage'
+        self.route('GET', ('markdown',), self.getMarkdown)
+
+    @access.public
+    @describeRoute(
+        Description('Public url for getting the homepage markdown.')
+    )
+    def getMarkdown(self, params):
+        return {KEY: self.model('setting').get(KEY)}
 
 def validateSettings(event):
     key, val = event.info['key'], event.info['value']
-    if key == 'homepage.markdown':
+    if key == KEY:
         event.preventDefault().stopPropagation()
-
 
 def load(info):
     events.bind('model.setting.validate', 'homepage', validateSettings)
-    # info['apiRoot'].homepage = rest.GoogleAnalytics()
+    info['apiRoot'].homepage = Homepage()

--- a/plugins/homepage/server/__init__.py
+++ b/plugins/homepage/server/__init__.py
@@ -24,6 +24,7 @@ from girder.api.rest import Resource
 
 KEY = 'homepage.markdown'
 
+
 class Homepage(Resource):
     def __init__(self):
         super(Homepage, self).__init__()
@@ -37,10 +38,11 @@ class Homepage(Resource):
     def getMarkdown(self, params):
         return {KEY: self.model('setting').get(KEY)}
 
+
 def validateSettings(event):
-    key, val = event.info['key'], event.info['value']
-    if key == KEY:
+    if event.info['key'] == KEY:
         event.preventDefault().stopPropagation()
+
 
 def load(info):
     events.bind('model.setting.validate', 'homepage', validateSettings)

--- a/plugins/homepage/server/__init__.py
+++ b/plugins/homepage/server/__init__.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+from girder import events
+
+
+def validateSettings(event):
+    key, val = event.info['key'], event.info['value']
+    if key == 'homepage.markdown':
+        event.preventDefault().stopPropagation()
+
+
+def load(info):
+    events.bind('model.setting.validate', 'homepage', validateSettings)
+    # info['apiRoot'].homepage = rest.GoogleAnalytics()

--- a/plugins/homepage/server/__init__.py
+++ b/plugins/homepage/server/__init__.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 ###############################################################################
-#  Copyright Kitware Inc.
+#  Copyright 2016 Kitware Inc.
 #
 #  Licensed under the Apache License, Version 2.0 ( the "License" );
 #  you may not use this file except in compliance with the License.

--- a/plugins/homepage/web_client/js/ConfigView.js
+++ b/plugins/homepage/web_client/js/ConfigView.js
@@ -1,0 +1,81 @@
+/**
+ * Administrative configuration view to configure the homepage markdown.
+ */
+girder.views.homepage_ConfigView = girder.View.extend({
+    events: {
+        'submit #g-homepage-form': function (event) {
+            event.preventDefault();
+            this._saveSettings([{
+                key: 'homepage.markdown',
+                value: this.editor.val()
+            }]);
+        }
+    },
+
+    initialize: function () {
+        this.editor = new girder.views.MarkdownWidget({
+            text: '',
+            prefix: 'homepage',
+            placeholder: 'Enter Markdown for the homepage',
+            allowedExtensions: ['png', 'jpg', 'jpeg', 'gif'],
+            enableUploads: false,
+            parentView: this
+        }).on('g:fileUploaded', function (args) {
+            // this.trigger('g:fileUploaded', args);
+        }, this);
+
+        girder.restRequest({
+            type: 'GET',
+            path: 'system/setting',
+            data: {
+                list: JSON.stringify(['homepage.markdown'])
+            }
+        }).done(_.bind(function (resp) {
+            this.render();
+            this.editor.val(resp['homepage.markdown']);
+        }, this));
+    },
+
+    render: function () {
+        this.$el.html(girder.templates.homepage_config());
+
+        this.editor.setElement(
+            this.$('.g-homepage-container')).render();
+
+        if (!this.breadcrumb) {
+            this.breadcrumb = new girder.views.PluginConfigBreadcrumbWidget({
+                pluginName: 'Homepage',
+                el: this.$('.g-config-breadcrumb-container'),
+                parentView: this
+            }).render();
+        }
+
+        return this;
+    },
+
+    _saveSettings: function (settings) {
+        girder.restRequest({
+            type: 'PUT',
+            path: 'system/setting',
+            data: {
+                list: JSON.stringify(settings)
+            },
+            error: null
+        }).done(_.bind(function () {
+            girder.events.trigger('g:alert', {
+                icon: 'ok',
+                text: 'Settings saved.',
+                type: 'success',
+                timeout: 4000
+            });
+        }, this)).error(_.bind(function (resp) {
+            this.$('#g-homepage-error-message').text(
+                resp.responseJSON.message
+            );
+        }, this));
+    }
+});
+
+girder.router.route('plugins/homepage/config', 'homepageConfig', function () {
+    girder.events.trigger('g:navigateTo', girder.views.homepage_ConfigView);
+});

--- a/plugins/homepage/web_client/js/ConfigView.js
+++ b/plugins/homepage/web_client/js/ConfigView.js
@@ -14,15 +14,11 @@ girder.views.homepage_ConfigView = girder.View.extend({
 
     initialize: function () {
         this.editor = new girder.views.MarkdownWidget({
-            text: '',
             prefix: 'homepage',
             placeholder: 'Enter Markdown for the homepage',
-            allowedExtensions: ['png', 'jpg', 'jpeg', 'gif'],
             enableUploads: false,
             parentView: this
-        }).on('g:fileUploaded', function (args) {
-            // this.trigger('g:fileUploaded', args);
-        }, this);
+        });
 
         girder.restRequest({
             type: 'GET',

--- a/plugins/homepage/web_client/js/setup.js
+++ b/plugins/homepage/web_client/js/setup.js
@@ -3,10 +3,7 @@ girder.exposePluginConfig('homepage', 'plugins/homepage/config');
 girder.wrap(girder.views.FrontPageView, 'render', function (render) {
     girder.restRequest({
         type: 'GET',
-        path: 'system/setting',
-        data: {
-            list: JSON.stringify(['homepage.markdown'])
-        }
+        path: 'homepage/markdown'
     }).done(_.bind(function (resp) {
         this.$el.html(girder.renderMarkdown(resp['homepage.markdown']));
     }, this));

--- a/plugins/homepage/web_client/js/setup.js
+++ b/plugins/homepage/web_client/js/setup.js
@@ -1,0 +1,15 @@
+girder.exposePluginConfig('homepage', 'plugins/homepage/config');
+
+girder.wrap(girder.views.FrontPageView, 'render', function (render) {
+    girder.restRequest({
+        type: 'GET',
+        path: 'system/setting',
+        data: {
+            list: JSON.stringify(['homepage.markdown'])
+        }
+    }).done(_.bind(function (resp) {
+        this.$el.html(girder.renderMarkdown(resp['homepage.markdown']));
+    }, this));
+
+    return this;
+});

--- a/plugins/homepage/web_client/stylesheets/config.styl
+++ b/plugins/homepage/web_client/stylesheets/config.styl
@@ -1,0 +1,2 @@
+.g-homepage-container
+  margin-bottom 10px

--- a/plugins/homepage/web_client/templates/homepage_config.jade
+++ b/plugins/homepage/web_client/templates/homepage_config.jade
@@ -1,0 +1,11 @@
+.g-config-breadcrumb-container
+
+p.g-homepage-description
+  | To configure the homepage content, enter Markdown here.
+
+.g-homepage-container
+
+p#g-homepage-error-message.g-validation-failed-message
+
+form#g-homepage-form(role="form")
+  input.btn.btn-sm.btn-primary(type="submit", value="Save")


### PR DESCRIPTION
@zachmullen @mgrauer 

This plugin allows an admin to replace the girder homepage with markdown-formatted content. Currently, image uploads are not handled in the markdown editor.
