### PR TITLE
Ansible client testing fixes

### DIFF
--- a/clients/ansible/test/CMakeLists.txt
+++ b/clients/ansible/test/CMakeLists.txt
@@ -23,7 +23,9 @@ function(add_ansible_test case)
     COMMAND "${ANSIBLE_PLAYBOOK_BIN}" -i ${ANSIBLE_INVENTORY} --private-key=${ANSIBLE_PRIVATE_KEY} -u ${ANSIBLE_USER} test_${case}.yml -v
     )
 
-  set_tests_properties("${name}" PROPERTIES DEPENDS vagrant_up)
+  set_tests_properties("${name}" PROPERTIES
+    DEPENDS vagrant_up
+    RUN_SERIAL ON)
   set_property(GLOBAL APPEND PROPERTY vagrant_tests "${name}")
 
 endfunction()

--- a/clients/ansible/test/CMakeLists.txt
+++ b/clients/ansible/test/CMakeLists.txt
@@ -43,4 +43,4 @@ add_test(
   COMMAND vagrant destroy -f
   )
 get_property(vagrant_tests GLOBAL PROPERTY vagrant_tests)
-set_tests_properties(vagrant_destroy PROPERTIES DEPENDS "${vagrannt_tests}")
+set_tests_properties(vagrant_destroy PROPERTIES DEPENDS "${vagrant_tests}")

--- a/clients/ansible/test/requirements.yml
+++ b/clients/ansible/test/requirements.yml
@@ -1,7 +1,7 @@
 ---
 - src: https://github.com/girder/ansible-role-girder
   name: girder
-  version: remotes/origin/change_mongo_version_string
+  version: remotes/origin/master
 
 - src: dstil.upstart
   name: upstart


### PR DESCRIPTION
@kotfic 
- `vagrant_destroy` test now properly depends on every other test
- pulls ansible galaxy role from the correct branch
- force ansible client tests to run serially (since they share the same database)
