### PR TITLE
Fix /resource/search TypeError

### DIFF
--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -255,7 +255,7 @@ class Model(ModelImporter):
         return self.collection.find_one(query, projection=fields, **kwargs)
 
     def textSearch(self, query, offset=0, limit=0, sort=None, fields=None,
-                   filters=None):
+                   filters=None, **kwargs):
         """
         Perform a full-text search against the text index for this collection.
 
@@ -284,7 +284,7 @@ class Model(ModelImporter):
         return cursor
 
     def prefixSearch(self, query, offset=0, limit=0, sort=None, fields=None,
-                     filters=None, prefixSearchFields=None):
+                     filters=None, prefixSearchFields=None, **kwargs):
         """
         Search for documents in this model's collection by a prefix string.
         The fields that will be searched based on this prefix must be set as

--- a/tests/cases/search_test.py
+++ b/tests/cases/search_test.py
@@ -19,7 +19,10 @@
 
 from .. import base
 
+from girder.api.v1 import resource
 from girder.constants import AccessType
+from girder.models.model_base import AccessControlledModel
+from girder.utility.acl_mixin import AccessControlMixin
 
 
 def setUpModule():
@@ -235,3 +238,16 @@ class SearchTestCase(base.TestCase):
             '_id': str(item1['_id']),
             'name': item1['name']
         }, resp.json['item'][0])
+
+        # Check search for model that is not access controlled
+        self.assertNotIsInstance(
+            self.model('assetstore'), AccessControlledModel)
+        self.assertNotIsInstance(
+            self.model('assetstore'), AccessControlMixin)
+        resource.allowedSearchTypes.add('assetstore')
+        resp = self.request(path='/resource/search', params={
+            'q': 'Test',
+            'mode': 'prefix',
+            'types': '["assetstore"]'
+        }, user=user)
+        self.assertEqual(1, len(resp.json['assetstore']))


### PR DESCRIPTION
This commit fixes an error when using the /resource/search endpoint to search
for models that aren't access controlled. The error message is similar to:

    TypeError: TypeError("prefixSearch() got an unexpected keyword argument 'user'")

Fixes #1404