### PR TITLE
Fix typo in --parent-type option name

### DIFF
--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -69,7 +69,7 @@ subparsers.required = True
 
 # Arguments shared by multiple subcommands
 _commonArgs = {
-    '--parent_type': dict(
+    '--parent-type': dict(
         required=False, default='folder',
         help='type of Girder parent target, one of (collection, folder, user)'),
     'parent_id': dict(help='id of Girder parent target'),

--- a/tests/cases/py_client/cli_test.py
+++ b/tests/cases/py_client/cli_test.py
@@ -125,7 +125,7 @@ class PythonCliTestCase(base.TestCase):
 
     def testUploadDownload(self):
         localDir = os.path.join(os.path.dirname(__file__), 'testdata')
-        args = ['upload', str(self.publicFolder['_id']), localDir]
+        args = ['upload', str(self.publicFolder['_id']), localDir, '--parent-type=folder']
         with self.assertRaises(girder_client.HttpError):
             invokeCli(args)
 


### PR DESCRIPTION
@mgrauer I made a typo during refactoring that was not caught by our tests, PTAL.