### PR TITLE
Prevent all disabled users from logging in

### DIFF
--- a/clients/web/test/spec/userSpec.js
+++ b/clients/web/test/spec/userSpec.js
@@ -462,7 +462,7 @@ describe('test account approval', function() {
         }, 'dialog rest requests to finish');
         girderTest.logout()();
     });
-    it('Try to login without approval', function() {
+    it('Try to login a disabled user', function() {
         runs(function () {
             expect(girder.currentUser).toBe(null);
         });
@@ -489,7 +489,7 @@ describe('test account approval', function() {
         });
 
         waitsFor(function () {
-            return $('.g-validation-failed-message:contains("Account approval")').length > 0;
+            return $('.g-validation-failed-message:contains("disabled")').length > 0;
         }, 'approval message to appear');
 
         runs(function () {

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -238,7 +238,7 @@ def requireAdmin(user, message=None):
     :type message: str or None
     :raises AccessException: If the user is not an administrator.
     """
-    if user is None or user.get('admin', False) is not True:
+    if user is None or not user['admin']:
         raise AccessException(message or 'Administrator access required.')
 
 

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -334,7 +334,7 @@ class File(Resource):
     def cancelUpload(self, upload, params):
         user = self.getCurrentUser()
 
-        if upload['userId'] != user['_id'] and not user.get('admin'):
+        if upload['userId'] != user['_id'] and not user['admin']:
             raise AccessException('You did not initiate this upload.')
 
         self.model('upload').cancelUpload(upload)

--- a/girder/api/v1/group.py
+++ b/girder/api/v1/group.py
@@ -253,7 +253,7 @@ class Group(Resource):
             id=params['userId'], user=user, level=AccessType.READ, exc=True)
 
         if force:
-            if not user.get('admin', False):
+            if not user['admin']:
                 mustBeAdmin = True
                 addPolicy = self.model('setting').get(
                     SettingKey.ADD_TO_GROUP_POLICY)

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -268,7 +268,8 @@ class User(Resource):
                     raise AccessException('Only admins may change admin state.')
 
         # Only admins can change status
-        if 'status' in params and params['status'] != user['status']:
+        if 'status' in params and \
+                params['status'] != user.get('status', 'enabled'):
             if self.getCurrentUser()['admin']:
                 user['status'] = params['status']
                 if user['status'] == 'enabled':

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -23,8 +23,7 @@ import datetime
 
 from ..describe import Description, describeRoute
 from girder.api import access
-from girder.api.rest import Resource, RestException, AccessException,\
-    filtermodel, loadmodel
+from girder.api.rest import Resource, RestException, AccessException, filtermodel, loadmodel
 from girder.constants import AccessType, SettingKey, TokenScope
 from girder.models.token import genToken
 from girder.utility import mail_utils
@@ -275,8 +274,7 @@ class User(Resource):
                     raise AccessException('Only admins may change admin state.')
 
         # Only admins can change status
-        if 'status' in params and \
-                params['status'] != user.get('status', 'enabled'):
+        if 'status' in params and params['status'] != user.get('status', 'enabled'):
             if not self.getCurrentUser()['admin']:
                 raise AccessException('Only admins may change status.')
             if user['status'] == 'pending' and params['status'] == 'enabled':

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -277,12 +277,12 @@ class User(Resource):
         # Only admins can change status
         if 'status' in params and \
                 params['status'] != user.get('status', 'enabled'):
-            if self.getCurrentUser()['admin']:
-                user['status'] = params['status']
-                if user['status'] == 'enabled':
-                    self.model('user')._sendApprovedEmail(user)
-            else:
+            if not self.getCurrentUser()['admin']:
                 raise AccessException('Only admins may change status.')
+            if user['status'] == 'pending' and params['status'] == 'enabled':
+                # Send email on the 'pending' -> 'enabled' transition
+                self.model('user')._sendApprovedEmail(user)
+            user['status'] = params['status']
 
         user = self.model('user').save(user)
         return self.model('user').filter(user, user)

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -139,6 +139,13 @@ class User(Resource):
             if not self.model('password').authenticate(user, password):
                 raise RestException('Login failed.', code=403)
 
+            # This has the same behavior as User.canLogin, but returns more
+            # detailed error messages
+            if user.get('status', 'enabled') == 'disabled':
+                raise RestException(
+                    'Account is disabled.', code=403,
+                    extra='disabled')
+
             if self.model('user').emailVerificationRequired(user):
                 raise RestException(
                     'Email verification required.', code=403,

--- a/girder/models/collection.py
+++ b/girder/models/collection.py
@@ -275,7 +275,7 @@ class Collection(AccessControlledModel):
         :param user: The user to test.
         :returns: bool
         """
-        if user['admin'] is True:
+        if user['admin']:
             return True
 
         policy = self.model('setting').get(SettingKey.COLLECTION_CREATE_POLICY)

--- a/girder/models/group.py
+++ b/girder/models/group.py
@@ -376,7 +376,7 @@ class Group(AccessControlledModel):
         if user is None:
             # Short-circuit the case of anonymous users
             return level == AccessType.READ and doc.get('public', False) is True
-        elif user.get('admin', False) is True:
+        elif user['admin']:
             # Short-circuit the case of admins
             return True
         elif level == AccessType.READ:
@@ -403,7 +403,7 @@ class Group(AccessControlledModel):
                 return AccessType.READ
             else:
                 return AccessType.NONE
-        elif user.get('admin', False):
+        elif user['admin']:
             return AccessType.ADMIN
         else:
             access = doc.get('access', {})

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -143,7 +143,7 @@ class Model(ModelImporter):
 
         keys = set(self._filterKeys[AccessType.READ])
 
-        if user and user.get('admin') is True:
+        if user and user['admin']:
             keys.update(self._filterKeys[AccessType.SITE_ADMIN])
 
         if additionalKeys:
@@ -655,7 +655,7 @@ class AccessControlledModel(Model):
             if level >= AccessType.ADMIN:
                 keys.update(self._filterKeys[AccessType.ADMIN])
 
-                if user.get('admin') is True:
+                if user['admin']:
                     keys.update(self._filterKeys[AccessType.SITE_ADMIN])
 
         if additionalKeys:
@@ -825,7 +825,7 @@ class AccessControlledModel(Model):
                 return AccessType.READ
             else:
                 return AccessType.NONE
-        elif user.get('admin', False):
+        elif user['admin']:
             return AccessType.ADMIN
         else:
             access = doc.get('access', {})
@@ -931,7 +931,7 @@ class AccessControlledModel(Model):
             # Anonymous users can only see public resources
             return False
 
-        if user.get('admin', False) is True:
+        if user['admin']:
             # Short-circuit the case of admins
             return True
 

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -284,7 +284,7 @@ class User(AccessControlledModel):
         """
         if user['admin']:
             return False
-        if not user.get('emailVerified', False):
+        if not user['emailVerified']:
             return self.model('setting').get(
                 SettingKey.EMAIL_VERIFICATION) == 'required'
         return False

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -282,7 +282,7 @@ class User(AccessControlledModel):
         Returns True if email verification is required and this user has not
         yet verified their email address.
         """
-        if user.get('admin'):
+        if user['admin']:
             return False
         if not user.get('emailVerified', False):
             return self.model('setting').get(
@@ -294,7 +294,7 @@ class User(AccessControlledModel):
         Returns True if the registration policy requires admin approval and
         this user has not yet been approved.
         """
-        if user.get('admin'):
+        if user['admin']:
             return False
         if user.get('status') != 'enabled':
             return self.model('setting').get(

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -296,7 +296,7 @@ class User(AccessControlledModel):
         """
         if user['admin']:
             return False
-        if user.get('status') != 'enabled':
+        if user.get('status', 'enabled') != 'enabled':
             return self.model('setting').get(
                 SettingKey.REGISTRATION_POLICY) == 'approve'
         return False

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -133,6 +133,9 @@ class User(AccessControlledModel):
         existing = self.findOne({})
         if existing is None:
             doc['admin'] = True
+            # Ensure settings don't stop this user from logging in
+            doc['emailVerified'] = True
+            doc['status'] = 'enabled'
 
         return doc
 

--- a/girder/utility/system.py
+++ b/girder/utility/system.py
@@ -124,7 +124,7 @@ def getStatus(mode='basic', user=None):
                  than basic mode.
     :returns: a status dictionary.
     """
-    isAdmin = (user is not None and user.get('admin', False) is True)
+    isAdmin = (user is not None and user['admin'])
 
     status = {}
     status['bootTime'] = psutil.boot_time()

--- a/tests/cases/user_test.py
+++ b/tests/cases/user_test.py
@@ -547,7 +547,7 @@ class UserTestCase(base.TestCase):
         # cannot login again
         resp = self.request('/user/authentication', basicAuth='user:password')
         self.assertStatus(resp, 403)
-        self.assertTrue(resp.json['extra'] == 'accountApproval')
+        self.assertEqual(resp.json['extra'], 'disabled')
 
     def testEmailVerification(self):
         self.model('setting').set(SettingKey.EMAIL_VERIFICATION, 'required')


### PR DESCRIPTION
* Perform filtering of all returned user documents in the user API
  * Models returned through the API should almost always be filtered. Users may not necessarily have access to every field in their own user document.
* Check for site admin in a more consistent way
  * User documents have had the `'admin'` property since the beginning of Girder, and it may only be `True` or `False`.
* Check for "user['emailVerified']" in a more consistent way
  * User documents have also had the 'emailVerified' property since the beginning of Girder, and it has always defaulted to False.
* Fix access to unset `user['status']` field
  * User documents from legacy databases do not have the `status` field set. While `status` gets set on `User.save` (see 3f450cc9a2540942f46db90aaaee939bbe85488b), it may not be set in time for some other operations.
* Prevent disabled users from logging in
  * Disabled users should not be able to log in, regardless of the registration policy. This includes disabled admin users.
  * `User.emailVerificationRequired` now uses the same logic for both admin and non-admin users. This means that newly created admin users will still have to verify their email addresses if the instance requires it generally.
  * `User.adminApprovalRequired` now uses the same logic for both admin and non-admin users. This means that newly created admin users will still have to have their accounts approved by another admin user if the instance requires it.
* Don't send approval emails to re-enabled users
  * An email message will only be sent on the transition from `'pending'` -> `'enabled'`. This should help to prevent misleading "approval" emails from being sent when users are changed `'disabled'` -> `'enabled'`.