### PR TITLE
Fix multipart uploads for s3

### DIFF
--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -89,6 +89,9 @@ def _generate_url_sigv4(self, expires_in, method, bucket='', key='',
     if version_id is not None:
         params['VersionId'] = version_id
 
+    if response_headers is not None:
+        params.update(response_headers)
+
     http_request = self.build_base_http_request(
         method, path, auth_path, headers=headers, host=host, params=params)
 
@@ -311,8 +314,7 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
             upload['s3']['partNumber'] += 1
 
             key = mp.upload_part_from_file(
-                chunk, upload['s3']['partNumber'],
-                headers=self._getRequestHeaders(upload))
+                chunk, upload['s3']['partNumber'])
             upload['received'] += key.size
         else:
             key = bucket.new_key(upload['s3']['key'])

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -314,7 +314,8 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
             upload['s3']['partNumber'] += 1
 
             key = mp.upload_part_from_file(
-                chunk, upload['s3']['partNumber'])
+                chunk, upload['s3']['partNumber'],
+                headers={'Content-Type': upload.get('mimeType', '')})
             upload['received'] += key.size
         else:
             key = bucket.new_key(upload['s3']['key'])


### PR DESCRIPTION
@zachmullen 

I added the `response_headers` clause when I noticed it differed from the boto source: https://github.com/boto/boto/blob/dd5f87c7d5c55b69aa23bb4c21010897eb0deb42/boto/s3/connection.py#L354-L378

But it's possible you removed it intentionally? I didn't check the history. It probably has nothing to do with the error I was getting.