### PR TITLE
Enforce max buffer length in SFTP download

### DIFF
--- a/girder/api/sftp.py
+++ b/girder/api/sftp.py
@@ -33,6 +33,7 @@ from girder.utility.model_importer import ModelImporter
 from six.moves import socketserver
 
 DEFAULT_PORT = 8022
+MAX_BUF_LEN = 10 * 1024 * 1024
 
 
 def _handleErrors(fun):
@@ -95,6 +96,9 @@ class _FileHandle(paramiko.SFTPHandle, ModelImporter):
         self.file = file
 
     def read(self, offset, length):
+        if length > MAX_BUF_LEN:
+            raise IOError('Requested chunk length is larger than the maximum allowed.')
+
         stream = self.model('file').download(
             self.file, headers=False, offset=offset, endByte=offset + length)
         return b''.join(stream())

--- a/girder/api/sftp.py
+++ b/girder/api/sftp.py
@@ -49,6 +49,7 @@ def _handleErrors(fun):
             return paramiko.SFTP_PERMISSION_DENIED
         except Exception:
             logger.exception('SFTP server internal error')
+            return paramiko.SFTP_FAILURE
 
     return wrapped
 
@@ -97,7 +98,8 @@ class _FileHandle(paramiko.SFTPHandle, ModelImporter):
 
     def read(self, offset, length):
         if length > MAX_BUF_LEN:
-            raise IOError('Requested chunk length is larger than the maximum allowed.')
+            raise IOError(
+                'Requested chunk length (%d) is larger than the maximum allowed.' % length)
 
         stream = self.model('file').download(
             self.file, headers=False, offset=offset, endByte=offset + length)

--- a/tests/cases/sftp_test.py
+++ b/tests/cases/sftp_test.py
@@ -155,6 +155,13 @@ class SftpTestCase(base.TestCase):
         self.assertEqual(file.read(2), b'he')
         self.assertEqual(file.read(), b'llo world')
 
+        # Make sure we enforce max buffer length
+        tmp, sftp.MAX_BUF_LEN = sftp.MAX_BUF_LEN, 2
+        file = sftpClient.file('/user/regularuser/Private/test.txt/test.txt', 'r', bufsize=4)
+        with self.assertRaises(IOError):
+            file.read()
+        sftp.MAX_BUF_LEN = tmp
+
         # Test stat capability
         info = sftpClient.stat('/user/regularuser/Private')
         self.assertTrue(stat.S_ISDIR(info.st_mode))


### PR DESCRIPTION
@cjh1 I just realized I forgot to add this change you requested yesterday. PTAL.