### PR TITLE
Registration approval

### DIFF
--- a/clients/web/src/stylesheets/body/userList.styl
+++ b/clients/web/src/stylesheets/body/userList.styl
@@ -17,6 +17,10 @@
   .g-space-used
     margin-top 2px
 
+  .g-user-status
+    margin-top 2px
+    color #d9534f
+
   .g-user-right-column
     border-left 1px solid #ddd
     padding-left 8px

--- a/clients/web/src/templates/body/systemConfiguration.jade
+++ b/clients/web/src/templates/body/systemConfiguration.jade
@@ -19,6 +19,10 @@ form.g-settings-form(role="form")
           selected=((settings['core.registration_policy'] ||
           defaults['core.registration_policy']) === "closed")
           ) Closed registration
+        option(value="approve",
+          selected=((settings['core.registration_policy'] ||
+          defaults['core.registration_policy']) === "approve")
+          ) Admin approval required
     .form-group
       label(for="g-core-email-verification") Email verification
       select#g-core-email-verification.form-control.input-sm

--- a/clients/web/src/templates/body/userList.jade
+++ b/clients/web/src/templates/body/userList.jade
@@ -14,11 +14,19 @@ each user in users
         i.icon-clock
         | Joined on
         span.g-user-joined-date  #{girder.formatDate(user.get('created'), girder.DATE_DAY)}
-      if (user.get('size') !== undefined)
+      if user.get('size') !== undefined
         .g-space-used
           i.icon-floppy
           | Currently using
           span.g-user-space-used  #{girder.formatSize(user.get('size'))}
+      if user.get('status') === 'disabled'
+        .g-user-status
+          i.icon-cancel-circled
+          | Account disabled
+      else if user.get('status') === 'pending'
+        .g-user-status
+          i.icon-attention-circled
+          | Account pending approval
     .g-user-title
       a.g-user-link(g-user-cid=user.cid)
         b= user.name()

--- a/clients/web/src/templates/body/userPage.jade
+++ b/clients/web/src/templates/body/userPage.jade
@@ -1,6 +1,6 @@
 .g-user-header
 
-  if (user.getAccessLevel() >= girder.AccessType.WRITE)
+  if user.getAccessLevel() >= girder.AccessType.WRITE
     .btn-group.pull-right
       button.g-user-actions-button.btn.btn-default.dropdown-toggle(
         data-toggle="dropdown", title="Item actions")
@@ -12,8 +12,23 @@
           a.g-edit-user(role="menuitem")
             i.icon-edit
             | Edit user
-        if (user.getAccessLevel() >= girder.AccessType.ADMIN)
+        if user.getAccessLevel() >= girder.AccessType.ADMIN
           li.divider(role="presentation")
+          if user.get('status') === 'pending'
+            li(role="presentation")
+              a.g-approve-user(role="menuitem")
+                i.icon-ok-squared
+                | Approve account
+          else if user.get('status') === 'active'
+            li(role="presentation")
+              a.g-disable-user(role="menuitem")
+                i.icon-cancel
+                | Disable account
+          else if user.get('status') === 'disabled'
+            li(role="presentation")
+              a.g-enable-user(role="menuitem")
+                i.icon-ok
+                | Enable account
           li(role="presentation")
             a.g-delete-user(role="menuitem")
               i.icon-trash

--- a/clients/web/src/templates/body/userPage.jade
+++ b/clients/web/src/templates/body/userPage.jade
@@ -19,7 +19,7 @@
               a.g-approve-user(role="menuitem")
                 i.icon-ok-squared
                 | Approve account
-          else if user.get('status') === 'active'
+          else if user.get('status') === 'enabled'
             li(role="presentation")
               a.g-disable-user(role="menuitem")
                 i.icon-cancel

--- a/clients/web/src/views/body/UserSettingsView.js
+++ b/clients/web/src/views/body/UserSettingsView.js
@@ -195,7 +195,7 @@ girder.router.route('useraccount/:id/verification/:token', 'accountVerify', func
         girder.events.trigger('g:alert', {
             icon: 'cancel',
             text: 'Could not verify email.',
-            type: 'error',
+            type: 'danger',
             timeout: 4000
         });
     }, this));

