### PR TITLE
Instead of just printing to stdout, also send information to logs.

### DIFF
--- a/girder/__init__.py
+++ b/girder/__init__.py
@@ -123,11 +123,13 @@ logger = _setupLogger()
 def logprint(*args, **kwargs):
     """
     Send a message to both stdout and the appropriate logs.  This behaves like
-    Python3's print statement, plus takes additional named parameters of
-    level (log level), color (one of the constants.TerminalColor values), and
-    exc_info (either True for the last exception or exception information).
+    Python3's print statement, plus takes additional named parameters:
 
-    Ideally, we should expose a config option to make this silent.
+    :param level: the log level.  This determines which log handlers will store
+        the log message.  The log is always sent to stdout.
+    :param color: one of the constants.TerminalColor values or None.
+    :param exc_info: None to not print exception information.  True for the
+        last exception, or a tuple of exception information.
     """
     data = six.StringIO()
     kwargs = (kwargs or {}).copy()

--- a/girder/__init__.py
+++ b/girder/__init__.py
@@ -18,11 +18,18 @@
 ###############################################################################
 
 import cherrypy
+import functools
+import logging
 import logging.handlers
 import os
+import six
+import StringIO
+import sys
+import traceback
 
 
-from girder.constants import LOG_ROOT, MAX_LOG_SIZE, LOG_BACKUP_COUNT
+from girder.constants import LOG_ROOT, MAX_LOG_SIZE, LOG_BACKUP_COUNT, \
+    TerminalColor
 from girder.utility import config, mkdir
 
 __version__ = '1.5.2'
@@ -112,6 +119,47 @@ def _setupLogger():
     return logger
 
 logger = _setupLogger()
+
+
+def logprint(*args, **kwargs):
+    """
+    Send a message to both stdout and the appropriate logs.  This behaves like
+    Python3's print statement, plus takes additional named parameters of
+    level (log level), color (one of the constants.TerminalColor values), and
+    exc_info (either True for the last exception or exception information).
+
+    Ideally, we should expose a config option to make this silent.
+    """
+    data = StringIO.StringIO()
+    kwargs = (kwargs or {}).copy()
+    level = kwargs.pop('level', logging.DEBUG)
+    color = kwargs.pop('color', None)
+    exc_info = kwargs.pop('exc_info', None)
+    kwargs['file'] = data
+    six.print_(*args, **kwargs)
+    data = data.getvalue().rstrip()
+    if exc_info and not isinstance(exc_info, tuple):
+        exc_info = sys.exc_info()
+        data += '\n' + ''.join(traceback.format_exception(*exc_info)).rstrip()
+    logger.log(level, data)
+    if color:
+        data = getattr(TerminalColor, color)(data)
+    six.print_(data, flush=True)
+
+# Expose common logging levels and colors as methods of logprint.
+logprint.info = functools.partial(logprint, level=logging.INFO, color='info')
+logprint.warning = functools.partial(
+    logprint, level=logging.WARNING, color='warning')
+logprint.error = functools.partial(
+    logprint, level=logging.ERROR, color='error')
+logprint.success = functools.partial(
+    logprint, level=logging.INFO, color='success')
+logprint.critical = functools.partial(
+    logprint, level=logging.CRITICAL, color='error')
+logprint.debug = logprint
+logprint.exception = functools.partial(
+    logprint, level=logging.ERROR, color='error', exc_info=True)
+
 
 # alias girder.plugin => girder.utility.plugin_utilities
 from girder.utility import plugin_utilities as plugin  # noqa

--- a/girder/__init__.py
+++ b/girder/__init__.py
@@ -23,7 +23,6 @@ import logging
 import logging.handlers
 import os
 import six
-import StringIO
 import sys
 import traceback
 
