### PR TITLE
Fixed boundHandler so it works without arguments

### DIFF
--- a/tests/cases/rest_decorator_test.py
+++ b/tests/cases/rest_decorator_test.py
@@ -70,6 +70,13 @@ class TestEndpointDecoratorException(base.TestCase):
         self.assertEqual(obj['type'], 'internal')
 
     def testBoundHandlerDecorator(self):
+
+        resp = self.request('/collection/unbound/default/noargs', params={
+            'val': False
+        })
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, True)
+
         resp = self.request('/collection/unbound/default', params={
             'val': False
         })

--- a/tests/test_plugins/test_plugin/server.py
+++ b/tests/test_plugins/test_plugin/server.py
@@ -26,6 +26,14 @@ from girder.utility.server import staticFile
 
 
 @access.public
+@boundHandler
+@describeRoute(None)
+def unboundHandlerDefaultNoArgs(self, params):
+    self.requireParams('val', params)
+    return not self.boolParam('val', params)
+
+
+@access.public
 @boundHandler()
 @describeRoute(None)
 def unboundHandlerDefault(self, params):
@@ -88,6 +96,8 @@ def load(info):
     info['serverRoot'].api = info['serverRoot'].girder.api
     del info['serverRoot'].girder.api
 
+    info['apiRoot'].collection.route('GET', ('unbound', 'default', 'noargs'),
+                                     unboundHandlerDefaultNoArgs)
     info['apiRoot'].collection.route('GET', ('unbound', 'default'),
                                      unboundHandlerDefault)
     info['apiRoot'].collection.route('GET', ('unbound', 'explicit'),


### PR DESCRIPTION
boundHandler decorator can be used without arguments by
saving the function passed into init and evaluating it when bound handler is
called. May want to rename ctx since it is used as an instance of
Resource or the function depending on whether boundhandler
is passed arguments.
PTAL
Fixes #1293 