### PR TITLE
The change to log errors despite unicode issues fails in Python3.

### DIFF
--- a/tests/web_client_test.py
+++ b/tests/web_client_test.py
@@ -182,7 +182,10 @@ class WebClientTestCase(base.TestCase):
                     hasJasmine = True
                 if 'Testing Finished' in line:
                     jasmineFinished = True
-                sys.stdout.write(line.encode('utf8', 'replace'))
+                try:
+                    sys.stdout.write(line)
+                except UnicodeEncodeError:
+                    sys.stdout.write(repr(line))
                 sys.stdout.flush()
             returncode = task.wait()
             if not retry and hasJasmine and jasmineFinished:


### PR DESCRIPTION
This should always log something, though the log will be uglier if it would have a Unicode error.

PR #1503 attempted to fix this.  This is another attempt.