### PR TITLE
Show collection public / private icon in list

### DIFF
--- a/clients/web/src/templates/body/collectionList.jade
+++ b/clients/web/src/templates/body/collectionList.jade
@@ -12,6 +12,13 @@
 each collection in collections
   .g-collection-list-entry
     .g-collection-right-column
+      .g-folder-privacy
+        if collection.get('public')
+          i.icon-globe
+          | Public
+        else
+          i.icon-lock
+          | Private
       .g-collection-created
         i.icon-clock
         | Created on


### PR DESCRIPTION
@zachmullen @mgrauer 

The hierarchyWidget shows public / private status on folders and such, but the collectionList didn't show it. So I added it:

<img width="882" alt="screen shot 2016-06-09 at 12 56 03 pm" src="https://cloud.githubusercontent.com/assets/520208/15938635/f364c7c4-2e41-11e6-9d08-17bd5c3f1596.png">
