### PR TITLE
Force compliant JSON output from REST layer

### DIFF
--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -406,7 +406,7 @@ def _createResponse(val):
         elif accept.value == 'text/html':  # pragma: no cover
             # Pretty-print and HTML-ify the response for the browser
             cherrypy.response.headers['Content-Type'] = 'text/html'
-            resp = json.dumps(val, indent=4, sort_keys=True,
+            resp = json.dumps(val, indent=4, sort_keys=True, allow_nan=False,
                               separators=(',', ': '), cls=JsonEncoder)
             resp = resp.replace(' ', '&nbsp;').replace('\n', '<br />')
             resp = '<div style="font-family:monospace;">%s</div>' % resp
@@ -415,7 +415,8 @@ def _createResponse(val):
     # Default behavior will just be normal JSON output. Keep this
     # outside of the loop body in case no Accept header is passed.
     cherrypy.response.headers['Content-Type'] = 'application/json'
-    return json.dumps(val, sort_keys=True, cls=JsonEncoder).encode('utf8')
+    return json.dumps(val, sort_keys=True, allow_nan=False,
+                      cls=JsonEncoder).encode('utf8')
 
 
 def _handleRestException(e):

--- a/tests/cases/rest_util_test.py
+++ b/tests/cases/rest_util_test.py
@@ -37,6 +37,10 @@ class TestResource(object):
     def returnsDate(self, *args, **kwargs):
         return {'key': date}
 
+    @rest.endpoint
+    def returnsInf(self, *args, **kwargs):
+        return {'value': float('inf')}
+
 
 class RestUtilTestCase(unittest.TestCase):
     """
@@ -92,3 +96,8 @@ class RestUtilTestCase(unittest.TestCase):
         self.assertEqual(json.loads(resp), {
             'key': date.replace(tzinfo=pytz.UTC).isoformat()
         })
+
+        # Returning infinity or NaN floats should raise a reasonable exception
+        regex = 'Out of range float values are not JSON compliant'
+        with six.assertRaisesRegex(self, ValueError, regex):
+            resp = resource.returnsInf()


### PR DESCRIPTION
Infinity, -Infinity and NaN are valid literal tokens in
javascript, but there is no way to represent them in JSON,
so we disallow their usage and leave it up to the route
handlers themselves to determine how to encode such values.

@cpatrick PTAL