### PR TITLE
add flags to hierarchy and itemlist views

### DIFF
--- a/clients/web/src/templates/widgets/hierarchyWidget.pug
+++ b/clients/web/src/templates/widgets/hierarchyWidget.pug
@@ -81,4 +81,5 @@
   .g-empty-parent-message.g-info-message-container.hide
     i.icon-info-circled
     |  This folder is empty.
-.g-folder-metadata
+if showMetadata
+  .g-folder-metadata

--- a/clients/web/src/templates/widgets/itemList.pug
+++ b/clients/web/src/templates/widgets/itemList.pug
@@ -3,15 +3,23 @@ ul.g-item-list
     li.g-item-list-entry
       if checkboxes
         input.g-list-checkbox(type="checkbox", g-item-cid=item.cid)
-      a.g-item-list-link.g-right-border(g-item-cid=item.cid)
-        i.icon-doc-text-inv
-        = item.name()
-      a(title="Download item", href=item.downloadUrl())
-        i.icon-download
-      a.g-view-inline(title="View in browser", target="_blank", rel="noopener noreferrer",
-          href=item.downloadUrl({contentDisposition: 'inline'}))
-        i.icon-eye
-      .g-item-size= formatSize(item.get('size'))
+      if downloadLinks || viewLinks
+        a.g-item-list-link.g-right-border(g-item-cid=item.cid)
+          i.icon-doc-text-inv
+          = item.name()
+      else
+        a.g-item-list-link(g-item-cid=item.cid)
+          i.icon-doc-text-inv
+          = item.name()
+      if downloadLinks
+        a(title="Download item", href=item.downloadUrl())
+          i.icon-download
+      if viewLinks
+        a.g-view-inline(title="View in browser", target="_blank", rel="noopener noreferrer",
+            href=item.downloadUrl({contentDisposition: 'inline'}))
+          i.icon-eye
+      if showSizes
+        .g-item-size= formatSize(item.get('size'))
   if (hasMore)
     li.g-show-more
       a.g-show-more-items

