### PR TITLE
Fix warnings from multiple errorReponse bindings to the same code

### DIFF
--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -268,14 +268,11 @@ class Description(object):
             reason = '\n\n'.join(reason)
 
         if code in self._responses:
-            print(TerminalColor.warning(
-                "WARNING: Error response for code '%s' is already defined "
-                "(old: '%s', new: '%s')"
-                % (code, self._responses[code]['description'], reason)))
-
-        self._responses[code] = {
-            'description': reason
-        }
+            self._responses[code]['description'] += '\n\n' + reason
+        else:
+            self._responses[code] = {
+                'description': reason
+            }
 
         return self
 


### PR DESCRIPTION
This fixes warnings like the following at server startup time:

    WARNING: Error response for code '400' is already defined (old: '['Path is invalid.']', new: 'Path refers to a resource that does not exist.')

We just add some structure to the description text to support multiple description bindings to the same error code. Swagger-ui renders these as markdown, so they appear as separate paragraph elements.