### PR TITLE
girder-install web should not use --production flag on npm install

### DIFF
--- a/girder/utility/install.py
+++ b/girder/utility/install.py
@@ -134,14 +134,11 @@ def runWebBuild(wd=None, dev=False, npm='npm', allPlugins=False, plugins=None, p
         raise Exception('npm executable not found')
 
     wd = wd or constants.PACKAGE_DIR
-    commands = []
-
-    commands.append((npm, 'install', '--unsafe-perm') if dev
-                    else (npm, 'install', '--production', '--unsafe-perm'))
-
     env = 'dev' if dev else 'prod'
-    commands.append([npm, 'run', 'build', '--', '--env=%s' % env] + _getPluginBuildArgs(
-        allPlugins, plugins))
+    commands = [
+        (npm, 'install', '--unsafe-perm'),
+        [npm, 'run', 'build', '--', '--env=%s' % env] + _getPluginBuildArgs(allPlugins, plugins)
+    ]
 
     for cmd in commands:
         if progress and progress.on:

--- a/tests/cases/install_test.py
+++ b/tests/cases/install_test.py
@@ -229,12 +229,12 @@ class InstallTestCase(base.TestCase):
 
         with mock.patch('subprocess.Popen', return_value=ProcMock()) as p:
             install.install_web()
-            self.assertTrue('--production' in p.mock_calls[0][1][0])
+            self.assertNotIn('--production', p.mock_calls[0][1][0])
 
         with mock.patch('subprocess.Popen', return_value=ProcMock()) as p:
             install.install_web(PluginOpts(dev=True))
 
-            self.assertTrue('--production' not in p.mock_calls[0][1][0])
+            self.assertNotIn('--production', p.mock_calls[0][1][0])
 
         # Test initiation of web install via the REST API
         user = self.model('user').createUser(
@@ -248,15 +248,14 @@ class InstallTestCase(base.TestCase):
 
             self.assertEqual(len(p.mock_calls), 2)
             self.assertEqual(
-                list(p.mock_calls[0][1][0]),
-                ['npm', 'install', '--production', '--unsafe-perm'])
+                list(p.mock_calls[0][1][0]), ['npm', 'install', '--unsafe-perm'])
             self.assertEqual(
                 list(p.mock_calls[1][1][0]),
                 ['npm', 'run', 'build', '--', '--env=prod', '--plugins='])
 
         # Test with progress (requires actually calling a subprocess)
         os.environ['PATH'] = '%s:%s' % (
-            os.path.join(os.path.dirname(__file__), 'mockpath'),
+            os.path.join(os.path.abspath(os.path.dirname(__file__)), 'mockpath'),
             os.environ.get('PATH', '')
         )
         resp = self.request('/system/web_build', method='POST', user=user, params={


### PR DESCRIPTION
We need the dev dependencies to build the code.

PTAL @girder/developers travis didn't catch this bug because we install on travis using the `--dev` flag.