### PR TITLE
Make sure web_client_admin test does not run parallel to any other tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,6 +68,8 @@ if(RUN_CORE_TESTS)
   add_web_client_test(swagger "${PROJECT_SOURCE_DIR}/clients/web/test/spec/swaggerSpec.js" BASEURL "/api/v1" NOCOVERAGE)
   add_web_client_test(browser "${PROJECT_SOURCE_DIR}/clients/web/test/spec/browserSpec.js")
 
+  set_property(TEST web_client_admin PROPERTY RUN_SERIAL ON)
+
   # Add tests for the local TestData module
   add_plugin_data_path("has_external_data" "${PROJECT_SOURCE_DIR}/tests/test_plugins/has_external_data")
   add_python_test(external_data_core


### PR DESCRIPTION
The `web_client_admin` test sporadically fails by getting SIGKILLed by the system due to OOM. This attempts to workaround the memory limitations on travis by ensuring that test does not run in parallel with any others.