### PR TITLE
Update base image in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:4.4.5
+FROM node:5
 MAINTAINER Patrick Reynolds <patrick.reynolds@kitware.com>
 
 EXPOSE 8080
@@ -30,6 +30,6 @@ COPY README.rst /girder/README.rst
 RUN pip install -e .[plugins]
 
 RUN npm install -g grunt-cli && npm cache clear
-RUN npm install --production --unsafe-perm && npm cache clear
+RUN npm install --unsafe-perm && npm cache clear
 RUN npm run build
 ENTRYPOINT ["python", "-m", "girder"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,6 @@ COPY package.json /girder/package.json
 COPY README.rst /girder/README.rst
 
 RUN pip install -e .[plugins]
+RUN girder-install web
 
-RUN npm install -g grunt-cli && npm cache clear
-RUN npm install --unsafe-perm && npm cache clear
-RUN npm run build
 ENTRYPOINT ["python", "-m", "girder"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY package.json /girder/package.json
 COPY README.rst /girder/README.rst
 
 RUN pip install -e .[plugins]
-RUN girder-install web
+RUN npm install --unsafe-perm
+RUN npm run build
 
 ENTRYPOINT ["python", "-m", "girder"]


### PR DESCRIPTION
With `node:4` npm is unable to handle `grunt-webpack`, which
requires `webpack-1.x`. With `node:5` it only issues warning.
Dropping --production flag, since some of the development
dependencies are explicitly required now.