### PR TITLE
Bump frozen Pillow version for security patches

### DIFF
--- a/plugins/thumbnails/requirements.txt
+++ b/plugins/thumbnails/requirements.txt
@@ -1,3 +1,3 @@
-Pillow==3.1.0
+Pillow==3.4.2
 pydicom==0.9.9
 numpy==1.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ hachoir-metadata==1.3.3 ; python_version < '3.0'
 hachoir-parser==1.3.4   ; python_version < '3.0'
 
 # thumbnails
-Pillow==3.3.2
+Pillow==3.4.2
 
 # dependencies of celery
 amqp==1.4.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ hachoir-metadata==1.3.3 ; python_version < '3.0'
 hachoir-parser==1.3.4   ; python_version < '3.0'
 
 # thumbnails
-Pillow==3.2.0
+Pillow==3.3.2
 
 # dependencies of celery
 amqp==1.4.9


### PR DESCRIPTION
This doesn't really affect our environment since the version in setup.py isn't pinned, but Gemnasium threw up an alert based on the requirements.txt file.