### PR TITLE
Change how we validate settings

### DIFF
--- a/girder/models/setting.py
+++ b/girder/models/setting.py
@@ -22,9 +22,10 @@ import cherrypy
 import pymongo
 import six
 
-from ..constants import SettingDefault, TerminalColor
+from ..constants import SettingDefault, SettingKey, TerminalColor
 from .model_base import Model, ValidationException
-from girder.utility import camelcase, plugin_utilities
+from girder.utility import plugin_utilities, setting_utilities
+from girder.utility.model_importer import ModelImporter
 from bson.objectid import ObjectId
 
 
@@ -87,177 +88,13 @@ class Setting(Model):
         assumes it is a core setting and does the validation here.
         """
         key = doc['key']
-
-        funcName = 'validate'+camelcase(key)
-        if callable(getattr(self, funcName, None)):
-            getattr(self, funcName)(doc)
+        validator = setting_utilities.getValidator(key)
+        if validator:
+            validator(doc)
         else:
-            raise ValidationException(
-                'Invalid setting key "%s".' % key, 'key')
+            raise ValidationException('Invalid setting key "%s".' % key, 'key')
 
         return doc
-
-    def validateCorePluginsEnabled(self, doc):
-        """
-        Ensures that the set of plugins passed in is a list of valid plugin
-        names. Removes any invalid plugin names, removes duplicates, and adds
-        all transitive dependencies to the enabled list.
-        """
-        if not isinstance(doc['value'], list):
-            raise ValidationException(
-                'Plugins enabled setting must be a list.', 'value')
-
-        # Add all transitive dependencies and store in toposorted order
-        doc['value'] = list(plugin_utilities.getToposortedPlugins(doc['value']))
-
-    def validateCoreAddToGroupPolicy(self, doc):
-        doc['value'] = doc['value'].lower()
-        if doc['value'] not in ('never', 'noadmin', 'nomod', 'yesadmin',
-                                'yesmod', ''):
-            raise ValidationException(
-                'Add to group policy must be one of "never", "noadmin", '
-                '"nomod", "yesadmin", or "yesmod".', 'value')
-
-    def validateCoreCollectionCreatePolicy(self, doc):
-        value = doc['value']
-
-        if not isinstance(value, dict):
-            raise ValidationException('Collection creation policy must be a '
-                                      'JSON object.')
-
-        for i, groupId in enumerate(value.get('groups', ())):
-            self.model('group').load(groupId, force=True, exc=True)
-            value['groups'][i] = ObjectId(value['groups'][i])
-
-        for i, userId in enumerate(value.get('users', ())):
-            self.model('user').load(userId, force=True, exc=True)
-            value['users'][i] = ObjectId(value['users'][i])
-
-        value['open'] = value.get('open', False)
-
-    def validateCoreCookieLifetime(self, doc):
-        try:
-            doc['value'] = int(doc['value'])
-            if doc['value'] > 0:
-                return
-        except ValueError:
-            pass  # We want to raise the ValidationException
-        raise ValidationException(
-            'Cookie lifetime must be an integer > 0.', 'value')
-
-    def validateCoreCorsAllowMethods(self, doc):
-        if isinstance(doc['value'], six.string_types):
-            methods = doc['value'].replace(",", " ").strip().upper().split()
-            # remove duplicates
-            methods = list(OrderedDict.fromkeys(methods))
-            doc['value'] = ", ".join(methods)
-            return
-        raise ValidationException(
-            'Allowed methods must be a comma-separated list or an empty '
-            'string.', 'value')
-
-    def validateCoreCorsAllowHeaders(self, doc):
-        if isinstance(doc['value'], six.string_types):
-            headers = doc['value'].replace(",", " ").strip().split()
-            # remove duplicates
-            headers = list(OrderedDict.fromkeys(headers))
-            doc['value'] = ", ".join(headers)
-            return
-        raise ValidationException(
-            'Allowed headers must be a comma-separated list or an empty '
-            'string.', 'value')
-
-    def validateCoreCorsAllowOrigin(self, doc):
-        if isinstance(doc['value'], six.string_types):
-            origins = doc['value'].replace(",", " ").strip().split()
-            origins = [origin.rstrip('/') for origin in origins]
-            # remove duplicates
-            origins = list(OrderedDict.fromkeys(origins))
-            doc['value'] = ", ".join(origins)
-            return
-        raise ValidationException(
-            'Allowed origin must be a comma-separated list of base urls or * '
-            'or an empty string.', 'value')
-
-    def validateCoreEmailFromAddress(self, doc):
-        if not doc['value']:
-            raise ValidationException(
-                'Email from address must not be blank.', 'value')
-
-    def validateCoreEmailHost(self, doc):
-        if isinstance(doc['value'], six.string_types):
-            doc['value'] = doc['value'].strip()
-            return
-        raise ValidationException(
-            'Email host must be a string.', 'value')
-
-    def defaultCoreEmailHost(self):
-        if (cherrypy.request and cherrypy.request.local and
-                cherrypy.request.local.name):
-            host = '://'.join((cherrypy.request.scheme,
-                               cherrypy.request.local.name))
-            if cherrypy.request.local.port != 80:
-                host += ':%d' % cherrypy.request.local.port
-            return host
-
-    def validateCoreRegistrationPolicy(self, doc):
-        doc['value'] = doc['value'].lower()
-        if doc['value'] not in ('open', 'closed', 'approve'):
-            raise ValidationException(
-                'Registration policy must be "open", "closed", or "approve".',
-                'value')
-
-    def validateCoreEmailVerification(self, doc):
-        doc['value'] = doc['value'].lower()
-        if doc['value'] not in ('required', 'optional', 'disabled'):
-            raise ValidationException(
-                'Email verification must be "required", "optional", or '
-                '"disabled".', 'value')
-
-    def validateCoreSmtpHost(self, doc):
-        if not doc['value']:
-            raise ValidationException(
-                'SMTP host must not be blank.', 'value')
-
-    def validateCoreSmtpPort(self, doc):
-        try:
-            doc['value'] = int(doc['value'])
-            if doc['value'] > 0:
-                return
-        except ValueError:
-            pass  # We want to raise the ValidationException
-        raise ValidationException('SMTP port must be an integer > 0.', 'value')
-
-    def validateCoreSmtpEncryption(self, doc):
-        if not doc['value'] in ['none', 'starttls', 'ssl']:
-            raise ValidationException(
-                'SMTP encryption must be one of "none", "starttls", or "ssl".',
-                'value')
-
-    def validateCoreSmtpUsername(self, doc):
-        # any string is acceptable
-        pass
-
-    def validateCoreSmtpPassword(self, doc):
-        # any string is acceptable
-        pass
-
-    def validateCoreUploadMinimumChunkSize(self, doc):
-        try:
-            doc['value'] = int(doc['value'])
-            if doc['value'] >= 0:
-                return
-        except ValueError:
-            pass  # We want to raise the ValidationException
-        raise ValidationException(
-            'Upload minimum chunk size must be an integer >= 0.',
-            'value')
-
-    def validateCoreUserDefaultFolders(self, doc):
-        if doc['value'] not in ('public_private', 'none'):
-            raise ValidationException(
-                'User default folders must be either "public_private" or '
-                '"none".', 'value')
 
     def get(self, key, default='__default__'):
         """
