### PR TITLE
Email verification

### DIFF
--- a/clients/web/src/templates/body/systemConfiguration.jade
+++ b/clients/web/src/templates/body/systemConfiguration.jade
@@ -26,6 +26,10 @@ form.g-settings-form(role="form")
           selected=((settings['core.email_verification'] ||
           defaults['core.email_verification']) === "required")
           ) Required
+        option(value="optional",
+          selected=((settings['core.email_verification'] ||
+          defaults['core.email_verification']) === "optional")
+          ) Optional
         option(value="disabled",
           selected=((settings['core.email_verification'] ||
           defaults['core.email_verification']) === "disabled")

--- a/clients/web/src/templates/body/systemConfiguration.jade
+++ b/clients/web/src/templates/body/systemConfiguration.jade
@@ -20,6 +20,17 @@ form.g-settings-form(role="form")
           defaults['core.registration_policy']) === "closed")
           ) Closed registration
     .form-group
+      label(for="g-core-email-verification") Email verification
+      select#g-core-email-verification.form-control.input-sm
+        option(value="required",
+          selected=((settings['core.email_verification'] ||
+          defaults['core.email_verification']) === "required")
+          ) Required
+        option(value="disabled",
+          selected=((settings['core.email_verification'] ||
+          defaults['core.email_verification']) === "disabled")
+          ) Disabled
+    .form-group
       label(for="g-core-add-to-group-policy") Allow members to be directly added to groups
       select#g-core-add-to-group-policy.form-control.input-sm
         option(value="never",

--- a/clients/web/src/views/body/SystemConfigurationView.js
+++ b/clients/web/src/views/body/SystemConfigurationView.js
@@ -48,6 +48,7 @@ girder.views.SystemConfigurationView = girder.View.extend({
             'core.email_from_address',
             'core.email_host',
             'core.registration_policy',
+            'core.email_verification',
             'core.smtp_host',
             'core.smtp.port',
             'core.smtp.encryption',

--- a/clients/web/src/views/body/UserSettingsView.js
+++ b/clients/web/src/views/body/UserSettingsView.js
@@ -168,3 +168,21 @@ girder.router.route('useraccount/:id/token/:token', 'accountToken', function (id
         girder.router.navigate('users', {trigger: true});
     }, this));
 });
+
+girder.router.route('useraccount/:id/verify/:token', 'accountVerify', function (id, token) {
+    girder.restRequest({
+        path: 'user/verify/' + id,
+        type: 'GET',
+        data: {token: token},
+        error: null
+    }).done(_.bind(function (resp) {
+        resp.user.token = resp.authToken.token;
+        girder.eventStream.close();
+        girder.currentUser = new girder.models.UserModel(resp.user);
+        girder.eventStream.open();
+        girder.events.trigger('g:login-changed');
+        girder.events.trigger('g:navigateTo', girder.views.FrontPageView);
+    }, this)).error(_.bind(function () {
+        girder.router.navigate('users', {trigger: true});
+    }, this));
+});

--- a/clients/web/src/views/body/UserSettingsView.js
+++ b/clients/web/src/views/body/UserSettingsView.js
@@ -182,6 +182,12 @@ girder.router.route('useraccount/:id/verify/:token', 'accountVerify', function (
         girder.eventStream.open();
         girder.events.trigger('g:login-changed');
         girder.events.trigger('g:navigateTo', girder.views.FrontPageView);
+        girder.events.trigger('g:alert', {
+            icon: 'ok',
+            text: 'Email verified.',
+            type: 'success',
+            timeout: 4000
+        });
     }, this)).error(_.bind(function () {
         girder.router.navigate('users', {trigger: true});
     }, this));

--- a/clients/web/src/views/body/UserSettingsView.js
+++ b/clients/web/src/views/body/UserSettingsView.js
@@ -169,10 +169,10 @@ girder.router.route('useraccount/:id/token/:token', 'accountToken', function (id
     }, this));
 });
 
