### PR TITLE
cancelJob should use updateJob not save.

### DIFF
--- a/plugins/jobs/plugin_tests/jobs_test.py
+++ b/plugins/jobs/plugin_tests/jobs_test.py
@@ -392,3 +392,19 @@ class JobsTestCase(base.TestCase):
         job = jobModel.createJob(title='test', type='x', user=self.users[0])
         job = jobModel.updateJob(job, otherFields={'other': 'fields'})
         self.assertEqual(job['other'], 'fields')
+
+    def testCancelJob(self):
+        jobModel = self.model('job', 'jobs')
+        job = jobModel.createJob(title='test', type='x', user=self.users[0])
+        # add to the log
+        job = jobModel.updateJob(job, log='entry 1\n')
+        # Reload without the log
+        job = jobModel.load(id=job['_id'], force=True)
+        self.assertEqual(len(job.get('log', [])), 0)
+        # Cancel
+        job = jobModel.cancelJob(job)
+        self.assertEqual(job['status'], JobStatus.CANCELED)
+        # Reloading should still have the log and be canceled
+        job = jobModel.load(id=job['_id'], force=True, includeLog=True)
+        self.assertEqual(job['status'], JobStatus.CANCELED)
+        self.assertEqual(len(job.get('log', [])), 1)

--- a/plugins/jobs/server/models/job.py
+++ b/plugins/jobs/server/models/job.py
@@ -76,7 +76,7 @@ class Job(AccessControlledModel):
     def cancelJob(self, job):
         """
         Revoke/cancel a job. This simply triggers the jobs.cancel event and
-        sets the job status  to CANCELED. If one of the event handlers
+        sets the job status to CANCELED. If one of the event handlers
         calls preventDefault() on the event, this job will *not* be put into
         the CANCELED state.
 
@@ -85,8 +85,7 @@ class Job(AccessControlledModel):
         event = events.trigger('jobs.cancel', info=job)
 
         if not event.defaultPrevented:
-            job['status'] = JobStatus.CANCELED
-            job = self.save(job)
+            job = self.updateJob(job, status=JobStatus.CANCELED)
 
         return job
 


### PR DESCRIPTION
Using save resets the log to the value of the job document passed to cancelJob, so it is the wrong behavior.