@@ -315,13 +152,196 @@ class Setting(Model):
         :param key: The key identifying the setting.
         :type key: str
         :returns: The default value if the key is present in both SettingKey
-                  and referenced in SettingDefault; otherwise None.
+            and referenced in SettingDefault; otherwise None.
         """
-        default = None
         if key in SettingDefault.defaults:
-            default = SettingDefault.defaults[key]
+            return SettingDefault.defaults[key]
         else:
-            funcName = 'default'+camelcase(key)
-            if callable(getattr(self, funcName, None)):
-                default = getattr(self, funcName)()
-        return default
+            fn = setting_utilities.getDefaultFunction(key)
+
+            if callable(fn):
+                return fn()
+        return None
+
+    @staticmethod
+    @setting_utilities.validator(SettingKey.PLUGINS_ENABLED)
+    def validateCorePluginsEnabled(doc):
+        """
+        Ensures that the set of plugins passed in is a list of valid plugin
+        names. Removes any invalid plugin names, removes duplicates, and adds
+        all transitive dependencies to the enabled list.
+        """
+        if not isinstance(doc['value'], list):
+            raise ValidationException('Plugins enabled setting must be a list.', 'value')
+
+        # Add all transitive dependencies and store in toposorted order
+        doc['value'] = list(plugin_utilities.getToposortedPlugins(doc['value']))
+
+    @staticmethod
+    @setting_utilities.validator(SettingKey.ADD_TO_GROUP_POLICY)
+    def validateCoreAddToGroupPolicy(doc):
+        doc['value'] = doc['value'].lower()
+        if doc['value'] not in ('never', 'noadmin', 'nomod', 'yesadmin', 'yesmod', ''):
+            raise ValidationException(
+                'Add to group policy must be one of "never", "noadmin", '
+                '"nomod", "yesadmin", or "yesmod".', 'value')
+
+    @staticmethod
+    @setting_utilities.validator(SettingKey.COLLECTION_CREATE_POLICY)
+    def validateCoreCollectionCreatePolicy(doc):
+        value = doc['value']
+
+        if not isinstance(value, dict):
+            raise ValidationException('Collection creation policy must be a JSON object.')
+
+        for i, groupId in enumerate(value.get('groups', ())):
+            ModelImporter.model('group').load(groupId, force=True, exc=True)
+            value['groups'][i] = ObjectId(value['groups'][i])
+
+        for i, userId in enumerate(value.get('users', ())):
+            ModelImporter.model('user').load(userId, force=True, exc=True)
+            value['users'][i] = ObjectId(value['users'][i])
+
+        value['open'] = value.get('open', False)
+
+    @staticmethod
+    @setting_utilities.validator(SettingKey.COOKIE_LIFETIME)
+    def validateCoreCookieLifetime(doc):
+        try:
+            doc['value'] = int(doc['value'])
+            if doc['value'] > 0:
+                return
+        except ValueError:
+            pass  # We want to raise the ValidationException
+        raise ValidationException('Cookie lifetime must be an integer > 0.', 'value')
+
+    @staticmethod
+    @setting_utilities.validator(SettingKey.CORS_ALLOW_METHODS)
+    def validateCoreCorsAllowMethods(doc):
+        if isinstance(doc['value'], six.string_types):
+            methods = doc['value'].replace(',', ' ').strip().upper().split()
+            # remove duplicates
+            methods = list(OrderedDict.fromkeys(methods))
+            doc['value'] = ', '.join(methods)
+            return
+        raise ValidationException(
+            'Allowed methods must be a comma-separated list or an empty string.', 'value')
+
+    @staticmethod
+    @setting_utilities.validator(SettingKey.CORS_ALLOW_HEADERS)
+    def validateCoreCorsAllowHeaders(doc):
+        if isinstance(doc['value'], six.string_types):
+            headers = doc['value'].replace(",", " ").strip().split()
+            # remove duplicates
+            headers = list(OrderedDict.fromkeys(headers))
+            doc['value'] = ", ".join(headers)
+            return
+        raise ValidationException(
+            'Allowed headers must be a comma-separated list or an empty string.', 'value')
+
+    @staticmethod
+    @setting_utilities.validator(SettingKey.CORS_ALLOW_ORIGIN)
+    def validateCoreCorsAllowOrigin(doc):
+        if isinstance(doc['value'], six.string_types):
+            origins = doc['value'].replace(",", " ").strip().split()
+            origins = [origin.rstrip('/') for origin in origins]
+            # remove duplicates
+            origins = list(OrderedDict.fromkeys(origins))
+            doc['value'] = ", ".join(origins)
+            return
+        raise ValidationException(
+            'Allowed origin must be a comma-separated list of base urls or * or an empty string.',
+            'value')
+
+    @staticmethod
+    @setting_utilities.validator(SettingKey.EMAIL_FROM_ADDRESS)
+    def validateCoreEmailFromAddress(doc):
+        if not doc['value']:
+            raise ValidationException('Email from address must not be blank.', 'value')
+
+    @staticmethod
+    @setting_utilities.validator(SettingKey.EMAIL_HOST)
+    def validateCoreEmailHost(doc):
+        if isinstance(doc['value'], six.string_types):
+            doc['value'] = doc['value'].strip()
+            return
+        raise ValidationException('Email host must be a string.', 'value')
+
+    @staticmethod
+    @setting_utilities.default(SettingKey.EMAIL_HOST)
+    def defaultCoreEmailHost():
+        if cherrypy.request and cherrypy.request.local and cherrypy.request.local.name:
+            host = '%s://%s' % (cherrypy.request.scheme, cherrypy.request.local.name)
+            if cherrypy.request.local.port != 80:
+                host += ':%d' % cherrypy.request.local.port
+            return host
+
+    @staticmethod
+    @setting_utilities.validator(SettingKey.REGISTRATION_POLICY)
+    def validateCoreRegistrationPolicy(doc):
+        doc['value'] = doc['value'].lower()
+        if doc['value'] not in ('open', 'closed', 'approve'):
+            raise ValidationException(
+                'Registration policy must be "open", "closed", or "approve".', 'value')
+
+    @staticmethod
+    @setting_utilities.validator(SettingKey.EMAIL_VERIFICATION)
+    def validateCoreEmailVerification(doc):
+        doc['value'] = doc['value'].lower()
+        if doc['value'] not in ('required', 'optional', 'disabled'):
+            raise ValidationException(
+                'Email verification must be "required", "optional", or "disabled".', 'value')
+
+    @staticmethod
+    @setting_utilities.validator(SettingKey.SMTP_HOST)
+    def validateCoreSmtpHost(doc):
+        if not doc['value']:
+            raise ValidationException('SMTP host must not be blank.', 'value')
+
+    @staticmethod
+    @setting_utilities.validator(SettingKey.SMTP_PORT)
+    def validateCoreSmtpPort(doc):
+        try:
+            doc['value'] = int(doc['value'])
+            if doc['value'] > 0:
+                return
+        except ValueError:
+            pass  # We want to raise the ValidationException
+        raise ValidationException('SMTP port must be an integer > 0.', 'value')
+
+    @staticmethod
+    @setting_utilities.validator(SettingKey.SMTP_ENCRYPTION)
+    def validateCoreSmtpEncryption(doc):
+        if not doc['value'] in ['none', 'starttls', 'ssl']:
+            raise ValidationException(
+                'SMTP encryption must be one of "none", "starttls", or "ssl".', 'value')
+
+    @staticmethod
+    @setting_utilities.validator(SettingKey.SMTP_USERNAME)
+    def validateCoreSmtpUsername(doc):
+        # any string is acceptable
+        pass
+
+    @staticmethod
+    @setting_utilities.validator(SettingKey.SMTP_PASSWORD)
+    def validateCoreSmtpPassword(doc):
+        # any string is acceptable
+        pass
+
+    @staticmethod
+    @setting_utilities.validator(SettingKey.UPLOAD_MINIMUM_CHUNK_SIZE)
+    def validateCoreUploadMinimumChunkSize(doc):
+        try:
+            doc['value'] = int(doc['value'])
+            if doc['value'] >= 0:
+                return
+        except ValueError:
+            pass  # We want to raise the ValidationException
+        raise ValidationException('Upload minimum chunk size must be an integer >= 0.', 'value')
+
+    @staticmethod
+    @setting_utilities.validator(SettingKey.USER_DEFAULT_FOLDERS)
+    def validateCoreUserDefaultFolders(doc):
+        if doc['value'] not in ('public_private', 'none'):
+            raise ValidationException(
+                'User default folders must be either "public_private" or "none".', 'value')

--- a/girder/utility/setting_utilities.py
+++ b/girder/utility/setting_utilities.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+_validators = {}
+_defaultFunctions = {}
+
+
+def registerValidator(key, fn):
+    """
+    Register a validator for a given setting key.
+
+    :param key: The setting key.
+    :type key: str
+    :param fn: The function that will validate this key.
+    :type fn: callable
+    """
+    _validators[key] = fn
+
+
+def getValidator(key):
+    """
+    Retrieve the validator function for the given key. Returns ``None`` if none is registered.
+    """
+    return _validators.get(key)
+
+
+def registerDefaultFunction(key, fn):
+    """
+    Register a default value function for a given setting key.
+
+    :param key: The setting key.
+    :type key: str
+    :param fn: The function that will return the default value for this key.
+    :type fn: callable
+    """
+    _defaultFunctions[key] = fn
+
+
+def getDefaultFunction(key):
+    """
+    Retrieve the default value function for the given key. Returns ``None`` if none is registered.
+    """
+    return _defaultFunctions.get(key)
+
+
+class validator(object):  # noqa: class name
+    def __init__(self, key):
+        """
+        Create a decorator indicating that the wrapped function is responsible for
+        validating the given key.
+
+        :param key: The key that this function validates.
+        :type key: str
+        """
+        self.key = key
+
+    def __call__(self, fn):
+        registerValidator(self.key, fn)
+        return fn
+
+
+class default(object):  # noqa: class name
+    def __init__(self, key):
+        """
+        Create a decorator indicating that the wrapped function is responsible for
+        providing the default value for the given key.
+
+        :param key: The key that this function validates.
+        :type key: str
+        """
+        self.key = key
+
+    def __call__(self, fn):
+        registerDefaultFunction(self.key, fn)
+        return fn

--- a/girder/utility/setting_utilities.py
+++ b/girder/utility/setting_utilities.py
@@ -17,6 +17,8 @@
 #  limitations under the License.
 ###############################################################################
 
+import six
+
 _validators = {}
 _defaultFunctions = {}
 
@@ -63,15 +65,18 @@ class validator(object):  # noqa: class name
     def __init__(self, key):
         """
         Create a decorator indicating that the wrapped function is responsible for
