### PR TITLE
Add a browser widget modal dialog

### DIFF
--- a/clients/web/src/templates/body/filesystemImport.jade
+++ b/clients/web/src/templates/body/filesystemImport.jade
@@ -23,9 +23,13 @@ form.g-filesystem-import-form
       option(value="collection") Collection
   .form-group
     label(for="g-filesystem-import-dest-id") Destination ID
-    input.form-control.input-sm#g-filesystem-import-dest-id(
-      type="text"
-      placeholder="Existing folder, user, or collection ID to use as the destination")
+    .input-group.input-group-sm
+      input.form-control.input-sm#g-filesystem-import-dest-id(
+        type="text"
+        placeholder="Existing folder, user, or collection ID to use as the destination")
+      .input-group-btn
+        button.btn.btn-default(type="button")
+          i.icon-folder-open
   .form-group
     label(for="g-filesystem-import-leaf-items") Leaf Folders as Items
     select.form-control#g-filesystem-import-leaf-items

--- a/clients/web/src/templates/body/filesystemImport.jade
+++ b/clients/web/src/templates/body/filesystemImport.jade
@@ -28,7 +28,7 @@ form.g-filesystem-import-form
         type="text"
         placeholder="Existing folder, user, or collection ID to use as the destination")
       .input-group-btn
-        button.btn.btn-default(type="button")
+        button.g-open-browser.btn.btn-default(type="button")
           i.icon-folder-open
   .form-group
     label(for="g-filesystem-import-leaf-items") Leaf Folders as Items

--- a/clients/web/src/templates/widgets/browserWidget.jade
+++ b/clients/web/src/templates/widgets/browserWidget.jade
@@ -20,4 +20,4 @@
       a.btn.btn-small.btn-default(data-dismiss='modal') Cancel
       button.g-submit-button.btn.btn-small.btn-primary(type='submit')
         i.icon-edit
-          | Save
+        | Save

--- a/clients/web/src/templates/widgets/browserWidget.jade
+++ b/clients/web/src/templates/widgets/browserWidget.jade
@@ -10,9 +10,10 @@
       .g-hierarchy-widget-container.g-wait-for-root.form-group.hidden
       .help-block.g-wait-for-root.hidden
         | #{help}
-      .g-selected-model.g-wait-for-root.form-group.hidden
-        label(for='g-selected-model').control-label Selected id
-        input#g-selected-model.form-control(type='text' readonly)
+      if preview
+        .g-selected-model.g-wait-for-root.form-group.hidden
+          label(for='g-selected-model').control-label Selected id
+          input#g-selected-model.form-control(type='text' readonly)
       .g-validation-failed-message.hidden
 
     .modal-footer

--- a/clients/web/src/templates/widgets/browserWidget.jade
+++ b/clients/web/src/templates/widgets/browserWidget.jade
@@ -3,13 +3,13 @@
     .modal-header
       button.close(data-dismiss='modal', aria-hidden='true', type='button') &times;
       h4.modal-title
-        | #{title}
+        = title
 
     .modal-body
       .g-hierarchy-root-container.form-group
       .g-hierarchy-widget-container.g-wait-for-root.form-group.hidden
       .help-block.g-wait-for-root.hidden
-        | #{help}
+        = help
       if preview
         .g-selected-model.g-wait-for-root.form-group.hidden
           label(for='g-selected-model').control-label Selected id
@@ -20,4 +20,4 @@
       a.btn.btn-small.btn-default(data-dismiss='modal') Cancel
       button.g-submit-button.btn.btn-small.btn-primary(type='submit')
         i.icon-edit
-        | Save
+        = submit

--- a/clients/web/src/templates/widgets/browserWidget.jade
+++ b/clients/web/src/templates/widgets/browserWidget.jade
@@ -1,0 +1,22 @@
+.modal-dialog
+  .modal-content
+    .modal-header
+      button.close(data-dismiss='modal', aria-hidden='true', type='button') &times;
+      h4.modal-title
+        | #{title}
+
+    .modal-body
+      .g-hierarchy-root-container.form-group
+      .g-hierarchy-widget-container.g-wait-for-root.form-group.hidden
+      .help-block.g-wait-for-root.hidden
+        | #{help}
+      .g-selected-model.g-wait-for-root.form-group.hidden
+        label(for='g-selected-model').control-label Selected id
+        input#g-selected-model.form-control(type='text' readonly)
+      .g-validation-failed-message.hidden
+
+    .modal-footer
+      a.btn.btn-small.btn-default(data-dismiss='modal') Cancel
+      button.g-submit-button.btn.btn-small.btn-primary(type='submit')
+        i.icon-edit
+          | Save

