### PR TITLE
Regular files should not show up in available plugin list

### DIFF
--- a/girder/utility/plugin_utilities.py
+++ b/girder/utility/plugin_utilities.py
@@ -278,9 +278,13 @@ def findAllPlugins():
     pluginDir = getPluginDir()
 
     for plugin in os.listdir(pluginDir):
+        path = os.path.join(pluginDir, plugin)
+        if not os.path.isdir(path):  # this also allows for symlinked directories
+            continue
+
         data = {}
-        configJson = os.path.join(pluginDir, plugin, 'plugin.json')
-        configYml = os.path.join(pluginDir, plugin, 'plugin.yml')
+        configJson = os.path.join(path, 'plugin.json')
+        configYml = os.path.join(path, 'plugin.yml')
         if os.path.isfile(configJson):
             with open(configJson) as conf:
                 try:

--- a/tests/cases/system_test.py
+++ b/tests/cases/system_test.py
@@ -226,6 +226,8 @@ class SystemTestCase(base.TestCase):
         resp = self.request(path='/system/plugins', user=self.users[0])
         self.assertStatusOk(resp)
         self.assertIn('all', resp.json)
+        self.assertNotIn('.gitignore', resp.json['all'])
+
         self.mockPluginDir(
             os.path.join(os.path.dirname(os.path.dirname(__file__)), 'test_plugins'))
 


### PR DESCRIPTION
".gitignore" and ".DS_Store" were showing up as plugins in my list prior to this change, which must have come in when we removed the deprecated feature of multiple plugin dirs.