### PR TITLE
Allow alternate tasks to be sent to girder worker

### DIFF
--- a/plugins/jobs/server/models/job.py
+++ b/plugins/jobs/server/models/job.py
@@ -117,7 +117,7 @@ class Job(AccessControlledModel):
 
     def createJob(self, title, type, args=(), kwargs=None, user=None, when=None,
                   interval=0, public=False, handler=None, async=False,
-                  save=True):
+                  save=True, otherFields=None):
         """
         Create a new job record.
 
@@ -149,6 +149,8 @@ class Job(AccessControlledModel):
         :type async: bool
         :param save: Whether the documented should be saved to the database.
         :type save: bool
+        :param otherFields: Any additional fields to set on the job.
+        :type otherFields: dict
         """
         now = datetime.datetime.utcnow()
 
@@ -157,6 +159,8 @@ class Job(AccessControlledModel):
 
         if kwargs is None:
             kwargs = {}
+
+        otherFields = otherFields or {}
 
         job = {
             'title': title,
@@ -175,6 +179,8 @@ class Job(AccessControlledModel):
             'async': async,
             'timestamps': []
         }
+
+        job.update(otherFields)
 
         self.setPublic(job, public=public)
 

--- a/plugins/worker/server/__init__.py
+++ b/plugins/worker/server/__init__.py
@@ -77,8 +77,10 @@ def schedule(event):
         # Stop event propagation since we have taken care of scheduling.
         event.stopPropagation()
 
+        task = job.get('celeryTaskName', 'girder_worker.run')
+
         # Send the task to celery
-        asyncResult = getCeleryApp().send_task('girder_worker.run', job['args'], job['kwargs'])
+        asyncResult = getCeleryApp().send_task(task, job['args'], job['kwargs'])
 
         # Set the job status to queued and record the task ID from celery.
         ModelImporter.model('job', 'jobs').updateJob(job, status=JobStatus.QUEUED, otherFields={


### PR DESCRIPTION
Maintains default ```girder_worker.run task```,  but allows alternate tasks to
be sent if 'celeryTaskName' is set on the job.

Also adds otherFields to createJob to mimik updateJob.

@cjh1 @mgrauer FYI
@zachmullen PTAL

