### PR TITLE
Consistancy check fixes

### DIFF
--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -449,13 +449,12 @@ class System(Resource):
 
     def _recalculateSizes(self, progress):
         fixes = 0
-        user = self.getCurrentUser()
         models = ['collection', 'user']
         steps = sum(self.model(model).find().count() for model in models)
         progress.update(total=steps, current=0)
         for model in models:
             for doc in self.model(model).find():
                 progress.update(increment=1)
-                _, f = self.model(model).updateSize(doc, user)
+                _, f = self.model(model).updateSize(doc)
                 fixes += f
         return fixes

--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -413,14 +413,13 @@ class System(Resource):
 
     def _fixBaseParents(self, progress):
         fixes = 0
-        user = self.getCurrentUser()
         models = ['folder', 'item']
         steps = sum(self.model(model).find().count() for model in models)
         progress.update(total=steps, current=0)
         for model in models:
             for doc in self.model(model).find():
                 progress.update(increment=1)
-                baseParent = self.model(model).parentsToRoot(doc, user=user)[0]
+                baseParent = self.model(model).parentsToRoot(doc, force=True)[0]
                 baseParentType = baseParent['type']
                 baseParentId = baseParent['object']['_id']
                 if (doc['baseParentType'] != baseParentType or

--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -434,14 +434,13 @@ class System(Resource):
 
     def _pruneOrphans(self, progress):
         count = 0
-        user = self.getCurrentUser()
         models = ['folder', 'item', 'file']
         steps = sum(self.model(model).find().count() for model in models)
         progress.update(total=steps, current=0)
         for model in models:
             for doc in self.model(model).find():
                 progress.update(increment=1)
-                if self.model(model).isOrphan(doc, user=user):
+                if self.model(model).isOrphan(doc):
                     self.model(model).remove(doc)
                     count += 1
         return count

--- a/girder/models/collection.py
+++ b/girder/models/collection.py
@@ -317,25 +317,27 @@ class Collection(AccessControlledModel):
             return sum(1 for _ in folderModel.filterResultsByPermission(
                 cursor=folders, user=user, level=level))
 
-    def updateSize(self, doc, user):
+    def updateSize(self, doc, user=None):
         """
         Recursively recomputes the size of this collection and its underlying
         folders and fixes the sizes as needed.
 
         :param doc: The collection.
         :type doc: dict
-        :param user: The admin user for permissions.
-        :type user: dict
+        :param user: (deprecated) Not used.
         """
         size = 0
         fixes = 0
-        folders = self.model('folder').childFolders(doc, 'collection', user)
+        folders = self.model('folder').find({
+            'parentId': doc['_id'],
+            'parentCollection': 'collection'
+        })
         for folder in folders:
             # fix folder size if needed
-            _, f = self.model('folder').updateSize(folder, user)
+            _, f = self.model('folder').updateSize(folder)
             fixes += f
             # get total recursive folder size
-            folder = self.model('folder').load(folder['_id'], user=user)
+            folder = self.model('folder').load(folder['_id'], force=True)
             size += self.model('folder').getSizeRecursive(folder)
         # fix value if incorrect
         if size != doc.get('size'):

--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -24,6 +24,7 @@ import six
 from .model_base import Model, ValidationException
 from girder import events
 from girder.constants import AccessType, CoreEventHandler
+from girder.models.model_base import AccessControlledModel
 from girder.utility import assetstore_utilities, acl_mixin
 
 
@@ -326,11 +327,17 @@ class File(acl_mixin.AccessControlMixin, Model):
             else:
                 # Invalid 'attachedToType'
                 return True
-            return not modelType.load(
-                file.get('attachedToId'), force=True)
+            if isinstance(modelType, (acl_mixin.AccessControlMixin,
+                                      AccessControlledModel)):
+                attachedDoc = modelType.load(
+                    file.get('attachedToId'), force=True)
+            else:
+                attachedDoc = modelType.load(
+                    file.get('attachedToId'))
         else:
-            return not self.model('item').load(
+            attachedDoc = self.model('item').load(
                 file.get('itemId'), force=True)
+        return not attachedDoc
 
     def updateSize(self, file):
         """

--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -314,15 +314,14 @@ class File(acl_mixin.AccessControlMixin, Model):
 
         :param file: The file to check.
         :type file: dict
-        :param user: The user for permissions.
-        :type user: dict or None
+        :param user: (deprecated) Not used.
         """
         if file.get('attachedToId'):
             return not self.model(file.get('attachedToType')).load(
-                file.get('attachedToId'), user=user)
+                file.get('attachedToId'), force=True)
         else:
             return not self.model('item').load(
-                file.get('itemId'), user=user)
+                file.get('itemId'), force=True)
 
     def updateSize(self, file):
         """

--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -19,6 +19,7 @@
 
 import cherrypy
 import datetime
+import six
 
 from .model_base import Model, ValidationException
 from girder import events
@@ -317,7 +318,15 @@ class File(acl_mixin.AccessControlMixin, Model):
         :param user: (deprecated) Not used.
         """
         if file.get('attachedToId'):
