### PR TITLE
Fix race condition in curation plugin test

### DIFF
--- a/plugins/curation/plugin_tests/curationSpec.js
+++ b/plugins/curation/plugin_tests/curationSpec.js
@@ -24,6 +24,7 @@ function _goToCurationDialog() {
         $('a.g-curation-button:visible').click();
     });
     girderTest.waitForDialog();
+    girderTest.waitForDialog();
 }
 
 describe('test the curation ui', function () {

--- a/plugins/curation/plugin_tests/curationSpec.js
+++ b/plugins/curation/plugin_tests/curationSpec.js
@@ -24,7 +24,6 @@ function _goToCurationDialog() {
         $('a.g-curation-button:visible').click();
     });
     girderTest.waitForDialog();
-    girderTest.waitForDialog();
 }
 
 describe('test the curation ui', function () {

--- a/plugins/curation/web_client/js/setup.js
+++ b/plugins/curation/web_client/js/setup.js
@@ -26,13 +26,13 @@ girder.wrap(girder.views.HierarchyWidget, 'render', function (render) {
 
 // launch modal when curation button is clicked
 girder.views.HierarchyWidget.prototype.events['click .g-curation-button'] = function (e) {
-    /* eslint-disable */
+    /* eslint-disable no-new */
     new girder.views.CurationDialog({
         el: $('#g-dialog-container'),
         parentView: this,
         folder: this.parentModel
     });
-    /* eslint-enable */
+    /* eslint-enable no-new */
 };
 
 // curation dialog

--- a/plugins/curation/web_client/js/setup.js
+++ b/plugins/curation/web_client/js/setup.js
@@ -30,7 +30,7 @@ girder.views.HierarchyWidget.prototype.events['click .g-curation-button'] = func
         el: $('#g-dialog-container'),
         parentView: this,
         folder: this.parentModel
-    }).render();
+    });
 };
 
 // curation dialog

--- a/plugins/curation/web_client/js/setup.js
+++ b/plugins/curation/web_client/js/setup.js
@@ -26,11 +26,13 @@ girder.wrap(girder.views.HierarchyWidget, 'render', function (render) {
 
 // launch modal when curation button is clicked
 girder.views.HierarchyWidget.prototype.events['click .g-curation-button'] = function (e) {
+    /* eslint-disable */
     new girder.views.CurationDialog({
         el: $('#g-dialog-container'),
         parentView: this,
         folder: this.parentModel
     });
+    /* eslint-enable */
 };
 
 // curation dialog


### PR DESCRIPTION
@zachmullen 

Since the dialog refreshes after a REST request, doing two calls to waitForDialog seems to fix the issue. I tested by making the curation endpoints sleep for one second before responding.