### PR TITLE
Explicitly enable Babel ES2015 transpilation

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,7 +9,7 @@
       "cover": {
         "plugins": [
           ["istanbul", {
-            "exclude": ["**/*.pug", "**/*.jade"]
+            "exclude": ["**/*.pug", "**/*.jade", "node_modules/**/*"]
           }]
         ]
       }

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ COPY Gruntfile.js /girder/Gruntfile.js
 COPY setup.py /girder/setup.py
 COPY package.json /girder/package.json
 COPY README.rst /girder/README.rst
+COPY .babelrc /girder/.babelrc
 
 RUN pip install -e .[plugins]
 RUN npm install --production --unsafe-perm

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY package.json /girder/package.json
 COPY README.rst /girder/README.rst
 
 RUN pip install -e .[plugins]
-RUN npm install --unsafe-perm
-RUN npm run build
+RUN npm install --production --unsafe-perm
+RUN npm run build -- --env=prod
 
 ENTRYPOINT ["python", "-m", "girder"]

--- a/grunt_tasks/webpack.config.js
+++ b/grunt_tasks/webpack.config.js
@@ -103,7 +103,10 @@ module.exports = {
             {
                 test: /\.js$/,
                 loader: 'babel-loader',
-                exclude: [paths.node_modules]
+                exclude: [paths.node_modules],
+                query: {
+                    presets: ['es2015']
+                }
             },
             // JSON files
             {
@@ -136,7 +139,12 @@ module.exports = {
             {
                 test: /\.(pug|jade)$/,
                 loaders: [
-                    'babel-loader',
+                    {
+                        loader: 'babel-loader',
+                        query: {
+                            presets: ['es2015']
+                        }
+                    },
                     'pug-loader'
                 ]
             },

--- a/grunt_tasks/webpack.config.js
+++ b/grunt_tasks/webpack.config.js
@@ -104,7 +104,7 @@ module.exports = {
             {
                 test: /\.js$/,
                 loader: 'babel-loader',
-                exclude: [paths.node_modules],
+                exclude: /node_modules/,
                 query: {
                     presets: [es2015Preset]
                 }

--- a/grunt_tasks/webpack.config.js
+++ b/grunt_tasks/webpack.config.js
@@ -22,6 +22,7 @@ var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var ProvidePlugin = webpack.ProvidePlugin;
 
 var paths = require('./webpack.paths.js');
+var es2015Preset = require.resolve('babel-preset-es2015');
 
 function fileLoader() {
     return {
@@ -105,7 +106,7 @@ module.exports = {
                 loader: 'babel-loader',
                 exclude: [paths.node_modules],
                 query: {
-                    presets: ['es2015']
+                    presets: [es2015Preset]
                 }
             },
             // JSON files
@@ -142,7 +143,7 @@ module.exports = {
                     {
                         loader: 'babel-loader',
                         query: {
-                            presets: ['es2015']
+                            presets: [es2015Preset]
                         }
                     },
                     'pug-loader'


### PR DESCRIPTION
Fixes #1648. This preset was enabled by default on some platforms,
but not others, including in our docker container. This fixes the
production build on those platforms.

This also changes the docker container to build the web client
code in production mode.

@Purg PTAL and let me know if this fixes your issue with the docker container.