### PR TITLE
Fix a few issues when files don't have an itemId.

### DIFF
--- a/girder/models/upload.py
+++ b/girder/models/upload.py
@@ -81,7 +81,7 @@ class Upload(Model):
             unspecified, the current assetstore is used.
         :type reference: str
         :param attachParent: if True, instead of creating an item within the
-            parent or giving the file an itemID, set itemID to None and set
+            parent or giving the file an itemId, set itemId to None and set
             attachedToType and attachedToId instead (using the values passed in
             parentType and parent).  This is intended for files that shouldn't
             appear as direct children of the parent, but are still associated
@@ -311,7 +311,7 @@ class Upload(Model):
         :param assetstore: An optional assetstore to use to store the file.  If
             unspecified, the current assetstore is used.
         :param attachParent: if True, instead of creating an item within the
-            parent or giving the file an itemID, set itemID to None and set
+            parent or giving the file an itemId, set itemId to None and set
             attachedToType and attachedToId instead (using the values passed in
             parentType and parent).  This is intended for files that shouldn't
             appear as direct children of the parent, but are still associated

--- a/girder/models/upload.py
+++ b/girder/models/upload.py
@@ -69,9 +69,8 @@ class Upload(Model):
         :type name: str
         :param parentType: The type of the parent: "folder" or "item".
         :type parentType: str
-        :param parent: The parent (item or folder) to upload into, or the id of
-            the parent.
-        :type parent: dict or str
+        :param parent: The parent (item or folder) to upload into.
+        :type parent: dict
         :param user: The user who is creating the file.
         :type user: dict
         :param mimeType: MIME type of the file.
@@ -81,11 +80,12 @@ class Upload(Model):
         :param assetstore: An optional assetstore to use to store the file.  If
             unspecified, the current assetstore is used.
         :type reference: str
-        :param attachParent: if True, instead of giving the file a parentType
-            and parent, mark those as None and set attachedToType and
-            attachedToId instead (using the values passed in parentType and
-            parent).  This is intended for files that shouldn't appear as
-            direct children of the parent, but are still associated with it.
+        :param attachParent: if True, instead of creating an item within the
+            parent or giving the file an itemID, set itemID to None and set
+            attachedToType and attachedToId instead (using the values passed in
+            parentType and parent).  This is intended for files that shouldn't
+            appear as direct children of the parent, but are still associated
+            with it.
         :type attach: boolean
         """
         upload = self.createUpload(
@@ -179,8 +179,8 @@ class Upload(Model):
             file['size'] = upload['size']
         else:  # Creating a new file record
             if upload.get('attachParent'):
-                pass
-            if upload['parentType'] == 'folder':
+                item = None
+            elif upload['parentType'] == 'folder':
                 # Create a new item with the name of the file.
                 item = self.model('item').createItem(
                     name=upload['name'], creator={'_id': upload['userId']},
@@ -299,9 +299,8 @@ class Upload(Model):
         :type name: str
         :param parentType: The type of the parent being uploaded into.
         :type parentType: str ('folder' or 'item')
-        :param parent: The document representing the parent or the id of the
-            parent.
-        :type parent: dict or str.
+        :param parent: The document representing the parent.
+        :type parent: dict.
         :param size: Total size in bytes of the whole file.
         :type size: int
         :param mimeType: The mimeType of the file.
@@ -311,12 +310,13 @@ class Upload(Model):
         :type reference: str
         :param assetstore: An optional assetstore to use to store the file.  If
             unspecified, the current assetstore is used.
-        :param attachParent: if True, instead of giving the file a parentType
-            and parent, mark those as None and set attachedToType and
-            attachedToId instead (using the values passed in parentType and
-            parent).  This is intended for files that shouldn't appear as
-            direct children of the parent, but are still associated with it.
-        :type attach: boolean
+        :param attachParent: if True, instead of creating an item within the
+            parent or giving the file an itemID, set itemID to None and set
+            attachedToType and attachedToId instead (using the values passed in
+            parentType and parent).  This is intended for files that shouldn't
+            appear as direct children of the parent, but are still associated
+            with it.
+        :type attachParent: boolean
         :returns: The upload document that was created.
         """
         assetstore = self.getTargetAssetstore(parentType, parent, assetstore)
