### PR TITLE
Don't send log information as part of a job_status notification.

### DIFF
--- a/plugins/jobs/plugin_tests/jobs_test.py
+++ b/plugins/jobs/plugin_tests/jobs_test.py
@@ -289,7 +289,8 @@ class JobsTestCase(base.TestCase):
         self.assertEqual(statusNotify['type'], 'job_status')
         self.assertEqual(statusNotify['data']['_id'], str(job['_id']))
         self.assertEqual(int(statusNotify['data']['status']), JobStatus.ERROR)
-        self.assertTrue('kwargs' not in statusNotify['data'])
+        self.assertNotIn('kwargs', statusNotify['data'])
+        self.assertNotIn('log', statusNotify['data'])
 
         self.assertEqual(progressNotify['type'], 'progress')
         self.assertEqual(progressNotify['data']['title'], job['title'])

--- a/plugins/jobs/server/models/job.py
+++ b/plugins/jobs/server/models/job.py
@@ -368,6 +368,7 @@ class Job(AccessControlledModel):
                 expires = now + datetime.timedelta(seconds=30)
                 filtered = self.filter(job, user)
                 filtered.pop('kwargs', None)
+                filtered.pop('log', None)
                 self.model('notification').createNotification(
                     type='job_status', data=filtered, user=user, expires=expires)
 


### PR DESCRIPTION
Because logs are sent in job_log notifications, they shouldn't be sent as part of the job_status.  Otherwise, it is likely that the notification is either large than necessary or contains stale information.

Fixes #1599.