### PR TITLE
Export plugins under `girder.plugins`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,3 +9,4 @@ clients/web/static/
 clients/web/test/
 build/
 _build/
+clients/web/src/plugins.js

--- a/clients/web/src/.gitignore
+++ b/clients/web/src/.gitignore
@@ -1,1 +1,2 @@
 version.js
+plugins.js

--- a/clients/web/src/index.js
+++ b/clients/web/src/index.js
@@ -9,6 +9,7 @@ import * as server from './server';
 import * as utilities from './utilities';
 import * as version from './version';
 import * as views from './views';
+import * as plugins from './plugins';
 import events from './events';
 import router from './router';
 
@@ -20,6 +21,7 @@ export {
   events,
   misc,
   models,
+  plugins,
   rest,
   router,
   server,

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -28,6 +28,7 @@ module.exports = function (grunt) {
     if (_.isString(plugins) && plugins) {
         plugins = plugins.split(',');
     } else if (!buildAll) {
+        fs.writeFileSync('clients/web/src/plugins.js', 'export {};');
         return;
     }
 

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -78,6 +78,7 @@ module.exports = function (grunt) {
         grunt.config.merge(cfg);
     };
 
+    var pluginExports = [];
     var configurePluginForBuilding = function (dir) {
         var plugin = path.basename(dir);
         var json = path.resolve(dir, 'plugin.json');
@@ -115,6 +116,8 @@ module.exports = function (grunt) {
         // Add webpack target and name resolution for this plugin if web_client/main.js exists
         var webClient = path.resolve(dir + '/web_client');
         var main =  webClient + '/main.js';
+        var index = webClient + '/index.js';
+
         if (fs.existsSync(main)) {
             grunt.config.merge({
                 webpack: {
@@ -130,6 +133,11 @@ module.exports = function (grunt) {
                     }
                 }
             });
+        }
+        if (fs.existsSync(index)) {
+            pluginExports.push(
+                `import * as ${plugin} from 'girder_plugins/${plugin}'; export { ${plugin} };`
+            );
         }
 
         function addDependencies(deps) {
@@ -193,6 +201,8 @@ module.exports = function (grunt) {
             configurePluginForBuilding(path.resolve(grunt.config.get('pluginDir'), name));
         });
     }
+
+    fs.writeFileSync('clients/web/src/plugins.js', pluginExports.join('\n'));
 
     /**
      * Register a "meta" task that will configure and run other tasks

--- a/plugins/jobs/web_client/main.js
+++ b/plugins/jobs/web_client/main.js
@@ -1,12 +1,4 @@
-import $ from 'jquery';
 import './routes';
 
 // Extends and overrides API
 import './views/HeaderUserView';
-
-// For testing (potentially temporary)
-import * as jobs from './index';
-$(function () {
-    window.girder.plugins = window.girder.plugins || {};
-    window.girder.plugins.jobs = jobs;
-});


### PR DESCRIPTION
This is the only way I could find to make plugins available globally.  Any method using dynamic require or the context module api will result in all plugins being built.

Plugins can export symbols by defining a file called `web_client/index.js`.  Currently only the `jobs` plugin does this, but we should add exports for the other plugins as well.  I can do that here if desired.