### PR TITLE
Add another mode for adding npm deps to fix Vega Gruntfile error

### DIFF
--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -107,14 +107,10 @@ module.exports = function (grunt) {
                 configurePlugin(plugin);
             }
 
-            if (config.grunt) {
-                grunt.log.writeln((
-                    'Found plugin: ' + plugin + ' (custom Gruntfile)'
-                ).bold);
-
+            function addDependencies (deps) {
                 // install any additional npm packages during init
                 npm = (
-                    _(config.grunt.dependencies || [])
+                    _(deps || [])
                         .map(function (version, dep) {
                             // escape any periods in the dependency version so
                             // that grunt.config.set does not descend on each
@@ -133,6 +129,18 @@ module.exports = function (grunt) {
                         'init.npm-install:' + npm.join(':'), {}
                     );
                 }
+            }
+
+            if (config.npm) {
+                addDependencies(config.npm.dependencies);
+            }
+
+            if (config.grunt) {
+                grunt.log.writeln((
+                    'Found plugin: ' + plugin + ' (custom Gruntfile)'
+                ).bold);
+
+                addDependencies(config.grunt.dependencies);
 
                 // load the plugin's gruntfile
                 try {

--- a/plugins/vega/plugin.json
+++ b/plugins/vega/plugin.json
@@ -2,7 +2,7 @@
     "name": "Vega file visualizer",
     "description": "Render Vega visualizations in the file info page.",
     "version": "1.0.0",
-    "grunt": {
+    "npm": {
         "dependencies": {
             "vega": "^2.6.0"
         }


### PR DESCRIPTION
Separates out an addDependencies() function for adding npm dependencies to Girder root from plugins. Now plugins can specify npm dependencies from either `grunt.dependencies` (meant for deps needed for the plugin build process) or `npm.dependencies` (meant for deps needed by "in-place build" plugins such as the core plugins). The latter is needed by the Vega plugin (which does not have a grunt build) and hadn't been supported until now - a warning about not having a Gruntfile occurs when trying to use `grunt.dependencies`.

`grunt.dependencies` could be deprecated in favor of `npm.dependencies` in the future, but this fix is backwards-compatible.