### PR TITLE
Add missing superclass constructor to Cats example

### DIFF
--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -167,6 +167,7 @@ classes, and we can add it to the API in the ``load()`` method. ::
 
     class Cat(Resource):
         def __init__(self):
+            super(Cat, self).__init__()
             self.resourceName = 'cat'
 
             self.route('GET', (), self.findCat)


### PR DESCRIPTION
If someone bases their plugin on Cats example he/she is greeted by:
` WARNING: Resource subclass "Cats" did not call "Resource__init__()" from its constructor.`
when starting girder.