### PR TITLE
Remove erroneous EXTERNAL_DATA reference

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,7 +72,7 @@ if(RUN_CORE_TESTS)
     EXTERNAL_DATA "test_file.txt"
   )
   add_python_test(external_data_plugin
-    EXTERNAL_DATA "test_file.txt" "plugins/has_external_data/test_file.txt"
+    EXTERNAL_DATA "plugins/has_external_data/test_file.txt"
   )
   set_property(TEST server_external_data_core PROPERTY LABELS girder_devel)
   set_property(TEST server_external_data_plugin PROPERTY LABELS girder_devel)


### PR DESCRIPTION
The external_data_plugin test definition references an external data file used
only by the external_data_core test. This commit removes the erroneous
reference.