### PR TITLE
Add template for data.kitware.com to ExternalData_URL_TEMPLATES

### DIFF
--- a/tests/TestData.cmake
+++ b/tests/TestData.cmake
@@ -14,7 +14,7 @@ set(_plugin_build_data_path "${_build_data_path}/plugins")
 # set the default mirror
 set(ExternalData_URL_TEMPLATES
   "https://midas3.kitware.com/midas/api/rest?method=midas.bitstream.download&checksum=%(hash)&algorithm=%(algo)"
-  "https://data.kitware.com:443/api/v1/file/hashsum/%(algo)/%(hash)/download"
+  "https://data.kitware.com/api/v1/file/hashsum/%(algo)/%(hash)/download"
 )
 
 # Expose the absolute path to the data file source tree because

--- a/tests/TestData.cmake
+++ b/tests/TestData.cmake
@@ -14,6 +14,7 @@ set(_plugin_build_data_path "${_build_data_path}/plugins")
 # set the default mirror
 set(ExternalData_URL_TEMPLATES
   "https://midas3.kitware.com/midas/api/rest?method=midas.bitstream.download&checksum=%(hash)&algorithm=%(algo)"
+  "https://data.kitware.com:443/api/v1/file/hashsum/%(algo)/%(hash)/download"
 )
 
 # Expose the absolute path to the data file source tree because


### PR DESCRIPTION
This will allow the storage of external data used for tests on data.kitware.com