@@ -339,8 +339,7 @@ class Upload(Model):
 
         if parentType and parent:
             upload['parentType'] = parentType.lower()
-            upload['parentId'] = ObjectId(
-                parent['_id'] if isinstance(parent, dict) else parent)
+            upload['parentId'] = parent['_id']
         else:
             upload['parentType'] = None
             upload['parentId'] = None

--- a/girder/utility/acl_mixin.py
+++ b/girder/utility/acl_mixin.py
@@ -52,16 +52,15 @@ class AccessControlMixin(object):
         """
         doc = Model.load(self, id=id, objectId=objectId, fields=fields, exc=exc)
 
-        if doc is not None:
+        if not force and doc is not None:
             if doc.get(self.resourceParent):
                 loadType = self.resourceColl
                 loadId = doc[self.resourceParent]
             else:
-                loadType = doc['attachedToType']
-                loadId = doc['attachedToId']
-
-        if not force and doc is not None:
-            self.model(loadType).load(loadId, level=level, user=user, exc=exc)
+                loadType = doc.get('attachedToType')
+                loadId = doc.get('attachedToId')
+            if loadType is not None and loadId is not None:
+                self.model(loadType).load(loadId, level=level, user=user, exc=exc)
 
         return doc
 

--- a/girder/utility/acl_mixin.py
+++ b/girder/utility/acl_mixin.py
@@ -59,8 +59,7 @@ class AccessControlMixin(object):
             else:
                 loadType = doc.get('attachedToType')
                 loadId = doc.get('attachedToId')
-            if loadType is not None and loadId is not None:
-                self.model(loadType).load(loadId, level=level, user=user, exc=exc)
+            self.model(loadType).load(loadId, level=level, user=user, exc=exc)
 
         return doc
 

--- a/plugins/provenance/plugin_tests/provenance_test.py
+++ b/plugins/provenance/plugin_tests/provenance_test.py
@@ -395,7 +395,7 @@ class ProvenanceTestCase(base.TestCase):
                             is (key == 'item'))
 
     def testProvenanceFileWithoutItem(self):
-        fileData = 'this is a test'
+        fileData = b'this is a test'
         file = self.model('upload').uploadFromFile(
             obj=six.BytesIO(fileData), size=len(fileData), name='test',
             parentType=None, parent=None, user=self.admin)

--- a/plugins/provenance/plugin_tests/provenance_test.py
+++ b/plugins/provenance/plugin_tests/provenance_test.py
@@ -18,6 +18,7 @@
 ###############################################################################
 
 import json
+import six
 
 from tests import base
 from girder import events
@@ -392,3 +393,13 @@ class ProvenanceTestCase(base.TestCase):
             self.assertTrue((eventName in events._mapping and 'provenance' in
                             [h['name'] for h in events._mapping[eventName]])
                             is (key == 'item'))
+
+    def testProvenanceFileWithoutItem(self):
+        fileData = 'this is a test'
+        file = self.model('upload').uploadFromFile(
+            obj=six.BytesIO(fileData), size=len(fileData), name='test',
+            parentType=None, parent=None, user=self.admin)
+        self.assertIsNone(file.get('itemId'))
+        file['name'] = 'test2'
+        file = self.model('file').save(file)
+        self.model('file').remove(file)

--- a/plugins/provenance/server/resource.py
+++ b/plugins/provenance/server/resource.py
@@ -392,15 +392,13 @@ class ResourceExt(Resource):
         :param event: the event with the file information.
         """
         file = event.info
