### PR TITLE
Collections view rendering

### DIFF
--- a/clients/web/src/stylesheets/body/collectionList.styl
+++ b/clients/web/src/stylesheets/body/collectionList.styl
@@ -17,6 +17,12 @@
     float right
     color #909090
 
+  .g-collection-description
+    background-color white
+    padding 8px 12px
+    border-radius 3px
+    border 1px solid #dedede
+
 .g-collection-list-header
   padding-bottom 10px
 

--- a/clients/web/src/stylesheets/body/groupList.styl
+++ b/clients/web/src/stylesheets/body/groupList.styl
@@ -14,7 +14,7 @@
     border-left 1px solid #ddd
     padding-left 8px
     display inline
-    width 235px
+    width 290px
     font-size 14px
     float right
     color #909090

--- a/clients/web/src/stylesheets/layout/global.styl
+++ b/clients/web/src/stylesheets/layout/global.styl
@@ -111,6 +111,20 @@ textarea
 /* Stuff that applies across the top level object lists */
 .g-top-level-list-title-container
   display inline-block
+  overflow hidden
+  white-space nowrap
+  width calc(100% - 350px)
+  position relative
+
+  .g-text-fade
+    height 30px
+    width 45px
+    position absolute
+    right 0
+    background linear-gradient(left, rgba(250, 250, 252, 0), rgba(250, 250, 252, 1))
+
+    &[public="false"]
+      background linear-gradient(left, rgba(255, 249, 234, 0), rgba(255, 249, 234, 1))
 
 .g-list-public-status-icon
   display inline-block

--- a/clients/web/src/templates/body/collectionList.pug
+++ b/clients/web/src/templates/body/collectionList.pug
@@ -33,6 +33,8 @@ each collection in collections
         span.g-text-fade(public=(collection.get('public') ? 'true' : 'false'))
       if collection.get('description')
         .g-collection-subtitle
-          a.g-show-description Show description#[i.icon-down-dir]
-          .g-collection-description
+          a.g-show-description(state="hidden", cid=collection.cid)
+            span Show description
+            i.icon-down-dir
     .g-clear-right
+    .g-collection-description(cid=collection.cid).hide

--- a/clients/web/src/templates/body/collectionList.pug
+++ b/clients/web/src/templates/body/collectionList.pug
@@ -30,6 +30,9 @@ each collection in collections
       .g-collection-title
         a.g-collection-link(g-collection-cid=collection.cid)
           b= collection.name()
-      .g-collection-subtitle
-        span.g-collection-description= collection.get('description')
+        span.g-text-fade(public=(collection.get('public') ? 'true' : 'false'))
+      if collection.get('description')
+        .g-collection-subtitle
+          a.g-show-description Show description#[i.icon-down-dir]
+          .g-collection-description
     .g-clear-right

--- a/clients/web/src/templates/body/collectionList.pug
+++ b/clients/web/src/templates/body/collectionList.pug
@@ -37,4 +37,4 @@ each collection in collections
             span Show description
             i.icon-down-dir
     .g-clear-right
-    .g-collection-description(cid=collection.cid).hide
+    .g-collection-description.hide(cid=collection.cid)

--- a/clients/web/src/views/body/CollectionsView.js
+++ b/clients/web/src/views/body/CollectionsView.js
@@ -8,8 +8,7 @@ import router from 'girder/router';
 import SearchFieldWidget from 'girder/views/widgets/SearchFieldWidget';
 import View from 'girder/views/View';
 import { cancelRestRequests } from 'girder/rest';
-import { renderMarkdown } from 'girder/misc';
-import { formatDate, formatSize, DATE_MINUTE } from 'girder/misc';
+import { formatDate, formatSize, renderMarkdown, DATE_MINUTE } from 'girder/misc';
 import { getCurrentUser } from 'girder/auth';
 
 import CollectionListTemplate from 'girder/templates/body/collectionList.pug';

--- a/clients/web/src/views/body/CollectionsView.js
+++ b/clients/web/src/views/body/CollectionsView.js
@@ -8,6 +8,7 @@ import router from 'girder/router';
 import SearchFieldWidget from 'girder/views/widgets/SearchFieldWidget';
 import View from 'girder/views/View';
 import { cancelRestRequests } from 'girder/rest';
+import { renderMarkdown } from 'girder/misc';
 import { formatDate, formatSize, DATE_MINUTE } from 'girder/misc';
 import { getCurrentUser } from 'girder/auth';
 
@@ -27,7 +28,8 @@ var CollectionsView = View.extend({
         'click button.g-collection-create-button': 'createCollectionDialog',
         'submit .g-collections-search-form': function (event) {
             event.preventDefault();
-        }
+        },
+        'click .g-show-description': '_toggleDescription'
     },
 
     initialize: function (settings) {
@@ -94,6 +96,25 @@ var CollectionsView = View.extend({
         collection.set('_id', result.id).on('g:fetched', function () {
             router.navigate('/collection/' + collection.get('_id'), {trigger: true});
         }, this).fetch();
+    },
+
+    _toggleDescription: function (e) {
+        const link = $(e.currentTarget);
+        const cid = link.attr('cid');
+        const dest = this.$(`.g-collection-description[cid="${cid}"]`);
+
+        if (link.attr('state') === 'hidden') {
+            renderMarkdown(this.collection.get(cid).get('description'), dest);
+            dest.removeClass('hide');
+            link.attr('state', 'visible');
+            link.find('i').removeClass('icon-down-dir').addClass('icon-up-dir');
+            link.find('span').text('Hide description');
+        } else {
+            dest.addClass('hide');
+            link.attr('state', 'hidden');
+            link.find('i').removeClass('icon-up-dir').addClass('icon-down-dir');
+            link.find('span').text('Show description');
+        }
     }
 });
 

--- a/clients/web/test/spec/collectionSpec.js
+++ b/clients/web/test/spec/collectionSpec.js
@@ -45,9 +45,21 @@ describe('Test collection actions', function () {
         }, 'collection list to appear');
 
         runs(function () {
-            expect($('.g-collection-list-entry').text().match('collName0').length > 0);
-        });
+            expect($('.g-collection-list-entry').text()).toContain('collName0');
+            expect($('.g-collection-subtitle').text()).toBe('Show description');
+            expect($('.g-collection-description:visible').length).toBe(0);
 
+            // Show description
+            $('.g-show-description').click();
+            expect($('.g-collection-subtitle').text()).toBe('Hide description');
+            expect($('.g-collection-description:visible').length).toBe(1);
+            expect($('.g-collection-description').text().trim()).toBe('coll Desc 0');
+
+            // Hide description
+            $('.g-show-description').click();
+            expect($('.g-collection-subtitle').text()).toBe('Show description');
+            expect($('.g-collection-description:visible').length).toBe(0);
+        });
     });
 
     it('create another collection',


### PR DESCRIPTION
@jcfr this contains the other changes you requested, namely improving the rendering of the collection list. Long collection names are now gracefully truncated, and descriptions are shown as markdown by clicking on a toggle. Hopefully this will encourage people to use more rich descriptions for their collections.

Depends on #1696 