### PR TITLE
Use HTML doctype for building Jade templates

### DIFF
--- a/grunt_tasks/build.js
+++ b/grunt_tasks/build.js
@@ -46,6 +46,7 @@ module.exports = function (grunt) {
             options: {
                 client: true,
                 compileDebug: false,
+                doctype: 'html',
                 namespace: 'girder.templates',
                 processName: function (filename) {
                     return path.basename(filename, '.jade');


### PR DESCRIPTION
This primarily affects self closing tags and boolean attributes.