### PR TITLE
Support file caching in girder python client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_install:
     - npm prune
     - pip install -U pip virtualenv
 install:
-    - pip install -r requirements-dev.txt -e . -e .[plugins] -e clients/python
+    - pip install -r requirements-dev.txt -e .[plugins] -e clients/python
     - npm install
 script:
     - mkdir _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_install:
     - npm prune
     - pip install -U pip virtualenv
 install:
-    - pip install -r requirements.txt -r requirements-dev.txt -e .
+    - pip install -r clients/python/requirements.txt -r requirements-dev.txt -e .
     - npm install
 script:
     - mkdir _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,8 @@ before_install:
     - npm prune
     - pip install -U pip virtualenv
 install:
-    - pip install -r clients/python/requirements.txt -r requirements-dev.txt -e .
+    - pip install -r requirements.txt -r requirements-dev.txt -e .
+    - pip install -r clients/python/requirements.txt -e clients/python
     - npm install
 script:
     - mkdir _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,7 @@ before_install:
     - npm prune
     - pip install -U pip virtualenv
 install:
-    - pip install -r requirements.txt -r requirements-dev.txt -e .
-    - pip install -r clients/python/requirements.txt -e clients/python
+    - pip install -r requirements-dev.txt -e . -e .[plugins] -e clients/python
     - npm install
 script:
     - mkdir _build

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -935,7 +935,7 @@ class GirderClient(object):
         else:
             # write to file-like object
             with open(tmp.name, 'rb') as fp:
-                self._copyFile(fp, path)
+                shutil.copyfileobj(fp, path)
             # delete the temp file
             os.remove(tmp.name)
 

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -908,7 +908,7 @@ class GirderClient(object):
         cacheKey = '\n'.join([self.urlBase, fileId, created])
 
         # see if file is in local cache
-        if self.cache:
+        if self.cache is not None:
             fp = self.cache.get(cacheKey, read=True)
             if fp:
                 with fp:
@@ -924,7 +924,7 @@ class GirderClient(object):
                 tmp.write(chunk)
 
         # save file in cache
-        if self.cache:
+        if self.cache is not None:
             with open(tmp.name, 'rb') as fp:
                 self.cache.set(cacheKey, fp, read=True)
 

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -928,12 +928,16 @@ class GirderClient(object):
             with open(tmp.name, 'rb') as fp:
                 self.cache.set(cacheKey, fp, read=True)
 
-        # save or stream file to caller
-        with open(tmp.name, 'rb') as fp:
-            self._copyFile(fp, path)
-
-        # delete the temp file
-        os.remove(tmp.name)
+        if isinstance(path, six.string_types):
+            # we can just rename the tempfile
+            _safeMakedirs(os.path.dirname(path))
+            os.rename(tmp.name, path)
+        else:
+            # write to file-like object
+            with open(tmp.name, 'rb') as fp:
+                self._copyFile(fp, path)
+            # delete the temp file
+            os.remove(tmp.name)
 
     def downloadItem(self, itemId, dest, name=None):
         """

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 ###############################################################################
 
+import diskcache
 import errno
 import getpass
 import glob
@@ -168,9 +169,7 @@ class GirderClient(object):
         if cacheSettings is None:
             self.cache = None
         else:
-            import diskcache
             self.cache = diskcache.Cache(**cacheSettings)
-
 
     def authenticate(self, username=None, password=None, interactive=False,
                      apiKey=None):

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -25,7 +25,9 @@ import mimetypes
 import os
 import re
 import requests
+import shutil
 import six
+import tempfile
 
 DEFAULT_PAGE_LIMIT = 50  # Number of results to fetch per request
 
@@ -114,7 +116,7 @@ class GirderClient(object):
     MAX_CHUNK_SIZE = 1024 * 1024 * 64
 
     def __init__(self, host=None, port=None, apiRoot=None, scheme=None,
-                 dryrun=False, blacklist=None, apiUrl=None):
+                 dryrun=False, blacklist=None, apiUrl=None, cacheSettings=None):
         """
         Construct a new GirderClient object, given a host name and port number,
         as well as a username and password which will be used in all requests
@@ -134,6 +136,8 @@ class GirderClient(object):
         :param scheme: A string containing the scheme for the Girder host,
             the default value is 'http'; if you pass 'https' you likely want
             to pass 443 for the port
+        :param cacheSettings: Settings to use with the diskcache library, or
+            None to disable caching.
         """
         if apiUrl is None:
             if apiRoot is None:
@@ -160,6 +164,13 @@ class GirderClient(object):
         self.item_upload_callbacks = []
         self.incomingMetadata = {}
         self.localMetadata = {}
+
+        if cacheSettings is None:
+            self.cache = None
+        else:
+            import diskcache
+            self.cache = diskcache.Cache(**cacheSettings)
+
 
     def authenticate(self, username=None, password=None, interactive=False,
                      apiKey=None):
@@ -384,6 +395,15 @@ class GirderClient(object):
         if updated:
             params['updated'] = str(updated)
         return self.put(url, parameters=params)
+
+    def getFile(self, fileId):
+        """
+        Retrieves a file by its ID.
+
+        :param fileId: A string containing the ID of the file to retrieve from
+            Girder.
+        """
+        return self.getResource('file', fileId)
 
     def listFile(self, itemId, limit=None, offset=None):
         """
