### PR TITLE
Fix a string encoding error on test failure

### DIFF
--- a/tests/web_client_test.py
+++ b/tests/web_client_test.py
@@ -182,7 +182,7 @@ class WebClientTestCase(base.TestCase):
                     hasJasmine = True
                 if 'Testing Finished' in line:
                     jasmineFinished = True
-                sys.stdout.write(line)
+                sys.stdout.write(line.encode('utf8', 'replace'))
                 sys.stdout.flush()
             returncode = task.wait()
             if not retry and hasJasmine and jasmineFinished:


### PR DESCRIPTION
I've seen the following error from time to time (e.g. see [here](http://my.cdash.org/testDetails.php?test=26779805&build=1022716)):
```
Traceback (most recent call last):
  File "tests/web_client_test.py", line 185, in testWebClientSpec
    sys.stdout.write(line)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 29-30: ordinal not in range(128)
```

While this isn't causing any errors, it is preventing the actual error message from being printed out.  I'm not entirely sure why stdout is being coerced into ascii, it could be the locale on travis or something having to do with piping the output through ctest, but this should ensure the conversion happens without raising any errors in the future.