### PR TITLE
Update requests for girder client

### DIFF
--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -24,7 +24,7 @@ from setuptools import setup, find_packages
 CLIENT_VERSION = '1.2.0'
 
 install_reqs = [
-    'requests',
+    'requests>=2.4.2',
     'six'
 ]
 with open('README.rst') as f:


### PR DESCRIPTION
Version 2.4.2 of requests is required for the json parameter added in #1350.