### PR TITLE
Increase file descriptor resource limit in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ before_install:
     # Show the memory state; this lets us more quickly determine when the
     # travis environment is bad
     - vmstat
+    # Mongo can use lots of file descriptors
+    - ulimit -S -n 2048
     - export CXX=g++-4.8
     - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]; then export PY3="true"; else export PY2="true"; fi
     - if [ -n "${PY3}" ]; then export MONGO_VERSION=3.0.7; export PY_COVG="OFF"; else export MONGO_VERSION=2.6.11; export PY_COVG="ON"; export DEPLOY=true; fi

--- a/clients/web/src/views/body/ItemView.js
+++ b/clients/web/src/views/body/ItemView.js
@@ -113,6 +113,7 @@ var ItemView = View.extend({
         // it. TODO: load the page and adjust only the action menu once
         // the access level is fetched.
         this.model.getAccessLevel(_.bind(function (accessLevel) {
+            this.accessLevel = accessLevel;
             this.$el.html(ItemPageTemplate({
                 item: this.model,
                 accessLevel: accessLevel,

--- a/clients/web/test/lib/jasmine-1.3.1/ConsoleReporter.js
+++ b/clients/web/test/lib/jasmine-1.3.1/ConsoleReporter.js
@@ -99,6 +99,10 @@
                     new Date().toISOString().replace(/:/g, '.') + '.png');
                 this.log('\n Error: ' + item.message, 'red');
                 this._printStackTrace(item.trace.stackArray);
+                window.callPhantom({
+                    action: 'exit',
+                    code: 1
+                });
             }
         }, this);
     };

--- a/clients/web/test/specRunner.js
+++ b/clients/web/test/specRunner.js
@@ -133,6 +133,10 @@ page.onCallback = function (data) {
                 fs.remove(uploadTemp);
             }
             break;
+        case 'exit':
+            // The "Testing Finished" string is magical and causes web_client_test.py not to retry
+            console.log('Testing Finished with status=' + data.code);
+            phantom.exit(data.code);
     }
 };
 

--- a/plugins/geospatial/plugin_tests/geospatialSpec.js
+++ b/plugins/geospatial/plugin_tests/geospatialSpec.js
@@ -57,9 +57,9 @@ $(function () {
             waitsFor(function () {
                 return $('.g-item-name:contains(Geospatial Item)').length === 1;
             }, 'the item page to load');
-            runs(function () {
-                expect($('.g-item-geospatial').length > 0).toBe(true);
-            });
+            waitsFor(function () {
+                return $('.g-item-geospatial').length > 0;
+            }, 'the geospatial widget to appear in the item view');
         });
     });
 });

--- a/plugins/geospatial/web_client/views/ItemView.js
+++ b/plugins/geospatial/web_client/views/ItemView.js
@@ -1,22 +1,19 @@
-import _ from 'underscore';
-
 import ItemView from 'girder/views/body/ItemView';
 import { wrap } from 'girder/utilities/PluginUtils';
 
 import GeospatialItemWidget from './GeospatialItemWidget';
 
 wrap(ItemView, 'render', function (render) {
-    this.model.getAccessLevel(_.bind(function (accessLevel) {
-        render.call(this);
+    this.once('g:rendered', function () {
         var element = $('<div class="g-item-geospatial"/>');
         $('.g-item-metadata').after(element);
         this.geospatialItemWidget = new GeospatialItemWidget({
-            accessLevel: accessLevel,
+            accessLevel: this.accessLevel,
             el: element,
             item: this.model,
             parentView: this
         });
-    }, this));
+    }, this);
 
-    return this;
+    return render.call(this);
 });


### PR DESCRIPTION
I had to increase the ulimit for file handles on my local machine in order to get mongo not to terminate, and the errors I was seeing locally were similar to the errors we have been seeing in the web client tests. This is an attempt to mitigate the travis failures in the web client testing, I have no idea if it will work though.