-        if 'itemId' not in file:
-            return
-        user = self.getProvenanceUser(file)
         itemId = file.get('itemId')
         # Don't attach provenance to an item based on files that are not
         # directly associated (we may want to revisit this and, when files are
         # attachedToType, add provenance to the appropriate type and ID).
         if not itemId:
             return
+        user = self.getProvenanceUser(file)
         item = self.model('item').load(id=itemId, force=True)
         if not item:
             return

--- a/plugins/provenance/server/resource.py
+++ b/plugins/provenance/server/resource.py
@@ -210,8 +210,9 @@ class ResourceExt(Resource):
 
     def getProvenanceUser(self, obj):
         """
-        Get the user that is associated with the object.  If it has no user,
-        get the user of the current session.
+        Get the user that is associated with the current provenance change.
+        This is the current session user, if there is one.  If not, it is the
+        object's user or creator.
         :param obj: a model object.
         :returns: user for the object or None.
         """

--- a/plugins/provenance/server/resource.py
+++ b/plugins/provenance/server/resource.py
@@ -330,7 +330,7 @@ class ResourceExt(Resource):
         :param event: the event with the file information.
         """
         curFile = event.info
-        if 'itemId' not in curFile or '_id' not in curFile:
+        if not curFile.get('itemId') or '_id' not in curFile:
             return
         user = self.getProvenanceUser(curFile)
         item = self.model('item').load(id=curFile['itemId'], force=True)
@@ -366,7 +366,7 @@ class ResourceExt(Resource):
         :param event: the event with the file information.
         """
         file = event.info
-        if 'itemId' not in file or not file['itemId'] or '_id' not in file:
+        if not file.get('itemId') or '_id' not in file:
             return
         user = self.getProvenanceUser(file)
         item = self.model('item').load(id=file['itemId'], force=True)
@@ -394,7 +394,13 @@ class ResourceExt(Resource):
         if 'itemId' not in file:
             return
         user = self.getProvenanceUser(file)
-        item = self.model('item').load(id=file['itemId'], force=True)
+        itemId = file.get('itemId')
+        # Don't attach provenance to an item based on files that are not
+        # directly associated (we may want to revisit this and, when files are
+        # attachedToType, add provenance to the appropriate type and ID).
+        if not itemId:
+            return
+        item = self.model('item').load(id=itemId, force=True)
         if not item:
             return
         updateEvent = {

--- a/plugins/thumbnails/server/worker.py
+++ b/plugins/thumbnails/server/worker.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 ###############################################################################
 
+from bson.objectid import ObjectId
 import functools
 import six
 import sys
@@ -116,7 +117,8 @@ def createThumbnail(width, height, crop, fileId, attachToType, attachToId):
 
     thumbnail = uploadModel.uploadFromFile(
         out, size=size, name='_thumb.jpg', parentType=attachToType,
-        parent=attachToId, user=None, mimeType='image/jpeg', attachParent=True)
+        parent={'_id': ObjectId(attachToId)}, user=None, mimeType='image/jpeg',
+        attachParent=True)
 
     return attachThumbnail(
         file, thumbnail, attachToType, attachToId, width, height)

--- a/plugins/thumbnails/server/worker.py
+++ b/plugins/thumbnails/server/worker.py
@@ -115,8 +115,8 @@ def createThumbnail(width, height, crop, fileId, attachToType, attachToId):
     out.seek(0)
 
     thumbnail = uploadModel.uploadFromFile(
-        out, size=size, name='_thumb.jpg', parentType=None, parent=None,
-        user=None, mimeType='image/jpeg')
+        out, size=size, name='_thumb.jpg', parentType=attachToType,
+        parent=attachToId, user=None, mimeType='image/jpeg', attachParent=True)
 
     return attachThumbnail(
         file, thumbnail, attachToType, attachToId, width, height)


### PR DESCRIPTION
When a file doesn't have an itemId OR an attached type and ID (which could happen while uploading a thumbnail, for instance), the acl mixin would fail.

When a file doesn't have an itemId, the provenance plugin would fail.