--- a/clients/web/src/templates/widgets/rootSelectorWidget.jade
+++ b/clients/web/src/templates/widgets/rootSelectorWidget.jade
@@ -1,0 +1,10 @@
+select.g-root-selector
+  each groupName in display
+    if groupName === 'Home' && home
+      option(value=home.id, selected=selected.id === home.id) Home
+    else if groupName in groups
+      - var group = groups[groupName];
+      optgroup(label=groupName)
+        each model in group
+          if home && model.id === home.id
+            option(value=model.id, data-group=groupName, selected=model.id === selected.id) #{format(mode)}

--- a/clients/web/src/templates/widgets/rootSelectorWidget.jade
+++ b/clients/web/src/templates/widgets/rootSelectorWidget.jade
@@ -1,10 +1,13 @@
-select.g-root-selector
+- selected = selected || {id: ''};
+select#g-root-selector.form-control(required)
+  if !selected.id
+    option(value="" disabled selected hidden) Select a root...
   each groupName in display
     if groupName === 'Home' && home
       option(value=home.id, selected=selected.id === home.id) Home
     else if groupName in groups
       - var group = groups[groupName];
       optgroup(label=groupName)
-        each model in group
-          if home && model.id === home.id
-            option(value=model.id, data-group=groupName, selected=model.id === selected.id) #{format(mode)}
+        each model in group.models
+          if !home || model.id !== home.id
+            option(value=model.id, data-group=groupName, selected=model.id === selected.id) #{format(model)}

--- a/clients/web/src/views/body/FilesystemImportView.js
+++ b/clients/web/src/views/body/FilesystemImportView.js
@@ -20,10 +20,24 @@ girder.views.FilesystemImportView = girder.View.extend({
                 destinationType: destType,
                 progress: true
             });
-        }
+        },
+        'click .g-open-browser': '_openBrowser'
     },
 
     initialize: function (settings) {
+        this._browserWidgetView = new girder.views.BrowserWidget({
+            parentView: this,
+            title: 'Destination',
+            help: 'Browse to a location to select it as the destination.',
+            validate: function (id) {
+                if (!id) {
+                    return 'Please select a valid root.';
+                }
+            }
+        });
+        this.listenTo(this._browserWidgetView, 'g:saved', function (val) {
+            this.$('#g-filesystem-import-dest-id').val(val);
+        });
         this.assetstore = settings.assetstore;
         this.render();
     },
@@ -32,5 +46,9 @@ girder.views.FilesystemImportView = girder.View.extend({
         this.$el.html(girder.templates.filesystemImport({
             assetstore: this.assetstore
         }));
+    },
+
+    _openBrowser: function () {
+        this._browserWidgetView.setElement($('#g-dialog-container')).render();
     }
 });

