### PR TITLE
Escape npm package names in the grunt config

### DIFF
--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -137,20 +137,15 @@ module.exports = function (grunt) {
             npm = (
                 _(deps || [])
                     .map(function (version, dep) {
-                        // escape any periods in the dependency version so
-                        // that grunt.config.set does not descend on each
-                        // version number component
-                        var escapedVersion = version.replace(/\./g, '\\.');
-
                         return [
                             dep,
-                            escapedVersion
+                            version
                         ].join('@');
                     })
             );
 
             if (npm.length) {
-                grunt.config.set('default.npm-install:' + npm.join(':'), {});
+                grunt.config.set('default.npm-install:' + grunt.config.escape(npm.join(':')), {});
             }
         }
 


### PR DESCRIPTION
Some packages on npm have periods in their name.  This escapes the whole `npm-install` option rather than just the versions.