### PR TITLE
Add config option for disabling the events daemon

### DIFF
--- a/girder/utility/config.py
+++ b/girder/utility/config.py
@@ -40,15 +40,15 @@ def _loadConfigsByPrecedent():
     """
     Load configuration in reverse order of precedent.
     """
-    configPaths = []
-    configPaths.append(
-        os.path.join(PACKAGE_DIR, 'conf', 'girder.dist.cfg'))
-    configPaths.append(
-        os.path.join(PACKAGE_DIR, 'conf', 'girder.local.cfg'))
-    configPaths.append(
-        os.path.join('/etc', 'girder.cfg'))
-    configPaths.append(
-        os.path.join(os.path.expanduser('~'), '.girder', 'girder.cfg'))
+    configPaths = [os.path.join(PACKAGE_DIR, 'conf', 'girder.dist.cfg')]
+
+    if 'GIRDER_TEST_DB' not in os.environ:
+        # we don't want to load the local config file if we are running tests
+        configPaths.append(os.path.join(PACKAGE_DIR, 'conf', 'girder.local.cfg'))
+
+    configPaths.append(os.path.join('/etc', 'girder.cfg'))
+    configPaths.append(os.path.join(os.path.expanduser('~'), '.girder', 'girder.cfg'))
+
     if 'GIRDER_CONFIG' in os.environ:
         configPaths.append(os.environ['GIRDER_CONFIG'])
 

--- a/tests/cases/events_test.py
+++ b/tests/cases/events_test.py
@@ -142,6 +142,8 @@ class EventsTestCase(unittest.TestCase):
 
     @mock.patch.object(events, 'daemon', new=events.ForegroundEventsDaemon())
     def testForegroundDaemon(self):
+        self.assertIsInstance(events.daemon, events.ForegroundEventsDaemon)
+
         # Should still be able to call start
         events.daemon.start()
 

--- a/tests/cases/events_test.py
+++ b/tests/cases/events_test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 ###############################################################################
 
+import six
 import time
 import unittest
 
@@ -136,3 +137,28 @@ class EventsTestCase(unittest.TestCase):
             self.assertEqual(events.daemon.eventQueue.qsize(), 0)
             self.assertEqual(self.ctr, 3)
             self.assertEqual(self.responses, ['foo'])
+            events.daemon.stop()
+
+    def testForegroundDaemon(self):
+        oldDaemon = events.daemon
+        events.daemon = events.ForegroundEventsDaemon()
+
+        # Should still be able to call start
+        events.daemon.start()
+
+        def callback(event):
+            self.ctr += 1
+            self.responses = event.responses
+
+        with events.bound('_test.event',  '_test.handler', self._raiseException):
+            with six.assertRaisesRegex(self, Exception, 'Failure condition'):
+                events.daemon.trigger('_test.event', None, callback)
+
+        with events.bound('_test.event',  '_test.handler', self._incrementWithResponse):
+            events.daemon.trigger('_test.event', {'amount': 2}, callback)
+
+        self.assertEqual(self.ctr, 3)
+        self.assertEqual(self.responses, ['foo'])
+
+        events.daemon.stop()
+        events.daemon = oldDaemon

--- a/tests/cases/events_test.py
+++ b/tests/cases/events_test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 ###############################################################################
 
+import mock
 import six
 import time
 import unittest
@@ -139,10 +140,8 @@ class EventsTestCase(unittest.TestCase):
             self.assertEqual(self.responses, ['foo'])
             events.daemon.stop()
 
+    @mock.patch.object(events, 'daemon', new=events.ForegroundEventsDaemon())
     def testForegroundDaemon(self):
-        oldDaemon = events.daemon
-        events.daemon = events.ForegroundEventsDaemon()
-
         # Should still be able to call start
         events.daemon.start()
 
@@ -161,4 +160,3 @@ class EventsTestCase(unittest.TestCase):
         self.assertEqual(self.responses, ['foo'])
 
         events.daemon.stop()
-        events.daemon = oldDaemon


### PR DESCRIPTION
@mgrauer PTAL. This allows a config file switch to be set such that `girder.events.daemon` simply becomes an alias for the normal, synchronous `girder.events`, which makes us no longer depend on having a background thread on the server.