### PR TITLE
Add download and inline-view links to item list

### DIFF
--- a/clients/web/src/stylesheets/body/itemPage.styl
+++ b/clients/web/src/stylesheets/body/itemPage.styl
@@ -71,3 +71,8 @@
 
 .g-item-actions-button
   margin-left 10px !important
+
+.g-right-border
+  margin-right 3px
+  border-right 1px solid #e3e3e3
+  padding-right 6px

--- a/clients/web/src/templates/widgets/itemList.jade
+++ b/clients/web/src/templates/widgets/itemList.jade
@@ -3,9 +3,13 @@ ul.g-item-list
     li.g-item-list-entry
       if checkboxes
         input.g-list-checkbox(type="checkbox", g-item-cid="#{item.cid}")
-      a.g-item-list-link(g-item-cid="#{item.cid}")
+      a.g-item-list-link.g-right-border(g-item-cid="#{item.cid}")
         i.icon-doc-text-inv
         | #{item.get('name')}
+      a.g-right-border(href=item.downloadUrl())
+        i.icon-download
+      a.g-view-inline(target="_blank" href=item.downloadUrl({contentDisposition: 'inline'}))
+        i.icon-eye
       .g-item-size #{girder.formatSize(item.get('size'))}
   if (hasMore)
     li.g-show-more

--- a/clients/web/src/templates/widgets/itemList.jade
+++ b/clients/web/src/templates/widgets/itemList.jade
@@ -6,7 +6,7 @@ ul.g-item-list
       a.g-item-list-link.g-right-border(g-item-cid="#{item.cid}")
         i.icon-doc-text-inv
         | #{item.get('name')}
-      a.g-right-border(href=item.downloadUrl())
+      a(href=item.downloadUrl())
         i.icon-download
       a.g-view-inline(target="_blank" href=item.downloadUrl({contentDisposition: 'inline'}))
         i.icon-eye

--- a/clients/web/src/templates/widgets/itemList.jade
+++ b/clients/web/src/templates/widgets/itemList.jade
@@ -6,9 +6,10 @@ ul.g-item-list
       a.g-item-list-link.g-right-border(g-item-cid="#{item.cid}")
         i.icon-doc-text-inv
         | #{item.get('name')}
-      a(href=item.downloadUrl())
+      a(title="Download item" href=item.downloadUrl())
         i.icon-download
-      a.g-view-inline(target="_blank" href=item.downloadUrl({contentDisposition: 'inline'}))
+      a.g-view-inline(title="View in browser" target="_blank"
+                      href=item.downloadUrl({contentDisposition: 'inline'}))
         i.icon-eye
       .g-item-size #{girder.formatSize(item.get('size'))}
   if (hasMore)

--- a/clients/web/src/views/widgets/ItemListWidget.js
+++ b/clients/web/src/views/widgets/ItemListWidget.js
@@ -40,6 +40,12 @@ girder.views.ItemListWidget = girder.View.extend({
             checkboxes: this._checkboxes
         }));
 
+        this.$('.g-item-list-entry a[title]').tooltip({
+            container: 'body',
+            placement: 'auto',
+            delay: 100
+        });
+
         var view = this;
         this.$('.g-list-checkbox').change(function () {
             var cid = $(this).attr('g-item-cid');


### PR DESCRIPTION
This adds download and inline-view links to each item in an item list, enabling to, e.g., open a sequence of images without having to click into each item and then back out again.