-girder.router.route('useraccount/:id/verify/:token', 'accountVerify', function (id, token) {
+girder.router.route('useraccount/:id/verification/:token', 'accountVerify', function (id, token) {
     girder.restRequest({
-        path: 'user/verify/' + id,
-        type: 'GET',
+        path: 'user/' + id + '/verification',
+        type: 'PUT',
         data: {token: token},
         error: null
     }).done(_.bind(function (resp) {

--- a/clients/web/src/views/layout/LoginView.js
+++ b/clients/web/src/views/layout/LoginView.js
@@ -29,7 +29,7 @@ girder.views.LoginView = girder.View.extend({
         'click .g-send-verification-email': function () {
             this.$('.g-validation-failed-message').html('');
             girder.restRequest({
-                path: 'user/verify',
+                path: 'user/verification',
                 type: 'PUT',
                 data: {login: this.$('#g-login').val()},
                 error: null

--- a/clients/web/src/views/layout/LoginView.js
+++ b/clients/web/src/views/layout/LoginView.js
@@ -15,10 +15,29 @@ girder.views.LoginView = girder.View.extend({
             girder.events.once('g:login.error', function (status, err) {
                 this.$('.g-validation-failed-message').text(err.responseJSON.message);
                 this.$('#g-login-button').removeClass('disabled');
+                if (err.responseJSON.extra == 'emailVerification') {
+                    var html = err.responseJSON.message +
+                        ' <a class="g-send-verification-email">Click here to send verification email.</a>';
+                    $('.g-validation-failed-message').html(html);
+                }
             }, this);
 
             this.$('#g-login-button').addClass('disabled');
             this.$('.g-validation-failed-message').text('');
+        },
+
+        'click .g-send-verification-email': function () {
+            this.$('.g-validation-failed-message').html('');
+            girder.restRequest({
+                path: 'user/verify',
+                type: 'PUT',
+                data: {login: this.$('#g-login').val()},
+                error: null
+            }).done(_.bind(function (resp) {
+                this.$('.g-validation-failed-message').html(resp.message);
+            }, this)).error(_.bind(function (err) {
+                this.$('.g-validation-failed-message').html(err.responseJSON.message);
+            }, this));
         },
 
         'click a.g-register-link': function () {

--- a/clients/web/src/views/layout/LoginView.js
+++ b/clients/web/src/views/layout/LoginView.js
@@ -15,7 +15,7 @@ girder.views.LoginView = girder.View.extend({
             girder.events.once('g:login.error', function (status, err) {
                 this.$('.g-validation-failed-message').text(err.responseJSON.message);
                 this.$('#g-login-button').removeClass('disabled');
-                if (err.responseJSON.extra == 'emailVerification') {
+                if (err.responseJSON.extra === 'emailVerification') {
                     var html = err.responseJSON.message +
                         ' <a class="g-send-verification-email">Click here to send verification email.</a>';
                     $('.g-validation-failed-message').html(html);

--- a/clients/web/src/views/layout/LoginView.js
+++ b/clients/web/src/views/layout/LoginView.js
@@ -30,7 +30,7 @@ girder.views.LoginView = girder.View.extend({
             this.$('.g-validation-failed-message').html('');
             girder.restRequest({
                 path: 'user/verification',
-                type: 'PUT',
+                type: 'POST',
                 data: {login: this.$('#g-login').val()},
                 error: null
             }).done(_.bind(function (resp) {

--- a/clients/web/src/views/layout/RegisterView.js
+++ b/clients/web/src/views/layout/RegisterView.js
@@ -30,15 +30,18 @@ girder.views.RegisterView = girder.View.extend({
                 } else {
                     var authToken = user.get('authToken') || {};
 
-                    girder.currentUser = user;
-                    girder.currentToken = authToken.token;
+                    if (authToken.token) {
+                        girder.currentUser = user;
+                        girder.currentToken = authToken.token;
 
-                    if (girder.corsAuth) {
-                        document.cookie = 'girderToken=' + girder.currentToken;
+                        if (girder.corsAuth) {
+                            document.cookie = 'girderToken=' + girder.currentToken;
+                        }
+
+                        girder.events.trigger('g:login');
                     }
 
                     girder.dialogs.handleClose('register', {replace: true});
-                    girder.events.trigger('g:login');
                 }
 
                 this.$el.modal('hide');

--- a/clients/web/src/views/layout/RegisterView.js
+++ b/clients/web/src/views/layout/RegisterView.js
@@ -39,6 +39,13 @@ girder.views.RegisterView = girder.View.extend({
                         }
 
                         girder.events.trigger('g:login');
+                    } else {
+                        girder.events.trigger('g:alert', {
+                            icon: 'ok',
+                            text: 'Check your email to verify registration.',
+                            type: 'success',
+                            timeout: 4000
+                        });
                     }
 
                     girder.dialogs.handleClose('register', {replace: true});

--- a/clients/web/test/spec/userSpec.js
+++ b/clients/web/test/spec/userSpec.js
@@ -356,3 +356,62 @@ describe('test the API key management tab', function () {
         });
     });
 });
+
+describe('test email verification', function() {
+    it('Turn on email verification', function () {
+        girderTest.logout()();
+        girderTest.login('admin', 'Admin', 'Admin', 'adminpassword!')();
+        runs(function () {
+            $("a.g-nav-link[g-target='admin']").click();
+        });
+        waitsFor(function () {
+            return $('.g-server-config').length > 0;
+        }, 'admin page to load');
+        girderTest.waitForLoad();
+        runs(function () {
+            $('.g-server-config').click();
+        });
+        waitsFor(function () {
+            return $('input#g-core-cookie-lifetime').length > 0;
+        }, 'settings page to load');
+        girderTest.waitForLoad();
+        runs(function () {
+            $('#g-core-email-verification').val('required');
+            $('.g-submit-settings').click();
+        });
+        waitsFor(function () {
+            return $('#g-alerts-container .alert-success').length > 0;
+        }, 'settings to save');
+    });
+    it('Try to login without verifying email', function() {
+        girderTest.logout()();
+        runs(function () {
+            expect(girder.currentUser).toBe(null);
+        });
+
+        waitsFor(function () {
+            return $('.g-login').length > 0;
+        }, 'Girder app to render');
+
+        girderTest.waitForLoad();
+
+        runs(function () {
+            $('.g-login').click();
+        });
+
+        girderTest.waitForDialog();
+        waitsFor(function () {
+            return $('input#g-login').length > 0;
+        }, 'register dialog to appear');
+
+        runs(function () {
+            $('#g-login').val('nonadmin');
+            $('#g-password').val('password!');
+            $('#g-login-button').click();
+        });
+
+        waitsFor(function () {
+            return $('.g-validation-failed-message:visible').length > 0;
+        }, 'email verification message to appear');
+    });
+});

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -445,6 +445,7 @@ class User(Resource):
             raise AccessException('The token is invalid or expired.')
 
         user['emailVerified'] = True
+        self.model('token').remove(token)
         authToken = self.sendAuthTokenCookie(user)
 
         return {

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -53,8 +53,8 @@ class User(Resource):
         self.route('PUT', ('password', 'temporary'),
                    self.generateTemporaryPassword)
         self.route('DELETE', ('password',), self.resetPassword)
-        self.route('GET', ('verify', ':id'), self.verifyEmail)
-        self.route('PUT', ('verify',), self.sendVerificationEmail)
+        self.route('PUT', (':id', 'verification'), self.verifyEmail)
+        self.route('PUT', ('verification',), self.sendVerificationEmail)
 
     @access.public
     @filtermodel(model='user')

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -200,10 +200,10 @@ class User(Resource):
             email=params['email'], firstName=params['firstName'],
             lastName=params['lastName'], admin=admin)
 
-        verifyEmail = self.model('setting').get(
+        emailVerificationRequired = self.model('setting').get(
             SettingKey.EMAIL_VERIFICATION) == 'required'
 
-        if currentUser is None and not verifyEmail:
+        if currentUser is None and not emailVerificationRequired:
             setattr(cherrypy.request, 'girderUser', user)
             token = self.sendAuthTokenCookie(user)
             user['authToken'] = {

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -137,6 +137,13 @@ class User(Resource):
             if not self.model('password').authenticate(user, password):
                 raise RestException('Login failed.', code=403)
 
+            if not user.get('emailVerified', False):
+                emailVerificationRequired = self.model('setting').get(
+                    SettingKey.EMAIL_VERIFICATION) == 'required'
+                if emailVerificationRequired:
+                    raise RestException(
+                        'Email verification required.', code=403)
+
             setattr(cherrypy.request, 'girderUser', user)
             token = self.sendAuthTokenCookie(user)
 

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -54,7 +54,7 @@ class User(Resource):
                    self.generateTemporaryPassword)
         self.route('DELETE', ('password',), self.resetPassword)
         self.route('PUT', (':id', 'verification'), self.verifyEmail)
-        self.route('PUT', ('verification',), self.sendVerificationEmail)
+        self.route('POST', ('verification',), self.sendVerificationEmail)
 
     @access.public
     @filtermodel(model='user')

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -200,7 +200,10 @@ class User(Resource):
             email=params['email'], firstName=params['firstName'],
             lastName=params['lastName'], admin=admin)
 
-        if currentUser is None:
+        verifyEmail = self.model('setting').get(
+            SettingKey.EMAIL_VERIFICATION) == 'required'
+
+        if currentUser is None and not verifyEmail:
             setattr(cherrypy.request, 'girderUser', user)
             token = self.sendAuthTokenCookie(user)
             user['authToken'] = {

--- a/girder/constants.py
+++ b/girder/constants.py
@@ -197,6 +197,7 @@ class TokenScope:
     ANONYMOUS_SESSION = 'core.anonymous_session'
     USER_AUTH = 'core.user_auth'
     TEMPORARY_USER_AUTH = 'core.user_auth.temporary'
+    EMAIL_VERIFICATION = 'core.email_verification'
     PLUGINS_ENABLED_READ = 'core.plugins.read'
     SETTINGS_READ = 'core.setting.read'
     ASSETSTORES_READ = 'core.assetstore.read'

--- a/girder/constants.py
+++ b/girder/constants.py
@@ -135,6 +135,7 @@ class SettingKey:
     EMAIL_FROM_ADDRESS = 'core.email_from_address'
     EMAIL_HOST = 'core.email_host'
     REGISTRATION_POLICY = 'core.registration_policy'
+    EMAIL_VERIFICATION = 'email_verification'
     SMTP_HOST = 'core.smtp_host'
     SMTP_PORT = 'core.smtp.port'
     SMTP_ENCRYPTION = 'core.smtp.encryption'
@@ -159,6 +160,7 @@ class SettingDefault:
         SettingKey.COOKIE_LIFETIME: 180,
         SettingKey.EMAIL_FROM_ADDRESS: 'Girder <no-reply@girder.org>',
         SettingKey.REGISTRATION_POLICY: 'open',
+        SettingKey.EMAIL_VERIFICATION: 'required',
         SettingKey.SMTP_HOST: 'localhost',
         SettingKey.SMTP_PORT: 25,
         SettingKey.SMTP_ENCRYPTION: 'none',

--- a/girder/constants.py
+++ b/girder/constants.py
@@ -135,7 +135,7 @@ class SettingKey:
     EMAIL_FROM_ADDRESS = 'core.email_from_address'
     EMAIL_HOST = 'core.email_host'
     REGISTRATION_POLICY = 'core.registration_policy'
-    EMAIL_VERIFICATION = 'email_verification'
+    EMAIL_VERIFICATION = 'core.email_verification'
     SMTP_HOST = 'core.smtp_host'
     SMTP_PORT = 'core.smtp.port'
     SMTP_ENCRYPTION = 'core.smtp.encryption'
@@ -160,7 +160,7 @@ class SettingDefault:
         SettingKey.COOKIE_LIFETIME: 180,
         SettingKey.EMAIL_FROM_ADDRESS: 'Girder <no-reply@girder.org>',
         SettingKey.REGISTRATION_POLICY: 'open',
-        SettingKey.EMAIL_VERIFICATION: 'required',
+        SettingKey.EMAIL_VERIFICATION: 'disabled',
         SettingKey.SMTP_HOST: 'localhost',
         SettingKey.SMTP_PORT: 25,
         SettingKey.SMTP_ENCRYPTION: 'none',

--- a/girder/mail_templates/emailVerification.mako
+++ b/girder/mail_templates/emailVerification.mako
@@ -1,0 +1,10 @@
+<%include file="_header.mako"/>
+
+<p>Please verify your email address by clicking this link:</p>
+
+<p><a href="${url}">${url}</a></p>
+
+<p>If you did not initiate this request, you can ignore this email.
+The link provided expires 24 hours after it was requested.</p>
+
+<%include file="_footer.mako"/>

--- a/girder/models/setting.py
+++ b/girder/models/setting.py
@@ -165,7 +165,7 @@ class Setting(Model):
 
     def validateCoreEmailVerification(self, doc):
         doc['value'] = doc['value'].lower()
-        if doc['value'] not in ('required', 'disabled'):
+        if doc['value'] not in ('required', 'optional', 'disabled'):
             raise ValidationException(
                 'Email verification must be either "required" or "disabled".',
                 'value')

--- a/girder/models/setting.py
+++ b/girder/models/setting.py
@@ -163,6 +163,13 @@ class Setting(Model):
                 'Registration policy must be either "open" or "closed".',
                 'value')
 
+    def validateCoreEmailVerification(self, doc):
+        doc['value'] = doc['value'].lower()
+        if doc['value'] not in ('required', 'disabled'):
+            raise ValidationException(
+                'Email verification must be either "required" or "disabled".',
+                'value')
+
     def validateCoreSmtpHost(self, doc):
         if not doc['value']:
             raise ValidationException(

--- a/girder/models/setting.py
+++ b/girder/models/setting.py
@@ -167,8 +167,8 @@ class Setting(Model):
         doc['value'] = doc['value'].lower()
         if doc['value'] not in ('required', 'optional', 'disabled'):
             raise ValidationException(
-                'Email verification must be either "required" or "disabled".',
-                'value')
+                'Email verification must be "required", "optional", or '
+                '"disabled".', 'value')
 
     def validateCoreSmtpHost(self, doc):
         if not doc['value']:

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -254,7 +254,7 @@ class User(AccessControlledModel):
     def _sendVerificationEmail(self, user):
         token = self.model('token').createToken(
             user, days=1, scope=TokenScope.EMAIL_VERIFICATION)
-        url = '%s/#useraccount/%s/verify/%s' % (
+        url = '%s/#useraccount/%s/verification/%s' % (
             mail_utils.getEmailUrlPrefix(), str(user['_id']), str(token['_id']))
         text = mail_utils.renderTemplate('emailVerification.mako', {
             'url': url

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -254,7 +254,7 @@ class User(AccessControlledModel):
     def _sendVerificationEmail(self, user):
         token = self.model('token').createToken(
             user, days=1, scope=TokenScope.EMAIL_VERIFICATION)
-        url = '%s/#useraccount/%s/token/%s' % (
+        url = '%s/#useraccount/%s/verify/%s' % (
             mail_utils.getEmailUrlPrefix(), str(user['_id']), str(token['_id']))
         text = mail_utils.renderTemplate('emailVerification.mako', {
             'url': url

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -241,6 +241,12 @@ class User(AccessControlledModel):
         self.setPassword(user, password, save=False)
         self.setPublic(user, public, save=False)
 
+        verifyEmail = self.model('setting').get(
+            SettingKey.EMAIL_VERIFICATION) == 'required'
+
+        if verifyEmail:
+            pass # send email
+
         return self.save(user)
 
     def _grantSelfAccess(self, event):

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -242,7 +242,7 @@ class User(AccessControlledModel):
         self.setPublic(user, public, save=False)
 
         verifyEmail = self.model('setting').get(
-            SettingKey.EMAIL_VERIFICATION) == 'required'
+            SettingKey.EMAIL_VERIFICATION) != 'disabled'
 
         if verifyEmail:
             pass # send email


### PR DESCRIPTION
A new core setting allows email verification to be disabled, optional or required.

If disabled, no verification email is sent.
If optional, verification email is sent but verification is not required to login.
If required, verification email is sent and verification is required to login.

This doesn't yet address the need for an admin to create an account and let the user set the password after clicking the link in the email.

We might need to add a way for a user to re-send the verification email if they can't find the original for whatever reason. Or, the forgot-password email could also set emailVerified to true.