### PR TITLE
[RFC] Allow to call a custom function while iterating over files in a folder

### DIFF
--- a/girder/models/collection.py
+++ b/girder/models/collection.py
@@ -147,9 +147,14 @@ class Collection(AccessControlledModel):
         return self.save(collection)
 
     def fileList(self, doc, user=None, path='', includeMetadata=False,
-                 subpath=True, mimeFilter=None, stream=True):
+                 subpath=True, mimeFilter=None, data=True):
         """
-        Generate a list of files within this collection's folders.
+        This function generates a list of 2-tuples whose first element is the
+        relative path to the file from the collection's root and whose second
+        element depends on the value of the `data` flag. If `data=True`, the
+        second element will be a generator that will generate the bytes of the
+        file data as stored in the assetstore. If `data=False`, the second
+        element is the file document itself.
 
         :param doc: the collection to list.
         :param user: a user used to validate data that is returned.
@@ -163,9 +168,9 @@ class Collection(AccessControlledModel):
         :param mimeFilter: Optional list of MIME types to filter by. Set to
             None to include all files.
         :type mimeFilter: list or tuple
-        :param stream: Return stream function with file data or file model
-            object if False
-        :type stream: bool
+        :param data: If True return raw content of each file as stored in the
+            assetstore, otherwise return file document.
+        :type data: bool
         """
         if subpath:
             path = os.path.join(path, doc['name'])
@@ -174,7 +179,7 @@ class Collection(AccessControlledModel):
                                                         parent=doc, user=user):
             for (filepath, file) in self.model('folder').fileList(
                     folder, user, path, includeMetadata, subpath=True,
-                    mimeFilter=mimeFilter, stream=stream):
+                    mimeFilter=mimeFilter, data=data):
                 yield (filepath, file)
 
     def subtreeCount(self, doc, includeItems=True, user=None, level=None):

--- a/girder/models/collection.py
+++ b/girder/models/collection.py
@@ -147,7 +147,7 @@ class Collection(AccessControlledModel):
         return self.save(collection)
 
     def fileList(self, doc, user=None, path='', includeMetadata=False,
-                 subpath=True, mimeFilter=None):
+                 subpath=True, mimeFilter=None, stream=True):
         """
         Generate a list of files within this collection's folders.
 
@@ -163,6 +163,9 @@ class Collection(AccessControlledModel):
         :param mimeFilter: Optional list of MIME types to filter by. Set to
             None to include all files.
         :type mimeFilter: list or tuple
+        :param stream: Return stream function with file data or file model
+            object if False
+        :type stream: bool
         """
         if subpath:
             path = os.path.join(path, doc['name'])
@@ -171,7 +174,7 @@ class Collection(AccessControlledModel):
                                                         parent=doc, user=user):
             for (filepath, file) in self.model('folder').fileList(
                     folder, user, path, includeMetadata, subpath=True,
-                    mimeFilter=mimeFilter):
+                    mimeFilter=mimeFilter, stream=stream):
                 yield (filepath, file)
 
     def subtreeCount(self, doc, includeItems=True, user=None, level=None):

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -658,17 +658,17 @@ class Folder(AccessControlledModel):
                                      user=user):
             if sub['name'] == metadataFile:
                 metadataFile = None
