### PR TITLE
Bump girder python client to 1.3.1

### DIFF
--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -21,7 +21,7 @@
 from setuptools import setup, find_packages
 
 
-CLIENT_VERSION = '1.3.0'
+CLIENT_VERSION = '1.3.1'
 
 install_reqs = [
     'diskcache',


### PR DESCRIPTION
@zachmullen I will package & upload to pypi once merged.

v1.3.1 adds support for diskcache.