### PR TITLE
Capture the return value of "Model.save" where it is used subsequently

### DIFF
--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -145,9 +145,9 @@ class Folder(AccessControlledModel):
             baseParent = pathFromRoot[0]
             doc['baseParentId'] = baseParent['object']['_id']
             doc['baseParentType'] = baseParent['type']
-            self.save(doc, triggerEvents=False)
+            doc = self.save(doc, triggerEvents=False)
         if doc is not None and 'lowerName' not in doc:
-            self.save(doc, triggerEvents=False)
+            doc = self.save(doc, triggerEvents=False)
 
         return doc
 
@@ -761,7 +761,7 @@ class Folder(AccessControlledModel):
                 newFolder[key] = copy.deepcopy(srcFolder[key])
                 updated = True
         if updated:
-            self.save(newFolder, triggerEvents=False)
+            newFolder = self.save(newFolder, triggerEvents=False)
         # Give listeners a chance to change things
         events.trigger('model.folder.copy.prepare', (srcFolder, newFolder))
         # copy items

--- a/girder/models/group.py
+++ b/girder/models/group.py
@@ -170,7 +170,7 @@ class Group(AccessControlledModel):
         if not group['_id'] in user['groups']:
             user['groups'].append(group['_id'])
             # saved again in setUserAccess...
-            self.model('user').save(user, validate=False)
+            user = self.model('user').save(user, validate=False)
 
         # Delete outstanding request if one exists
         self._deleteRequest(group, user)
@@ -208,7 +208,7 @@ class Group(AccessControlledModel):
 
             if not user['_id'] in group['requests']:
                 group['requests'].append(user['_id'])
-                self.save(group, validate=False)
+                group = self.save(group, validate=False)
 
         return group
 
@@ -278,7 +278,7 @@ class Group(AccessControlledModel):
         user['groupInvites'] = list(filter(
             lambda inv: not inv['groupId'] == group['_id'],
             user.get('groupInvites', [])))
-        self.model('user').save(user, validate=False)
+        user = self.model('user').save(user, validate=False)
 
         # Remove all group access for this user on this group.
         self.setUserAccess(group, user, level=None, save=True)

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -131,9 +131,9 @@ class Item(acl_mixin.AccessControlMixin, Model):
             baseParent = pathFromRoot[0]
             doc['baseParentId'] = baseParent['object']['_id']
             doc['baseParentType'] = baseParent['type']
-            self.save(doc, triggerEvents=False)
+            doc = self.save(doc, triggerEvents=False)
         if doc is not None and 'lowerName' not in doc:
-            self.save(doc, triggerEvents=False)
+            doc = self.save(doc, triggerEvents=False)
 
         return doc
 
@@ -383,7 +383,7 @@ class Item(acl_mixin.AccessControlMixin, Model):
                 newItem[key] = copy.deepcopy(srcItem[key])
         # add a reference to the original item
         newItem['copyOfItem'] = srcItem['_id']
-        self.save(newItem, triggerEvents=False)
+        newItem = self.save(newItem, triggerEvents=False)
 
         # Give listeners a chance to change things
         events.trigger('model.item.copy.prepare', (srcItem, newItem))

--- a/girder/models/upload.py
+++ b/girder/models/upload.py
@@ -192,7 +192,7 @@ class Upload(Model):
 
         event_document = {'file': file, 'upload': upload}
         events.trigger('model.file.finalizeUpload.before', event_document)
-        self.model('file').save(file)
+        file = self.model('file').save(file)
         events.trigger('model.file.finalizeUpload.after', event_document)
         self.remove(upload)
 

--- a/plugins/celery_jobs/server/__init__.py
+++ b/plugins/celery_jobs/server/__init__.py
@@ -71,7 +71,7 @@ def schedule(event):
     job = event.info
     if job['handler'] == 'celery':
         job['status'] = JobStatus.QUEUED
-        ModelImporter.model('job', 'jobs').save(job)
+        job = ModelImporter.model('job', 'jobs').save(job)
         event.stopPropagation()
         celeryapp.send_task(
             job['type'], job['args'], job['kwargs'])

--- a/plugins/curation/server/__init__.py
+++ b/plugins/curation/server/__init__.py
@@ -165,7 +165,7 @@ class CuratedFolder(Resource):
                 'REJECTED: ' + folder['name'],
                 'curation.rejected.mako')
 
-        self.model('folder').save(folder)
+        folder = self.model('folder').save(folder)
         curation['public'] = folder.get('public')
         return curation
 
