### PR TITLE
[WIP] Build one big app chunk

### DIFF
--- a/clients/web-external/index.html
+++ b/clients/web-external/index.html
@@ -1,7 +1,5 @@
 <head>
-    <link rel="stylesheet" href="/girder/static/built/girder.ext.min.css">
     <link rel="stylesheet" href="/girder/static/built/girder.app.min.css">
-    <script src="/girder/static/built/girder.ext.min.js"></script>
     <script src="/girder/static/built/girder.app.min.js"></script>
     <script src="main.js"></script>
 </head>

--- a/clients/web/src/main.js
+++ b/clients/web/src/main.js
@@ -1,3 +1,4 @@
+import './globals';
 import * as girder from 'girder';
 
 window.girder = girder;

--- a/clients/web/test/testEnv.pug
+++ b/clients/web/test/testEnv.pug
@@ -11,10 +11,7 @@ html(lang="en")
     #g-global-info-apiroot.hide %HOST%#{apiRoot}
     #g-global-info-staticroot.hide %HOST%#{staticRoot}
 
-    each js in jsFilesUncovered
-      script(src=js)
-
-    each js in jsFilesCovered
+    each js in jsFiles
       script(src=js)
 
     script(src="testing.min.js")

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -621,17 +621,9 @@ girderTest.waitForDialog = function (desc) {
 girderTest.promise = $.when();
 
 /**
- * Import a javascript file and.
+ * This function is no longer necessary.
  */
-girderTest.addScript = function (url) {
-    var defer = new $.Deferred();
-    girderTest.promise.then(function () {
-        $.getScript(url).done(function () {
-            defer.resolve();
-        });
-    });
-    girderTest.promise = defer.promise();
-};
+girderTest.addScript = $.noop;
 
 /**
  * An alias to addScript for backwards compatibility.

--- a/docs/external-web-clients.rst
+++ b/docs/external-web-clients.rst
@@ -39,13 +39,7 @@ assuming Girder is hosted at ``/girder``:
 
 .. code-block:: html
 
-    <script src="/girder/static/built/girder.ext.min.js"></script>
     <script src="/girder/static/built/girder.app.min.js"></script>
-
-.. note::
-   ``girder.ext.min.js`` includes requirements for Girder, including jQuery,
-   Bootstrap, Underscore, and Backbone. You may wish to use your own versions
-   of these separately and not include ``girder.ext.min.js``.
 
 
 Extending Girder's Backbone application
@@ -119,13 +113,7 @@ To use Girder UI components, you will need the following CSS files in your HTML:
 
 .. code-block:: html
 
-    <link rel="stylesheet" href="/girder/static/built/girder.ext.min.css">
     <link rel="stylesheet" href="/girder/static/built/girder.app.min.css">
-
-.. note::
-   ``girder.ext.min.css`` includes requirements for Girder, including Bootstrap
-   and some additional Bootstrap extensions. You may wish to use your own
-   versions of these separately and not include ``girder.ext.min.css``.
 
 To make login and logout controls, provide a dialog container and
 login/logout/register links, and a container where the dialogs will be rendered:

--- a/girder/utility/webroot.mako
+++ b/girder/utility/webroot.mako
@@ -6,30 +6,20 @@
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Droid+Sans:400,700">
     <link rel="stylesheet" href="${staticRoot}/built/fontello/css/fontello.css">
     <link rel="stylesheet" href="${staticRoot}/built/fontello/css/animation.css">
-    <link rel="stylesheet" href="${staticRoot}/built/girder.ext.min.css">
     <link rel="stylesheet" href="${staticRoot}/built/girder.app.min.css">
     <link rel="icon" type="image/png" href="${staticRoot}/img/Girder_Favicon.png">
-    % for plugin in pluginCss:
-    <link rel="stylesheet" href="${staticRoot}/built/plugins/${plugin}/plugin.min.css">
-    % endfor
   </head>
   <body>
     <div id="g-global-info-apiroot" class="hide">${apiRoot}</div>
     <div id="g-global-info-staticroot" class="hide">${staticRoot}</div>
-    <script src="${staticRoot}/built/girder.ext.min.js"></script>
     <script src="${staticRoot}/built/girder.app.min.js"></script>
     <script>
-    $(function () {
       girder.events.trigger('g:appload.before');
-      var app = new girder.views.App({
+      new girder.views.App({
         el: 'body',
         parentView: null
       });
       girder.events.trigger('g:appload.after');
-    });
     </script>
-    % for plugin in pluginJs:
-    <script src="${staticRoot}/built/plugins/${plugin}/plugin.min.js"></script>
-    % endfor
   </body>
 </html>

--- a/girder/utility/webroot.py
+++ b/girder/utility/webroot.py
@@ -88,16 +88,3 @@ class Webroot(WebrootBase):
             'staticRoot': '',
             'title': 'Girder'
         }
-
-    def _renderHTML(self):
-        self.vars['pluginCss'] = []
-        self.vars['pluginJs'] = []
-        builtDir = os.path.join(constants.STATIC_ROOT_DIR, 'clients', 'web',
-                                'static', 'built', 'plugins')
-        for plugin in self.vars['plugins']:
-            if os.path.exists(os.path.join(builtDir, plugin, 'plugin.min.css')):
-                self.vars['pluginCss'].append(plugin)
-            if os.path.exists(os.path.join(builtDir, plugin, 'plugin.min.js')):
-                self.vars['pluginJs'].append(plugin)
-
-        return super(Webroot, self)._renderHTML()

--- a/grunt_tasks/dev.js
+++ b/grunt_tasks/dev.js
@@ -51,12 +51,6 @@ module.exports = function (grunt) {
     grunt.registerTask('test-env-html', 'Build the phantom test html page.', function () {
         var pug = require('pug');
         var buffer = fs.readFileSync('clients/web/test/testEnv.pug');
-        var dependencies = [
-            '/clients/web/static/built/girder.ext.min.js'
-        ];
-        var inputs = [
-            '/clients/web/static/built/girder.app.min.js'
-        ];
 
         var fn = pug.compile(buffer, {
             client: false,
@@ -65,11 +59,11 @@ module.exports = function (grunt) {
         fs.writeFileSync('clients/web/static/built/testing/testEnv.html', fn({
             cssFiles: [
                 '/clients/web/static/built/fontello/css/fontello.css',
-                '/clients/web/static/built/girder.ext.min.css',
                 '/clients/web/static/built/girder.app.min.css'
             ],
-            jsFilesUncovered: dependencies,
-            jsFilesCovered: inputs,
+            jsFiles: [
+                '/clients/web/static/built/girder.app.min.js'
+            ],
             staticRoot: '/static',
             apiRoot: '/api/v1'
         }));

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -123,9 +123,6 @@ module.exports = function (grunt) {
             grunt.config.merge({
                 webpack: {
                     options: {
-                        entry: {
-                            [`plugins/${plugin}/plugin`]: main
-                        },
                         resolve: {
                             alias: {
                                 [`girder_plugins/${plugin}`]: webClient
@@ -134,6 +131,8 @@ module.exports = function (grunt) {
                     }
                 }
             });
+
+            pluginExports.push(`import 'girder_plugins/${plugin}/main';`);
         }
         if (fs.existsSync(index)) {
             pluginExports.push(

--- a/grunt_tasks/webpack.config.js
+++ b/grunt_tasks/webpack.config.js
@@ -17,7 +17,6 @@
 var webpack = require('webpack');
 var path = require('path');
 
-var CommonsChunkPlugin = webpack.optimize.CommonsChunkPlugin;
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var ProvidePlugin = webpack.ProvidePlugin;
 
@@ -49,10 +48,6 @@ function urlLoader(options) {
 
 module.exports = {
     entry: {
-        'girder.ext': [
-            // This make sure some globals like $, moment, Backbone are available for testing
-            path.join(paths.web_src, 'globals.js')
-        ],
         'girder.app': path.join(paths.web_src, 'main.js')
     },
     output: {
@@ -60,10 +55,6 @@ module.exports = {
         filename: '[name].min.js'
     },
     plugins: [
-        new CommonsChunkPlugin({
-            names: ['girder.app', 'girder.ext'],
-            minChunks: 2
-        }),
         // Automatically detect jQuery and $ as free var in modules
         // and inject the jquery library. This is required by many jquery plugins
         new ProvidePlugin({

--- a/tests/cases/webroot_test.py
+++ b/tests/cases/webroot_test.py
@@ -39,4 +39,4 @@ class WebRootTestCase(base.TestCase):
         self.assertStatus(resp, 200)
         body = self.getBody(resp)
         self.assertTrue('girder.app.min.js' in body)
-        self.assertTrue('girder.ext.min.js' in body)
+        self.assertTrue('girder.app.min.css' in body)


### PR DESCRIPTION
Results from discussion on #1652. We've chosen to punt on trying to get good dynamic module loading for plugin code working in webpack, at least for now. A web client rebuild will now be required when the set of active plugins changes, but all the linking will be done at build time into one large bundle.

The main thing left to figure out is how our testing environment should handle this. We don't want to have to do a webpack build for every single web_client test to build in all the necessary plugins, so it would be nice to have *some* way to hack in runtime loading of plugins just for testing.

ping @jbeezley @ronichoudhury 