### PR TITLE
PEP 396 compliance

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -30,6 +30,8 @@ import shutil
 import six
 import tempfile
 
+__version__ = '1.3.1'
+
 DEFAULT_PAGE_LIMIT = 50  # Number of results to fetch per request
 
 _safeNameRegex = re.compile(r'^[/\\]+')

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -31,6 +31,7 @@ import six
 import tempfile
 
 __version__ = '1.3.1'
+__license__ = 'Apache 2.0'
 
 DEFAULT_PAGE_LIMIT = 50  # Number of results to fetch per request
 

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -17,7 +17,6 @@
 #  limitations under the License.
 ###############################################################################
 
-import girder_client
 from setuptools import setup, find_packages
 
 install_reqs = [
@@ -28,10 +27,16 @@ install_reqs = [
 with open('README.rst') as f:
     readme = f.read()
 
+init = os.path.join(os.path.dirname(__file__), 'girder_client', '__init__.py')
+with open(init) as fd:
+    version = re.search(
+        r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
+        fd.read(), re.MULTILINE).group(1)
+
 # perform the install
 setup(
     name='girder-client',
-    version=girder_client.__version__,
+    version=version,
     description='Python client for interacting with Girder servers',
     long_description=readme,
     author='Kitware, Inc.',

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -17,11 +17,8 @@
 #  limitations under the License.
 ###############################################################################
 
-
+import girder_client
 from setuptools import setup, find_packages
-
-
-CLIENT_VERSION = '1.3.0'
 
 install_reqs = [
     'diskcache',
@@ -34,7 +31,7 @@ with open('README.rst') as f:
 # perform the install
 setup(
     name='girder-client',
-    version=CLIENT_VERSION,
+    version=girder_client.__version__,
     description='Python client for interacting with Girder servers',
     long_description=readme,
     author='Kitware, Inc.',

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -17,6 +17,8 @@
 #  limitations under the License.
 ###############################################################################
 
+import os
+import re
 from setuptools import setup, find_packages
 
 install_reqs = [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,15 +15,16 @@
 import os
 import sys
 
-# The full version, including alpha/beta/rc tags.
-release = '1.5.2'
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 ROOT_DIR = os.path.abspath('..')
 sys.path.insert(1, ROOT_DIR)
 sys.path.insert(1, os.path.join(ROOT_DIR, 'clients', 'python'))
+
+import girder
+
+release = girder.__version__
 
 
 # Creating mock imports so that readthedocs works even though building
@@ -78,7 +79,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Girder'
-copyright = u'2014-2015, Kitware'
+copyright = u'2014-2016, Kitware'
 
 # The short X.Y version.
 version = '.'.join(release.split('.')[:2])

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -290,7 +290,7 @@ are stored as releases inside the official
 recommended process for generating a new release is described here.
 
 1.  From the target commit, set the desired version number in ``package.json``
-    and ``docs/conf.py``.  Create a new commit and note the SHA; this will
+    and ``girder/__init__.py``. Create a new commit and note the SHA; this will
     become the release tag.
 
 2.  Ensure that all tests pass.
@@ -347,9 +347,9 @@ version. The rules for versioning the python client package are as follows:
 
 The process for releasing the python client is as follows:
 
-1.  Set the version number inside ``clients/python/setup.py`` according to the
-    above rules. It is set in the line near the top of the file that looks like
-    ``CLIENT_VERSION = 'x.y.z'``
+1.  Set the version number inside ``clients/python/girder_client/__init__.py`` according
+    to the above rules. It is set in the line near the top of the file that looks like
+    ``__version__ = 'x.y.z'``
 
 2.  Change to the ``clients/python`` directory of the source tree and build the
     package using the following commands.

--- a/girder/__init__.py
+++ b/girder/__init__.py
@@ -26,6 +26,7 @@ from girder.constants import LOG_ROOT, MAX_LOG_SIZE, LOG_BACKUP_COUNT
 from girder.utility import config, mkdir
 
 __version__ = '1.5.2'
+__license__ = 'Apache 2.0'
 
 
 class LogLevelFilter(object):

--- a/girder/__init__.py
+++ b/girder/__init__.py
@@ -25,6 +25,8 @@ import os
 from girder.constants import LOG_ROOT, MAX_LOG_SIZE, LOG_BACKUP_COUNT
 from girder.utility import config, mkdir
 
+__version__ = '1.5.2'
+
 
 class LogLevelFilter(object):
     """

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,9 @@
 #  limitations under the License.
 ###############################################################################
 
-import girder
 import json
 import os
+import re
 import shutil
 import sys
 
@@ -96,10 +96,16 @@ if sys.version_info[0] == 2:
         ]
     })
 
+init = os.path.join(os.path.dirname(__file__), 'girder', '__init__.py')
+with open(init) as fd:
+    version = re.search(
+        r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
+        fd.read(), re.MULTILINE).group(1)
+
 # perform the install
 setup(
     name='girder',
-    version=girder.__version__,
+    version=version,
     description='Web-based data management platform',
     long_description=readme,
     author='Kitware, Inc.',

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 ###############################################################################
 
+import girder
 import json
 import os
 import shutil
@@ -56,9 +57,6 @@ class InstallWithOptions(install):
 
 with open('README.rst') as f:
     readme = f.read()
-
-with open('package.json') as f:
-    version = json.load(f)['version']
 
 install_reqs = [
     'bcrypt',
@@ -101,7 +99,7 @@ if sys.version_info[0] == 2:
 # perform the install
 setup(
     name='girder',
-    version=version,
+    version=girder.__version__,
     description='Web-based data management platform',
     long_description=readme,
     author='Kitware, Inc.',


### PR DESCRIPTION
@girder/developers PTAL. [PEP 396](https://www.python.org/dev/peps/pep-0396/) provides a standard way of including a version identifier inside packages.

This shouldn't be merged until after #1460 is merged.