### PR TITLE
Increase JS coverage threshold to 80%

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(COVERAGE_MINIMUM_PASS 90 CACHE STRING "Minimum python coverage threshold percent")
-set(JS_COVERAGE_MINIMUM_PASS 75 CACHE STRING "Minimum JS coverage threshold percent")
+set(JS_COVERAGE_MINIMUM_PASS 80 CACHE STRING "Minimum JS coverage threshold percent")
 
 # Test if mongod is present for tests that require it.
 find_program(MONGOD_EXECUTABLE mongod)


### PR DESCRIPTION
We are already well above this number, and it seems like a reasonable lower bound. I'm doing this now because it's listed on the TODO list to get done prior to 2.0 release.

Codecov actually gives us even better enforcement that our diffs (i.e. the lines of code that we actually changed on a PR) have sufficient coverage, so this is fairly moot.