### PR TITLE
Allow to upload/download files using resource path

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -922,11 +922,11 @@ class GirderClient(object):
         """
         Download a folder recursively from Girder into a local directory.
 
-        :param folderId: Id of the Girder folder to download.
+        :param folderId: Id of the Girder folder or resource path to download.
         :param dest: The local download destination.
         """
         offset = 0
-
+        folderId = self._checkResourcePath(folderId)
         while True:
             folders = self.get('folder', parameters={
                 'limit': DEFAULT_PAGE_LIMIT,
@@ -1212,7 +1212,7 @@ class GirderClient(object):
 
         :param file_pattern: a glob pattern for files that will be uploaded,
             recursively copying any file folder structures.
-        :param parent_id: id of the parent in Girder.
+        :param parent_id: id of the parent in Girder or resource path.
         :param parent_type: one of (collection,folder,user), default of folder.
         :param leaf_folders_as_items: bool whether leaf folders should have all
             files uploaded as single items.
@@ -1220,6 +1220,7 @@ class GirderClient(object):
             the same name in the same location, or create a new one instead.
         """
         empty = True
+        parent_id = self._checkResourcePath(parent_id)
         for current_file in glob.iglob(file_pattern):
             empty = False
             current_file = os.path.normpath(current_file)
@@ -1243,3 +1244,10 @@ class GirderClient(object):
                     leaf_folders_as_items, reuse_existing)
         if empty:
             print('No matching files: ' + file_pattern)
+
+    def _checkResourcePath(self, objId):
+        if isinstance(objId, six.string_types) and objId.startswith('/'):
+            obj = self.resourceLookup(objId, test=True)
+            if obj is not None:
+                return obj['_id']
+        return objId

--- a/tests/cases/py_client/cli_test.py
+++ b/tests/cases/py_client/cli_test.py
@@ -169,6 +169,11 @@ class PythonCliTestCase(base.TestCase):
                         username='mylogin', password='password')
         self.assertEqual(ret['exitVal'], 0)
 
+        # Download again to same location, using path, we should not get errors
+        ret = invokeCli(('-c', 'download', '/user/mylogin/Public/testdata',
+                         downloadDir), username='mylogin', password='password')
+        self.assertEqual(ret['exitVal'], 0)
+
         # Try uploading using API key
         ret = invokeCli(['--api-key', self.apiKey['key']] + args)
         self.assertEqual(ret['exitVal'], 0)

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -556,3 +556,18 @@ class PythonClientTestCase(base.TestCase):
         self.assertEqual(resp['type'], 'rest')
         self.assertEqual(resp['message'],
                          'Path not found: %s' % (testInvalidPath))
+
+    def testUploadWithPath(self):
+        testUser = self.model('user').createUser(
+            firstName='Jeffrey', lastName='Abrams', login='jjabrams',
+            password='password', email='jjabrams@email.com')
+        publicFolder = six.next(self.model('folder').childFolders(
+            parentType='user', parent=testUser, user=None, limit=1))
+        self.client.upload(self.libTestDir, '/user/jjabrams/Public')
+
+        parent = six.next(self.model('folder').childFolders(
+            parentType='folder', parent=publicFolder,
+            user=testUser, limit=0))
+        self.assertEqual([f['name'] for f in self.model('folder').childFolders(
+            parentType='folder', parent=parent,
+            user=testUser, limit=0)], ['sub0', 'sub1', 'sub2'])


### PR DESCRIPTION
Utilizing resource path for target during upload/download is a bit more human-friendly:

```
girder-cli -c upload --api-url ... --api-key ... /user/xarthisius/Public ~/ala.txt
```

versus

```
girder-cli -c upload --api-url ... --api-key ... 570bd8fc2f2b14000176822d ~/ala.txt
```