--- a/clients/web/src/views/widgets/HierarchyWidget.js
+++ b/clients/web/src/views/widgets/HierarchyWidget.js
@@ -118,6 +118,10 @@ var HierarchyWidget = View.extend({
         this._showActions = _.has(settings, 'showActions') ? settings.showActions : true;
         this._showItems = _.has(settings, 'showItems') ? settings.showItems : true;
         this._checkboxes = _.has(settings, 'checkboxes') ? settings.checkboxes : true;
+        this._downloadLinks = _.has(settings, 'downloadLinks') ? settings.downloadLinks : true;
+        this._viewLinks = _.has(settings, 'viewLinks') ? settings.viewLinks : true;
+        this._showSizes = _.has(settings, 'showSizes') ? settings.showSizes : true;
+        this._showMetadata = _.has(settings, 'showMetadata') ? settings.showMetadata : true;
         this._routing = _.has(settings, 'routing') ? settings.routing : true;
         this._appendPages = _.has(settings, 'appendPages') ? settings.appendPages : false;
         this._onItemClick = settings.onItemClick || function (item) {
@@ -204,6 +208,9 @@ var HierarchyWidget = View.extend({
         this.itemListView = new ItemListWidget({
             folderId: this.parentModel.get('_id'),
             checkboxes: this._checkboxes,
+            downloadLinks: this._downloadLinks,
+            viewLinks: this._viewLinks,
+            showSizes: this._showSizes,
             parentView: this
         });
         this.itemListView.on('g:itemClicked', this._onItemClick, this)
@@ -265,6 +272,7 @@ var HierarchyWidget = View.extend({
             level: this.parentModel.getAccessLevel(),
             AccessType: AccessType,
             showActions: this._showActions,
+            showMetadata: this._showMetadata,
             checkboxes: this._checkboxes,
             capitalize: capitalize
         }));
@@ -282,7 +290,9 @@ var HierarchyWidget = View.extend({
         if (this.parentModel.resourceName === 'folder' && this._showItems) {
             this.itemListView.setElement(this.$('.g-item-list-container')).render();
             this.metadataWidget.setItem(this.parentModel);
-            this.metadataWidget.setElement(this.$('.g-folder-metadata')).render();
+            if (this._showMetadata) {
+                this.metadataWidget.setElement(this.$('.g-folder-metadata')).render();
+            }
         }
 
         this.$('[title]').tooltip({

--- a/clients/web/src/views/widgets/ItemListWidget.js
+++ b/clients/web/src/views/widgets/ItemListWidget.js
@@ -25,6 +25,12 @@ var ItemListWidget = View.extend({
     initialize: function (settings) {
         this.checked = [];
         this._checkboxes = settings.checkboxes;
+        this._downloadLinks = (
+          _.has(settings, 'downloadLinks') ? settings.downloadLinks : true);
+        this._viewLinks = (
+          _.has(settings, 'viewLinks') ? settings.viewLinks : true);
+        this._showSizes = (
+          _.has(settings, 'showSizes') ? settings.showSizes : true);
 
         new LoadingAnimation({
             el: this.$el,
@@ -47,7 +53,10 @@ var ItemListWidget = View.extend({
             items: this.collection.toArray(),
             hasMore: this.collection.hasNextPage(),
             formatSize: formatSize,
-            checkboxes: this._checkboxes
+            checkboxes: this._checkboxes,
+            downloadLinks: this._downloadLinks,
+            viewLinks: this._viewLinks,
+            showSizes: this._showSizes
         }));
 
         this.$('.g-item-list-entry a[title]').tooltip({

--- a/clients/web/test/spec/customWidgetsSpec.js
+++ b/clients/web/test/spec/customWidgetsSpec.js
@@ -164,6 +164,142 @@
                 expect($('.g-folder-list-link').text()).toBe('subfolder');
                 expect($('.g-item-list-link').length).toBe(0);
             });
+
+            runs(function () {
+                $('body').empty().off();
+
+                new girder.views.widgets.HierarchyWidget({
+                    el: 'body',
+                    parentModel: folder,
+                    downloadLinks: false,
+                    showActions: false,
+                    parentView: null
+                });
+            });
+
+            waitsFor(function () {
+                return $('.g-hierarchy-widget').length > 0 &&
+                       $('.g-folder-list-link').length > 0 &&
+                       $('.g-item-list-link').length > 0;
+            }, 'the hierarchy widget to display without download links');
+
+            runs(function () {
+                expect($('.g-upload-here-button').length).toBe(0);
+                expect($('.g-hierarchy-actions-header').length).toBe(0);
+                expect($('.g-list-checkbox').length).toBe(2);
+                expect($('.g-select-all').length).toBe(0);
+                expect($('a[title="Download item"]').length).toBe(0);
+            });
+
+            runs(function () {
+                $('body').empty().off();
+
+                new girder.views.widgets.HierarchyWidget({
+                    el: 'body',
+                    parentModel: folder,
+                    viewLinks: false,
+                    showActions: false,
+                    parentView: null
+                });
+            });
+
+            waitsFor(function () {
+                return $('.g-hierarchy-widget').length > 0 &&
+                       $('.g-folder-list-link').length > 0 &&
+                       $('.g-item-list-link').length > 0;
+            }, 'the hierarchy widget to display without view links');
+
+            runs(function () {
+                expect($('.g-upload-here-button').length).toBe(0);
+                expect($('.g-hierarchy-actions-header').length).toBe(0);
+                expect($('.g-list-checkbox').length).toBe(2);
+                expect($('.g-select-all').length).toBe(0);
+                expect($('.g-view-inline').length).toBe(0);
+            });
+
+            runs(function () {
+                $('body').empty().off();
+
+                new girder.views.widgets.HierarchyWidget({
+                    el: 'body',
+                    parentModel: folder,
+                    downloadLinks: false,
+                    viewLinks: false,
+                    showActions: false,
+                    parentView: null
+                });
+            });
+
+            waitsFor(function () {
+                return $('.g-hierarchy-widget').length > 0 &&
+                       $('.g-folder-list-link').length > 0 &&
+                       $('.g-item-list-link').length > 0;
+            }, ('the hierarchy widget to display neither ' +
+                'view nor download links'));
+
+            runs(function () {
+                expect($('.g-upload-here-button').length).toBe(0);
+                expect($('.g-hierarchy-actions-header').length).toBe(0);
+                expect($('.g-list-checkbox').length).toBe(2);
+                expect($('.g-select-all').length).toBe(0);
+                expect($('.g-view-inline').length).toBe(0);
+                expect($('a[title="Download item"]').length).toBe(0);
+
+                /* no border shown when there are no links */
+                expect($('.g-right-border').length).toBe(0);
+            });
+
+            runs(function () {
+                $('body').empty().off();
+
+                new girder.views.widgets.HierarchyWidget({
+                    el: 'body',
+                    parentModel: folder,
+                    showMetadata: false,
+                    showActions: false,
+                    parentView: null
+                });
+            });
+
+            waitsFor(function () {
+                return $('.g-hierarchy-widget').length > 0 &&
+                       $('.g-folder-list-link').length > 0 &&
+                       $('.g-item-list-link').length > 0;
+            }, 'the hierarchy widget to display without the metadata widget');
+
+            runs(function () {
+                expect($('.g-upload-here-button').length).toBe(0);
+                expect($('.g-hierarchy-actions-header').length).toBe(0);
+                expect($('.g-list-checkbox').length).toBe(2);
+                expect($('.g-select-all').length).toBe(0);
+                expect($('.g-folder-metadata').length).toBe(0);
+            });
+
+            runs(function () {
+                $('body').empty().off();
+
+                new girder.views.widgets.HierarchyWidget({
+                    el: 'body',
+                    parentModel: folder,
+                    showSizes: false,
+                    showActions: false,
+                    parentView: null
+                });
+            });
+
+            waitsFor(function () {
+                return $('.g-hierarchy-widget').length > 0 &&
+                       $('.g-folder-list-link').length > 0 &&
+                       $('.g-item-list-link').length > 0;
+            }, 'the hierarchy widget to display without item sizes');
+
+            runs(function () {
+                expect($('.g-upload-here-button').length).toBe(0);
+                expect($('.g-hierarchy-actions-header').length).toBe(0);
+                expect($('.g-list-checkbox').length).toBe(2);
+                expect($('.g-select-all').length).toBe(0);
+                expect($('.g-item-size').length).toBe(0);
+            });
         });
     });
 


### PR DESCRIPTION
 - add flags to allow for more fine-grain control over the
   hierarchy and itemlist views

 - ItemListWidget
   - add flag "downloadLinks"
   - add flag "viewLinks"
   - add flag "showSizes"

 - HierarchyWidget
   - add flag "showMetadata"
   - add flag "downloadLinks" (forwarded to ItemListWidget)
   - add flag "viewLinks" (forwarded to ItemListWidget)
   - add flag "showSizes" (forwarded to ItemListWidget)