-            for (filepath, func) in self.fileList(
+            for (filepath, file) in self.fileList(
                     sub, user, path, includeMetadata, subpath=True,
                     mimeFilter=mimeFilter, stream=stream):
-                yield (filepath, func)
+                yield (filepath, file)
         for item in self.childItems(folder=doc):
             if item['name'] == metadataFile:
                 metadataFile = None
-            for (filepath, func) in self.model('item').fileList(
+            for (filepath, file) in self.model('item').fileList(
                     item, user, path, includeMetadata, mimeFilter=mimeFilter,
                     stream=stream):
-                yield (filepath, func)
+                yield (filepath, file)
         if includeMetadata and metadataFile and doc.get('meta', {}):
             def stream():
                 yield json.dumps(doc['meta'], default=str)

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -624,9 +624,14 @@ class Folder(AccessControlledModel):
         return count
 
     def fileList(self, doc, user=None, path='', includeMetadata=False,
-                 subpath=True, mimeFilter=None, stream=True):
+                 subpath=True, mimeFilter=None, data=True):
         """
-        Generate a list of files within this folder.
+        This function generates a list of 2-tuples whose first element is the
+        relative path to the file from the folder's root and whose second
+        element depends on the value of the `data` flag. If `data=True`, the
+        second element will be a generator that will generate the bytes of the
+        file data as stored in the assetstore. If `data=False`, the second
+        element is the file document itself.
 
         :param doc: The folder to list.
         :param user: The user used for access.
@@ -643,12 +648,12 @@ class Folder(AccessControlledModel):
         :param mimeFilter: Optional list of MIME types to filter by. Set to
             None to include all files.
         :type mimeFilter: list or tuple
-        :param stream: Return stream function with file data or file model
-            object if False
-        :type stream: bool
+        :param data: If True return raw content of each file as stored in the
+            assetstore, otherwise return file document.
+        :type data: bool
         :returns: Iterable over files in this folder, where each element is a
                   tuple of (path name of the file, stream function with file
-                  data).
+                  data or file object).
         :rtype: generator(str, func)
         """
         if subpath:
@@ -660,14 +665,14 @@ class Folder(AccessControlledModel):
                 metadataFile = None
             for (filepath, file) in self.fileList(
                     sub, user, path, includeMetadata, subpath=True,
-                    mimeFilter=mimeFilter, stream=stream):
+                    mimeFilter=mimeFilter, data=data):
                 yield (filepath, file)
         for item in self.childItems(folder=doc):
             if item['name'] == metadataFile:
                 metadataFile = None
             for (filepath, file) in self.model('item').fileList(
                     item, user, path, includeMetadata, mimeFilter=mimeFilter,
-                    stream=stream):
+                    data=data):
                 yield (filepath, file)
         if includeMetadata and metadataFile and doc.get('meta', {}):
             def stream():

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -624,7 +624,7 @@ class Folder(AccessControlledModel):
         return count
 
     def fileList(self, doc, user=None, path='', includeMetadata=False,
-                 subpath=True, mimeFilter=None, streamCallback=None):
+                 subpath=True, mimeFilter=None, stream=True):
         """
         Generate a list of files within this folder.
 
@@ -643,9 +643,9 @@ class Folder(AccessControlledModel):
         :param mimeFilter: Optional list of MIME types to filter by. Set to
             None to include all files.
         :type mimeFilter: list or tuple
-        :param streamCallback: Optional function with args and kwargs that
-            will be called for each file instead of streaming raw data.
-        :type streamCallback: tuple
+        :param stream: Return stream function with file data or file model
+            object if False
+        :type stream: bool
         :returns: Iterable over files in this folder, where each element is a
                   tuple of (path name of the file, stream function with file
                   data).
@@ -660,14 +660,14 @@ class Folder(AccessControlledModel):
                 metadataFile = None
             for (filepath, func) in self.fileList(
                     sub, user, path, includeMetadata, subpath=True,
-                    mimeFilter=mimeFilter, streamCallback=streamCallback):
+                    mimeFilter=mimeFilter, stream=stream):
                 yield (filepath, func)
         for item in self.childItems(folder=doc):
             if item['name'] == metadataFile:
                 metadataFile = None
             for (filepath, func) in self.model('item').fileList(
                     item, user, path, includeMetadata, mimeFilter=mimeFilter,
-                    streamCallback=streamCallback):
+                    stream=stream):
                 yield (filepath, func)
         if includeMetadata and metadataFile and doc.get('meta', {}):
             def stream():

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -22,6 +22,7 @@ import datetime
 import json
 import os
 import six
+import functools
 
 from bson.objectid import ObjectId
 from .model_base import Model, ValidationException, GirderException
@@ -396,7 +397,7 @@ class Item(acl_mixin.AccessControlMixin, Model):
         return newItem
 
     def fileList(self, doc, user=None, path='', includeMetadata=False,
-                 subpath=True, mimeFilter=None, streamCallback=None):
+                 subpath=True, mimeFilter=None, stream=True):
         """
         Generate a list of files within this item.
 
