### PR TITLE
Add an endpoint to lookup the path of a resource

### DIFF
--- a/docs/api-docs.rst
+++ b/docs/api-docs.rst
@@ -194,6 +194,9 @@ Utility
 .. automodule:: girder.utility.progress
    :members:
 
+.. automodule:: girder.utility.path
+   :members:
+
 Constants
 ---------
 .. automodule:: girder.constants

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -28,6 +28,7 @@ from girder.models.model_base import AccessControlledModel
 from girder.utility import acl_mixin
 from girder.utility import parseTimestamp
 from girder.utility import ziputil
+from girder.utility import path as path_util
 from girder.utility.progress import ProgressContext
 
 # Plugins can modify this set to allow other types to be searched
@@ -196,7 +197,7 @@ class Resource(BaseResource):
             will return None instead of throwing exception when
             path doesn't exist
         """
-        pathArray = [token for token in path.split('/') if token]
+        pathArray = path_util.split(path)[1:]
         model = pathArray[0]
 
         parent = None
@@ -307,7 +308,7 @@ class Resource(BaseResource):
                 break
 
         path.insert(0, type)
-        return '/' + '/'.join(path)
+        return '/' + path_util.join(path)
 
     @access.cookie(force=True)
     @access.public(scope=TokenScope.DATA_READ)

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -197,7 +197,8 @@ class Resource(BaseResource):
             will return None instead of throwing exception when
             path doesn't exist
         """
-        pathArray = path_util.split(path)[1:]
+        path = path.lstrip('/')
+        pathArray = path_util.split(path)
         model = pathArray[0]
 
         parent = None

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -44,6 +44,7 @@ class Resource(BaseResource):
         self.route('GET', ('search',), self.search)
         self.route('GET', ('lookup',), self.lookup)
         self.route('GET', (':id',), self.getResource)
+        self.route('GET', (':id', 'path'), self.path)
         self.route('PUT', (':id', 'timestamp'), self.setTimestamp)
         self.route('GET', ('download',), self.download)
         self.route('POST', ('download',), self.download)
@@ -259,6 +260,55 @@ class Resource(BaseResource):
         test = self.boolParam('test', params, default=False)
         return self._lookUpPath(params['path'], self.getCurrentUser(), test)
 