--- a/clients/web/src/views/body/UserSettingsView.js
+++ b/clients/web/src/views/body/UserSettingsView.js
@@ -176,11 +176,13 @@ girder.router.route('useraccount/:id/verification/:token', 'accountVerify', func
         data: {token: token},
         error: null
     }).done(_.bind(function (resp) {
-        resp.user.token = resp.authToken.token;
-        girder.eventStream.close();
-        girder.currentUser = new girder.models.UserModel(resp.user);
-        girder.eventStream.open();
-        girder.events.trigger('g:login-changed');
+        if (resp.authToken) {
+            resp.user.token = resp.authToken.token;
+            girder.eventStream.close();
+            girder.currentUser = new girder.models.UserModel(resp.user);
+            girder.eventStream.open();
+            girder.events.trigger('g:login-changed');
+        }
         girder.events.trigger('g:navigateTo', girder.views.FrontPageView);
         girder.events.trigger('g:alert', {
             icon: 'ok',
@@ -189,6 +191,12 @@ girder.router.route('useraccount/:id/verification/:token', 'accountVerify', func
             timeout: 4000
         });
     }, this)).error(_.bind(function () {
-        girder.router.navigate('users', {trigger: true});
+        girder.events.trigger('g:navigateTo', girder.views.FrontPageView);
+        girder.events.trigger('g:alert', {
+            icon: 'cancel',
+            text: 'Could not verify email.',
+            type: 'error',
+            timeout: 4000
+        });
     }, this));
 });

--- a/clients/web/src/views/body/UserView.js
+++ b/clients/web/src/views/body/UserView.js
@@ -21,6 +21,21 @@
                         });
                     }, this)
                 });
+            },
+
+            'click a.g-approve-user': function () {
+                this._setAndSave(
+                    {status: 'enabled'}, 'Approved user account.');
+            },
+
+            'click a.g-disable-user': function () {
+                this._setAndSave(
+                    {status: 'disabled'}, 'Disabled user account.');
+            },
+
+            'click a.g-enable-user': function () {
+                this._setAndSave(
+                    {status: 'enabled'}, 'Enabled user account.');
             }
         },
 
@@ -91,6 +106,25 @@
             this.itemCreate = false;
 
             return this;
+        },
+
+        _setAndSave: function (data, message) {
+            this.model.set(data);
+            this.model.off('g:saved').on('g:saved', function () {
+                girder.events.trigger('g:alert', {
+                    icon: 'ok',
+                    text: message,
+                    type: 'success',
+                    timeout: 4000
+                });
+                this.render();
+            }, this).off('g:error').on('g:error', function (err) {
+                girder.events.trigger('g:alert', {
+                    icon: 'cancel',
+                    text: err.responseJSON.message,
+                    type: 'danger'
+                });
+            }).save();
         }
     });
 

--- a/clients/web/test/spec/userSpec.js
+++ b/clients/web/test/spec/userSpec.js
@@ -413,5 +413,68 @@ describe('test email verification', function() {
         waitsFor(function () {
             return $('.g-validation-failed-message:visible').length > 0;
         }, 'email verification message to appear');
+
+        runs(function () {
+            $("a[data-dismiss='modal']").click();
+        });
+    });
+});
+
+describe('test account approval', function() {
+    it('Turn on approval policy', function () {
+        // girderTest.logout()();
+        girderTest.login('admin', 'Admin', 'Admin', 'adminpassword!')();
+        runs(function () {
+            $("a.g-nav-link[g-target='admin']").click();
+        });
+        waitsFor(function () {
+            return $('.g-server-config').length > 0;
+        }, 'admin page to load');
+        girderTest.waitForLoad();
+        runs(function () {
+            $('.g-server-config').click();
+        });
+        waitsFor(function () {
+            return $('input#g-core-cookie-lifetime').length > 0;
+        }, 'settings page to load');
+        girderTest.waitForLoad();
+        runs(function () {
+            $('#g-core-registration-policy').val('approve');
+            $('.g-submit-settings').click();
+        });
+        waitsFor(function () {
+            return $('#g-alerts-container .alert-success').length > 0;
+        }, 'settings to save');
+    });
+    it('Try to login without approval', function() {
+        girderTest.logout()();
+        runs(function () {
+            expect(girder.currentUser).toBe(null);
+        });
+
+        waitsFor(function () {
+            return $('.g-login').length > 0;
+        }, 'Girder app to render');
+
+        girderTest.waitForLoad();
+
+        runs(function () {
+            $('.g-login').click();
+        });
+
+        girderTest.waitForDialog();
+        waitsFor(function () {
+            return $('input#g-login').length > 0;
+        }, 'register dialog to appear');
+
+        runs(function () {
+            $('#g-login').val('nonadmin');
+            $('#g-password').val('password!');
+            $('#g-login-button').click();
+        });
+
+        waitsFor(function () {
+            return $('.g-validation-failed-message:visible').length > 0;
+        }, 'approval message to appear');
     });
 });