@@ -865,25 +885,56 @@ class GirderClient(object):
             name = name.replace(os.path.altsep, '_')
         return _safeNameRegex.sub('_', name)
 
-    def downloadFile(self, fileId, path):
+    def _copyFile(self, fp, path):
         """
-        Download a file to the given local path.
-
-        :param fileId: The ID of the Girder file to download.
-        :param path: The local path to write the file to, or
-            a file-like object.
+        Copy the `fp` file-like object to `path` which may be a filename string
+        or another file-like object to write to.
         """
-        req = requests.get('%sfile/%s/download' % (self.urlBase, fileId),
-                           headers={'Girder-Token': self.token})
         if isinstance(path, six.string_types):
             _safeMakedirs(os.path.dirname(path))
-
-            with open(path, 'wb') as fd:
-                for chunk in req.iter_content(chunk_size=65536):
-                    fd.write(chunk)
+            with open(path, 'wb') as dst:
+                shutil.copyfileobj(fp, dst)
         else:
+            # assume `path` is a file-like object
+            shutil.copyfileobj(fp, path)
+
+    def downloadFile(self, fileId, path, created=None):
+        """
+        Download a file to the given local path or file-like object.
+
+        :param fileId: The ID of the Girder file to download.
+        :param path: The path to write the file to, or a file-like object.
+        """
+        created = created or self.getFile(fileId)['created']
+        cacheKey = '\n'.join([self.urlBase, fileId, created])
+
+        # see if file is in local cache
+        if self.cache:
+            fp = self.cache.get(cacheKey, read=True)
+            if fp:
+                with fp:
+                    self._copyFile(fp, path)
+                return
+
+        # download to a tempfile
+        req = requests.get(
+            '%sfile/%s/download' % (self.urlBase, fileId),
+            stream=True, headers={'Girder-Token': self.token})
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
             for chunk in req.iter_content(chunk_size=65536):
