### PR TITLE
updateJob failed with only otherFields set.

### DIFF
--- a/plugins/jobs/plugin_tests/jobs_test.py
+++ b/plugins/jobs/plugin_tests/jobs_test.py
@@ -364,3 +364,9 @@ class JobsTestCase(base.TestCase):
 
             with self.assertRaises(ValidationException):
                 jobModel.updateJob(job, status=4321)  # Should fail
+
+    def testUpdateOtherFields(self):
+        jobModel = self.model('job', 'jobs')
+        job = jobModel.createJob(title='test', type='x', user=self.users[0])
+        job = jobModel.updateJob(job, otherFields={'other': 'fields'})
+        self.assertEqual(job['other'], 'fields')

--- a/plugins/jobs/server/models/job.py
+++ b/plugins/jobs/server/models/job.py
@@ -316,6 +316,8 @@ class Job(AccessControlledModel):
             updates['$set'][k] = v
 
         if updates['$set'] or updates['$push']:
+            if not updates['$push']:
+                del updates['$push']
             job['updated'] = now
             updates['$set']['updated'] = now
 


### PR DESCRIPTION
If job.updateJob was called with only the otherFields parameter set, it failed because it passed an empty `$push` parameter to mongo.