@@ -130,7 +129,7 @@ def logprint(*args, **kwargs):
 
     Ideally, we should expose a config option to make this silent.
     """
-    data = StringIO.StringIO()
+    data = six.StringIO()
     kwargs = (kwargs or {}).copy()
     level = kwargs.pop('level', logging.DEBUG)
     color = kwargs.pop('color', None)

--- a/girder/api/docs.py
+++ b/girder/api/docs.py
@@ -20,7 +20,7 @@
 import collections
 import functools
 import six
-from girder.constants import TerminalColor
+from girder import logprint
 
 models = collections.defaultdict(dict)
 # routes is dict of dicts of lists
@@ -149,7 +149,7 @@ def addModel(name, model, resources=None, silent=False):
             models[resource][name] = model
     else:
         if not silent:
-            print(TerminalColor.warning(
+            logprint.warning(
                 'WARNING: adding swagger models without specifying resources '
-                'to bind to is discouraged (%s).' % name))
+                'to bind to is discouraged (%s).' % name)
         models[None][name] = model

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -26,8 +26,8 @@ import sys
 import traceback
 
 from . import docs
-from girder import events, logger
-from girder.constants import SettingKey, TerminalColor, TokenScope, SortDir
+from girder import events, logger, logprint
+from girder.constants import SettingKey, TokenScope, SortDir
 from girder.models.model_base import AccessException, GirderException, \
     ValidationException
 from girder.utility.model_importer import ModelImporter
@@ -629,10 +629,10 @@ class Resource(ModelImporter):
         """
         if not hasattr(self, '_routes'):
             Resource.__init__(self)
-            print(TerminalColor.warning(
+            logprint.warning(
                 'WARNING: Resource subclass "%s" did not call '
                 '"Resource__init__()" from its constructor.' %
-                self.__class__.__name__))
+                self.__class__.__name__)
 
     def route(self, method, route, handler, nodoc=False, resource=None):
         """
@@ -677,26 +677,26 @@ class Resource(ModelImporter):
                     info=handler.description.asDict(), handler=handler)
         elif not nodoc:
             routePath = '/'.join([resource] + list(route))
-            print(TerminalColor.warning(
+            logprint.warning(
                 'WARNING: No description docs present for route %s %s' % (
-                    method, routePath)))
+                    method, routePath))
 
         # Warn if there is no access decorator on the handler function
         if not hasattr(handler, 'accessLevel'):
             routePath = '/'.join([resource] + list(route))
-            print(TerminalColor.warning(
+            logprint.warning(
                 'WARNING: No access level specified for route %s %s' % (
-                    method, routePath)))
+                    method, routePath))
 
         if method.lower() not in ('head', 'get') \
             and hasattr(handler, 'cookieAuth') \
             and not (isinstance(handler.cookieAuth, tuple) and
                      handler.cookieAuth[1]):
             routePath = '/'.join([resource] + list(route))
-            print(TerminalColor.warning(
-                  'WARNING: Cannot allow cookie authentication for '
-                  'route %s %s without specifying "force=True"' % (
-                      method, routePath)))
+            logprint.warning(
+                'WARNING: Cannot allow cookie authentication for '
+                'route %s %s without specifying "force=True"' % (
+                    method, routePath))
 
     def removeRoute(self, method, route, handler=None, resource=None):
         """

--- a/girder/events.py
+++ b/girder/events.py
@@ -45,7 +45,6 @@ import contextlib
 import threading
 import types
 
-from .constants import TerminalColor
 import girder
 from six.moves import queue
 
@@ -127,7 +126,7 @@ class AsyncEventsThread(threading.Thread):
         put to sleep until someone calls trigger() on it with a new event to
         dispatch.
         """
-        print(TerminalColor.info('Started asynchronous event manager thread.'))
+        girder.logprint.info('Started asynchronous event manager thread.')
 
         while not self.terminate:
             eventName, info, callback = self.eventQueue.get(block=True)
@@ -140,7 +139,7 @@ class AsyncEventsThread(threading.Thread):
                     'In handler for event "%s":' % eventName)
                 pass  # Must continue the event loop even if handler failed
 
-        print(TerminalColor.info('Stopped asynchronous event manager thread.'))
+        girder.logprint.info('Stopped asynchronous event manager thread.')
 
     def trigger(self, eventName, info=None, callback=None):
         """

--- a/girder/models/__init__.py
+++ b/girder/models/__init__.py
@@ -20,10 +20,9 @@
 import pymongo
 
 from pymongo.read_preferences import ReadPreference
-from girder import logger
+from girder import logger, logprint
 from girder.external.mongodb_proxy import MongoProxy
 from girder.utility import config