@@ -180,7 +180,7 @@ class CuratedFolder(Resource):
         """
         pc.update(increment=1)
         folder['public'] = public
-        self.model('folder').save(folder)
+        folder = self.model('folder').save(folder)
         subfolders = self.model('folder').find({
             'parentId': folder['_id'],
             'parentCollection': 'folder'
@@ -197,7 +197,7 @@ class CuratedFolder(Resource):
         for doc in folder['access']['users'] + folder['access']['groups']:
             if doc['level'] == AccessType.WRITE:
                 doc['level'] = AccessType.READ
-        self.model('folder').save(folder)
+        folder = self.model('folder').save(folder)
         subfolders = self.model('folder').find({
             'parentId': folder['_id'],
             'parentCollection': 'folder'
@@ -214,7 +214,7 @@ class CuratedFolder(Resource):
         for doc in folder['access']['users'] + folder['access']['groups']:
             if doc['level'] == AccessType.READ:
                 doc['level'] = AccessType.WRITE
-        self.model('folder').save(folder)
+        folder = self.model('folder').save(folder)
         subfolders = self.model('folder').find({
             'parentId': folder['_id'],
             'parentCollection': 'folder'

--- a/plugins/jobs/plugin_tests/jobs_test.py
+++ b/plugins/jobs/plugin_tests/jobs_test.py
@@ -54,7 +54,7 @@ class JobsTestCase(base.TestCase):
             self.job = event.info
             if self.job['handler'] == 'my_handler':
                 self.job['status'] = JobStatus.RUNNING
-                self.model('job', 'jobs').save(self.job)
+                self.job = self.model('job', 'jobs').save(self.job)
                 self.assertEqual(self.job['args'], ('hello', 'world'))
                 self.assertEqual(self.job['kwargs'], {'a': 'b'})
 

--- a/plugins/jobs/server/models/job.py
+++ b/plugins/jobs/server/models/job.py
@@ -86,7 +86,7 @@ class Job(AccessControlledModel):
 
         if not event.defaultPrevented:
             job['status'] = JobStatus.CANCELED
-            self.save(job)
+            job = self.save(job)
 
         return job
 

--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -146,7 +146,7 @@ class AssetstoreTestCase(base.TestCase):
         # list it
         oldroot = assetstore['root']
         assetstore['root'] = '///invalidpath'
-        self.model('assetstore').save(assetstore, validate=False)
+        assetstore = self.model('assetstore').save(assetstore, validate=False)
         assetstoresAfter = list(self.model('assetstore').list())
         self.assertEqual(len(assetstoresBefore), len(assetstoresAfter))
         self.assertIsNone([
@@ -311,13 +311,13 @@ class AssetstoreTestCase(base.TestCase):
             name='fake', creator=self.admin, item=item, size=1, assetstore=self.assetstore)
         fake['path'] = 'nonexistent/path/to/file'
         fake['sha512'] = '...'
-        self.model('file').save(fake)
+        fake = self.model('file').save(fake)
 
         fakeImport = self.model('file').createFile(
             name='fakeImport', creator=self.admin, item=item, size=1, assetstore=self.assetstore)
         fakeImport['imported'] = True
         fakeImport['path'] = '/nonexistent/path/to/file'
-        self.model('file').save(fakeImport)
+        fakeImport = self.model('file').save(fakeImport)
 
         adapter = assetstore_utilities.getAssetstoreAdapter(self.assetstore)
         self.assertTrue(inspect.isgeneratorfunction(adapter.findInvalidFiles))
@@ -801,7 +801,7 @@ class AssetstoreTestCase(base.TestCase):
 
         # Set the assetstore to read only, attempt to delete it
         assetstore['readOnly'] = True
-        self.model('assetstore').save(assetstore)
+        assetstore = self.model('assetstore').save(assetstore)
 
         def fn(*args, **kwargs):
             raise Exception('get_all_multipart_uploads should not be called')

--- a/tests/cases/folder_test.py
+++ b/tests/cases/folder_test.py
@@ -429,7 +429,7 @@ class FolderTestCase(base.TestCase):
         # fields
         del folder['lowerName']
         del folder['baseParentType']
-        self.model('folder').save(folder, validate=False)
+        folder = self.model('folder').save(folder, validate=False)
 
         folder = self.model('folder').find({'_id': folder['_id']})[0]
         self.assertNotHasKeys(folder, ('lowerName', 'baseParentType'))

--- a/tests/cases/item_test.py
+++ b/tests/cases/item_test.py
@@ -454,7 +454,7 @@ class ItemTestCase(base.TestCase):
 
         # set a private property
         item['private'] = 'very secret metadata'
-        self.model('item').save(item)
+        item = self.model('item').save(item)
 
         # get the item from the rest api
         resp = self.request(path='/item/%s' % str(item['_id']), method='GET',
@@ -512,7 +512,7 @@ class ItemTestCase(base.TestCase):
         # Force the item to be saved without lowerName and baseParentType fields
         del item['lowerName']
         del item['baseParentType']
-        self.model('item').save(item, validate=False)
+        item = self.model('item').save(item, validate=False)
 
         item = self.model('item').find({'_id': item['_id']})[0]
         self.assertNotHasKeys(item, ('lowerName', 'baseParentType'))
@@ -537,7 +537,7 @@ class ItemTestCase(base.TestCase):
         # corrected.
         item['description'] = 1
         del item['lowerName']
-        self.model('item').save(item, validate=False)
+        item = self.model('item').save(item, validate=False)
         item = self.model('item').find({'_id': item['_id']})[0]
         self.assertNotHasKeys(item, ('lowerName', ))
         self.model('item').load(item['_id'], force=True)


### PR DESCRIPTION
The contract of `Model.save` does not guarantee that the argument will be correctly mutated. Rather, the caller should overwrite the passed document with the return value.