### PR TITLE
Unbreak symlinked plugin web client build

### DIFF
--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -85,7 +85,7 @@ module.exports = function (grunt) {
         var config = {}, npm;
         var cfgFile = 'no config file';
 
-        if (!fs.lstatSync(dir).isDirectory()) {
+        if (!fs.statSync(dir).isDirectory()) {
             grunt.fail.warn('Plugin directory not found: ' + dir);
             return;
         }


### PR DESCRIPTION
@girder/developers PTAL, I just noticed my npm build breaking when I had a symlinked plugin, because for some reason we were using lstat instead of stat.