### PR TITLE
Add originalItemId flag to copied items

### DIFF
--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -51,7 +51,7 @@ class Item(acl_mixin.AccessControlMixin, Model):
         self.exposeFields(level=AccessType.READ, fields=(
             '_id', 'size', 'updated', 'description', 'created', 'meta',
             'creatorId', 'folderId', 'name', 'baseParentType', 'baseParentId',
-            'originalItemId'))
+            'copyOfItem'))
 
     def filter(self, *args, **kwargs):
         """
@@ -382,7 +382,7 @@ class Item(acl_mixin.AccessControlMixin, Model):
             if key not in filteredItem and key not in newItem:
                 newItem[key] = copy.deepcopy(srcItem[key])
         # add a reference to the original item
-        newItem['originalItemId'] = srcItem['_id']
+        newItem['copyOfItem'] = srcItem['_id']
         self.save(newItem, triggerEvents=False)
 
         # Give listeners a chance to change things

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -50,7 +50,8 @@ class Item(acl_mixin.AccessControlMixin, Model):
 
         self.exposeFields(level=AccessType.READ, fields=(
             '_id', 'size', 'updated', 'description', 'created', 'meta',
-            'creatorId', 'folderId', 'name', 'baseParentType', 'baseParentId'))
+            'creatorId', 'folderId', 'name', 'baseParentType', 'baseParentId',
+            'originalItemId'))
 
     def filter(self, *args, **kwargs):
         """
@@ -377,13 +378,13 @@ class Item(acl_mixin.AccessControlMixin, Model):
             folder=folder, name=name, creator=creator, description=description)
         # copy metadata and other extension values
         filteredItem = self.filter(newItem, creator)
-        updated = False
         for key in srcItem:
             if key not in filteredItem and key not in newItem:
                 newItem[key] = copy.deepcopy(srcItem[key])
-                updated = True
-        if updated:
-            self.save(newItem, triggerEvents=False)
+        # add a reference to the original item
+        newItem['originalItemId'] = srcItem['_id']
+        self.save(newItem, triggerEvents=False)
+
         # Give listeners a chance to change things
         events.trigger('model.item.copy.prepare', (srcItem, newItem))
         # copy files

--- a/tests/cases/item_test.py
+++ b/tests/cases/item_test.py
@@ -621,6 +621,9 @@ class ItemTestCase(base.TestCase):
                                     'text': 'copied_item'})
         self.assertStatusOk(resp)
         self.assertEqual(newItem['_id'], resp.json[0]['_id'])
+        # Check that the provenance tag correctly points back
+        # to the original item
+        self.assertEqual(newItem['copyOfItem'], origItem['_id'])
         # Check if we can download the files from the old item and that they
         # are distinct from the files in the original item
         resp = self.request(path='/item/%s/files' % origItem['_id'],


### PR DESCRIPTION
Fix #1412

I *think* this is probably best stored in the root level, as opposed to inside `'meta'`, but feel free to correct me.