-            return not self.model(file.get('attachedToType')).load(
+            attachedToType = file.get('attachedToType')
+            if isinstance(attachedToType, six.string_types):
+                modelType = self.model(attachedToType)
+            elif isinstance(attachedToType, list) and len(attachedToType) == 2:
+                modelType = self.model(*attachedToType)
+            else:
+                # Invalid 'attachedToType'
+                return True
+            return not modelType.load(
                 file.get('attachedToId'), force=True)
         else:
             return not self.model('item').load(

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -844,26 +844,28 @@ class Folder(AccessControlledModel):
         return not self.model(folder.get('parentCollection')).load(
             folder.get('parentId'), user=user)
 
-    def updateSize(self, doc, user):
+    def updateSize(self, doc, user=None):
         """
         Recursively recomputes the size of this folder and its underlying
         folders and fixes the sizes as needed.
 
         :param doc: The folder.
         :type doc: dict
-        :param user: The admin user for permissions.
-        :type user: dict
+        :param user: (deprecated) Not used.
         """
         size = 0
         fixes = 0
         # recursively fix child folders but don't include their size
-        children = self.childFolders(doc, 'folder', user)
+        children = self.model('folder').find({
+            'parentId': doc['_id'],
+            'parentCollection': 'folder'
+        })
         for child in children:
-            _, f = self.model('folder').updateSize(child, user)
+            _, f = self.model('folder').updateSize(child)
             fixes += f
         # get correct size from child items
         for item in self.childItems(doc):
-            s, f = self.model('item').updateSize(item, user)
+            s, f = self.model('item').updateSize(item)
             size += s
             fixes += f
         # fix value if incorrect

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -838,11 +838,10 @@ class Folder(AccessControlledModel):
 
         :param folder: The folder to check.
         :type folder: dict
-        :param user: The user for permissions.
-        :type user: dict or None
+        :param user: (deprecated) Not used.
         """
         return not self.model(folder.get('parentCollection')).load(
-            folder.get('parentId'), user=user)
+            folder.get('parentId'), force=True)
 
     def updateSize(self, doc, user=None):
         """

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -476,15 +476,14 @@ class Item(acl_mixin.AccessControlMixin, Model):
         return not self.model('folder').load(
             item.get('folderId'), user=user)
 
-    def updateSize(self, doc, user):
+    def updateSize(self, doc, user=None):
         """
         Recomputes the size of this item and its underlying
         files and fixes the sizes as needed.
 
         :param doc: The item.
         :type doc: dict
-        :param user: The admin user for permissions.
-        :type user: dict
+        :param user: (deprecated) Not used.
         """
         # get correct size from child files
         size = 0

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -470,11 +470,10 @@ class Item(acl_mixin.AccessControlMixin, Model):
 
         :param item: The item to check.
         :type item: dict
-        :param user: The user for permissions.
-        :type user: dict or None
+        :param user: (deprecated) Not used.
         """
         return not self.model('folder').load(
-            item.get('folderId'), user=user)
+            item.get('folderId'), force=True)
 
     def updateSize(self, doc, user=None):
         """

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -456,25 +456,27 @@ class User(AccessControlledModel):
             return sum(1 for _ in folderModel.filterResultsByPermission(
                 cursor=folders, user=filterUser, level=level))
 
-    def updateSize(self, doc, user):
+    def updateSize(self, doc, user=None):
         """
         Recursively recomputes the size of this user and its underlying
         folders and fixes the sizes as needed.
 
         :param doc: The user.
         :type doc: dict
-        :param user: The admin user for permissions.
-        :type user: dict
+        :param user: (deprecated) Not used.
         """
         size = 0
         fixes = 0
-        folders = self.model('folder').childFolders(doc, 'user', user)
+        folders = self.model('folder').find({
+            'parentId': doc['_id'],
+            'parentCollection': 'user'
+        })
         for folder in folders:
             # fix folder size if needed
-            _, f = self.model('folder').updateSize(folder, user)
+            _, f = self.model('folder').updateSize(folder)
             fixes += f
             # get total recursive folder size
-            folder = self.model('folder').load(folder['_id'], user=user)
+            folder = self.model('folder').load(folder['_id'], force=True)
             size += self.model('folder').getSizeRecursive(folder)
         # fix value if incorrect
         if size != doc.get('size'):


### PR DESCRIPTION
* Make Model "updateSize" methods not require a user
  * Access controls never have an impact on the "size" of Collections, Users, Folders, or Items. Sizes for Collections and Users represent the total size of all content recursively within them, regardless of whether a given user has access to any of it.
  * As a practical matter, the system consistancy check which typically calls "updateSize" may only be run by a site admin user, who will have access to everything.
* Remove user access checks from _fixBaseParents in consistancy check
  * A user may have access to a sub-folder that is within a parent folder or collection that the user does not have access to (this is how "unlisted" folders can be implemented). Regardless, these sub-folders should always have an accurate "baseParentId" and "baseParentType", even if a user does not have rights to actually traverse to this base.
  * As a practical matter, the system consistancy check may only be run by a site admin user, who will have access to everything.
* Remove user access checks from _pruneOrphans in consistancy check
  * A user may have access to a sub-folder that is within a parent folder or collection that the user does not have access to (this is how "unlisted" folders can be implemented). Thus, these sort of sub-folders are not technically 'orphans' and definitely should not be removed.
  * As a practical matter, the system consistancy check may only be run by a site admin user, who will have access to everything.
* Make "File.isOrphan" work with references to non-access-controlled models
  * Plugins may attach Files to non-access-controlled models. Previously, this was causing "File.isOrphan" to raise unhandled exceptions.
* Make "File.isOrphan" work with plugin "attachedToType" Models
  * Plugins may want to attach Files to plugin-based Model types. These should be handled gracefully and not cause Files to appear orphaned.
  * These plugins are expected to set "attachedToType" to be a list of the form ["model_type", "plugin_name"].