### PR TITLE
Use VIRTUAL_ENV Python executable for tests

### DIFF
--- a/tests/JavascriptTests.cmake
+++ b/tests/JavascriptTests.cmake
@@ -214,6 +214,11 @@ function(add_web_client_test case specFile)
     set(test_module "tests.web_client_test")
   endif()
 
+  set(VIRTUAL_ENV $ENV{VIRTUAL_ENV})
+  if(VIRTUAL_ENV)
+    set(PYTHON_EXECUTABLE ${VIRTUAL_ENV}/bin/python)
+  endif()
+
   add_test(
       NAME ${testname}
       WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"


### PR DESCRIPTION
Just getting started with the web client testing and it was breaking with Python imports. Turns out it was not using my virtual environment, so I made this change. It works, but not sure if it's the best approach (maybe PYTHON_EXECUTABLE shouldn't be overwritten or maybe this check should be done at some higher level, which I tried but failed at), so please review. @zachmullen @cpatrick 