### PR TITLE
Use global process object for node compatibility

### DIFF
--- a/grunt_tasks/fontello.js
+++ b/grunt_tasks/fontello.js
@@ -1,5 +1,4 @@
 module.exports = function (grunt) {
-    var process = require('process');
     var fs = require('fs');
     var path = require('path');
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "grunt-contrib-symlink": "~1.0.0",
     "grunt-curl": "^2.2.0",
     "grunt-zip": "~0.17.1",
-    "grunt-shell": ">=0.2.1",
+    "grunt-shell": "1.3.1",
     "grunt-gitinfo": "~0.1.0",
     "grunt-file-creator": "~0.1.0",
     "grunt-npm-install": "~0.2.0",


### PR DESCRIPTION
I'm pretty sure this require statement is unnecessary.  Only newer versions of node make `process` available as a module.