### PR TITLE
Add methods to set apiRoot and staticRoot

### DIFF
--- a/clients/web/src/rest.js
+++ b/clients/web/src/rest.js
@@ -6,7 +6,7 @@ import events from 'girder/events';
 import { getCurrentToken, cookie } from 'girder/auth';
 
 var apiRoot = $('#g-global-info-apiroot').text().replace('%HOST%', window.location.origin) || '/api/v1';
-var staticRoot = $('#g-global-info-staticroot').text().replace('%HOST%', window.location.origin) || 'static';
+var staticRoot = $('#g-global-info-staticroot').text().replace('%HOST%', window.location.origin) || '/static';
 var uploadHandlers = {};
 var uploadChunkSize = 1024 * 1024 * 64; // 64MB
 

--- a/clients/web/src/rest.js
+++ b/clients/web/src/rest.js
@@ -11,6 +11,23 @@ var uploadHandlers = {};
 var uploadChunkSize = 1024 * 1024 * 64; // 64MB
 
 /**
+ * Set the root path to the API.
+ *
+ * @param path The full root path for the API.
+ */
+function setApiRoot(root) {
+    apiRoot = root;
+}
+
+/** Set the root path to the static content.
+ *
+ * @param path The full root path for the static content.
+ */
+function setStaticRoot(root) {
+    staticRoot = root;
+}
+
+/**
  * Make a request to the REST API. Bind a "done" handler to the return
  * value that will be called when the response is successful. To bind a
  * custom error handler, bind an "error" handler to the return promise,
@@ -183,6 +200,8 @@ function setUploadChunkSize(val) {
 export {
     apiRoot,
     staticRoot,
+    setApiRoot,
+    setStaticRoot,
     uploadHandlers,
     restRequest,
     numberOutstandingRestRequests,

--- a/clients/web/src/rest.js
+++ b/clients/web/src/rest.js
@@ -5,8 +5,8 @@ import Backbone from 'backbone';
 import events from 'girder/events';
 import { getCurrentToken, cookie } from 'girder/auth';
 
-var apiRoot = $('#g-global-info-apiroot').text().replace('%HOST%', window.location.origin);
-var staticRoot = $('#g-global-info-staticroot').text().replace('%HOST%', window.location.origin);
+var apiRoot = $('#g-global-info-apiroot').text().replace('%HOST%', window.location.origin) || '/api/v1';
+var staticRoot = $('#g-global-info-staticroot').text().replace('%HOST%', window.location.origin) || 'static';
 var uploadHandlers = {};
 var uploadChunkSize = 1024 * 1024 * 64; // 64MB
 

--- a/clients/web/test/spec/setApiSpec.js
+++ b/clients/web/test/spec/setApiSpec.js
@@ -10,11 +10,9 @@ describe('Test setApiRoot() and setStaticRoot() functions', function () {
         });
 
         runs(function () {
-            var host = 'http://localhost:30019';
-
             // Test the default values.
-            expect(girder.rest.apiRoot).toBe(host + '/api/v1');
-            expect(girder.rest.staticRoot).toBe(host + '/static');
+            expect(girder.rest.apiRoot.slice(girder.rest.apiRoot.indexOf('/', 7))).toBe('/api/v1');
+            expect(girder.rest.staticRoot.slice(girder.rest.staticRoot.indexOf('/', 7))).toBe('/static');
 
             var apiRootVal = '/foo/bar/v2';
             girder.rest.setApiRoot(apiRootVal);

--- a/clients/web/test/spec/setApiSpec.js
+++ b/clients/web/test/spec/setApiSpec.js
@@ -1,0 +1,28 @@
+/**
+ * Start the girder backbone app.
+ */
+girderTest.startApp();
+
+describe('Test setApiRoot() and setStaticRoot() functions', function () {
+    it('Check for default values and mutation', function () {
+        waitsFor(function () {
+            return $('.g-frontpage-body').length > 0;
+        });
+
+        runs(function () {
+            var host = 'http://localhost:30019';
+
+            // Test the default values.
+            expect(girder.rest.apiRoot).toBe(host + '/api/v1');
+            expect(girder.rest.staticRoot).toBe(host + '/static');
+
+            var apiRootVal = '/foo/bar/v2';
+            girder.rest.setApiRoot(apiRootVal);
+            expect(girder.rest.apiRoot).toBe(apiRootVal);
+
+            var staticRootVal = 'dynamic';
+            girder.rest.setStaticRoot(staticRootVal);
+            expect(girder.rest.staticRoot).toBe(staticRootVal);
+        });
+    });
+});

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -77,6 +77,7 @@ if(RUN_CORE_TESTS)
   add_web_client_test(empty_layout "${PROJECT_SOURCE_DIR}/clients/web/test/spec/emptyLayoutSpec.js")
   add_web_client_test(swagger "${PROJECT_SOURCE_DIR}/clients/web/test/spec/swaggerSpec.js" BASEURL "/api/v1")
   add_web_client_test(browser "${PROJECT_SOURCE_DIR}/clients/web/test/spec/browserSpec.js")
+  add_web_client_test(set_api "${PROJECT_SOURCE_DIR}/clients/web/test/spec/setApiSpec.js")
 
   if (BUILD_JAVASCRIPT_TESTS)
     set_property(TEST web_client_admin PROPERTY RUN_SERIAL ON)


### PR DESCRIPTION
Setting these values via special elements in application code is unusual and unintuitive. This PR adds `setApiRoot()` and `setStaticRoot()` functions to the REST module, and sets reasonable defaults for these values when the elements are missing and the functions aren't called. The magic elements are still queried so this change is fully backward compatible.