### PR TITLE
Change girder.dist.cfg to use equals delimiter instead of colon

### DIFF
--- a/girder/conf/girder.dist.cfg
+++ b/girder/conf/girder.dist.cfg
@@ -1,27 +1,27 @@
 [global]
-server.socket_host: "0.0.0.0"
-server.socket_port: 8080
-server.thread_pool: 100
+server.socket_host = "0.0.0.0"
+server.socket_port = 8080
+server.thread_pool = 100
 
 [auth]
 # Use "bcrypt" or "sha512"
-hash_alg: "bcrypt"
+hash_alg = "bcrypt"
 
 # Exponent for bcrypt complexity (default=12).
 # Don't change this unless you know what it means.
-bcrypt_rounds: 12
+bcrypt_rounds = 12
 
 [database]
-uri: "mongodb://localhost:27017/girder"
-replica_set: None
+uri = "mongodb://localhost:27017/girder"
+replica_set = None
 
 [server]
 # Set to "production" or "development"
-mode: "development"
-api_root: "api/v1"
-static_root: "static"
+mode = "development"
+api_root = "api/v1"
+static_root = "static"
 # The api_static_root is the route from the 'api' path to the 'static' path
-api_static_root: "../static"
+api_static_root = "../static"
 
 # [logging]
 # log_root="/path/to/log/root"
@@ -33,15 +33,15 @@ api_static_root: "../static"
 
 [users]
 # Regular expression used to validate user emails
-email_regex: "^[\w\.\-\+]*@[\w\.\-]*\.\w+$"
+email_regex = "^[\w\.\-\+]*@[\w\.\-]*\.\w+$"
 
 # Regular expression that logins must match. All logins are lower()ed before validation.
-login_regex: "^[a-z][\da-z\-\.]{3,}$"
+login_regex = "^[a-z][\da-z\-\.]{3,}$"
 # Text that will be presented to the user if their login fails the regex
-login_description: "Login must be at least 4 characters, start with a letter, and may only contain \
-                    letters, numbers, dashes, and dots."
+login_description = "Login must be at least 4 characters, start with a letter, and may only contain \
+                     letters, numbers, dashes, and dots."
 
 # Regular expression that passwords must match
-password_regex: ".{6}.*"
+password_regex = ".{6}.*"
 # Text that will be presented to the user if their password fails the regex
-password_description: "Password must be at least 6 characters."
+password_description = "Password must be at least 6 characters."


### PR DESCRIPTION
If we want programmatic manipulation of our `.cfg` (via ansible or otherwise) then the easiest solution is to use `=` as the delimiter in our `.cfg` files.

More detail:
The built in `ConfigParser` (Python2) reads with either delimiter in mind, but is hardcoded to write out using `=` as the delimiter. This becomes an issue when using the `ini_file` module from Ansible as it duplicates entries. I can put in a PR to fix this in Ansible, but I imagine it will take a long time for it to be incorporated.