### PR TITLE
use shutil.move instead of os.rename

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -934,7 +934,7 @@ class GirderClient(object):
         if isinstance(path, six.string_types):
             # we can just rename the tempfile
             _safeMakedirs(os.path.dirname(path))
-            os.rename(tmp.name, path)
+            shutil.move(tmp.name, path)
         else:
             # write to file-like object
             with open(tmp.name, 'rb') as fp:


### PR DESCRIPTION
Using `os.rename` causes problems when renaming across filesystems.

See [here](http://stackoverflow.com/a/11593707),
[here](https://mail.python.org/pipermail/tutor/2011-April/083076.html),
and the documentation [here](https://docs.python.org/3.4/library/shutil.html#shutil.move).

We ran into an issue on SUMO, and we think fixing this issue will address it.  Details [here](https://github.com/osumo/osumo-project/pull/3).