### PR TITLE
Support anonymous sftp when check_auth_none is not called

### DIFF
--- a/girder/api/sftp.py
+++ b/girder/api/sftp.py
@@ -216,7 +216,10 @@ class _ServerAdapter(paramiko.ServerInterface, ModelImporter):
         return 'password'
 
     def check_auth_none(self, username):
-        return paramiko.AUTH_FAILED
+        if username.lower() == 'anonymous':
+            return paramiko.AUTH_SUCCESSFUL
+        else:
+            return paramiko.AUTH_FAILED
 
     def check_auth_password(self, username, password):
         if username.lower() == 'anonymous':

--- a/tests/cases/sftp_test.py
+++ b/tests/cases/sftp_test.py
@@ -193,6 +193,25 @@ class SftpTestCase(base.TestCase):
         sftpClient.close()
         client.close()
 
+        # Test that any username other than anonymous will fail using auth_none.
+        sock = socket.socket()
+        sock.connect(('localhost', TEST_PORT))
+        trans = paramiko.Transport(sock)
+        trans.connect()
+        with self.assertRaises(paramiko.ssh_exception.BadAuthenticationType):
+            trans.auth_none('')
+        trans.close()
+        sock.close()
+
+        sock = socket.socket()
+        sock.connect(('localhost', TEST_PORT))
+        trans = paramiko.Transport(sock)
+        trans.connect()
+        with self.assertRaises(paramiko.ssh_exception.BadAuthenticationType):
+            trans.auth_none('eponymous')
+        trans.close()
+        sock.close()
+
         # Test that a connection can be opened for anonymous access using auth_none.
         sock = socket.socket()
         sock.connect(('localhost', TEST_PORT))


### PR DESCRIPTION
The Cyberduck app doesn't pass the password separately (or maybe doesn't pass anything) when trying to connect with anonymous sftp, as `check_auth_password` is never called.

This fix allows Cyberduck to use anonymous sftp.