### PR TITLE
Resolve node modules correctly inside symlinked plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,8 +75,8 @@
     "webpack-dev-server": "^2.1.0-beta.0"
   },
   "scripts": {
-    "build": "grunt init && grunt",
-    "watch": "grunt --watch",
+    "build": "grunt init && NODE_PATH=$PWD/node_modules grunt",
+    "watch": "NODE_PATH=$PWD/node_modules grunt --watch",
     "lint": "eslint --cache clients/web Gruntfile.js grunt_tasks scripts && pug-lint clients/web/src/templates",
     "docs": "grunt docs"
   }


### PR DESCRIPTION
There is an unfortunate issue resolving node modules from files symlinked from outside of the main girder path.  It came up in the [large_image plugin](https://github.com/DigitalSlideArchive/large_image/pull/111) when trying to resolve the external geojs dependency.  It looks like the node developers are treating it as a WONTFIX.  See here for the gory details: https://github.com/nodejs/node/issues/3402.

In terms of the fix here, it would be better if I could inject the `NODE_PATH` environment variable inside the `Gruntfile.js`, but it looks like that variable needs to be set before loading the script.  This probably breaks windows builds, but I can't think of any other way to do it besides telling users to always set that environment variable manually.