### PR TITLE
Remove support for nonstandard filter() kwargs

### DIFF
--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -24,6 +24,10 @@ Server changes
   folder models has been removed.
 * The unused ``user`` parameter of the ``isOrphan`` methods in the file, item, and folder models
   has been removed.
+* Several core models supported an older, nonstandard kwarg format in their ``filter`` method.
+  This is no longer supported; the argument representing the document to filter is now always
+  called ``doc`` rather than using the model name for the kwarg. If you were using positional args
+  or using the ``filterModel`` decorator, this change will not affect your code.
 * Multiple configurable plugin loading paths are no longer supported. Use
   ``girder-install plugin <your_plugin_path>`` to install plugins that are not already in the
   plugins directory. Pass ``-s`` to that command to symlink instead of copying the directory.
@@ -136,3 +140,5 @@ Built-in plugin changes
 
 * **Jobs**: The deprecated ``jobs.filter`` event was removed. Use the standard ``exposeFields`` and
   ``hideFields`` methods on the job model instead.
+* **OAuth**: For legacy backward compatibility, the Google provider was previously enabled by
+  default. This is no longer the case.

--- a/girder/models/collection.py
+++ b/girder/models/collection.py
@@ -43,18 +43,6 @@ class Collection(AccessControlledModel):
             '_id', 'name', 'description', 'public', 'created', 'updated',
             'size'))
 
-    def filter(self, *args, **kwargs):
-        """
-        Preserved override for kwarg backwards compatibility. Prior to the
-        refactor for centralizing model filtering, this method's first formal
-        parameter was called "collection", whereas the centralized version's
-        first parameter is called "doc". This override simply detects someone
-        using the old kwarg and converts it to the new form.
-        """
-        if 'collection' in kwargs:
-            args = [kwargs.pop('collection')] + list(args)
-        return super(Collection, self).filter(*args, **kwargs)
-
     def validate(self, doc):
         doc['name'] = doc['name'].strip()
         if doc['description']:

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -54,18 +54,6 @@ class Folder(AccessControlledModel):
             'size', 'meta', 'parentId', 'parentCollection', 'creatorId',
             'baseParentType', 'baseParentId'))
 
-    def filter(self, *args, **kwargs):
-        """
-        Preserved override for kwarg backwards compatibility. Prior to the
-        refactor for centralizing model filtering, this method's first formal
-        parameter was called "folder", whereas the centralized version's first
-        parameter is called "doc". This override simply detects someone using
-        the old kwarg and converts it to the new form.
-        """
-        if 'folder' in kwargs:
-            args = [kwargs.pop('folder')] + list(args)
-        return super(Folder, self).filter(*args, **kwargs)
-
     def validate(self, doc, allowRename=False):
         """
         Validate the name and description of the folder, ensure that it is

--- a/girder/models/group.py
+++ b/girder/models/group.py
@@ -70,33 +70,6 @@ class Group(AccessControlledModel):
                     CoreEventHandler.GROUP_CREATOR_ACCESS,
                     self._grantCreatorAccess)
 
-    def filter(self, *args, **kwargs):
-        """
-        Preserved override for kwarg backwards compatibility. Prior to the
-        refactor for centralizing model filtering, this method's first formal
-        parameter was called "group", whereas the centralized version's first
-        parameter is called "doc". This override simply detects someone using
-        the old kwarg and converts it to the new form.
-
-        The old method for this model took two boolean kwargs, ``accessList``
-        and ``requests``. These options are now deprecated, but are still
-        supported for backward compatibility.
-        """
-        if 'group' in kwargs:
-            args = [kwargs.pop('group')] + list(args)
-
-        acl = kwargs.pop('accessList') if 'accessList' in kwargs else False
-        reqs = kwargs.pop('requests') if 'requests' in kwargs else False
-
-        group = super(Group, self).filter(*args, **kwargs)
-
-        if acl and 'access' not in group:
-            group['access'] = self.getFullAccessList(args[0])
-        if reqs and 'requests' not in group:
-            group['requests'] = list(self.getFullRequestList(args[0]))
-
-        return group
-
     def validate(self, doc):
         doc['name'] = doc['name'].strip()
         doc['lowerName'] = doc['name'].lower()

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -53,18 +53,6 @@ class Item(acl_mixin.AccessControlMixin, Model):
             'creatorId', 'folderId', 'name', 'baseParentType', 'baseParentId',
             'copyOfItem'))
 
-    def filter(self, *args, **kwargs):
-        """
-        Preserved override for kwarg backwards compatibility. Prior to the
-        refactor for centralizing model filtering, this method's first formal
-        parameter was called "item", whereas the centralized version's first
-        parameter is called "doc". This override simply detects someone using
-        the old kwarg and converts it to the new form.
-        """
-        if 'item' in kwargs:
-            args = [kwargs.pop('item')] + list(args)
-        return Model.filter(self, *args, **kwargs)
-
     def _validateString(self, value):
         """
         Make sure a value is a string and is stripped of whitespace.

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -57,19 +57,6 @@ class User(AccessControlledModel):
                     CoreEventHandler.USER_DEFAULT_FOLDERS,
                     self._addDefaultFolders)
 
-    def filter(self, *args, **kwargs):
-        """
-        Preserved override for kwarg backwards compatibility. Prior to the
-        refactor for centralizing model filtering, this method's first formal
-        parameter was called "folder", whereas the centralized version's first
-        parameter is called "doc". This override simply detects someone using
-        the old kwarg and converts it to the new form.
-        """
-        if 'currentUser' in kwargs and 'user' in kwargs:
-            args = [kwargs.pop('user')] + list(args)
-            kwargs['user'] = kwargs.pop('currentUser')
-        return super(User, self).filter(*args, **kwargs)
-
     def validate(self, doc):
         """
         Validate the user every time it is stored in the database.

--- a/plugins/oauth/server/__init__.py
+++ b/plugins/oauth/server/__init__.py
@@ -76,6 +76,4 @@ def load(info):
 
     info['apiRoot'].oauth = rest.OAuth()
 
-    # Make Google on by default for backward compatibility. To turn it off,
-    # users will need to hit one of the "Save" buttons on the config page.
-    SettingDefault.defaults[constants.PluginSettings.PROVIDERS_ENABLED] = ['google']
+    SettingDefault.defaults[constants.PluginSettings.PROVIDERS_ENABLED] = []


### PR DESCRIPTION
Fingers crossed, this is the last breaking change before we can cut 2.0.