### PR TITLE
Add collection methods (list, get, create) to python client

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -402,7 +402,8 @@ class GirderClient(object):
         }
         return self.createResource('collection', params)
 
-    def createFolder(self, parentId, name, description='', parentType='folder'):
+    def createFolder(self, parentId, name, description='', parentType='folder',
+                     public=None):
         """
         Creates and returns a folder.
 
@@ -414,6 +415,8 @@ class GirderClient(object):
             'name': name,
             'description': description
         }
+        if public is not None:
+            params['public'] = public
         return self.createResource('folder', params)
 
     def getFolder(self, folderId):

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -391,9 +391,20 @@ class GirderClient(object):
 
         return self.listResource('item', params)
 
+    def createCollection(self, name, description='', public=False):
+        """
+        Creates and returns a collection.
+        """
+        params = {
+            'name': name,
+            'description': description,
+            'public': public
+        }
+        return self.createResource('collection', params)
+
     def createFolder(self, parentId, name, description='', parentType='folder'):
         """
-        Creates and returns a folder
+        Creates and returns a folder.
 
         :param parentType: One of ('folder', 'user', 'collection')
         """

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -402,6 +402,15 @@ class GirderClient(object):
             params['limit'] = limit
         return self.listResource('collection', params)
 
+    def getCollection(self, collectionId):
+        """
+        Retrieves a collection by its ID.
+
+        :param collectionId: A string containing the ID of the collection to
+            retrieve from Girder.
+        """
+        return self.getResource('collection', collectionId)
+
     def createCollection(self, name, description='', public=False):
         """
         Creates and returns a collection.

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -391,6 +391,17 @@ class GirderClient(object):
 
         return self.listResource('item', params)
 
+    def listCollection(self, limit=None):
+        """
+        Retrieves a list of collections.
+
+        :param limit: the result set size limit.
+        """
+        params = {}
+        if limit:
+            params['limit'] = limit
+        return self.listResource('collection', params)
+
     def createCollection(self, name, description='', public=False):
         """
         Creates and returns a collection.

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -179,10 +179,11 @@ class PythonClientTestCase(base.TestCase):
         # Test collection creation and retrieval
         c1 = self.client.createCollection('c1')
         c2 = self.client.createCollection('c2')
-        cs = self.client.listCollection()
-        self.assertEqual(len(cs), 2)
-        self.assertIn(c1, cs)
-        self.assertIn(c2, cs)
+        collections = self.client.listCollection()
+        self.assertEqual(len(collections), 2)
+        ids = [c['_id'] for c in collections]
+        self.assertIn(c1['_id'], ids)
+        self.assertIn(c2['_id'], ids)
 
     def testUploadCallbacks(self):
         callbackUser = self.model('user').createUser(

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -176,6 +176,14 @@ class PythonClientTestCase(base.TestCase):
         self.client.createFolder(privateFolder['_id'], name='Subfolder')
         self.client.inheritAccessControlRecursive(privateFolder['_id'])
 
+        # Test collection creation and retrieval
+        c1 = self.client.createCollection('c1')
+        c2 = self.client.createCollection('c2')
+        cs = self.client.listCollection()
+        self.assertEqual(len(cs), 2)
+        self.assertIn(c1, cs)
+        self.assertIn(c2, cs)
+
     def testUploadCallbacks(self):
         callbackUser = self.model('user').createUser(
             firstName='Callback', lastName='Last', login='callback',

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -177,13 +177,19 @@ class PythonClientTestCase(base.TestCase):
         self.client.inheritAccessControlRecursive(privateFolder['_id'])
 
         # Test collection creation and retrieval
-        c1 = self.client.createCollection('c1')
-        c2 = self.client.createCollection('c2')
+        c1 = self.client.createCollection('c1', public=False)
+        c2 = self.client.createCollection('c2', public=True)
         collections = self.client.listCollection()
         self.assertEqual(len(collections), 2)
         ids = [c['_id'] for c in collections]
         self.assertIn(c1['_id'], ids)
         self.assertIn(c2['_id'], ids)
+        c1 = self.client.getCollection(c1['_id'])
+        c2 = self.client.getCollection(c2['_id'])
+        self.assertEqual(c1['name'], 'c1')
+        self.assertEqual(c2['name'], 'c2')
+        self.assertFalse(c1['public'])
+        self.assertTrue(c2['public'])
 
     def testUploadCallbacks(self):
         callbackUser = self.model('user').createUser(


### PR DESCRIPTION
@cpatrick 

createFolder and createItem were there, I figure createCollection deserves a place too.