@@ -419,12 +420,12 @@ class Item(acl_mixin.AccessControlMixin, Model):
         :param mimeFilter: Optional list of MIME types to filter by. Set to
             None to include all files.
         :type mimeFilter: list or tuple
-        :param streamCallback: Optional function with args and kwargs that
-            will be called for each file instead of streaming raw data.
-        :type streamCallback: tuple
+        :param stream: Return stream function with file data or file model
+            object if False
+        :type stream: bool
         :returns: Iterable over files in this item, where each element is a
                   tuple of (path name of the file, stream function with file
-                  data).
+                  data or file object).
         :rtype: generator(str, func)
         """
         if subpath:
@@ -434,22 +435,19 @@ class Item(acl_mixin.AccessControlMixin, Model):
                 path = os.path.join(path, doc['name'])
         metadataFile = 'girder-item-metadata.json'
 
-        try:
-            streamCallbackFunc, streamCallbackArgs, streamCallbackKwargs = \
-                streamCallback
-        except (TypeError, ValueError):
-            streamCallbackFunc = self.model('file').download
-            streamCallbackArgs = []
-            streamCallbackKwargs = {'headers': False}
+        if stream:
+            returnFunc = functools.partial(self.model('file').download,
+                                           headers=False)
+        else:
+            def returnFunc(item):
+                return item
 
         for file in self.childFiles(item=doc):
             if not self._mimeFilter(file, mimeFilter):
                 continue
             if file['name'] == metadataFile:
                 metadataFile = None
-            yield (os.path.join(path, file['name']),
-                   streamCallbackFunc(file, *streamCallbackArgs,
-                                      **streamCallbackKwargs))
+            yield (os.path.join(path, file['name']), returnFunc(file))
         if includeMetadata and metadataFile and len(doc.get('meta', {})):
             def stream():
                 yield json.dumps(doc['meta'], default=str)

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -396,9 +396,14 @@ class Item(acl_mixin.AccessControlMixin, Model):
         return newItem
 
     def fileList(self, doc, user=None, path='', includeMetadata=False,
-                 subpath=True, mimeFilter=None, stream=True):
+                 subpath=True, mimeFilter=None, data=True):
         """
-        Generate a list of files within this item.
+        This function generates a list of 2-tuples whose first element is the
+        relative path to the file from the item's root and whose second
+        element depends on the value of the `data` flag. If `data=True`, the
+        second element will be a generator that will generate the bytes of the
+        file data as stored in the assetstore. If `data=False`, the second
+        element will be the file document itself.
 
         :param doc: The item to list.
         :param user: A user used to validate data that is returned.  This isn't
@@ -419,9 +424,9 @@ class Item(acl_mixin.AccessControlMixin, Model):
         :param mimeFilter: Optional list of MIME types to filter by. Set to
             None to include all files.
         :type mimeFilter: list or tuple
-        :param stream: Return stream function with file data or file model
-            object if False
-        :type stream: bool
+        :param data: If True return raw content of each file as stored in the
+            assetstore, otherwise return file document.
+        :type data: bool
         :returns: Iterable over files in this item, where each element is a
                   tuple of (path name of the file, stream function with file
                   data or file object).
@@ -439,7 +444,7 @@ class Item(acl_mixin.AccessControlMixin, Model):
                 continue
             if file['name'] == metadataFile:
                 metadataFile = None
-            if stream:
+            if data:
                 val = self.model('file').download(file, headers=False)
             else:
                 val = file

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -278,9 +278,14 @@ class User(AccessControlledModel):
                 privateFolder, user, AccessType.ADMIN, save=True)
 
     def fileList(self, doc, user=None, path='', includeMetadata=False,
-                 subpath=True, stream=True):
+                 subpath=True, data=True):
         """
-        Generate a list of files within this user's folders.
+        This function generates a list of 2-tuples whose first element is the
+        relative path to the file from the user's folders root and whose second
+        element depends on the value of the `data` flag. If `data=True`, the
+        second element will be a generator that will generate the bytes of the
+        file data as stored in the assetstore. If `data=False`, the second
+        element is the file document itself.
 
         :param doc: the user to list.
         :param user: a user used to validate data that is returned.
@@ -291,9 +296,9 @@ class User(AccessControlledModel):
                                 metadata[-(number).json that is distinct from
                                 any file within the item.
         :param subpath: if True, add the user's name to the path.
-        :param stream: Return stream function with file data or file model
-            object if False
-        :type stream: bool
+        :param data: If True return raw content of each file as stored in the
+            assetstore, otherwise return file document.
+        :type data: bool
         """
         if subpath:
             path = os.path.join(path, doc['login'])
