### PR TITLE
Only keep EventStream open if the window is visible

### DIFF
--- a/clients/web/src/utilities/EventStream.js
+++ b/clients/web/src/utilities/EventStream.js
@@ -66,6 +66,7 @@ prototype.open = function () {
             }
             stream.trigger('g:event.' + obj.type, obj);
         };
+        this._stopHeartbeat = false;
         this._heartbeat();
     } else {
         console.error('EventSource is not supported on this platform.');

--- a/clients/web/src/utilities/EventStream.js
+++ b/clients/web/src/utilities/EventStream.js
@@ -23,6 +23,27 @@ function EventStream(settings) {
 
 var prototype = EventStream.prototype;
 
+/*
+ * This method is used to kill the event stream socket when the girder tab is not
+ * visible using window.requestAnimationFrame. It creates a dead man switch to
+ * close the frame after 5 seconds if requestAnimationFrame is not called in that time.
+ */
+prototype._heartbeat = function () {
+    if (!this._stopHeartbeat) {
+        window.requestAnimationFrame(() => { this._heartbeat(); });
+    }
+
+    if (this._eventSource) {
+        window.clearTimeout(this._closeTimeout);
+        this._closeTimeout = window.setTimeout(() => {
+            this._eventSource.close();
+            this._eventSource = null;
+        }, 5000);
+    } else {
+        this.open();
+    }
+};
+
 prototype.open = function () {
     if (window.EventSource) {
         var stream = this,
@@ -45,12 +66,14 @@ prototype.open = function () {
             }
             stream.trigger('g:event.' + obj.type, obj);
         };
+        this._heartbeat();
     } else {
         console.error('EventSource is not supported on this platform.');
     }
 };
 
 prototype.close = function () {
+    this._stopHeartbeat = true;
     if (this._eventSource) {
         this._eventSource.close();
         this._eventSource = null;


### PR DESCRIPTION
@brianhelba this addresses the issue you saw with many girder tabs open in chrome with the event stream socket causing new connections to girder to block. Now, once a tab is backgrounded, the event stream is shut off after 5 seconds. Once the tab is visible again, the stream is re-opened.