-from girder.constants import TerminalColor
 
 _dbClients = {}
 
@@ -84,8 +83,8 @@ def getDbConnection(uri=None, replicaSet=None, autoRetry=True, **kwargs):
 
     if uri is None:
         dbUriRedacted = 'mongodb://localhost:27017/girder'
-        print(TerminalColor.warning('WARNING: No MongoDB URI specified, using '
-                                    'the default value'))
+        logprint.warning('WARNING: No MongoDB URI specified, using '
+                         'the default value')
 
         client = pymongo.MongoClient(dbUriRedacted, **clientOptions)
     else:
@@ -107,6 +106,5 @@ def getDbConnection(uri=None, replicaSet=None, autoRetry=True, **kwargs):
     desc = ''
     if replicaSet:
         desc += ', replica set: %s' % replicaSet
-    print(TerminalColor.info('Connected to MongoDB: %s%s' % (dbUriRedacted,
-                                                             desc)))
+    logprint.info('Connected to MongoDB: %s%s' % (dbUriRedacted, desc))
     return client

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -27,9 +27,8 @@ import six
 from bson.objectid import ObjectId
 from bson.errors import InvalidId
 from pymongo.errors import WriteError
-from girder import events
-from girder.constants import AccessType, CoreEventHandler, TerminalColor, \
-    TEXT_SCORE_SORT_MAX
+from girder import events, logprint
+from girder.constants import AccessType, CoreEventHandler, TEXT_SCORE_SORT_MAX
 from girder.external.mongodb_proxy import MongoProxy
 from girder.models import getDbConnection
 from girder.utility.model_importer import ModelImporter
@@ -86,8 +85,7 @@ class Model(ModelImporter):
                     textIdx, weights=self._textIndex,
                     default_language=self._textLanguage)
             except pymongo.errors.OperationFailure:
