### PR TITLE
Add -U flag when installing plugin requirements files

### DIFF
--- a/girder/utility/install.py
+++ b/girder/utility/install.py
@@ -129,7 +129,7 @@ def install_plugin(opts):
                     print(constants.TerminalColor.info(
                         'Installing pip requirements for %s from %s.' % (name, reqs)))
 
-                    if pip.main(['install', '-r', reqs]) != 0:
+                    if pip.main(['install', '-U', '-r', reqs]) != 0:
                         raise Exception('Failed to install pip requirements at %s.' % reqs)
 
         targetPath = os.path.join(getPluginDir(), name)


### PR DESCRIPTION
@manthey @cdeepakroy the issue we just ran into when installing HistomicsTK pip requirements made me realize we should probably be passing the `-U` flag, which applies recursively. I haven't yet verified that this would fix the issue we saw, but it seems likely, and seems like a good idea regardless.