### PR TITLE
Render all hierarchy descriptions as markdown

### DIFF
--- a/clients/web/src/stylesheets/body/itemPage.styl
+++ b/clients/web/src/stylesheets/body/itemPage.styl
@@ -1,6 +1,7 @@
 .g-item-header
   border-bottom 1px solid #ddd
-  margin-bottom 15px
+  margin-bottom 12px
+  padding-bottom 8px
   font-size 16px
   color #555
 

--- a/clients/web/src/templates/body/collectionPage.pug
+++ b/clients/web/src/templates/body/collectionPage.pug
@@ -29,7 +29,8 @@
             | Delete collection
 
   .g-collection-name.g-body-title= collection.name()
-  .g-collection-description.g-body-subtitle= collection.get('description')
+  if collection.get('description')
+    .g-collection-description!= renderMarkdown(collection.get('description'))
   .g-clear-right
 
 .g-collection-hierarchy-container

--- a/clients/web/src/templates/body/itemPage.pug
+++ b/clients/web/src/templates/body/itemPage.pug
@@ -29,7 +29,8 @@
               | Delete item
 
   .g-item-name.g-body-title= item.name()
-  .g-item-description.g-body-subtitle= item.get('description')
+
+.g-item-description!= renderMarkdown(item.get('description'))
 
 .g-item-info
   .g-item-info-header

--- a/clients/web/src/templates/widgets/collectionInfoDialog.pug
+++ b/clients/web/src/templates/widgets/collectionInfoDialog.pug
@@ -14,7 +14,7 @@ mixin dateInfo(intro, property)
         span= collection.name()
     .modal-body
       if collection.get('description')
-        .g-info-dialog-description != renderMarkdown(collection.get('description'))
+        .g-info-dialog-description!= renderMarkdown(collection.get('description'))
 
       .g-collection-info-lines
         +dateInfo('Created ', 'created')

--- a/clients/web/src/templates/widgets/editCollectionWidget.pug
+++ b/clients/web/src/templates/widgets/editCollectionWidget.pug
@@ -13,8 +13,8 @@
           label.control-label(for="g-name") Name
           input.input-sm#g-name.form-control(type="text", placeholder="Enter collection name")
         .form-group
-          label.control-label(for="g-description") Description (optional)
-          textarea.input-sm#g-description.form-control(placeholder="Enter collection description")
+          label.control-label Description (optional)
+          .g-description-editor-container
         .g-validation-failed-message
       .modal-footer
         a.btn.btn-small.btn-default(data-dismiss="modal") Cancel

--- a/clients/web/src/templates/widgets/editItemWidget.pug
+++ b/clients/web/src/templates/widgets/editItemWidget.pug
@@ -13,8 +13,8 @@
           label.control-label(for="g-name") Name
           input.input-sm#g-name.form-control(type="text", placeholder="Enter item name")
         .form-group
-          label.control-label(for="g-description") Description (optional)
-          textarea.input-sm#g-description.form-control(placeholder="Enter item description")
+          label.control-label Description (optional)
+          .g-description-editor-container
         .g-validation-failed-message
       .modal-footer
         a.btn.btn-small.btn-default(data-dismiss="modal") Cancel

--- a/clients/web/src/views/body/CollectionView.js
+++ b/clients/web/src/views/body/CollectionView.js
@@ -11,6 +11,7 @@ import View from 'girder/views/View';
 import { AccessType } from 'girder/constants';
 import { cancelRestRequests } from 'girder/rest';
 import { confirm } from 'girder/dialog';
+import { renderMarkdown } from 'girder/misc';
 import events from 'girder/events';
 
 import CollectionPageTemplate from 'girder/templates/body/collectionPage.pug';
