### PR TITLE
Allow use of local fontello archive instead of downloading

### DIFF
--- a/grunt_tasks/build.js
+++ b/grunt_tasks/build.js
@@ -160,24 +160,6 @@ module.exports = function (grunt) {
             }
         },
 
-        curl: {
-            fontello: {
-                src: 'https://data.kitware.com/api/v1/file/57c5d1fc8d777f10f269dece/download',
-                dest: 'clients/web/static/built/fontello.zip'
-            }
-        },
-
-        unzip: {
-            fontello: {
-                src: 'clients/web/static/built/fontello.zip',
-                dest: 'clients/web/static/built/fontello/',
-                router: function (file) {
-                    // remove the first path component
-                    return file.split(path.sep).slice(1).join(path.sep);
-                }
-            }
-        },
-
         symlink: {
             options: {
                 overwrite: true,
@@ -242,11 +224,7 @@ module.exports = function (grunt) {
             'uglify:ext_js': {},
             'copy:swagger': {},
             'copy:jsoneditor': {},
-            'concat:ext_css': {},
-            'curl:fontello': {},
-            'unzip:fontello': {
-                dependencies: ['curl:fontello']
-            }
+            'concat:ext_css': {}
         },
 
         default: {

--- a/grunt_tasks/fontello.js
+++ b/grunt_tasks/fontello.js
@@ -28,7 +28,7 @@ module.exports = function (grunt) {
         grunt.config.merge({
             copy: {
                 fontello: {
-                    files:[{
+                    files: [{
                         src: localArchive,
                         dest: archivePath
                     }]
@@ -41,7 +41,7 @@ module.exports = function (grunt) {
                     dependencies: ['copy:fontello']
                 }
             }
-        })
+        });
     } else {
         // Download font archive from data.kitware.com
         grunt.config.merge({
@@ -60,6 +60,4 @@ module.exports = function (grunt) {
             }
         });
     }
-
-
 };

--- a/grunt_tasks/fontello.js
+++ b/grunt_tasks/fontello.js
@@ -1,0 +1,65 @@
+module.exports = function (grunt) {
+    var process = require('process');
+    var fs = require('fs');
+    var path = require('path');
+
+    var archivePath = 'clients/web/static/built/fontello.zip';
+
+    grunt.config.merge({
+        unzip: {
+            fontello: {
+                src: archivePath,
+                dest: 'clients/web/static/built/fontello/',
+                router: function (file) {
+                    // remove the first path component
+                    return file.split(path.sep).slice(1).join(path.sep);
+                }
+            }
+        }
+    });
+
+    var localArchive = process.env.GIRDER_LOCAL_FONTELLO_ARCHIVE;
+    if (localArchive) {
+        // Use an already existing local fontello zip file
+        if (!fs.existsSync(localArchive)) {
+            grunt.fail.warn('fontello local archive does not exist: ' + localArchive);
+        }
+        grunt.log.writeln(('Using local fontello archive: ' + localArchive).blue);
+        grunt.config.merge({
+            copy: {
+                fontello: {
+                    files:[{
+                        src: localArchive,
+                        dest: archivePath
+                    }]
+                }
+            },
+
+            init: {
+                'copy:fontello': {},
+                'unzip:fontello': {
+                    dependencies: ['copy:fontello']
+                }
+            }
+        })
+    } else {
+        // Download font archive from data.kitware.com
+        grunt.config.merge({
+            curl: {
+                fontello: {
+                    src: 'https://data.kitware.com/api/v1/file/57c5d1fc8d777f10f269dece/download',
+                    dest: archivePath
+                }
+            },
+
+            init: {
+                'curl:fontello': {},
+                'unzip:fontello': {
+                    dependencies: ['curl:fontello']
+                }
+            }
+        });
+    }
+
+
+};

--- a/tests/packaging/pip_install_girder.sh
+++ b/tests/packaging/pip_install_girder.sh
@@ -85,6 +85,8 @@ else
     exit 1
 fi
 
+# Use the already downloaded fontello archive.
+export GIRDER_LOCAL_FONTELLO_ARCHIVE=${PROJECT_SOURCE_DIR}/clients/web/static/built/fontello.zip
 # Build the web client code
 girder-install web || exit 1
 


### PR DESCRIPTION
This is controlled via the `GIRDER_LOCAL_FONTELLO_ARCHIVE` variable.

@cpatrick PTAL