### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ COPY package.json /girder/package.json
 COPY README.rst /girder/README.rst
 
 RUN pip install -e .[plugins]
-RUN npm install --production --unsafe-perm
-RUN npm run build -- --env=prod
+RUN girder-install web --all-plugins
 
 ENTRYPOINT ["python", "-m", "girder"]


### PR DESCRIPTION
The command `npm run build -- --env=prod` still tries to run development tasks.  See the build on [dockerhub](https://hub.docker.com/r/girder/girder/builds/bvvjr9rpzwi9nsvzzj7dhlm/). 