### PR TITLE
Remove the dependencies section of the ansible role docs

### DIFF
--- a/devops/ansible/roles/girder/README.md
+++ b/devops/ansible/roles/girder/README.md
@@ -24,20 +24,6 @@ Role Variables
 | girder_force      | no       | yes          | Whether provisioning should discard modified files in the working directory. |
 | girder_web        | no       | yes          | Whether to build the Girder web client.                                      |
 
-Dependencies
-------------
-
-This role depends on the following roles from Ansible Galaxy:
-
-* `Stouts.mongodb`
-
-These will be automatically fetched if your requirements.yml file contains:
-```
----
-
-- src: girder.girder
-```
-
 Examples
 --------
 Examples can be found [here](https://github.com/girder/girder/tree/master/devops/ansible/examples).


### PR DESCRIPTION
@kotfic This was left behind from the older version of the role, there are no
dependencies of the current role.