+    def _getResourceName(self, type, doc):
+        if type == 'user':
+            return doc['login']
+        elif type in ('file', 'item', 'folder', 'user', 'collection'):
+            return doc['name']
+        else:
+            raise RestException(
+                'Invalid resource type.'
+            )
+
+    def _getResourceParent(self, type, doc):
+        if type == 'file':
+            return doc['itemId'], 'item'
+        elif type == 'item':
+            return doc['folderId'], 'folder'
+        elif type == 'folder':
+            return doc['parentId'], doc['parentCollection']
+        else:
+            raise RestException(
+                'Invalid resource type.'
+            )
+
+    @access.public(scope=TokenScope.DATA_READ)
+    @describeRoute(
+        Description('Get path of a resource.')
+        .param('id', 'The ID of the resource.', paramType='path')
+        .param('type', 'The type of the resource (item, file, etc.).')
+        .errorResponse('ID was invalid.')
+        .errorResponse('Invalid resource type.')
+        .errorResponse('Read access was denied for the resource.', 403)
+    )
+    def path(self, id, params):
+        path = []
+        type = params['type']
+        while True:
+            doc = self._getResource(id, type)
+            if doc is None:
+                raise RestException('Invalid resource id.')
+            name = self._getResourceName(type, doc)
+            path.insert(0, name)
+
+            if type in ('file', 'item', 'folder'):
+                id, type = self._getResourceParent(type, doc)
+            else:
+                break
+
+        path.insert(0, type)
+        return '/' + '/'.join(path)
+
     @access.cookie(force=True)
     @access.public(scope=TokenScope.DATA_READ)
     @describeRoute(
@@ -366,6 +416,14 @@ class Resource(BaseResource):
                             ctx.update(current=current,
                                        message='Deleted ' + kind)
 
+    def _getResource(self, id, type):
+        model = self._getResourceModel(type)
+        if (isinstance(model, (acl_mixin.AccessControlMixin,
+                               AccessControlledModel))):
+            user = self.getCurrentUser()
+            return model.load(id=id, user=user, level=AccessType.READ)
+        return model.load(id=id)
+
     @access.admin
     @describeRoute(
         Description('Get any resource by ID.')
@@ -375,12 +433,7 @@ class Resource(BaseResource):
         .errorResponse('Read access was denied for the resource.', 403)
     )
     def getResource(self, id, params):
-        model = self._getResourceModel(params['type'])
-        if (isinstance(model, (acl_mixin.AccessControlMixin,
-                               AccessControlledModel))):
-            user = self.getCurrentUser()
-            return model.load(id=id, user=user, level=AccessType.READ)
-        return model.load(id=id)
+        return self._getResource(id, params['type'])
 
     @access.admin
     @describeRoute(

--- a/girder/utility/path.py
+++ b/girder/utility/path.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright 2013 Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+"""This module contains utility methods for parsing girder path strings."""
+
+import re
+
+
+def encode(token):
+    """Escape special characters in a token for path representation.
+
+    :param str token: The token to encode
+    :return: The encoded string
+    :rtype: str
+    """
+    return token.replace('\\', '\\\\').replace('/', '\\/')
+
+
+def decode(token):
+    """Unescape special characters in a token from a path representation.
+
+    :param str token: The token to decode
+    :return: The decoded string
+    :rtype: str
+    """
+    return token.replace('\/', '/').replace('\\\\', '\\')
+
+
+def split(path):
+    """Split an encoded path string into decoded tokens.
+
+    :param str path: An encoded path string
+    :return: A list of decoded tokens
+    :rtype: list
+    """
+    # It would be better to split by the regex `(?<!\\)(?>\\\\)*/`,
+    # but python does't support atomic grouping. :(
+    chunks = path.split('/')
+    processed = [chunks[0]]
+
+    # matches an odd number of backslashes at the end of the string
+    escape = re.compile(r'(?<!\\)(?:\\\\)*\\$')
+
+    # Loop through the chunks and check if any of the forward slashes was
+    # escaped.
+    for chunk in chunks[1:]:
+        if escape.search(processed[-1]):
+            # join the chunks
+            processed[-1] = processed[-1] + '/' + chunk
+        else:
+            # append a new token
+            processed.append(chunk)
+
+    # now decode all of the tokens and return
+    return [decode(token) for token in processed]
+
+
+def join(tokens):
+    """Join a list of tokens into an encoded path string.
+
+    :param list tokens: A list of tokens
+    :return: The encoded path string
+    :rtype: str
+    """
+    return '/'.join([encode(token) for token in tokens])

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ if(RUN_CORE_TESTS)
   add_python_test(token)
   add_python_test(user)
   add_python_test(webroot)
+  add_python_test(path_utilities)
 
   add_python_test(py_client.cli BIND_SERVER RESOURCE_LOCKS py_client_test_dir)
   add_python_test(py_client.lib BIND_SERVER RESOURCE_LOCKS py_client_test_dir)

--- a/tests/cases/path_utilities_test.py
+++ b/tests/cases/path_utilities_test.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+import unittest
+from girder.utility import path
+
+strings = [
+    ('abcd', 'abcd'),
+    ('/', '\/'),
+    ('\\', '\\\\'),
+    ('/\\', '\/\\\\'),
+    ('\\//\\', '\\\\\/\/\\\\'),
+    ('a\\\\b//c\\d', 'a\\\\\\\\b\/\/c\\\\d')
+]
+
+paths = [
+    ('abcd', ['abcd']),
+    ('/abcd', ['', 'abcd']),
+    ('/ab/cd/ef/gh', ['', 'ab', 'cd', 'ef', 'gh']),
+    ('/ab/cd//', ['', 'ab', 'cd', '', '']),
+    ('ab\\/cd', ['ab/cd']),
+    ('ab\/c/d', ['ab/c', 'd']),
+    ('ab\//cd', ['ab/', 'cd']),
+    ('ab/\/cd', ['ab', '/cd']),
+    ('ab\\\\/cd', ['ab\\', 'cd']),
+    ('ab\\\\/\\\\cd', ['ab\\', '\\cd']),
+    ('ab\\\\\\/\\\\cd', ['ab\\/\\cd']),
+    ('/\\\\abcd\\\\/', ['', '\\abcd\\', '']),
+    ('/\\\\\\\\/\\//\\\\', ['', '\\\\', '/', '\\'])
+]
+
+
+class TestPathUtilities(unittest.TestCase):
+    """Tests the girder.utility.path module."""
+
+    def testEncodeStrings(self):
+        for raw, encoded in strings:
+            self.assertEqual(path.encode(raw), encoded)
+
+    def testDecodeStrings(self):
+        for raw, encoded in strings:
+            self.assertEqual(path.decode(encoded), raw)
+
+    def testSplitPath(self):
+        for pth, tokens in paths:
+            self.assertEqual(path.split(pth), tokens)
+
+    def testJoinTokens(self):
+        for pth, tokens in paths:
+            self.assertEqual(path.join(tokens), pth)

--- a/tests/cases/resource_test.py
+++ b/tests/cases/resource_test.py
@@ -476,6 +476,62 @@ class ResourceTestCase(base.TestCase):
         self.assertStatusOk(resp)
         self.assertEqual(resp.json, None)
 
+    def testGetResourcePath(self):
+        self._createFiles()
+
+        # Get a user's path
+        resp = self.request(path='/resource/' + str(self.user['_id']) + '/path',
+                            method='GET', user=self.user,
+                            params={'type': 'user'})
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, '/user/userlogin')
+
+        # Get a collection's path
+        resp = self.request(path='/resource/' + str(self.collection['_id']) + '/path',
+                            method='GET', user=self.user,
+                            params={'type': 'collection'})
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, '/collection/Test Collection')
+
+        # Get a folder's path
+        resp = self.request(path='/resource/' + str(self.adminSubFolder['_id']) + '/path',
+                            method='GET', user=self.user,
+                            params={'type': 'folder'})
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, '/user/goodlogin/Public/Folder 1')
+
+        # Get an item's path
+        resp = self.request(path='/resource/' + str(self.items[2]['_id']) + '/path',
+                            method='GET', user=self.user,
+                            params={'type': 'item'})
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, '/user/goodlogin/Public/Folder 1/Item 3')
+
+        # Get a file's path
+        resp = self.request(path='/resource/' + str(self.file1['_id']) + '/path',
+                            method='GET', user=self.user,
+                            params={'type': 'file'})
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, '/user/goodlogin/Public/Item 1/File 1')
+
+        # Test access denied response
+        resp = self.request(path='/resource/' + str(self.adminPrivateFolder['_id']) + '/path',
+                            method='GET', user=self.user,
+                            params={'type': 'folder'})
+        self.assertStatus(resp, 403)
+
+        # Test invalid id response
+        resp = self.request(path='/resource/' + str(self.user['_id']) + '/path',
+                            method='GET', user=self.user,
+                            params={'type': 'folder'})
+        self.assertStatus(resp, 400)
+
+        # Test invalid type response
+        resp = self.request(path='/resource/' + str(self.user['_id']) + '/path',
+                            method='GET', user=self.user,
+                            params={'type': 'invalid type'})
+        self.assertStatus(resp, 400)
+
     def testMove(self):
         self._createFiles()
         # Move item1 from the public to the private folder