-                path.write(chunk)
+                tmp.write(chunk)
+
+        # save file in cache
+        if self.cache:
+            with open(tmp.name, 'rb') as fp:
+                self.cache.set(cacheKey, fp, read=True)
+
+        # save or stream file to caller
+        with open(tmp.name, 'rb') as fp:
+            self._copyFile(fp, path)
+
+        # delete the temp file
+        os.remove(tmp.name)
 
     def downloadItem(self, itemId, dest, name=None):
         """
@@ -914,7 +965,8 @@ class GirderClient(object):
                 if len(files) == 1 and files[0]['name'] == name:
                     self.downloadFile(
                         files[0]['_id'],
-                        os.path.join(dest, self.transformFilename(name)))
+                        os.path.join(dest, self.transformFilename(name)),
+                        created=files[0]['created'])
                     break
                 else:
                     dest = os.path.join(dest, self.transformFilename(name))
@@ -923,7 +975,8 @@ class GirderClient(object):
             for file in files:
                 self.downloadFile(
                     file['_id'],
-                    os.path.join(dest, self.transformFilename(file['name'])))
+                    os.path.join(dest, self.transformFilename(file['name'])),
+                    created=file['created'])
 
             first = False
             offset += len(files)

--- a/clients/python/requirements.txt
+++ b/clients/python/requirements.txt
@@ -1,2 +1,3 @@
+diskcache==1.6.7
 requests==2.10.0
 six==1.10.0

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -24,6 +24,7 @@ from setuptools import setup, find_packages
 CLIENT_VERSION = '1.3.0'
 
 install_reqs = [
+    'diskcache',
     'requests>=2.4.2',
     'six'
 ]

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -460,21 +460,21 @@ class PythonClientTestCase(base.TestCase):
         def mock(url, request):
             hits.append(url)
 
-        expected = 'tests/cases/py_client/_libTestDir/sub0/f'
+        expected = b'tests/cases/py_client/_libTestDir/sub0/f'
 
         with httmock.HTTMock(mock):
             # download the file
             obj = six.BytesIO()
             client.downloadFile(file['_id'], obj)
-            self.assertEqual(obj.getvalue(), expected)
+            self.assertTrue(obj.getvalue().endswith(expected))
             self.assertEqual(len(hits), 1)
             # this should hit the cache only
             obj = six.BytesIO()
             client.downloadFile(file['_id'], obj)
-            self.assertEqual(obj.getvalue(), expected)
+            self.assertTrue(obj.getvalue().endswith(expected))
             self.assertEqual(len(hits), 1)
 
-        expected = 'new file contents!'
+        expected = b'new file contents!'
         size = len(expected)
         stream = six.BytesIO(expected)
         self.client.uploadFileContents(file['_id'], stream, size)
@@ -483,7 +483,7 @@ class PythonClientTestCase(base.TestCase):
             # file should download again
             obj = six.BytesIO()
             client.downloadFile(file['_id'], obj)
-            self.assertEqual(obj.getvalue(), expected)
+            self.assertTrue(obj.getvalue().endswith(expected))
             self.assertEqual(len(hits), 2)
 
     def testAddMetadataToItem(self):

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -459,7 +459,6 @@ class PythonClientTestCase(base.TestCase):
         @httmock.urlmatch(path=r'.*/file/.+/download$')
         def mock(url, request):
             hits.append(url)
-            return
 
         expected = 'tests/cases/py_client/_libTestDir/sub0/f'
 

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -464,24 +464,24 @@ class PythonClientTestCase(base.TestCase):
 
         with httmock.HTTMock(mock):
             # download the file
-            obj = StringIO()
+            obj = six.BytesIO()
             client.downloadFile(file['_id'], obj)
             self.assertEqual(obj.getvalue(), expected)
             self.assertEqual(len(hits), 1)
             # this should hit the cache only
-            obj = StringIO()
+            obj = six.BytesIO()
             client.downloadFile(file['_id'], obj)
             self.assertEqual(obj.getvalue(), expected)
             self.assertEqual(len(hits), 1)
 
         expected = 'new file contents!'
         size = len(expected)
-        stream = StringIO(expected)
+        stream = six.BytesIO(expected)
         self.client.uploadFileContents(file['_id'], stream, size)
 
         with httmock.HTTMock(mock):
             # file should download again
-            obj = StringIO()
+            obj = six.BytesIO()
             client.downloadFile(file['_id'], obj)
             self.assertEqual(obj.getvalue(), expected)
             self.assertEqual(len(hits), 2)

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -440,6 +440,52 @@ class PythonClientTestCase(base.TestCase):
         with open(path, 'rb') as f:
             self.assertEqual(f.read(), obj.read())
 
+    def testDownloadCache(self):
+        item = self.client.createItem(
+            self.publicFolder['_id'], 'SomethingEvenMoreUnique')
+        path = os.path.join(self.libTestDir, 'sub0', 'f')
+        file = self.client.uploadFileToItem(item['_id'], path)
+
+        # create another client with caching enabled
+        cacheSettings = {'directory': os.path.join(self.libTestDir, 'cache')}
+        client = girder_client.GirderClient(
+            port=os.environ['GIRDER_PORT'], cacheSettings=cacheSettings)
+        client.authenticate(self.user['login'], self.password)
+        self.assertNotEqual(client.cache, None)
+
+        # track file downloads
+        hits = []
+        @httmock.urlmatch(path=r'.*/file/.+/download$')
+        def mock(url, request):
+            hits.append(url)
+            return
+
+        expected = 'tests/cases/py_client/_libTestDir/sub0/f'
+
+        with httmock.HTTMock(mock):
+            # download the file
+            obj = StringIO()
+            client.downloadFile(file['_id'], obj)
+            self.assertEqual(obj.getvalue(), expected)
+            self.assertEqual(len(hits), 1)
+            # this should hit the cache only
+            obj = StringIO()
+            client.downloadFile(file['_id'], obj)
+            self.assertEqual(obj.getvalue(), expected)
+            self.assertEqual(len(hits), 1)
+
+        expected = 'new file contents!'
+        size = len(expected)
+        stream = StringIO(expected)
+        self.client.uploadFileContents(file['_id'], stream, size)
+
+        with httmock.HTTMock(mock):
+            # file should download again
+            obj = StringIO()
+            client.downloadFile(file['_id'], obj)
+            self.assertEqual(obj.getvalue(), expected)
+            self.assertEqual(len(hits), 2)
+
     def testAddMetadataToItem(self):
         item = self.client.createItem(self.publicFolder['_id'],
                                       'Itemty McItemFace', '')

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -455,6 +455,7 @@ class PythonClientTestCase(base.TestCase):
 
         # track file downloads
         hits = []
+
         @httmock.urlmatch(path=r'.*/file/.+/download$')
         def mock(url, request):
             hits.append(url)


### PR DESCRIPTION
This PR lets the girder python client cache files. The `downloadFile` method will use a disk-backed cache if configured. Downloaded files will be saved in the cache and later calls to `downloadFile` can simply fetch the file from the cache instead of downloading it again from Girder.

The [diskcache](https://pypi.python.org/pypi/diskcache/) library is used as the cache. It should work well even for very large files as it can store file-like objects by reading them in chunks.

Here is an example configuration:

```python
CACHE_SETTINGS = {
    'directory': '/tmp/cache',
    'eviction_policy': 'least-recently-used',
    'size_limit': 10 * 2 ** 30, # 10 GB
}

gc = girder_client.GirderClient(apiUrl=GIRDER_URL, cacheSettings=CACHE_SETTINGS)
# ...
gc.downloadFile(fileId, path)
```
