### PR TITLE
Remove resolve.extensions option from webpack config

### DIFF
--- a/grunt_tasks/webpack.config.js
+++ b/grunt_tasks/webpack.config.js
@@ -190,7 +190,6 @@ module.exports = {
         alias: {
             'girder': paths.web_src
         },
-        extensions: ['.styl', '.css', '.pug', '.jade', '.js', ''],
         modules: [
             paths.clients_web,
             paths.plugins,


### PR DESCRIPTION
This doesn't seem to be needed and it can interfere with expected "node semantics" in ES6 code importing index files via directory.