### PR TITLE
Do not return full user document with API key token creation

### DIFF
--- a/girder/api/v1/api_key.py
+++ b/girder/api/v1/api_key.py
@@ -143,9 +143,13 @@ class ApiKey(Resource):
 
         user, token = self.model('api_key').createToken(key, days=days)
 
-        # Return the same structure as a normal user login
+        # Return the same structure as a normal user login, except do not
+        # include the full user document since the key may not authorize
+        # reading user information.
         return {
-            'user': self.model('user').filter(user, user),
+            'user': {
+                '_id': user['_id']
+            },
             'authToken': {
                 'token': token['_id'],
                 'expires': token['expires'],


### PR DESCRIPTION
ping @ronichoudhury 

I considered an alternate solution where we conditionally include the full user document only if the token has the USER_INFO_READ permission. If you'd prefer that behavior, I can change it to do that instead.