### PR TITLE
Collapse build matrix to improve CI response time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
 env:
     - GIRDER_TEST_GROUP=python
     - GIRDER_TEST_GROUP=browser
-    - GIRDER_TEST_GROUP=packaging
     - GIRDER_TEST_GROUP=other
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_install:
     - npm prune
     - pip install -U pip virtualenv
 install:
-    - if [ "$GIRDER_TEST_GROUP" == "python" -o "$GIRDER_TEST_GROUP" == "browser" -o "$GIRDER_TEST_GROUP" == "other" ] ; then pip install -r requirements.txt -r requirements-dev.txt -e . ; fi
+    - pip install -r requirements.txt -r requirements-dev.txt -e .
     - npm install
 script:
     - mkdir _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,11 @@ python:
 env:
     - GIRDER_TEST_GROUP=python
     - GIRDER_TEST_GROUP=browser
-    - GIRDER_TEST_GROUP=other
 
 matrix:
     exclude:
         - python: 3.4
           env: GIRDER_TEST_GROUP=browser
-        - python: 3.4
-          env: GIRDER_TEST_GROUP=other
 
 cache:
     directories:
@@ -30,7 +27,7 @@ before_install:
     - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]; then export PY3="true"; else export PY2="true"; fi
     - if [ -n "${PY3}" ]; then export MONGO_VERSION=3.0.7; export PY_COVG="OFF"; else export MONGO_VERSION=2.6.11; export PY_COVG="ON"; export DEPLOY=true; fi
     - if [ -n "${PY3}" ]; then export IGNORE_PLUGINS=hdfs_assetstore,metadata_extractor; fi
-    - if [ "$GIRDER_TEST_GROUP" != "other" ] ; then CACHE=$HOME/.cache source ./scripts/install_mongo.sh ; fi
+    - CACHE=$HOME/.cache source ./scripts/install_mongo.sh
     - mkdir /tmp/db
     - (mongod --dbpath=/tmp/db >/dev/null 2>/dev/null || true ) &
     - mongod --version || true

--- a/cmake/travis_continuous.cmake
+++ b/cmake/travis_continuous.cmake
@@ -6,41 +6,25 @@ set(test_group "$ENV{GIRDER_TEST_GROUP}")
 set(CTEST_SITE "Travis")
 set(CTEST_BUILD_NAME "Linux-$ENV{TRAVIS_BRANCH}-Mongo-$ENV{MONGO_VERSION}-${test_group}")
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
-set(include_label ".*")
-set(exclude_label "")
-
-if(test_group STREQUAL python)
-  set(include_label "girder_python")
-elseif(test_group STREQUAL browser)
-  set(include_label "girder_browser")
-elseif(test_group STREQUAL packaging)
-  set(include_label "girder_packaging")
-elseif(test_group STREQUAL other)
-  set(exclude_label "(girder_python|girder_browser|girder_packaging)")
-endif()
 
 ctest_start("Continuous")
 ctest_configure()
 ctest_build()
 
-if(test_group STREQUAL other)
+if(test_group STREQUAL python)
   ctest_test(
     PARALLEL_LEVEL 4 RETURN_VALUE res
-    EXCLUDE_LABEL "${exclude_label}"
+    INCLUDE_LABEL girder_python
   )
-else()
+elseif(test_group STREQUAL browser)
   ctest_test(
     PARALLEL_LEVEL 4 RETURN_VALUE res
-    INCLUDE_LABEL "${include_label}"
+    EXCLUDE_LABEL girder_python
   )
+  file(RENAME "${CTEST_BINARY_DIRECTORY}/js_coverage.xml" "${CTEST_BINARY_DIRECTORY}/coverage.xml")
 endif()
 
-if(test_group STREQUAL "python")
-  ctest_coverage()
-elseif(test_group STREQUAL "browser")
-  file(RENAME "${CTEST_BINARY_DIRECTORY}/js_coverage.xml" "${CTEST_BINARY_DIRECTORY}/coverage.xml")
-  ctest_coverage()
-endif()
+ctest_coverage()
 
 file(REMOVE "${CTEST_BINARY_DIRECTORY}/coverage.xml")
 ctest_submit()

--- a/tests/packaging/CMakeLists.txt
+++ b/tests/packaging/CMakeLists.txt
@@ -35,7 +35,7 @@ add_test(
 )
 
 set_property(TEST packaging_generate
-  PROPERTY LABELS girder_packaging
+  PROPERTY LABELS girder_python
 )
 
 add_test(
@@ -45,7 +45,7 @@ add_test(
 )
 
 set_property(TEST packaging_verify_contents
-  PROPERTY LABELS girder_packaging
+  PROPERTY LABELS girder_python
 )
 set_property(TEST packaging_verify_contents
   PROPERTY DEPENDS packaging_generate
@@ -64,7 +64,7 @@ add_test(
 )
 
 set_property(TEST packaging_install
-  PROPERTY LABELS girder_packaging
+  PROPERTY LABELS girder_python
 )
 set_property(TEST packaging_install
   PROPERTY DEPENDS "packaging_generate"
@@ -83,7 +83,7 @@ add_test(
 )
 
 set_property(TEST packaging_plugin_install
-  PROPERTY LABELS girder_packaging
+  PROPERTY LABELS girder_python
 )
 set_property(TEST packaging_plugin_install
   PROPERTY DEPENDS "packaging_install"


### PR DESCRIPTION
Given the limits on concurrent build runs, plus the overhead associated with each one, it makes sense to combine the `packaging` and `python` labels. This means we now have only one label that needs to be run in both python 2 and 3, making our total build count 4 instead of 6, which will increase our CI response time significantly in high traffic situations.