--- a/tests/cases/resource_test.py
+++ b/tests/cases/resource_test.py
@@ -106,7 +106,7 @@ class ResourceTestCase(base.TestCase):
         self.items.append(self.model('item').createItem(
             'Item 2', self.admin, self.adminPublicFolder))
         self.items.append(self.model('item').createItem(
-            'Item 3', self.admin, self.adminSubFolder))
+            'It\\em/3', self.admin, self.adminSubFolder))
         self.items.append(self.model('item').createItem(
             'Item 4', self.admin, self.collectionPrivateFolder))
         self.items.append(self.model('item').createItem(
@@ -435,7 +435,7 @@ class ResourceTestCase(base.TestCase):
         privateFolder = self.collectionPrivateFolder['name']
         paths = ('/user/goodlogin/Public/Item 1',
                  '/user/goodlogin/Public/Item 2',
-                 '/user/goodlogin/Public/Folder 1/Item 3',
+                 '/user/goodlogin/Public/Folder 1/It\\\\em\\/3',
                  '/collection/Test Collection/%s/Item 4' % privateFolder,
                  '/collection/Test Collection/%s/Item 5' % privateFolder)
 
@@ -505,7 +505,7 @@ class ResourceTestCase(base.TestCase):
                             method='GET', user=self.user,
                             params={'type': 'item'})
         self.assertStatusOk(resp)
-        self.assertEqual(resp.json, '/user/goodlogin/Public/Folder 1/Item 3')
+        self.assertEqual(resp.json, '/user/goodlogin/Public/Folder 1/It\\\\em\\/3')
 
         # Get a file's path
         resp = self.request(path='/resource/' + str(self.file1['_id']) + '/path',


### PR DESCRIPTION
This is roughly the inverse of `GET /resource/lookup` and is helpful for client codes that treat girder objects as file-like paths.  It is valid for collections, users, folders, items, and files.

A couple of sticky points here:
* A name containing a slash (`/`) will not be escaped and will break lookups in the other direction.  If desired, I can add some logic to handle that case for both endpoints.
* It is possible (I believe) for a folder to be readable that has a parent folder that is not readable.  In this case, the code here will respond with a `403` if the user lacks read permissions on any document in the parent hierarchy because that would leak private information (e.g. the document's name).