-                print(
-                    TerminalColor.warning('WARNING: Text search not enabled.'))
+                logprint.warning('WARNING: Text search not enabled.')
 
     def exposeFields(self, level, fields):
         """

--- a/girder/models/setting.py
+++ b/girder/models/setting.py
@@ -22,8 +22,9 @@ import cherrypy
 import pymongo
 import six
 
-from ..constants import SettingDefault, SettingKey, TerminalColor
+from ..constants import SettingDefault, SettingKey
 from .model_base import Model, ValidationException
+from girder import logprint
 from girder.utility import plugin_utilities, setting_utilities
 from girder.utility.model_importer import ModelImporter
 from bson.objectid import ObjectId
@@ -71,9 +72,9 @@ class Setting(Model):
                            'count': {'$sum': 1}}}, {
                 '$match': {'count': {'$gt': 1}}}])
             for duplicate in duplicates:
-                print(TerminalColor.warning(
+                logprint.warning(
                     'Removing duplicate setting with key %s.' % (
-                        duplicate['key'])))
+                        duplicate['key']))
                 # Remove all of the duplicates.  Keep the item with the lowest
                 # id in Mongo.
                 for duplicateId in sorted(duplicate['ids'])[1:]:

--- a/girder/utility/__init__.py
+++ b/girder/utility/__init__.py
@@ -26,7 +26,7 @@ import pytz
 import re
 import string
 
-from girder.constants import TerminalColor
+import girder
 import girder.events
 
 try:
@@ -34,8 +34,8 @@ try:
     random = SystemRandom()
     random.random()  # potentially raises NotImplementedError
 except NotImplementedError:  # pragma: no cover
-    print(TerminalColor.warning(
-        'WARNING: using non-cryptographically secure PRNG.'))
+    girder.logprint.warning(
+        'WARNING: using non-cryptographically secure PRNG.')
     import random
 
 

--- a/girder/utility/plugin_utilities.py
+++ b/girder/utility/plugin_utilities.py
@@ -330,7 +330,7 @@ def findEntryPointPlugins(allPlugins):
                         entry_point.name, configJson) as conf:
                     try:
                         data = json.load(codecs.getreader('utf8')(conf))
-                    except ValueError as e:
+                    except ValueError:
                         logprint.exception(
                             'ERROR: Plugin "%s": plugin.json is not valid '
                             'JSON.' % entry_point.name)
@@ -377,7 +377,7 @@ def findAllPlugins(curConfig=None):
                 with open(configJson) as conf:
                     try:
                         data = json.load(conf)
-                    except ValueError as e:
+                    except ValueError:
                         logprint.exception(
                             'ERROR: Plugin "%s": plugin.json is not valid '
                             'JSON.' % plugin)

--- a/girder/utility/plugin_utilities.py
+++ b/girder/utility/plugin_utilities.py
@@ -34,7 +34,6 @@ import json
 import os
 import six
 import sys
-import traceback
 import yaml
 import importlib
 
@@ -340,7 +339,7 @@ def findEntryPointPlugins(allPlugins):
                         entry_point.name, configYml) as conf:
                     try:
                         data = yaml.safe_load(conf)
-                    except yaml.YAMLError as e:
+                    except yaml.YAMLError:
                         logprint.exception(
                             'ERROR: Plugin "%s": plugin.yml is not valid '
                             'YAML.' % entry_point.name)
@@ -386,7 +385,7 @@ def findAllPlugins(curConfig=None):
                 with open(configYml) as conf:
                     try:
                         data = yaml.safe_load(conf)
-                    except yaml.YAMLError as e:
+                    except yaml.YAMLError:
                         logprint.exception(
                             'ERROR: Plugin "%s": plugin.yml is not valid '
                             'YAML.' % plugin)

--- a/girder/utility/plugin_utilities.py
+++ b/girder/utility/plugin_utilities.py
@@ -41,8 +41,8 @@ import importlib
 import pkg_resources
 from pkg_resources import iter_entry_points
 
-from girder.constants import PACKAGE_DIR, ROOT_DIR, ROOT_PLUGINS_PACKAGE, \
-    TerminalColor
+from girder import logprint
+from girder.constants import PACKAGE_DIR, ROOT_DIR, ROOT_PLUGINS_PACKAGE
 from girder.models.model_base import ValidationException
 from girder.utility import config as _config, mail_utils, mkdir
 
@@ -77,17 +77,17 @@ def loadPlugins(plugins, root, appconf, apiRoot=None, curConfig=None,
         curConfig = _config.getConfig()
 
     if 'plugins' in curConfig and 'plugin_directory' in curConfig['plugins']:
-        print(TerminalColor.warning(
+        logprint.warning(
             'Warning: the plugin_directory setting is deprecated. Please use '
             'the `girder-install plugin` command and remove this setting from '
-            'your config file.'))
+            'your config file.')
 
     if ROOT_PLUGINS_PACKAGE not in sys.modules:
         module = imp.new_module(ROOT_PLUGINS_PACKAGE)
         girder.plugins = module
         sys.modules[ROOT_PLUGINS_PACKAGE] = module
 
-    print(TerminalColor.info('Resolving plugin dependencies...'))
+    logprint.info('Resolving plugin dependencies...')
 
     if buildDag:
         plugins = getToposortedPlugins(plugins, curConfig, ignoreMissing=True)
@@ -96,12 +96,10 @@ def loadPlugins(plugins, root, appconf, apiRoot=None, curConfig=None,
         try:
             root, appconf, apiRoot = loadPlugin(
                 plugin, root, appconf, apiRoot, curConfig=curConfig)
-            print(TerminalColor.success('Loaded plugin "%s"' % plugin))
+            logprint.success('Loaded plugin "%s"' % plugin)
         except Exception:
-            print(TerminalColor.error(
-                'ERROR: Failed to load plugin "%s":' % plugin))
-            girder.logger.exception('Plugin load failure: %s' % plugin)
-            traceback.print_exc()
+            logprint.exception(
+                'ERROR: Failed to load plugin "%s":' % plugin)
 
     return root, appconf, apiRoot
 
@@ -122,8 +120,7 @@ def getToposortedPlugins(plugins, curConfig=None, ignoreMissing=False):
         if plugin not in allPlugins:
             message = 'Required plugin %s does not exist.' % plugin
             if ignoreMissing:
-                print(TerminalColor.error(message))
-                girder.logger.error(message)
+                logprint.error(message)
                 return
             else:
                 raise ValidationException(message)
@@ -281,8 +278,8 @@ def getPluginDirs(curConfig=None):
         try:
             mkdir(pluginDir)
         except OSError:
-            print(TerminalColor.warning(
-                'Could not create plugin directory %s.' % pluginDir))
+            logprint.warning(
+                'Could not create plugin directory %s.' % pluginDir)
 
             failedPluginDirs.add(pluginDir)
 
@@ -335,22 +332,18 @@ def findEntryPointPlugins(allPlugins):
                     try:
                         data = json.load(codecs.getreader('utf8')(conf))
                     except ValueError as e:
-                        print(
-                            TerminalColor.error(
-                                'ERROR: Plugin "%s": plugin.json is not valid '
-                                'JSON.' % entry_point.name))
-                        print(e)
+                        logprint.exception(
+                            'ERROR: Plugin "%s": plugin.json is not valid '
+                            'JSON.' % entry_point.name)
             elif pkg_resources.resource_exists(entry_point.name, configYml):
                 with pkg_resources.resource_stream(
                         entry_point.name, configYml) as conf:
                     try:
                         data = yaml.safe_load(conf)
                     except yaml.YAMLError as e:
-                        print(
-                            TerminalColor.error(
-                                'ERROR: Plugin "%s": plugin.yml is not valid '
-                                'YAML.' % entry_point.name))
-                        print(e)
+                        logprint.exception(
+                            'ERROR: Plugin "%s": plugin.yml is not valid '
+                            'YAML.' % entry_point.name)
         except ImportError:
             pass
         if data == {}:
@@ -370,7 +363,7 @@ def findAllPlugins(curConfig=None):
     findEntryPointPlugins(allPlugins)
     pluginDirs = getPluginDirs(curConfig)
     if not pluginDirs:
-        print(TerminalColor.warning('Plugin directory not found.'))
+        logprint.warning('Plugin directory not found.')
         return allPlugins
 
     for pluginDir in pluginDirs:
@@ -386,21 +379,17 @@ def findAllPlugins(curConfig=None):
                     try:
                         data = json.load(conf)
                     except ValueError as e:
-                        print(
-                            TerminalColor.error(
-                                ('ERROR: Plugin "%s": '
-                                 'plugin.json is not valid JSON.') % plugin))
-                        print(e)
+                        logprint.exception(
+                            'ERROR: Plugin "%s": plugin.json is not valid '
+                            'JSON.' % plugin)
             elif os.path.isfile(configYml):
                 with open(configYml) as conf:
                     try:
                         data = yaml.safe_load(conf)
                     except yaml.YAMLError as e:
-                        print(
-                            TerminalColor.error(
-                                ('ERROR: Plugin "%s": '
-                                 'plugin.yml is not valid YAML.') % plugin))
-                        print(e)
+                        logprint.exception(
+                            'ERROR: Plugin "%s": plugin.yml is not valid '
+                            'YAML.' % plugin)
 
             allPlugins[plugin] = {
                 'name': data.get('name', plugin),

--- a/girder/utility/server.py
+++ b/girder/utility/server.py
@@ -22,7 +22,7 @@ import mimetypes
 import os
 
 import girder.events
-from girder import constants
+from girder import constants, logprint
 from girder.utility import plugin_utilities, model_importer
 from girder.utility import config
 from . import webroot
@@ -93,7 +93,7 @@ def configureServer(test=False, plugins=None, curConfig=None):
         }})
 
     mode = curConfig['server']['mode'].lower()
-    print(constants.TerminalColor.info('Running in mode: ' + mode))
+    logprint.info('Running in mode: ' + mode)
     cherrypy.config['engine.autoreload.on'] = mode == 'development'
 
     # Don't import this until after the configs have been read; some module


### PR DESCRIPTION
Except for the install utilities, all print statements now go through the `logprint` function.  This still prints the value to stdout with the appropriate terminal color.  It also send the information to the configure logs (if any).  This simplifies printing in color, as instead of `print(TerminalColor.info(msg))`, one can use `logprint.info(msg)`.  It also adds exception printing support and a few additional log levels.

This resolves issue #602.