--- a/clients/web/src/views/body/FilesystemImportView.js
+++ b/clients/web/src/views/body/FilesystemImportView.js
@@ -27,8 +27,8 @@ girder.views.FilesystemImportView = girder.View.extend({
     initialize: function (settings) {
         this._browserWidgetView = new girder.views.BrowserWidget({
             parentView: this,
-            title: 'Destination',
-            help: 'Browse to a location to select it as the destination.',
+            titleText: 'Destination',
+            helpText: 'Browse to a location to select it as the destination.',
             validate: function (id) {
                 if (!id) {
                     return 'Please select a valid root.';

--- a/clients/web/src/views/body/FilesystemImportView.js
+++ b/clients/web/src/views/body/FilesystemImportView.js
@@ -29,6 +29,7 @@ girder.views.FilesystemImportView = girder.View.extend({
             parentView: this,
             titleText: 'Destination',
             helpText: 'Browse to a location to select it as the destination.',
+            submitText: 'Select Destination',
             validate: function (id) {
                 if (!id) {
                     return 'Please select a valid root.';

--- a/clients/web/src/views/widgets/BrowserWidget.js
+++ b/clients/web/src/views/widgets/BrowserWidget.js
@@ -11,8 +11,9 @@ girder.views.BrowserWidget = girder.View.extend({
     /**
      * Initialize the widget.
      * @param {object} settings
-     * @param {string} [titleText] Text to display in the modal header
+     * @param {string} [titleText="Select an item"] Text to display in the modal header
      * @param {string} [helpText] Info text to display below the hierarchy widget
+     * @param {string} [submitText="Save"] Text to display on the submit button
      * @param {boolean} [showItems=false] Show items in the hierarchy widget
      * @param {boolean} [showPreview=true] Show a preview of the current object id
      * @param {function} [validate] A validation function returning a string that is displayed on error
@@ -26,6 +27,7 @@ girder.views.BrowserWidget = girder.View.extend({
         this.helpText = settings.helpText;
         this.showItems = settings.showItems;
         this.showPreview = settings.showPreview || true;
+        this.submitText = settings.submitText || 'Save';
 
         // generate the root selection view and listen to it's events
         this._rootSelectionView = new girder.views.RootSelectorWidget(_.extend({
@@ -42,7 +44,8 @@ girder.views.BrowserWidget = girder.View.extend({
             girder.templates.browserWidget({
                 title: this.titleText,
                 help: this.helpText,
-                preview: this.showPreview
+                preview: this.showPreview,
+                submit: this.submitText
             })
         ).girderModal(this);
         this._renderRootSelection();

--- a/clients/web/src/views/widgets/BrowserWidget.js
+++ b/clients/web/src/views/widgets/BrowserWidget.js
@@ -8,12 +8,25 @@ girder.views.BrowserWidget = girder.View.extend({
         'click .g-submit-button': '_submitButton'
     },
 
+    /**
+     * Initialize the widget.
+     * @param {object} settings
+     * @param {string} [titleText] Text to display in the modal header
+     * @param {string} [helpText] Info text to display below the hierarchy widget
+     * @param {boolean} [showItems=false] Show items in the hierarchy widget
+     * @param {boolean} [showPreview=true] Show a preview of the current object id
+     * @param {function} [validate] A validation function returning a string that is displayed on error
+     */
     initialize: function (settings) {
+        // store options
         settings = settings || {};
-        this.title = settings.title || 'Select an item';
+        this.titleText = settings.titleText || 'Select an item';
         this.validate = settings.validate || function () {};
-        this.help = settings.help;
+        this.helpText = settings.helpText;
         this.showItems = settings.showItems;
+        this.showPreview = settings.showPreview || true;
+
+        // generate the root selection view and listen to it's events
         this._rootSelectionView = new girder.views.RootSelectorWidget({
             parentView: this,
             display: ['Collections', 'Users']
@@ -27,12 +40,20 @@ girder.views.BrowserWidget = girder.View.extend({
     render: function () {
         this.$el.html(
             girder.templates.browserWidget({
-                title: this.title,
-                help: this.help
+                title: this.titleText,
+                help: this.helpText,
+                preview: this.showPreview
             })
         ).girderModal(this);
         this._renderRootSelection();
         return this;
+    },
+
+    /**
+     * Return the selected model id.
+     */
+    selectedModel: function () {
+        return this.$('#g-selected-model').val();
     },
 
     _renderRootSelection: function () {
@@ -83,9 +104,5 @@ girder.views.BrowserWidget = girder.View.extend({
             this.$el.modal('hide');
             this.trigger('g:saved', model);
         }
-    },
-
-    selectedModel: function () {
-        return this.$('#g-selected-model').val();
     }
 });

--- a/clients/web/src/views/widgets/BrowserWidget.js
+++ b/clients/web/src/views/widgets/BrowserWidget.js
@@ -16,6 +16,7 @@ girder.views.BrowserWidget = girder.View.extend({
      * @param {boolean} [showItems=false] Show items in the hierarchy widget
      * @param {boolean} [showPreview=true] Show a preview of the current object id
      * @param {function} [validate] A validation function returning a string that is displayed on error
+     * @param {object} [rootSelectorSettings] Settings passed to the root selector widget
      */
     initialize: function (settings) {
         // store options
@@ -27,10 +28,9 @@ girder.views.BrowserWidget = girder.View.extend({
         this.showPreview = settings.showPreview || true;
 
         // generate the root selection view and listen to it's events
-        this._rootSelectionView = new girder.views.RootSelectorWidget({
-            parentView: this,
-            display: ['Collections', 'Users']
-        });
+        this._rootSelectionView = new girder.views.RootSelectorWidget(_.extend({
+            parentView: this
+        }, settings.rootSelectorSettings));
         this.listenTo(this._rootSelectionView, 'g:selected', function (evt) {
             this._root = evt.root;
             this._renderHierarchyView();
@@ -86,6 +86,7 @@ girder.views.BrowserWidget = girder.View.extend({
     },
 
     _selectItem: function () {
+        // for future extensibility, do something when an item is clicked
     },
 
     _selectModel: function () {

--- a/clients/web/src/views/widgets/BrowserWidget.js
+++ b/clients/web/src/views/widgets/BrowserWidget.js
@@ -68,7 +68,7 @@ girder.views.BrowserWidget = girder.View.extend({
         if (this._hierarchyView) {
             this.stopListening(this._hierarchyView);
             this._hierarchyView.off();
-            this.$('.h-hierarchy-widget').empty();
+            this.$('.g-hierarchy-widget-container').empty();
         }
         if (!this._root) {
             return;

--- a/clients/web/src/views/widgets/BrowserWidget.js
+++ b/clients/web/src/views/widgets/BrowserWidget.js
@@ -1,0 +1,91 @@
+/**
+ * This widget provides the user with an interface similar to a filesystem
+ * browser to pick a single user, collection, folder, or item from a
+ * hierarchical view.
+ */
+girder.views.BrowserWidget = girder.View.extend({
+    events: {
+        'click .g-submit-button': '_submitButton'
+    },
+
+    initialize: function (settings) {
+        settings = settings || {};
+        this.title = settings.title || 'Select an item';
+        this.validate = settings.validate || function () {};
+        this.help = settings.help;
+        this.showItems = settings.showItems;
+        this._rootSelectionView = new girder.views.RootSelectorWidget({
+            parentView: this,
+            display: ['Collections', 'Users']
+        });
+        this.listenTo(this._rootSelectionView, 'g:selected', function (evt) {
+            this._root = evt.root;
+            this._renderHierarchyView();
+        });
+    },
+
+    render: function () {
+        this.$el.html(
+            girder.templates.browserWidget({
+                title: this.title,
+                help: this.help
+            })
+        ).girderModal(this);
+        this._renderRootSelection();
+        return this;
+    },
+
+    _renderRootSelection: function () {
+        this._rootSelectionView.setElement(this.$('.g-hierarchy-root-container')).render();
+        this._renderHierarchyView();
+    },
+
+    _renderHierarchyView: function () {
+        if (this._hierarchyView) {
+            this.stopListening(this._hierarchyView);
+            this._hierarchyView.off();
+            this.$('.h-hierarchy-widget').empty();
+        }
+        if (!this._root) {
+            return;
+        }
+        this.$('.g-wait-for-root').removeClass('hidden');
+        this._hierarchyView = new girder.views.HierarchyWidget({
+            parentView: this,
+            parentModel: this._root,
+            checkboxes: false,
+            routing: false,
+            showActions: false,
+            showItems: this.showItems,
+            onItemClick: _.bind(this._selectItem, this)
+        });
+        this.listenTo(this._hierarchyView, 'g:setCurrentModel', this._selectModel);
+        this._hierarchyView.setElement(this.$('.g-hierarchy-widget-container')).render();
+        this._selectModel();
+    },
+
+    _selectItem: function () {
+    },
+
+    _selectModel: function () {
+        this.$('.g-validation-failed-message').addClass('hidden');
+        this.$('.g-selected-model').removeClass('has-error');
+        this.$('#g-selected-model').val(this._hierarchyView.parentModel.id);
+    },
+
+    _submitButton: function () {
+        var model = this.selectedModel();
+        var message = this.validate(model);
+        if (message) {
+            this.$('.g-selected-model').addClass('has-error');
+            this.$('.g-validation-failed-message').removeClass('hidden').text(message);
+        } else {
+            this.$el.modal('hide');
+            this.trigger('g:saved', model);
+        }
+    },
+
+    selectedModel: function () {
+        return this.$('#g-selected-model').val();
+    }
+});

--- a/clients/web/src/views/widgets/RootSelectorWidget.js
+++ b/clients/web/src/views/widgets/RootSelectorWidget.js
@@ -114,7 +114,7 @@ girder.views.RootSelectorWidget = girder.View.extend({
     },
 
     /**
-     * Called when a collections was modified.  Rerenders the view.
+     * Called when a collection is modified... rerenders the view.
      */
     _updateGroup: function (collection) {
         this.trigger('g:group', {

--- a/clients/web/src/views/widgets/RootSelectorWidget.js
+++ b/clients/web/src/views/widgets/RootSelectorWidget.js
@@ -1,0 +1,151 @@
+/**
+ * This widget creates a dropdown box allowing the user to select
+ * "root" paths for a hierarchy widget.
+ *
+ * @emits RootSelectorWidget#g:selected The selected element changed
+ * @type {object}
+ * @property {girder.Model|null} root The selected root model
+ * @property {string|null} group The selection group
+ *
+ * @emits RootSelectorWidget#g:group A collection group was updated
+ * @type {object}
+ * @property {girder.Collection} collection
+ */
+girder.views.RootSelectorWidget = girder.View.extend({
+    events: {
+        'change #g-select-root': '_selectRoot'
+    },
+
+    /**
+     * Initialize the widget.  The caller can configure the list of items
+     * that are present in the select box.  If no values are given, then
+     * appropriate rest calls will be made to fetch models automatically.
+     *
+     * Additional categories of roots can be provided via an object mapping,
+     * for example:
+     *
+     *   {
+     *     friends: new girder.collections.UserCollection([...]),
+     *     saved: new girder.collections.FolderCollection([...])
+     *   }
+     *
+     * Only a single page of results are displayed for each collection provided.
+     * The default maximum number can be configured, but for more sophisticated
+     * behavior, the caller should act on the collection objects directly and
+     * rerender.
+     *
+     * @param {object} settings
+     * @param {girder.models.UserModel} [settings.home=girder.currentUser]
+     * @param {object} [settings.groups] Additional collection groups to add
+     * @param {number} [settings.pageLimit=25] The maximum number of models to fetch
+     * @param {girder.Model} [settings.selected] The default/current selection
+     * @param {string[]} [settings.display=['Home', 'Collections', 'Users'] Display order
+     * @param {boolean} [settings.reset=true] Always fetch from offset 0
+     */
+    initialize: function (settings) {
+        settings = settings || {};
+
+        this.pageLimit = settings.pageLimit || 25;
+
+        // collections are provided for public access here
+        this.groups = {
+            'Collections': new girder.collections.CollectionCollection(),
+            'Users': new girder.collections.UserCollection()
+        };
+
+        this.groups.Collections.pageLimit = settings.pageLimit;
+        this.groups.Users.pageLimit = settings.pageLimit;
+        this.groups.Users.sortField = 'login';
+
+        // override default selection groups
+        _.extend(this.groups, settings.groups);
+
+        // attach collection change events
+        _.each(this.groups, _.bind(function (group) {
+            this.listenTo(group, 'g:changed', this._updateGroup);
+        }, this));
+
+        // possible values that determine rendered behavior for "Home":
+        //   - model: show this model as Home
+        //   - undefined|null: use girder.currentUser
+        this.home = settings.home;
+
+        // we need to fetch the collections and rerender on login
+        this.listenTo(girder.events, 'g:login', this.fetch);
+
+        this.selected = settings.selected;
+        this.display = settings.display || ['Home', 'Collections', 'Users'];
+
+        this.fetch();
+    },
+
+    render: function () {
+        this._home = this.home || girder.currentUser;
+
+        girder.templates.rootSelectorWidget({
+            home: this._home,
+            groups: this.groups,
+            display: this.display,
+            selected: this.selected,
+            format: this._formatName
+        });
+    },
+
+    /**
+     * Called when the user selects a new item.  Resolves the
+     * model object from the DOM and triggers the g:selected event.
+     */
+    _selectRoot: function (evt) {
+        var sel = this.$(':selected');
+        var id = sel.val();
+        var group = sel.data('group') || null;
+        this.selected = null;
+        if (_.has(this.groups, group)) {
+            this.selected = this.groups[group].get(id);
+        } else if (this._home && this._home.id === id) {
+            this.selected = this._home;
+        }
+        this.selected = this.$(':selected').data('model');
+        this.trigger('g:selected', {
+            root: this.selected,
+            group: group
+        });
+    },
+
+    /**
+     * Called when a collections was modified.  Rerenders the view.
+     */
+    _updateGroup: function (collection) {
+        this.trigger('g:group', {
+            collection: collection
+        });
+        this.render();
+    },
+
+    /**
+     * Return a string to display for the given model.
+     */
+    _formatName: function (model) {
+        var name = model.id;
+        switch (model.get('_modelType')) {
+            case 'user':
+                name = model.get('login');
+                break;
+            case 'folder':
+            case 'collection':
+                name = model.get('name');
+                break;
+        }
+        return name;
+    },
+
+    /**
+     * Fetch all collections from the server.
+     */
+    fetch: function () {
+        var reset = this.reset;
+        _.each(this.groups, function (name, collection) {
+            collection.fetch(null, reset);
+        });
+    }
+});

--- a/clients/web/src/views/widgets/RootSelectorWidget.js
+++ b/clients/web/src/views/widgets/RootSelectorWidget.js
@@ -13,7 +13,7 @@
  */
 girder.views.RootSelectorWidget = girder.View.extend({
     events: {
-        'change #g-select-root': '_selectRoot'
+        'change #g-root-selector': '_selectRoot'
     },
 
     /**
@@ -82,13 +82,15 @@ girder.views.RootSelectorWidget = girder.View.extend({
     render: function () {
         this._home = this.home || girder.currentUser;
 
-        girder.templates.rootSelectorWidget({
-            home: this._home,
-            groups: this.groups,
-            display: this.display,
-            selected: this.selected,
-            format: this._formatName
-        });
+        this.$el.html(
+            girder.templates.rootSelectorWidget({
+                home: this._home,
+                groups: this.groups,
+                display: this.display,
+                selected: this.selected,
+                format: this._formatName
+            })
+        );
     },
 
     /**
@@ -105,7 +107,6 @@ girder.views.RootSelectorWidget = girder.View.extend({
         } else if (this._home && this._home.id === id) {
             this.selected = this._home;
         }
-        this.selected = this.$(':selected').data('model');
         this.trigger('g:selected', {
             root: this.selected,
             group: group
@@ -144,7 +145,7 @@ girder.views.RootSelectorWidget = girder.View.extend({
      */
     fetch: function () {
         var reset = this.reset;
-        _.each(this.groups, function (name, collection) {
+        _.each(this.groups, function (collection) {
             collection.fetch(null, reset);
         });
     }

--- a/clients/web/test/spec/browserSpec.js
+++ b/clients/web/test/spec/browserSpec.js
@@ -1,0 +1,330 @@
+/* globals waitsFor, runs, girderTest, expect, describe, it, beforeEach, afterEach */
+// girderTest.startApp();
+
+describe('Test the hierarchy browser modal', function () {
+    var testEl;
+    var restRequest;
+    var requestArgs = [];
+    var requestContext = [];
+    var returnVal;
+    var onRestRequest;
+    var transition;
+
+    beforeEach(function () {
+        testEl = $('<div/>').appendTo('body');
+        restRequest = girder.restRequest;
+        returnVal = null;
+        girder.restRequest = function () {
+            requestContext.push(this);
+            requestArgs.push(_.toArray(arguments));
+            if (onRestRequest) {
+                return onRestRequest.apply(this, arguments);
+            }
+            return $.when(returnVal);
+        };
+        transition = $.support.transition;
+        $.support.transition = false;
+    });
+    afterEach(function () {
+        testEl.remove();
+        girder.logout();
+        girder.restRequest = restRequest;
+        $.support.transition = transition;
+    });
+
+    describe('root selection', function () {
+        it('defaults', function () {
+            returnVal = [];
+            var view = new girder.views.RootSelectorWidget({el: testEl, parentView: null});
+            var select = view.$('select#g-root-selector');
+            expect(select.length).toBe(1);
+            expect(select.find('option:eq(0)').text()).toBe('Select a root...');
+            expect(select.find('optgroup[label="Collections"]').length).toBe(1);
+            expect(select.find('optgroup[label="Users"]').length).toBe(1);
+        });
+
+        it('display order', function () {
+            returnVal = [];
+            var view = new girder.views.RootSelectorWidget({
+                el: testEl,
+                parentView: null,
+                display: ['Users']
+            });
+            var select = view.$('select#g-root-selector');
+            expect(select.length).toBe(1);
+            expect(select.find('option:eq(0)').text()).toBe('Select a root...');
+            expect(select.find('optgroup[label="Collections"]').length).toBe(0);
+            expect(select.find('optgroup[label="Users"]').length).toBe(1);
+        });
+
+        it('user logged in', function () {
+            girder.currentUser = new girder.models.UserModel({
+                _id: '0',
+                login: 'johndoe',
+                firstName: 'John',
+                lastName: 'Doe'
+            });
+
+            returnVal = [];
+            var view = new girder.views.RootSelectorWidget({
+                el: testEl,
+                parentView: null
+            });
+            var select = view.$('select#g-root-selector');
+            expect(select.length).toBe(1);
+            expect(select.find('option:eq(0)').text()).toBe('Select a root...');
+            expect(select.find('option[value="0"]').text()).toBe('Home');
+        });
+
+        it('rerender on login', function () {
+            returnVal = [];
+            var view = new girder.views.RootSelectorWidget({
+                el: testEl,
+                parentView: null
+            });
+            returnVal = {
+                user: {
+                    _id: '0',
+                    login: 'johndoe',
+                    firstName: 'John',
+                    lastName: 'Doe'
+                },
+                authToken: {
+                    token: ''
+                }
+            };
+            girder.login('johndoe', 'password');
+
+            var select = view.$('select#g-root-selector');
+            expect(select.length).toBe(1);
+            expect(select.find('option:eq(0)').text()).toBe('Select a root...');
+            expect(select.find('option[value="0"]').text()).toBe('Home');
+        });
+
+        it('custom optgroup', function () {
+            var col = new girder.collections.CollectionCollection();
+
+            returnVal = [];
+            var view = new girder.views.RootSelectorWidget({
+                el: testEl,
+                parentView: null,
+                groups: {
+                    Custom: col
+                },
+                display: ['Collections', 'Custom']
+            });
+
+            var select = view.$('select#g-root-selector');
+            expect(select.length).toBe(1);
+            expect(select.find('option:eq(0)').text()).toBe('Select a root...');
+            expect(select.find('optgroup:eq(0)').prop('label')).toBe('Collections');
+            expect(select.find('optgroup:eq(1)').prop('label')).toBe('Custom');
+
+            returnVal = [
+                {_id: 'abc', name: 'custom 1', _modelType: 'collection'},
+                {_id: 'def', name: 'custom 2', _modelType: 'user', login: 'thelogin'},
+                {_id: '123', name: 'custom 3', _modelType: 'folder'}
+            ];
+            col.fetch();
+
+            select = view.$('select#g-root-selector');
+            var opt = select.find('optgroup[label="Custom"] > option[value="abc"]');
+            expect(opt.data('group')).toBe('Custom');
+            expect(opt.text()).toBe('custom 1');
+
+            opt = select.find('optgroup[label="Custom"] > option[value="def"]');
+            expect(opt.data('group')).toBe('Custom');
+            expect(opt.text()).toBe('thelogin');
+
+            opt = select.find('optgroup[label="Custom"] > option[value="123"]');
+            expect(opt.data('group')).toBe('Custom');
+            expect(opt.text()).toBe('custom 3');
+        });
+
+        it('respond to user selection', function () {
+            returnVal = [
+                {_id: 'abc', name: 'custom 1', _modelType: 'collection'},
+                {_id: 'def', name: 'custom 2', _modelType: 'user', login: 'thelogin'},
+                {_id: '123', name: 'custom 3', _modelType: 'folder'}
+            ];
+            var col = new girder.collections.CollectionCollection();
+            col.fetch();
+
+            returnVal = [];
+            var view = new girder.views.RootSelectorWidget({
+                el: testEl,
+                parentView: null,
+                groups: {
+                    Custom: col
+                },
+                display: ['Collections', 'Custom']
+            });
+
+            var called = 0;
+            view.on('g:selected', function (evt) {
+                expect(evt.root.attributes).toEqual({
+                    _id: '123',
+                    name: 'custom 3',
+                    _modelType: 'folder'
+                });
+                called += 1;
+            });
+
+            view.$('select').val('123').trigger('change');
+            expect(called).toBe(1);
+        });
+
+        it('respond to Home selection', function () {
+            girder.currentUser = new girder.models.UserModel({
+                _id: '0',
+                login: 'johndoe',
+                firstName: 'John',
+                lastName: 'Doe'
+            });
+            returnVal = [
+                {_id: 'abc', name: 'custom 1', _modelType: 'collection'},
+                {_id: 'def', name: 'custom 2', _modelType: 'user', login: 'thelogin'},
+                {_id: '123', name: 'custom 3', _modelType: 'folder'}
+            ];
+            var col = new girder.collections.CollectionCollection();
+            col.fetch();
+
+            returnVal = [];
+            var view = new girder.views.RootSelectorWidget({
+                el: testEl,
+                parentView: null,
+                groups: {
+                    Custom: col
+                },
+                display: ['Home', 'Collections', 'Custom']
+            });
+
+            var called = 0;
+            view.on('g:selected', function (evt) {
+                expect(evt.root.attributes).toEqual({
+                    _id: '0',
+                    login: 'johndoe',
+                    firstName: 'John',
+                    lastName: 'Doe'
+                });
+                called += 1;
+            });
+
+            view.$('select').val('0').trigger('change');
+            expect(called).toBe(1);
+        });
+
+        it('preselected option', function () {
+            returnVal = [
+                {_id: 'abc', name: 'custom 1', _modelType: 'collection'},
+                {_id: 'def', name: 'custom 2', _modelType: 'user', login: 'thelogin'},
+                {_id: '123', name: 'custom 3', _modelType: 'folder'}
+            ];
+            var col = new girder.collections.CollectionCollection();
+            col.fetch();
+
+            returnVal = [];
+            var view = new girder.views.RootSelectorWidget({
+                el: testEl,
+                parentView: null,
+                groups: {
+                    Custom: col
+                },
+                display: ['Collections', 'Custom'],
+                selected: col.models[2]
+            });
+
+            var select = view.$('select#g-root-selector');
+            expect(select.length).toBe(1);
+            expect(select.val()).toBe('123');
+        });
+    });
+
+    describe('browser modal', function () {
+        var view;
+
+        var hw;
+        var hwSettings;
+        var hwCalls;
+        var hwView;
+
+        beforeEach(function () {
+            hw = girder.views.HierarchyWidget;
+            hwCalls = 0;
+            girder.views.HierarchyWidget = Backbone.View.extend({
+                initialize: function (settings) {
+                    hwCalls += 1;
+                    hwSettings = settings;
+                    hwView = this;
+                    this.parentModel = settings.parentModel;
+                }
+            });
+        });
+        afterEach(function () {
+            if (view) {
+                view.$el.modal('hide');
+            }
+            girder.views.HierarchyWidget = hw;
+        });
+        it('defaults', function () {
+            returnVal = [];
+            view = new girder.views.BrowserWidget({
+                parentView: null
+            }).render();
+
+            expect(view.$('.modal-title').text()).toBe('Select an item');
+            expect(view.$('#g-root-selector').length).toBe(1);
+
+            view.$('.g-submit-button').click();
+            expect(view.$el.css('display')).toBe('none');
+        });
+
+        it('validation', function () {
+            returnVal = [];
+            view = new girder.views.BrowserWidget({
+                parentView: null,
+                validate: function () {return 'invalid';} 
+            }).render();
+
+            view.$('.g-submit-button').click();
+            expect(view.$el.hasClass('in')).toBe(true);
+            expect(view.$('.g-validation-failed-message').text()).toBe('invalid');
+            expect(view.$('.g-validation-falied-message').hasClass('hidden')).toBe(false);
+        });
+
+        it('render hierarchy', function () {
+            girder.currentUser = new girder.models.UserModel({
+                _id: '0',
+                login: 'johndoe',
+                firstName: 'John',
+                lastName: 'Doe'
+            });
+
+            returnVal = [];
+            view = new girder.views.BrowserWidget({
+                parentView: null,
+                helpText: 'This is helpful',
+                showItems: false,
+                titleText: 'This is a title',
+                rootSelectorSettings: {
+                    display: ['Home']
+                }
+            }).render();
+
+            expect(view.$('.modal-title').text()).toBe('This is a title');
+            view.$('#g-root-selector').val('0').trigger('change');
+
+            expect(hwSettings.parentModel).toBe(girder.currentUser);
+            expect(view.$('g-hierarchy-widget-container').hasClass('hidden')).toBe(false);
+            expect(view.$('#g-selected-model').val()).toBe(girder.currentUser.id);
+
+            var ncalls = 0;
+            view.on('g:saved', function (id) {
+                ncalls += 1;
+                expect(id).toBe(girder.currentUser.id);
+            });
+            view.$('.g-submit-button').click();
+            expect(ncalls).toBe(1);
+        });
+    });
+});

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -65,6 +65,7 @@ if(RUN_CORE_TESTS)
   add_web_client_test(datetime_widget "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dateTimeWidgetSpec.js")
   add_web_client_test(empty_layout "${PROJECT_SOURCE_DIR}/clients/web/test/spec/emptyLayoutSpec.js")
   add_web_client_test(swagger "${PROJECT_SOURCE_DIR}/clients/web/test/spec/swaggerSpec.js" BASEURL "/api/v1" NOCOVERAGE)
+  add_web_client_test(browser "${PROJECT_SOURCE_DIR}/clients/web/test/spec/browserSpec.js")
 
   # Add tests for the local TestData module
   add_plugin_data_path("has_external_data" "${PROJECT_SOURCE_DIR}/tests/test_plugins/has_external_data")


### PR DESCRIPTION
This adds a modal dialog for selecting a path graphically.  The dialog returns a model id that can be a collection, user, folder, or item.  For a usage example, I added a button to the `FilesystemImportView` so that you can browse to the import path rather than enter an id manually.

It looks something like this:
![screen shot 2016-07-11 at 12 22 44 pm](https://cloud.githubusercontent.com/assets/31890/16738110/57b52b86-4762-11e6-87e0-5f439f75fbbf.png)

