### PR TITLE
Fix support for multiple allowed origins

### DIFF
--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -579,9 +579,6 @@ def _setCommonCORSHeaders():
             cherrypy.response.headers[key] = allowed_list[0]
         elif origin in allowed_list:
             cherrypy.response.headers[key] = origin
-        else:
-            # They'll be rejected, this is purely for information
-            cherrypy.response.headers[key] = allowed
 
 
 class RestException(Exception):

--- a/tests/cases/routes_test.py
+++ b/tests/cases/routes_test.py
@@ -138,3 +138,19 @@ class RoutesTestCase(base.TestCase):
         self.assertEqual(resp.headers['Access-Control-Allow-Headers'],
                          SettingDefault.defaults[SettingKey.CORS_ALLOW_HEADERS])
         self.assertEqual(resp.headers['Access-Control-Allow-Methods'], 'POST')
+
+        # Set multiple allowed origins
+        self.model('setting').set(SettingKey.CORS_ALLOW_ORIGIN,
+                                  'http://foo.com, http://bar.com')
+        resp = self.request(
+            path='/dummy/test', method='GET', additionalHeaders=[
+                ('Origin', 'http://bar.com')
+            ], isJson=False)
+        self.assertEqual(resp.headers['Access-Control-Allow-Origin'],
+                         'http://bar.com')
+
+        resp = self.request(
+            path='/dummy/test', method='GET', additionalHeaders=[
+                ('Origin', 'http://invalid.com')
+            ], isJson=False)
+        self.assertNotIn('Access-Control-Allow-Origin', resp.headers)


### PR DESCRIPTION
The access-control-allow-origin header will only cause a CORS
request to succeed if it contains a single domain value, which
must either be '*' or the value of the 'Origin' request header.