### PR TITLE
Add PUT /resource/:id/timestamp to set timestamps

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 ###############################################################################
 
+import datetime
 import errno
 import getpass
 import glob
@@ -334,6 +335,24 @@ class GirderClient(object):
         search for a list of resources based on params.
         """
         return self.get(path, params)
+
+    def setResourceTimestamp(self, id, type, created=None, updated=None):
+        """
+        Set the created or updated timestamps for a resource.
+        """
+        url = 'resource/%s/timestamp' % id
+        params = {
+            'type': type,
+        }
+        if created:
+            if isinstance(created, datetime.datetime):
+                created = created.strftime('%Y-%m-%d %H:%M:%S')
+            params['created'] = created
+        if updated:
+            if isinstance(updated, datetime.datetime):
+                updated = updated.strftime('%Y-%m-%d %H:%M:%S')
+            params['updated'] = updated
+        return self.put(url, parameters=params)
 
     def listFile(self, itemId, limit=None, offset=None):
         """

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -17,7 +17,6 @@
 #  limitations under the License.
 ###############################################################################
 
-import datetime
 import errno
 import getpass
 import glob
@@ -345,13 +344,9 @@ class GirderClient(object):
             'type': type,
         }
         if created:
-            if isinstance(created, datetime.datetime):
-                created = created.strftime('%Y-%m-%d %H:%M:%S')
-            params['created'] = created
+            params['created'] = str(created)
         if updated:
-            if isinstance(updated, datetime.datetime):
-                updated = updated.strftime('%Y-%m-%d %H:%M:%S')
-            params['updated'] = updated
+            params['updated'] = str(updated)
         return self.put(url, parameters=params)
 
     def listFile(self, itemId, limit=None, offset=None):

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -18,6 +18,7 @@
 ###############################################################################
 
 import cherrypy
+import datetime
 import json
 
 from ..describe import Description, describeRoute
@@ -43,6 +44,7 @@ class Resource(BaseResource):
         self.route('GET', ('search',), self.search)
         self.route('GET', ('lookup',), self.lookup)
         self.route('GET', (':id',), self.getResource)
+        self.route('PUT', (':id', 'timestamp'), self.setTimestamp)
         self.route('GET', ('download',), self.download)
         self.route('POST', ('download',), self.download)
         self.route('PUT', ('move',), self.moveResources)
@@ -379,6 +381,34 @@ class Resource(BaseResource):
             user = self.getCurrentUser()
             return model.load(id=id, user=user, level=AccessType.READ)
         return model.load(id=id)
+
+    @access.admin
+    @describeRoute(
+        Description('Set the created or updated timestamp for a resource.')
+        .param('id', 'The ID of the resource.', paramType='path')
+        .param('type', 'The type of the resource (item, file, etc.).')
+        .param('created', 'The new created timestamp.', required=False)
+        .param('updated', 'The new updated timestamp.', required=False)
+        .errorResponse('ID was invalid.')
+        .errorResponse('Access was denied for the resource.', 403)
+    )
+    def setTimestamp(self, id, params):
+        user = self.getCurrentUser()
+        model = self._getResourceModel(params['type'])
+        doc = model.load(id=id, user=user, level=AccessType.WRITE)
+        if not doc:
+            raise RestException('Resource not found.')
+        if 'created' in params:
+            if 'created' not in doc:
+                raise RestException('Resource has no "created" field.')
+            doc['created'] = datetime.datetime.strptime(
+                params['created'], '%Y-%m-%d %H:%M:%S')
+        if 'updated' in params:
+            if 'updated' not in doc:
+                raise RestException('Resource has no "updated" field.')
+            doc['updated'] = datetime.datetime.strptime(
+                params['updated'], '%Y-%m-%d %H:%M:%S')
+        return model.save(doc)
 
     def _prepareMoveOrCopy(self, params):
         user = self.getCurrentUser()

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -18,7 +18,6 @@
 ###############################################################################
 
 import cherrypy
-import datetime
 import json
 
 from ..describe import Description, describeRoute
@@ -27,6 +26,7 @@ from girder.constants import AccessType, TokenScope
 from girder.api import access
 from girder.models.model_base import AccessControlledModel
 from girder.utility import acl_mixin
+from girder.utility import parseTimestamp
 from girder.utility import ziputil
 from girder.utility.progress import ProgressContext
 
@@ -401,13 +401,11 @@ class Resource(BaseResource):
         if 'created' in params:
             if 'created' not in doc:
                 raise RestException('Resource has no "created" field.')
-            doc['created'] = datetime.datetime.strptime(
-                params['created'], '%Y-%m-%d %H:%M:%S')
+            doc['created'] = parseTimestamp(params['created'])
         if 'updated' in params:
             if 'updated' not in doc:
                 raise RestException('Resource has no "updated" field.')
-            doc['updated'] = datetime.datetime.strptime(
-                params['updated'], '%Y-%m-%d %H:%M:%S')
+            doc['updated'] = parseTimestamp(params['updated'])
         return model.save(doc)
 
     def _prepareMoveOrCopy(self, params):

--- a/girder/utility/__init__.py
+++ b/girder/utility/__init__.py
@@ -40,7 +40,7 @@ except NotImplementedError:  # pragma: no cover
 
 
 def parseTimestamp(x, naive=True):
-    '''
+    """
     Parse a datetime string using the python-dateutil package.
 
     If no timezone information is included, assume UTC. If timezone information
@@ -48,7 +48,7 @@ def parseTimestamp(x, naive=True):
 
     If naive is True (the default), drop the timezone information such that a
     naive datetime is returned.
-    '''
+    """
     dt = dateutil.parser.parse(x)
     if dt.tzinfo:
         dt = dt.astimezone(pytz.utc).replace(tzinfo=None)

--- a/girder/utility/__init__.py
+++ b/girder/utility/__init__.py
@@ -18,6 +18,7 @@
 ###############################################################################
 
 import datetime
+import dateutil.parser
 import errno
 import json
 import os
@@ -36,6 +37,25 @@ except NotImplementedError:  # pragma: no cover
     print(TerminalColor.warning(
         'WARNING: using non-cryptographically secure PRNG.'))
     import random
+
+
+def parseTimestamp(x, naive=True):
+    '''
+    Parse a datetime string using the python-dateutil package.
+
+    If no timezone information is included, assume UTC. If timezone information
+    is included, convert to UTC.
+
+    If naive is True (the default), drop the timezone information such that a
+    naive datetime is returned.
+    '''
+    dt = dateutil.parser.parse(x)
+    if dt.tzinfo:
+        dt = dt.astimezone(pytz.utc).replace(tzinfo=None)
+    if naive:
+        return dt
+    else:
+        return pytz.utc.localize(dt)
 
 
 def genToken(length=64):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ Mako==1.0.4
 pymongo==3.2.2
 PyYAML==3.11
 psutil==4.2.0
+python-dateutil==2.5.3
 pytz==2016.4
 requests==2.10.0
 six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ install_reqs = [
     'PyYAML',
     'requests',
     'psutil',
+    'python-dateutil',
     'pytz',
     'six>=1.9'
 ]


### PR DESCRIPTION
For Midas to Girder migration, it is desirable to maintain the 'created' timestamp for the entities.

This PR adds a single endpoint, /resource/:id/timestamp, accessible only to admins for this purpose, instead of updating all of the endpoints for collections, users, folders, items, etc.

It also updates the girder python client with a method for this endpoint.

Tests WIP. Feedback welcome.