### PR TITLE
Turn off coveralls for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,9 +74,8 @@ script:
     - git fetch --unshallow
 
 after_success:
-    - npm install -g codecov coveralls
+    - npm install -g codecov
     - codecov -f _build/coverage/lcov.info
-    - coveralls < _build/coverage/lcov.info
 
 deploy:
     provider: heroku


### PR DESCRIPTION
After the nice side-by-side evaluation of codecov vs. coveralls, I think codecov wins out.

If anyone has a strong preference for coveralls, please speak up on this thread.

ping @jbeezley 