--- a/clients/web/test/spec/userSpec.js
+++ b/clients/web/test/spec/userSpec.js
@@ -3,8 +3,10 @@
  */
 girderTest.startApp();
 
+var registeredUsers = [];
+
 describe('Create an admin and non-admin user', function () {
-    var link, registeredUsers = [];
+    var link;
 
     it('register a user (first is admin)',
         girderTest.createUser('admin',
@@ -380,11 +382,11 @@ describe('test email verification', function() {
             $('.g-submit-settings').click();
         });
         waitsFor(function () {
-            return $('#g-alerts-container .alert-success').length > 0;
-        }, 'settings to save');
+            return girder.numberOutstandingRestRequests() === 0;
+        }, 'dialog rest requests to finish');
+        girderTest.logout()();
     });
     it('Try to login without verifying email', function() {
-        girderTest.logout()();
         runs(function () {
             expect(girder.currentUser).toBe(null);
         });
@@ -402,16 +404,16 @@ describe('test email verification', function() {
         girderTest.waitForDialog();
         waitsFor(function () {
             return $('input#g-login').length > 0;
-        }, 'register dialog to appear');
+        }, 'login dialog to appear');
 
         runs(function () {
-            $('#g-login').val('nonadmin');
-            $('#g-password').val('password!');
+            $('#g-login').val('user2');
+            $('#g-password').val('password');
             $('#g-login-button').click();
         });
 
         waitsFor(function () {
-            return $('.g-validation-failed-message:visible').length > 0;
+            return $('.g-validation-failed-message:contains("Email verification")').length > 0;
         }, 'email verification message to appear');
 
         runs(function () {
@@ -422,7 +424,6 @@ describe('test email verification', function() {
 
 describe('test account approval', function() {
     it('Turn on approval policy', function () {
-        // girderTest.logout()();
         girderTest.login('admin', 'Admin', 'Admin', 'adminpassword!')();
         runs(function () {
             $("a.g-nav-link[g-target='admin']").click();
@@ -440,14 +441,28 @@ describe('test account approval', function() {
         girderTest.waitForLoad();
         runs(function () {
             $('#g-core-registration-policy').val('approve');
+            $('#g-core-email-verification').val('disabled');
             $('.g-submit-settings').click();
         });
         waitsFor(function () {
-            return $('#g-alerts-container .alert-success').length > 0;
-        }, 'settings to save');
+            return girder.numberOutstandingRestRequests() === 0;
+        }, 'dialog rest requests to finish');
+        runs(function () {
+            girder.router.navigate('user/' + registeredUsers[1].id,
+                                   {trigger: true});
+        });
+        waitsFor(function () {
+            return $('.g-disable-user').length > 0;
+        }, 'user page to load');
+        runs(function () {
+            $('.g-disable-user').click();
+        });
+        waitsFor(function () {
+            return girder.numberOutstandingRestRequests() === 0;
+        }, 'dialog rest requests to finish');
+        girderTest.logout()();
     });
     it('Try to login without approval', function() {
-        girderTest.logout()();
         runs(function () {
             expect(girder.currentUser).toBe(null);
         });
@@ -465,16 +480,20 @@ describe('test account approval', function() {
         girderTest.waitForDialog();
         waitsFor(function () {
             return $('input#g-login').length > 0;
-        }, 'register dialog to appear');
+        }, 'login dialog to appear');
 
         runs(function () {
             $('#g-login').val('nonadmin');
-            $('#g-password').val('password!');
+            $('#g-password').val('newpassword');
             $('#g-login-button').click();
         });
 
         waitsFor(function () {
-            return $('.g-validation-failed-message:visible').length > 0;
+            return $('.g-validation-failed-message:contains("Account approval")').length > 0;
         }, 'approval message to appear');
+
+        runs(function () {
+            $("a[data-dismiss='modal']").click();
+        });
     });
 });

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -268,15 +268,13 @@ class User(Resource):
                     raise AccessException('Only admins may change admin state.')
 
         # Only admins can change status
-        if 'status' in params:
-            newStatus = params['status']
+        if 'status' in params and params['status'] != user['status']:
             if self.getCurrentUser()['admin']:
-                user['status'] = newStatus
-                if newStatus == 'enabled':
+                user['status'] = params['status']
+                if user['status'] == 'enabled':
                     self.model('user')._sendApprovedEmail(user)
             else:
-                if newStatus != user['status']:
-                    raise AccessException('Only admins may change status.')
+                raise AccessException('Only admins may change status.')
 
         return self.model('user').save(user)
 

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -245,7 +245,7 @@ class User(Resource):
         .param('email', 'The email of the user.')
         .param('admin', 'Is the user a site admin (admin access required)',
                required=False, dataType='boolean')
-        .param('status', 'The status of the user account.',
+        .param('status', 'The account status (admin access required)',
                required=False, enum=['pending', 'enabled', 'disabled'])
         .errorResponse()
         .errorResponse('You do not have write access for this user.', 403)

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -272,6 +272,8 @@ class User(Resource):
             newStatus = params['status']
             if self.getCurrentUser()['admin']:
                 user['status'] = newStatus
+                if newStatus == 'enabled':
+                    self.model('user')._sendApprovedEmail(user)
             else:
                 if newStatus != user['status']:
                     raise AccessException('Only admins may change status.')

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -245,6 +245,8 @@ class User(Resource):
         .param('email', 'The email of the user.')
         .param('admin', 'Is the user a site admin (admin access required)',
                required=False, dataType='boolean')
+        .param('status', 'The status of the user account.',
+               required=False, enum=['pending', 'enabled', 'disabled'])
         .errorResponse()
         .errorResponse('You do not have write access for this user.', 403)
         .errorResponse('Must be an admin to create an admin.', 403)
@@ -264,6 +266,15 @@ class User(Resource):
             else:
                 if newAdminState != user['admin']:
                     raise AccessException('Only admins may change admin state.')
+
+        # Only admins can change status
+        if 'status' in params:
+            newStatus = params['status']
+            if self.getCurrentUser()['admin']:
+                user['status'] = newStatus
+            else:
+                if newStatus != user['status']:
+                    raise AccessException('Only admins may change status.')
 
         return self.model('user').save(user)
 

--- a/girder/mail_templates/accountApproval.mako
+++ b/girder/mail_templates/accountApproval.mako
@@ -1,0 +1,11 @@
+<%include file="_header.mako"/>
+
+<p>Someone has registered a new account that needs admin approval.</p>
+
+<p>Login: ${user.get('login')}</p>
+<p>Email: ${user.get('email')}</p>
+<p>Name: ${user.get('firstName')} ${user.get('lastName')}</p>
+
+<p><a href="${url}">${url}</a></p>
+
+<%include file="_footer.mako"/>

--- a/girder/mail_templates/accountApproved.mako
+++ b/girder/mail_templates/accountApproved.mako
@@ -1,0 +1,7 @@
+<%include file="_header.mako"/>
+
+<p>Your account has been approved. You may now login.</p>
+
+<p><a href="${url}">${url}</a></p>
+
+<%include file="_footer.mako"/>

--- a/girder/models/setting.py
+++ b/girder/models/setting.py
@@ -158,9 +158,9 @@ class Setting(Model):
 
     def validateCoreRegistrationPolicy(self, doc):
         doc['value'] = doc['value'].lower()
-        if doc['value'] not in ('open', 'closed'):
+        if doc['value'] not in ('open', 'closed', 'approve'):
             raise ValidationException(
-                'Registration policy must be either "open" or "closed".',
+                'Registration policy must be "open", "closed", or "approve".',
                 'value')
 
     def validateCoreEmailVerification(self, doc):

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -49,7 +49,8 @@ class User(AccessControlledModel):
             '_id', 'login', 'public', 'firstName', 'lastName', 'admin',
             'created'))
         self.exposeFields(level=AccessType.ADMIN, fields=(
-            'size', 'email', 'groups', 'groupInvites'))
+            'size', 'email', 'groups', 'groupInvites', 'status',
+            'emailVerified'))
 
         events.bind('model.user.save.created',
                     CoreEventHandler.USER_SELF_ACCESS, self._grantSelfAccess)
@@ -226,6 +227,9 @@ class User(AccessControlledModel):
         :type public: bool
         :returns: The user document that was created.
         """
+        requireApproval = self.model('setting').get(
+            SettingKey.REGISTRATION_POLICY) == 'approve'
+
         user = {
             'login': login,
             'email': email,
@@ -233,7 +237,7 @@ class User(AccessControlledModel):
             'lastName': lastName,
             'created': datetime.datetime.utcnow(),
             'emailVerified': False,
-            'status': 'pending',
+            'status': 'pending' if requireApproval else 'active',
             'admin': admin,
             'size': 0,
             'groups': [],

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -233,6 +233,7 @@ class User(AccessControlledModel):
             'lastName': lastName,
             'created': datetime.datetime.utcnow(),
             'emailVerified': False,
+            'status': 'pending',
             'admin': admin,
             'size': 0,
             'groups': [],

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -94,6 +94,10 @@ class User(AccessControlledModel):
             raise ValidationException('Last name must not be empty.',
                                       'lastName')
 
+        if doc['status'] not in ('pending', 'enabled', 'disabled'):
+            raise ValidationException(
+                'Status must be pending, enabled, or disabled.', 'status')
+
         if '@' in doc['login']:
             # Hard-code this constraint so we can always easily distinguish
             # an email address from a login
@@ -237,7 +241,7 @@ class User(AccessControlledModel):
             'lastName': lastName,
             'created': datetime.datetime.utcnow(),
             'emailVerified': False,
-            'status': 'pending' if requireApproval else 'active',
+            'status': 'pending' if requireApproval else 'enabled',
             'admin': admin,
             'size': 0,
             'groups': [],

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -262,7 +262,7 @@ class User(AccessControlledModel):
     def canLogin(self, user):
         """
         Returns True if the user is allowed to login, e.g. email verification
-        is not required and admin approval is not required.
+        is not needed and admin approval is not needed.
         """
         if self.emailVerificationRequired(user):
             return False
@@ -295,9 +295,11 @@ class User(AccessControlledModel):
         return False
 
     def _sendApprovalEmail(self, user):
+        url = '%s/#user/%s' % (
+            mail_utils.getEmailUrlPrefix(), str(user['_id']))
         text = mail_utils.renderTemplate('accountApproval.mako', {
             'user': user,
-            'url': '', # TODO
+            'url': url
         })
         mail_utils.sendEmail(
             toAdmins=True,

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -307,7 +307,17 @@ class User(AccessControlledModel):
         })
         mail_utils.sendEmail(
             toAdmins=True,
-            subject='Girder: User registration approval',
+            subject='Girder: Account pending approval',
+            text=text)
+
+    def _sendApprovedEmail(self, user):
+        text = mail_utils.renderTemplate('accountApproved.mako', {
+            'user': user,
+            'url': mail_utils.getEmailUrlPrefix()
+        })
+        mail_utils.sendEmail(
+            to=user.get('email'),
+            subject='Girder: Account approved',
             text=text)
 
     def _sendVerificationEmail(self, user):

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -268,6 +268,8 @@ class User(AccessControlledModel):
         Returns True if email verification is required and this user has not
         yet verified their email address.
         """
+        if user.get('admin'):
+            return False
         if not user.get('emailVerified', False):
             return self.model('setting').get(
                 SettingKey.EMAIL_VERIFICATION) == 'required'
@@ -278,6 +280,8 @@ class User(AccessControlledModel):
         Returns True if the registration policy requires admin approval and
         this user has not yet been approved.
         """
+        if user.get('admin'):
+            return False
         if user.get('status') != 'enabled':
             return self.model('setting').get(
                 SettingKey.REGISTRATION_POLICY) == 'approve'

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -233,6 +233,8 @@ class User(AccessControlledModel):
         """
         requireApproval = self.model('setting').get(
             SettingKey.REGISTRATION_POLICY) == 'approve'
+        if admin:
+            requireApproval = False
 
         user = {
             'login': login,

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -254,6 +254,9 @@ class User(AccessControlledModel):
         if verifyEmail:
             self._sendVerificationEmail(user)
 
+        if requireApproval:
+            self._sendApprovalEmail(user)
+
         return user
 
     def canLogin(self, user):
@@ -290,6 +293,16 @@ class User(AccessControlledModel):
             return self.model('setting').get(
                 SettingKey.REGISTRATION_POLICY) == 'approve'
         return False
+
+    def _sendApprovalEmail(self, user):
+        text = mail_utils.renderTemplate('accountApproval.mako', {
+            'user': user,
+            'url': '', # TODO
+        })
+        mail_utils.sendEmail(
+            toAdmins=True,
+            subject='Girder: User registration approval',
+            text=text)
 
     def _sendVerificationEmail(self, user):
         token = self.model('token').createToken(

--- a/plugins/oauth/server/providers/base.py
+++ b/plugins/oauth/server/providers/base.py
@@ -148,7 +148,7 @@ class ProviderBase(model_importer.ModelImporter):
         # Create the user if it's still not found
         if not user:
             policy = cls.model('setting').get(SettingKey.REGISTRATION_POLICY)
-            if policy != 'open':
+            if policy == 'closed':
                 raise RestException(
                     'Registration on this instance is closed. Contact an '
                     'administrator to create an account for you.')

--- a/tests/cases/user_test.py
+++ b/tests/cases/user_test.py
@@ -507,8 +507,9 @@ class UserTestCase(base.TestCase):
         user = self.model('user').createUser(
             'user', 'password', 'User', 'User', 'user@example.com')
 
+        # pop email
         self.assertTrue(base.mockSmtp.waitForMail())
-        msg = base.mockSmtp.getMail(parse=True)
+        base.mockSmtp.getMail(parse=True)
 
         # cannot login without being approved
         resp = self.request('/user/authentication', basicAuth='user:password')


### PR DESCRIPTION
@zachmullen @mgrauer @cpatrick 

This PR adds a new "Registration policy" option called "Admin approval required"

In this mode, users can register themselves but cannot login until an admin approves their account.

As an added bonus, admins can also "disable" user accounts to prevent them from logging in. This may be useful for the case where you don't want to delete the user account but don't want them logging in anymore.

The user list is updated so admins can see users with disabled or pending approval status:

![screen shot 2016-06-23 at 9 58 29 am](https://cloud.githubusercontent.com/assets/520208/16309568/2893b590-3937-11e6-9187-acef424e76d7.png)

To approve an account, the admin clicks on a user and then clicks Actions > Approve account as shown here:

![screen shot 2016-06-23 at 9 59 58 am](https://cloud.githubusercontent.com/assets/520208/16309584/3acdfad6-3937-11e6-8c40-6cba504ae08d.png)

Admins are emailed when a new user registers, with a link to go directly to this page.

Once approved, the user is notified by email that they can now login.