### PR TITLE
Return promises for async methods on models

### DIFF
--- a/clients/web/src/collections/Collection.js
+++ b/clients/web/src/collections/Collection.js
@@ -55,14 +55,14 @@ var Collection = Backbone.Collection.extend({
      */
     fetchPreviousPage: function (params) {
         this.offset = Math.max(0, this.offset - this.length - this.pageLimit);
-        this.fetch(_.extend({}, this.params, params || {}));
+        return this.fetch(_.extend({}, this.params, params || {}));
     },
 
     /**
      * Fetch the previous page of this collection, emitting g:changed when done.
      */
     fetchNextPage: function (params) {
-        this.fetch(_.extend({}, this.params, params || {}));
+        return this.fetch(_.extend({}, this.params, params || {}));
     },
 
     /**
@@ -126,6 +126,7 @@ var Collection = Backbone.Collection.extend({
             this.trigger('g:changed');
         }, this));
         xhr.girder = {fetch: true};
+        return xhr;
     }
 });
 

--- a/clients/web/src/models/AccessControlledModel.js
+++ b/clients/web/src/models/AccessControlledModel.js
@@ -24,7 +24,7 @@ var AccessControlledModel = Model.extend({
             return;
         }
 
-        restRequest({
+        return restRequest({
             path: (this.altUrl || this.resourceName) + '/' + this.get('_id') + '/access',
             type: 'PUT',
             data: _.extend({
@@ -36,8 +36,6 @@ var AccessControlledModel = Model.extend({
         }, this)).error(_.bind(function (err) {
             this.trigger('g:error', err);
         }, this));
-
-        return this;
     },
 
     /**
@@ -54,7 +52,7 @@ var AccessControlledModel = Model.extend({
         }
 
         if (!this.get('access') || force) {
-            restRequest({
+            return restRequest({
                 path: (this.altUrl || this.resourceName) + '/' + this.get('_id') + '/access',
                 type: 'GET'
             }).done(_.bind(function (resp) {
@@ -64,14 +62,14 @@ var AccessControlledModel = Model.extend({
                     this.set('access', resp);
                 }
                 this.trigger('g:accessFetched');
+                return resp;
             }, this)).error(_.bind(function (err) {
                 this.trigger('g:error', err);
             }, this));
         } else {
             this.trigger('g:accessFetched');
+            return $.when(this.get('access'));
         }
-
-        return this;
     }
 });
 

--- a/clients/web/src/models/ApiKeyModel.js
+++ b/clients/web/src/models/ApiKeyModel.js
@@ -7,7 +7,7 @@ var ApiKeyModel = AccessControlledModel.extend({
     resourceName: 'api_key',
 
     setActive: function (active) {
-        restRequest({
+        return restRequest({
             path: 'api_key/' + this.id,
             method: 'PUT',
             data: {
@@ -17,17 +17,16 @@ var ApiKeyModel = AccessControlledModel.extend({
             this.set({active: active});
             this.trigger('g:setActive');
         }, this));
-
-        return this;
     },
 
     save: function () {
         // Scope needs to be sent to the server as JSON
         var scope = this.get('scope');
         this.attributes.scope = JSON.stringify(scope);
-        AccessControlledModel.prototype.save.call(this, arguments);
+        var promise = AccessControlledModel.prototype.save.call(this, arguments);
         // Restore scope to its original state
         this.attributes.scope = scope;
+        return promise;
     }
 });
 

--- a/clients/web/src/models/AssetstoreModel.js
+++ b/clients/web/src/models/AssetstoreModel.js
@@ -19,7 +19,7 @@ var AssetstoreModel = Model.extend({
     },
 
     import: function (params) {
-        restRequest({
+        return restRequest({
             path: 'assetstore/' + this.get('_id') + '/import',
             type: 'POST',
             data: params,
@@ -29,8 +29,6 @@ var AssetstoreModel = Model.extend({
         }, this)).error(_.bind(function (resp) {
             this.trigger('g:error', resp);
         }, this));
-
-        return this;
     },
 
     save: function () {
@@ -38,7 +36,7 @@ var AssetstoreModel = Model.extend({
             // Coerce to an octal string to disambiguate
             this.set('perms', this.get('perms').toString(8));
         }
-        Model.prototype.save.call(this, arguments);
+        return Model.prototype.save.call(this, arguments);
     }
 });
 

--- a/clients/web/src/models/GroupModel.js
+++ b/clients/web/src/models/GroupModel.js
@@ -18,7 +18,7 @@ var GroupModel = AccessControlledModel.extend({
      */
     sendInvitation: function (userId, accessType, request, params) {
         params = params || {};
-        restRequest({
+        return restRequest({
             path: this.resourceName + '/' + this.get('_id') + '/invitation',
             data: _.extend({
                 userId: userId,
@@ -47,7 +47,7 @@ var GroupModel = AccessControlledModel.extend({
      * already been invited to the group.
      */
     joinGroup: function () {
-        restRequest({
+        return restRequest({
             path: this.resourceName + '/' + this.get('_id') + '/member',
             type: 'POST'
         }).done(_.bind(function (resp) {
@@ -68,7 +68,7 @@ var GroupModel = AccessControlledModel.extend({
      * outstanding invitation to this group, call joinGroup instead.
      */
     requestInvitation: function () {
-        restRequest({
+        return restRequest({
             path: this.resourceName + '/' + this.get('_id') + '/member',
             type: 'POST'
         }).done(_.bind(function (resp) {
@@ -93,7 +93,7 @@ var GroupModel = AccessControlledModel.extend({
         } else if (level === AccessType.ADMIN) {
             role = 'admin';
         }
-        restRequest({
+        return restRequest({
             path: this.resourceName + '/' + this.get('_id') + '/' + role,
             data: {
                 userId: user.get('_id')
@@ -121,7 +121,7 @@ var GroupModel = AccessControlledModel.extend({
         } else if (level === AccessType.ADMIN) {
             role = 'admin';
         }
-        restRequest({
+        return restRequest({
             path: this.resourceName + '/' + this.get('_id') + '/' + role +
                 '?userId=' + userId,
             type: 'DELETE'
@@ -141,7 +141,7 @@ var GroupModel = AccessControlledModel.extend({
      * @param userId The ID of the user to remove.
      */
     removeMember: function (userId) {
-        restRequest({
+        return restRequest({
             path: this.resourceName + '/' + this.get('_id') +
                   '/member?userId=' + userId,
             type: 'DELETE'

--- a/clients/web/src/models/ItemModel.js
+++ b/clients/web/src/models/ItemModel.js
@@ -40,7 +40,7 @@ var ItemModel = Model.extend({
      * Get the path to the root of the hierarchy
      */
     getRootPath: function (callback) {
-        restRequest({
+        return restRequest({
             path: this.resourceName + '/' + this.get('_id') + '/rootpath'
         }).done(_.bind(function (resp) {
             callback(resp);

--- a/clients/web/src/models/Model.js
+++ b/clients/web/src/models/Model.js
@@ -64,7 +64,7 @@ var Model = Backbone.Model.extend({
             }
         }, this);
 
-        restRequest({
+        return restRequest({
             path: path,
             type: type,
             data: data,
@@ -75,8 +75,6 @@ var Model = Backbone.Model.extend({
         }, this)).error(_.bind(function (err) {
             this.trigger('g:error', err);
         }, this));
-
-        return this;
     },
 
     /**
@@ -102,7 +100,7 @@ var Model = Backbone.Model.extend({
         if (opts.ignoreError) {
             restOpts.error = null;
         }
-        restRequest(restOpts).done(_.bind(function (resp) {
+        return restRequest(restOpts).done(_.bind(function (resp) {
             this.set(resp);
             if (opts.extraPath) {
                 this.trigger('g:fetched.' + opts.extraPath);
@@ -112,8 +110,6 @@ var Model = Backbone.Model.extend({
         }, this)).error(_.bind(function (err) {
             this.trigger('g:error', err);
         }, this));
-
-        return this;
     },
 
     /**
@@ -167,7 +163,7 @@ var Model = Backbone.Model.extend({
             args.error = null;
         }
 
-        restRequest(args).done(_.bind(function () {
+        return restRequest(args).done(_.bind(function () {
             if (this.collection) {
                 this.collection.remove(this);
             }
@@ -175,8 +171,6 @@ var Model = Backbone.Model.extend({
         }, this)).error(_.bind(function (err) {
             this.trigger('g:error', err);
         }, this));
-
-        return this;
     },
 
     /**

--- a/clients/web/src/models/UserModel.js
+++ b/clients/web/src/models/UserModel.js
@@ -87,7 +87,7 @@ var UserModel = Model.extend({
      * Change the password for this user.
      */
     changePassword: function (oldPassword, newPassword) {
-        restRequest({
+        return restRequest({
             path: this.resourceName + '/password',
             data: {
                 old: oldPassword,
@@ -106,7 +106,7 @@ var UserModel = Model.extend({
      * Change the password for another user (as an admin).
      */
     adminChangePassword: function (newPassword) {
-        restRequest({
+        return restRequest({
             path: this.resourceName + '/' + this.id + '/password',
             data: {
                 password: newPassword

--- a/clients/web/src/views/body/CollectionView.js
+++ b/clients/web/src/views/body/CollectionView.js
@@ -34,7 +34,7 @@ var CollectionView = View.extend({
                 yesText: 'Delete',
                 escapedHtml: true,
                 confirmCallback: _.bind(function () {
-                    this.model.destroy().on('g:deleted', function () {
+                    this.model.on('g:deleted', function () {
                         events.trigger('g:alert', {
                             icon: 'ok',
                             text: 'Collection deleted.',
@@ -42,7 +42,7 @@ var CollectionView = View.extend({
                             timeout: 4000
                         });
                         router.navigate('collections', {trigger: true});
-                    });
+                    }).destroy();
                 }, this)
             });
         }

--- a/clients/web/src/views/body/ItemView.js
+++ b/clients/web/src/views/body/ItemView.js
@@ -93,7 +93,7 @@ var ItemView = View.extend({
             yesText: 'Delete',
             escapedHtml: true,
             confirmCallback: _.bind(function () {
-                this.model.destroy().on('g:deleted', function () {
+                this.model.on('g:deleted', function () {
                     router.navigate(parentRoute, {trigger: true});
                 }).off('g:error').on('g:error', function () {
                     page.render();
@@ -103,7 +103,7 @@ var ItemView = View.extend({
                         type: 'danger',
                         timeout: 4000
                     });
-                });
+                }).destroy();
             }, this)
         });
     },

--- a/clients/web/src/views/body/UserView.js
+++ b/clients/web/src/views/body/UserView.js
@@ -34,9 +34,9 @@ var UserView = View.extend({
                 yesText: 'Delete',
                 escapedHtml: true,
                 confirmCallback: _.bind(function () {
-                    this.model.destroy().on('g:deleted', function () {
+                    this.model.on('g:deleted', function () {
                         router.navigate('users', {trigger: true});
-                    });
+                    }).destroy();
                 }, this)
             });
         },

--- a/clients/web/src/views/widgets/ApiKeyListWidget.js
+++ b/clients/web/src/views/widgets/ApiKeyListWidget.js
@@ -16,9 +16,9 @@ var ApiKeyListWidget = View.extend({
         'click .g-api-key-toggle-active': function (e) {
             var apiKey = this._getModelFromEvent(e);
             var toggleActive = _.bind(function () {
-                apiKey.setActive(!apiKey.get('active')).once('g:setActive', function () {
+                apiKey.once('g:setActive', function () {
                     this.render();
-                }, this);
+                }, this).setActive(!apiKey.get('active'));
             }, this);
 
             if (apiKey.get('active')) {
@@ -55,7 +55,7 @@ var ApiKeyListWidget = View.extend({
                 yesText: 'Delete',
                 escapedHtml: true,
                 confirmCallback: _.bind(function () {
-                    apiKey.destroy().on('g:deleted', function () {
+                    apiKey.on('g:deleted', function () {
                         events.trigger('g:alert', {
                             icon: 'ok',
                             text: 'API key deleted.',
@@ -63,7 +63,7 @@ var ApiKeyListWidget = View.extend({
                             timeout: 3000
                         });
                         this.render();
-                    }, this);
+                    }, this).destroy();
                 }, this)
             });
         }

--- a/clients/web/src/views/widgets/CollectionInfoWidget.js
+++ b/clients/web/src/views/widgets/CollectionInfoWidget.js
@@ -12,10 +12,10 @@ var CollectionInfoWidget = View.extend({
     initialize: function () {
         this.needToFetch = !this.model.has('nFolders');
         if (this.needToFetch) {
-            this.model.fetch({extraPath: 'details'}).once('g:fetched.details', function () {
+            this.model.once('g:fetched.details', function () {
                 this.needToFetch = false;
                 this.render();
-            }, this);
+            }, this).fetch({extraPath: 'details'});
         }
     },
 

--- a/clients/web/src/views/widgets/FolderInfoWidget.js
+++ b/clients/web/src/views/widgets/FolderInfoWidget.js
@@ -12,10 +12,10 @@ var FolderInfoWidget = View.extend({
     initialize: function () {
         this.needToFetch = !this.model.has('nItems') || !this.model.has('nFolders');
         if (this.needToFetch) {
-            this.model.fetch({extraPath: 'details'}).once('g:fetched.details', function () {
+            this.model.once('g:fetched.details', function () {
                 this.needToFetch = false;
                 this.render();
-            }, this);
+            }, this).fetch({extraPath: 'details'});
         }
     },
 

--- a/clients/web/src/views/widgets/HierarchyWidget.js
+++ b/clients/web/src/views/widgets/HierarchyWidget.js
@@ -415,17 +415,17 @@ var HierarchyWidget = View.extend({
             escapedHtml: true,
             yesText: 'Delete',
             confirmCallback: _.bind(function () {
-                this.parentModel.destroy({
-                    throwError: true,
-                    progress: true
-                }).on('g:deleted', function () {
+                this.parentModel.on('g:deleted', function () {
                     if (type === 'collection') {
                         router.navigate('collections', {trigger: true});
                     } else if (type === 'folder') {
                         this.breadcrumbs.pop();
                         this.setCurrentModel(this.breadcrumbs.slice(-1)[0]);
                     }
-                }, this);
+                }, this).destroy({
+                    throwError: true,
+                    progress: true
+                });
             }, this)
         };
         confirm(params);

--- a/clients/web/test/spec/customWidgetsSpec.js
+++ b/clients/web/test/spec/customWidgetsSpec.js
@@ -35,7 +35,9 @@
                     lastName: 'Last'
                 }).on('g:saved', function () {
                     user = _user;
-                }).save();
+                });
+
+                _user.save();
             });
 
             waitsFor(function () {
@@ -51,7 +53,9 @@
                     name: 'top level folder'
                 }).on('g:saved', function () {
                     folder = _folder;
-                }).save();
+                });
+
+                _folder.save();
             });
 
             waitsFor(function () {
@@ -67,7 +71,9 @@
                     name: 'subfolder'
                 }).on('g:saved', function () {
                     subfolder = _subfolder;
-                }).save();
+                });
+
+                _subfolder.save();
             });
 
             waitsFor(function () {
@@ -82,7 +88,9 @@
                     name: 'an item'
                 }).on('g:saved', function () {
                     item = _item;
-                }).save();
+                });
+
+                _item.save();
             });
 
             waitsFor(function () {

--- a/clients/web/test/spec/dataSpec.js
+++ b/clients/web/test/spec/dataSpec.js
@@ -767,7 +767,9 @@ describe('Test FileModel static upload functions', function () {
                 name: 'top level folder'
             }).on('g:saved', function () {
                 folder = _folder;
-            }).save();
+            });
+
+            _folder.save();
         });
 
         waitsFor(function () {
@@ -782,7 +784,9 @@ describe('Test FileModel static upload functions', function () {
                 name: 'an item'
             }).on('g:saved', function () {
                 item = _item;
-            }).save();
+            });
+
+            _item.save();
         });
 
         waitsFor(function () {


### PR DESCRIPTION
Note: This is a PR targeted at the 2.0 integration branch.

This makes the backward incompatible change to all async methods on models and collections to return `jqXHR` objects rather than `this`.  This change is made for two reasons:

1. This is the signature of the [superclass methods](http://backbonejs.org/#Model-fetch).
2. It allows you to avoid the callback hell described in #1072 by using `Promise.all` or `$.when` on the returned objects.