### PR TITLE
Fixes #1432. Allow test harnessing of individual classes or methods

### DIFF
--- a/tests/PythonTests.cmake
+++ b/tests/PythonTests.cmake
@@ -83,7 +83,7 @@ function(add_python_test case)
   set(name "server_${case}")
 
   set(_options BIND_SERVER PY2_ONLY)
-  set(_args NAME PLUGIN SUBMODULE)
+  set(_args PLUGIN SUBMODULE)
   set(_multival_args RESOURCE_LOCKS TIMEOUT EXTERNAL_DATA)
   cmake_parse_arguments(fn "${_options}" "${_args}" "${_multival_args}" ${ARGN})
 
@@ -103,12 +103,9 @@ function(add_python_test case)
     set(other_covg "")
   endif()
 
-  if(fn_NAME)
-    set(name ${fn_NAME})
-  endif()
-
   if(fn_SUBMODULE)
     set(module ${module}.${fn_SUBMODULE})
+    set(name ${name}.${fn_SUBMODULE})
   endif()
 
   if(PYTHON_COVERAGE)

--- a/tests/PythonTests.cmake
+++ b/tests/PythonTests.cmake
@@ -83,7 +83,7 @@ function(add_python_test case)
   set(name "server_${case}")
 
   set(_options BIND_SERVER PY2_ONLY)
-  set(_args PLUGIN SUBMODULE)
+  set(_args DBNAME PLUGIN SUBMODULE)
   set(_multival_args RESOURCE_LOCKS TIMEOUT EXTERNAL_DATA)
   cmake_parse_arguments(fn "${_options}" "${_args}" "${_multival_args}" ${ARGN})
 
@@ -124,7 +124,13 @@ function(add_python_test case)
     )
   endif()
 
-  string(REPLACE "." "_" _db_name ${name})
+  if(fn_DBNAME)
+    set(_db_name ${fn_DBNAME})
+  else()
+    set(_db_name ${name})
+  endif()
+
+  string(REPLACE "." "_" _db_name ${_db_name})
   set_property(TEST ${name} PROPERTY ENVIRONMENT
     "PYTHONPATH=$ENV{PYTHONPATH}${_separator}${pythonpath}${_separator}${PROJECT_SOURCE_DIR}/clients/python"
     "GIRDER_TEST_DB=mongodb://localhost:27017/girder_test_${_db_name}"

--- a/tests/PythonTests.cmake
+++ b/tests/PythonTests.cmake
@@ -83,7 +83,7 @@ function(add_python_test case)
   set(name "server_${case}")
 
   set(_options BIND_SERVER PY2_ONLY)
-  set(_args PLUGIN)
+  set(_args NAME PLUGIN SUBMODULE)
   set(_multival_args RESOURCE_LOCKS TIMEOUT EXTERNAL_DATA)
   cmake_parse_arguments(fn "${_options}" "${_args}" "${_multival_args}" ${ARGN})
 
@@ -101,6 +101,14 @@ function(add_python_test case)
     set(module tests.cases.${case}_test)
     set(pythonpath "")
     set(other_covg "")
+  endif()
+
+  if(fn_NAME)
+    set(name ${fn_NAME})
+  endif()
+
+  if(fn_SUBMODULE)
+    set(module ${module}.${fn_SUBMODULE})
   endif()
 
   if(PYTHON_COVERAGE)


### PR DESCRIPTION
@cdeepakroy @brianhelba This addresses what we just discussed on the call. Here's an example of using this feature, shown on one of our core tests. Before:

    add_python_test(api_key)

After (to test a single method):

    add_python_test(api_key NAME api_key.listKeys SUBMODULE ApiKeyTestCase.testListKeys)

After (to test a single class);

    add_python_test(api_key NAME api_key.ApiKeyTestCase SUBMODULE ApiKeyTestCase)