@@ -301,7 +306,7 @@ class User(AccessControlledModel):
                                                         parent=doc, user=user):
             for (filepath, file) in self.model('folder').fileList(
                     folder, user, path, includeMetadata, subpath=True,
-                    stream=stream):
+                    data=data):
                 yield (filepath, file)
 
     def subtreeCount(self, doc, includeItems=True, user=None, level=None):

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -278,7 +278,7 @@ class User(AccessControlledModel):
                 privateFolder, user, AccessType.ADMIN, save=True)
 
     def fileList(self, doc, user=None, path='', includeMetadata=False,
-                 subpath=True):
+                 subpath=True, stream=True):
         """
         Generate a list of files within this user's folders.
 
@@ -291,13 +291,17 @@ class User(AccessControlledModel):
                                 metadata[-(number).json that is distinct from
                                 any file within the item.
         :param subpath: if True, add the user's name to the path.
+        :param stream: Return stream function with file data or file model
+            object if False
+        :type stream: bool
         """
         if subpath:
             path = os.path.join(path, doc['login'])
         for folder in self.model('folder').childFolders(parentType='user',
                                                         parent=doc, user=user):
             for (filepath, file) in self.model('folder').fileList(
-                    folder, user, path, includeMetadata, subpath=True):
+                    folder, user, path, includeMetadata, subpath=True,
+                    stream=stream):
                 yield (filepath, file)
 
     def subtreeCount(self, doc, includeItems=True, user=None, level=None):

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -341,6 +341,14 @@ class FileTestCase(base.TestCase):
             path='/file/chunk', user=self.user, fields=fields, files=files)
         self.assertStatusOk(resp)
 
+        # List files in the folder
+        testFolder = self.model('folder').load(test['_id'], force=True)
+        fileList = [(path, file['name'])
+                    for (path, file) in self.model('folder').fileList(
+                        testFolder, user=self.user,
+                        subpath=True, stream=False)]
+        self.assertEqual(fileList, [(u'Test/random.bin', u'random.bin')])
+
         # Download the folder
         resp = self.request(
             path='/folder/%s/download' % str(self.privateFolder['_id']),

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -346,7 +346,7 @@ class FileTestCase(base.TestCase):
         fileList = [(path, file['name'])
                     for (path, file) in self.model('folder').fileList(
                         testFolder, user=self.user,
-                        subpath=True, stream=False)]
+                        subpath=True, data=False)]
         self.assertEqual(fileList, [(u'Test/random.bin', u'random.bin')])
 
         # Download the folder


### PR DESCRIPTION
I'd like to iterate over files in a given Girder's folder and perform some action. Current implementation of `.fileList()` method does exactly that, yet doesn't allow to do anything except get raw data stream. With this change `fileList` becomes more flexible, e.g.:

```
@access.public(scope=TokenScope.DATA_READ)
@loadmodel(model='folder', level=AccessType.READ)
@describeRoute(
    Description('Get physical paths for files in folder.')
    .param('id', 'The ID of the folder.', paramType='path')
    .errorResponse('ID was invalid.')
    .errorResponse('Read access was denied for the folder.', 403)
)
@boundHandler()
def myHandler(self, folder, params):
    user = self.getCurrentUser()
    result = {}
    for (path, item) in self.model('folder').fileList(
            folder, user=user, subpath=True, stream=False):
        assetstore = self.model('assetstore').load(item['assetstoreId'])
        adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
        result[path] = adapter.fullPath(item)
    return result

def load(info):
    info['apiRoot'].folder.route('GET', (':id', 'contents'), myHandler)
```

allows to get mapping between Girder's filenames and physical paths in filesystem assetstore.