@@ -124,7 +125,8 @@ var CollectionView = View.extend({
     render: function () {
         this.$el.html(CollectionPageTemplate({
             collection: this.model,
-            AccessType: AccessType
+            AccessType: AccessType,
+            renderMarkdown: renderMarkdown
         }));
 
         this.hierarchyWidget.setElement(

--- a/clients/web/src/views/body/ItemView.js
+++ b/clients/web/src/views/body/ItemView.js
@@ -13,7 +13,7 @@ import { AccessType } from 'girder/constants';
 import { cancelRestRequests } from 'girder/rest';
 import { confirm, handleClose } from 'girder/dialog';
 import events from 'girder/events';
-import { formatSize, formatDate, DATE_SECOND } from 'girder/misc';
+import { formatSize, formatDate, renderMarkdown, DATE_SECOND } from 'girder/misc';
 
 import ItemPageTemplate from 'girder/templates/body/itemPage.pug';
 
@@ -120,6 +120,7 @@ var ItemView = View.extend({
                 AccessType: AccessType,
                 formatSize: formatSize,
                 formatDate: formatDate,
+                renderMarkdown: renderMarkdown,
                 DATE_SECOND: DATE_SECOND
             }));
 

--- a/clients/web/src/views/widgets/EditCollectionWidget.js
+++ b/clients/web/src/views/widgets/EditCollectionWidget.js
@@ -2,6 +2,7 @@ import $ from 'jquery';
 
 import CollectionModel from 'girder/models/CollectionModel';
 import View from 'girder/views/View';
+import MarkdownWidget from 'girder/views/widgets/MarkdownWidget';
 import { handleClose, handleOpen } from 'girder/dialog';
 
 import EditCollectionWidgetTemplate from 'girder/templates/widgets/editCollectionWidget.pug';
@@ -19,7 +20,7 @@ var EditCollectionWidget = View.extend({
 
             var fields = {
                 name: this.$('#g-name').val(),
-                description: this.$('#g-description').val()
+                description: this.descriptionEditor.val()
             };
 
             if (this.model) {
@@ -28,6 +29,7 @@ var EditCollectionWidget = View.extend({
                 this.createCollection(fields);
             }
 
+            this.descriptionEditor.saveText();
             this.$('button.g-save-collection').girderEnable(false);
             this.$('.g-validation-failed-message').text('');
         }
@@ -35,6 +37,13 @@ var EditCollectionWidget = View.extend({
 
     initialize: function (settings) {
         this.model = settings.model || null;
+        this.descriptionEditor = new MarkdownWidget({
+            text: this.model ? this.model.get('description') : '',
+            prefix: 'collection-description',
+            placeholder: 'Enter a description',
+            enableUploads: false,
+            parentView: this
+        });
     },
 
     render: function () {
@@ -59,6 +68,7 @@ var EditCollectionWidget = View.extend({
             }
         });
         modal.trigger($.Event('ready.girder.modal', {relatedTarget: modal}));
+        this.descriptionEditor.setElement(this.$('.g-description-editor-container')).render();
         this.$('#g-name').focus();
 
         if (view.model) {

--- a/clients/web/src/views/widgets/EditFolderWidget.js
+++ b/clients/web/src/views/widgets/EditFolderWidget.js
@@ -29,6 +29,7 @@ var EditFolderWidget = View.extend({
                 this.createFolder(fields);
             }
 
+            this.descriptionEditor.saveText();
             this.$('button.g-save-folder').girderEnable(false);
             this.$('.g-validation-failed-message').text('');
         }

--- a/clients/web/src/views/widgets/EditItemWidget.js
+++ b/clients/web/src/views/widgets/EditItemWidget.js
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import _ from 'underscore';
 
 import ItemModel from 'girder/models/ItemModel';
+import MarkdownWidget from 'girder/views/widgets/MarkdownWidget';
 import View from 'girder/views/View';
 import { handleClose, handleOpen } from 'girder/dialog';
 
@@ -18,7 +19,7 @@ var EditItemWidget = View.extend({
         'submit #g-item-edit-form': function () {
             var fields = {
                 name: this.$('#g-name').val(),
-                description: this.$('#g-description').val()
+                description: this.descriptionEditor.val()
             };
 
             if (this.item) {
@@ -37,35 +38,44 @@ var EditItemWidget = View.extend({
     initialize: function (settings) {
         this.item = settings.item || null;
         this.parentModel = settings.parentModel;
+        this.descriptionEditor = new MarkdownWidget({
+            text: this.item ? this.item.get('description') : '',
+            prefix: 'item-description',
+            placeholder: 'Enter a description',
+            parent: this.folder,
+            enableUploads: false,
+            parentView: this
+        });
     },
 
     render: function () {
         var view = this;
         var modal = this.$el.html(EditItemWidgetTemplate({
-            item: this.item}))
-            .girderModal(this).on('shown.bs.modal', function () {
-                view.$('#g-name').focus();
-                if (view.item) {
-                    handleOpen('itemedit');
-                } else {
-                    handleOpen('itemcreate');
-                }
-            }).on('hidden.bs.modal', function () {
-                if (view.create) {
-                    handleClose('itemcreate');
-                } else {
-                    handleClose('itemedit');
-                }
-            }).on('ready.girder.modal', function () {
-                if (view.item) {
-                    view.$('#g-name').val(view.item.get('name'));
-                    view.$('#g-description').val(view.item.get('description'));
-                    view.create = false;
-                } else {
-                    view.create = true;
-                }
-            });
+            item: this.item
+        })).girderModal(this).on('shown.bs.modal', function () {
+            view.$('#g-name').focus();
+            if (view.item) {
+                handleOpen('itemedit');
+            } else {
+                handleOpen('itemcreate');
+            }
+        }).on('hidden.bs.modal', function () {
+            if (view.create) {
+                handleClose('itemcreate');
+            } else {
+                handleClose('itemedit');
+            }
+        }).on('ready.girder.modal', function () {
+            if (view.item) {
+                view.$('#g-name').val(view.item.get('name'));
+                view.$('#g-description').val(view.item.get('description'));
+                view.create = false;
+            } else {
+                view.create = true;
+            }
+        });
         modal.trigger($.Event('ready.girder.modal', {relatedTarget: modal}));
+        this.descriptionEditor.setElement(this.$('.g-description-editor-container')).render();
 
         return this;
     },

--- a/clients/web/src/views/widgets/EditItemWidget.js
+++ b/clients/web/src/views/widgets/EditItemWidget.js
@@ -28,6 +28,7 @@ var EditItemWidget = View.extend({
                 this.createItem(fields);
             }
 
+            this.descriptionEditor.saveText();
             this.$('button.g-save-item').girderEnable(false);
             this.$('.g-validation-failed-message').empty();
 
@@ -42,7 +43,6 @@ var EditItemWidget = View.extend({
             text: this.item ? this.item.get('description') : '',
             prefix: 'item-description',
             placeholder: 'Enter a description',
-            parent: this.folder,
             enableUploads: false,
             parentView: this
         });

--- a/clients/web/src/views/widgets/MarkdownWidget.js
+++ b/clients/web/src/views/widgets/MarkdownWidget.js
@@ -202,6 +202,15 @@ var MarkdownWidget = View.extend({
         } else {
             return this.$('.g-markdown-text').val();
         }
+    },
+
+    /**
+     * Normally, calling render() on this widget will reset it to its initial text
+     * value. Call this to set the text value that should be shown on re-render
+     * to the current value of the text area.
+     */
+    saveText: function () {
+        this.text = this.val();
     }
 });
 

--- a/clients/web/test/spec/itemSpec.js
+++ b/clients/web/test/spec/itemSpec.js
@@ -129,7 +129,7 @@ describe('Test item creation, editing, and deletion', function () {
 
         runs(function () {
             $('#g-name').val('Test Item Name');
-            $('#g-description').val('Test Item Description');
+            $('#item-description-write .g-markdown-text').val('Test Item Description');
             $('.g-save-item').click();
         });
 
@@ -148,7 +148,7 @@ describe('Test item creation, editing, and deletion', function () {
 
         runs(function () {
             expect($('.g-item-name').text()).toBe("Test Item Name");
-            expect($('.g-item-description').text()).toBe("Test Item Description");
+            expect($('.g-item-description').text().trim()).toBe("Test Item Description");
         });
     });
 


### PR DESCRIPTION
In the worker tasks plugin, items represent analyses, and it makes sense that they may have rich descriptions that we want to display when configuring the task for execution.

This makes the item description consistent with folder descriptions in the web client.