-        validating the given key.
+        validating the given key or set of keys.
 
-        :param key: The key that this function validates.
-        :type key: str
+        :param key: The key(s) that this function validates.
+        :type key: str or iterable of str
         """
-        self.key = key
+        if isinstance(key, six.string_types):
+            key = {key}
+        self.keys = key
 
     def __call__(self, fn):
-        registerValidator(self.key, fn)
+        for k in self.keys:
+            registerValidator(k, fn)
         return fn
 
 
@@ -79,13 +84,16 @@ class default(object):  # noqa: class name
     def __init__(self, key):
         """
         Create a decorator indicating that the wrapped function is responsible for
-        providing the default value for the given key.
+        providing the default value for the given key or set of keys.
 
-        :param key: The key that this function validates.
-        :type key: str
+        :param key: The key(s) that this function validates.
+        :type key: str or iterable of str
         """
-        self.key = key
+        if isinstance(key, six.string_types):
+            key = {key}
+        self.keys = key
 
     def __call__(self, fn):
-        registerDefaultFunction(self.key, fn)
+        for k in self.keys:
+            registerDefaultFunction(k, fn)
         return fn

--- a/plugins/autojoin/server/__init__.py
+++ b/plugins/autojoin/server/__init__.py
@@ -1,13 +1,14 @@
 from girder import events
+from girder.utility import setting_utilities
 from girder.utility.model_importer import ModelImporter
 
 
-def validateSettings(event):
+@setting_utilities.validator('autojoin')
+def validateSettings(doc):
     """
     Allow the autojoin setting key.
     """
-    if event.info['key'] == 'autojoin':
-        event.preventDefault().stopPropagation()
+    pass  # any value is valid
 
 
 def userCreated(event):
@@ -27,5 +28,4 @@ def userCreated(event):
 
 
 def load(info):
-    events.bind('model.setting.validate', 'autojoin', validateSettings)
     events.bind('model.user.save.created', 'autojoin', userCreated)

--- a/plugins/google_analytics/server/__init__.py
+++ b/plugins/google_analytics/server/__init__.py
@@ -17,21 +17,16 @@
 #  limitations under the License.
 ###############################################################################
 
-from girder import events
 from girder.models.model_base import ValidationException
+from girder.utility import setting_utilities
 from . import constants, rest
 
 
-def validateSettings(event):
-    key, val = event.info['key'], event.info['value']
-
-    if key == constants.PluginSettings.GOOGLE_ANALYTICS_TRACKING_ID:
-        if not val:
-            raise ValidationException(
-                'Google Analytics Tracking ID must not be empty.', 'value')
-        event.preventDefault().stopPropagation()
+@setting_utilities.validator(constants.PluginSettings.GOOGLE_ANALYTICS_TRACKING_ID)
+def validateTrackingId(doc):
+    if not doc['value']:
+        raise ValidationException('Google Analytics Tracking ID must not be empty.', 'value')
 
 
 def load(info):
-    events.bind('model.setting.validate', 'google_analytics', validateSettings)
     info['apiRoot'].google_analytics = rest.GoogleAnalytics()

--- a/plugins/homepage/server/__init__.py
+++ b/plugins/homepage/server/__init__.py
@@ -17,10 +17,10 @@
 #  limitations under the License.
 ###############################################################################
 
-from girder import events
 from girder.api import access
 from girder.api.describe import Description, describeRoute
 from girder.api.rest import Resource
+from girder.utility import setting_utilities
 from girder.utility.model_importer import ModelImporter
 
 KEY = 'homepage.markdown'
@@ -45,20 +45,18 @@ class Homepage(Resource):
         }
 
 
-def validateSettings(event):
-    if event.info['key'] == KEY:
-        event.preventDefault().stopPropagation()
+@setting_utilities.validator(KEY)
+def validateHomepageMarkdown(event):
+    pass
 
 
 def getOrCreateAssetsFolder():
     collection = ModelImporter.model('collection').createCollection(
         NAME, public=False, reuseExisting=True)
     folder = ModelImporter.model('folder').createFolder(
-        collection, NAME, parentType='collection', public=True,
-        reuseExisting=True)
+        collection, NAME, parentType='collection', public=True, reuseExisting=True)
     return folder
 
 
 def load(info):
-    events.bind('model.setting.validate', 'homepage', validateSettings)
     info['apiRoot'].homepage = Homepage()

--- a/plugins/user_quota/server/__init__.py
+++ b/plugins/user_quota/server/__init__.py
@@ -19,33 +19,31 @@
 
 from girder import events
 from girder.models.model_base import ValidationException
+from girder.utility import setting_utilities
 from . import constants
 from .quota import QuotaPolicy, ValidateSizeQuota
 
 
-def validateSettings(event):
-    key, val = event.info['key'], event.info['value']
+@setting_utilities.validator((
+    constants.PluginSettings.QUOTA_DEFAULT_USER_QUOTA,
+    constants.PluginSettings.QUOTA_DEFAULT_COLLECTION_QUOTA
+))
+def validateSettings(doc):
+    val = doc['value']
 
-    if key in (constants.PluginSettings.QUOTA_DEFAULT_USER_QUOTA,
-               constants.PluginSettings.QUOTA_DEFAULT_COLLECTION_QUOTA):
-        (val, err) = ValidateSizeQuota(val)
-        if err:
-            raise ValidationException(err, 'value')
-        event.info['value'] = val
-        event.preventDefault().stopPropagation()
+    val, err = ValidateSizeQuota(val)
+    if err:
+        raise ValidationException(err, 'value')
+    doc['value'] = val
 
 
 def load(info):
     quota = QuotaPolicy()
-    info['apiRoot'].collection.route('GET', (':id', 'quota'),
-                                     quota.getCollectionQuota)
-    info['apiRoot'].collection.route('PUT', (':id', 'quota'),
-                                     quota.setCollectionQuota)
+    info['apiRoot'].collection.route('GET', (':id', 'quota'), quota.getCollectionQuota)
+    info['apiRoot'].collection.route('PUT', (':id', 'quota'), quota.setCollectionQuota)
     info['apiRoot'].user.route('GET', (':id', 'quota'), quota.getUserQuota)
     info['apiRoot'].user.route('PUT', (':id', 'quota'), quota.setUserQuota)
-    events.bind('model.setting.validate', 'userQuota', validateSettings)
-    events.bind('model.upload.assetstore', 'userQuota',
-                quota.getUploadAssetstore)
+
+    events.bind('model.upload.assetstore', 'userQuota', quota.getUploadAssetstore)
     events.bind('model.upload.save', 'userQuota', quota.checkUploadStart)
-    events.bind('model.upload.finalize', 'userQuota',
-                quota.checkUploadFinalize)
+    events.bind('model.upload.finalize', 'userQuota', quota.checkUploadFinalize)

--- a/tests/cases/setting_test.py
+++ b/tests/cases/setting_test.py
@@ -52,7 +52,7 @@ class SettingTestCase(base.TestCase):
                              if indices[index]['key'][0][0] == 'key'))
         coll.create_index('key')
         for val in range(3, 8):
-            coll.save({'key': 'duplicate', 'value': val})
+            coll.insert_one({'key': 'duplicate', 'value': val})
         # Check that we've broken things
         indices = coll.index_information()
         self.assertGreaterEqual(settingModel.get('duplicate'), 3)
@@ -101,3 +101,10 @@ class SettingTestCase(base.TestCase):
 
         setting = settingModel.set('test.key2', 'original')
         self.assertEqual(setting['value'], 'modified')
+
+    def testDefault(self):
+        @setting_utilities.default('test.key')
+        def default():
+            return 'default value'
+
+        self.assertEqual(self.model('setting').get('test.key'), 'default value')

--- a/tests/cases/setting_test.py
+++ b/tests/cases/setting_test.py
@@ -17,7 +17,10 @@
 #  limitations under the License.
 #############################################################################
 
+import six
 from .. import base
+from girder.models.model_base import ValidationException
+from girder.utility import setting_utilities
 
 
 def setUpModule():
@@ -67,3 +70,34 @@ class SettingTestCase(base.TestCase):
                          not indices[index].get('unique') for index in indices))
         self.assertEqual(settingModel.get('duplicate'), 3)
         self.assertEqual(settingModel.find({'key': 'duplicate'}).count(), 1)
+
+    def testValidators(self):
+        settingModel = self.model('setting')
+
+        @setting_utilities.validator('test.key1')
+        def key1v1(doc):
+            raise ValidationException('key1v1')
+
+        with six.assertRaisesRegex(self, ValidationException, '^key1v1$'):
+            settingModel.set('test.key1', '')
+
+        @setting_utilities.validator('test.key1')
+        def key1v2(doc):
+            raise ValidationException('key1v2')
+
+        with six.assertRaisesRegex(self, ValidationException, '^key1v2$'):
+            settingModel.set('test.key1', '')
+
+        @setting_utilities.validator('test.key2')
+        def key2v1(doc):
+            raise ValidationException('key2v1')
+
+        with six.assertRaisesRegex(self, ValidationException, '^key2v1$'):
+            settingModel.set('test.key2', '')
+
+        @setting_utilities.validator('test.key2', replace=True)
+        def key2v2(doc):
+            doc['value'] = 'modified'
+
+        setting = settingModel.set('test.key2', 'original')
+        self.assertEqual(setting['value'], 'modified')


### PR DESCRIPTION
We now provide a convenient decorator method for registering setting validation functions. This alleviates the needs for plugins to bind to the setting validate event and check the keys themselves, although that will still work as before.

Thanks to @mgrauer for floating this idea in the 2.0 wish list. Since it turns out it's not a breaking change, I've PRed it against master.