### PR TITLE
In prod environment, only install prod npm dependencies

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ include girder/girder-version.json
 include package.json
 include README.rst
 include girder/conf/girder.dist.cfg
+include scripts/postNpmInstall.js
 recursive-exclude tests *
 recursive-include clients/web *
 recursive-include girder/mail_templates *

--- a/girder/utility/install.py
+++ b/girder/utility/install.py
@@ -133,11 +133,15 @@ def runWebBuild(wd=None, dev=False, npm='npm', allPlugins=False, plugins=None, p
         ))
         raise Exception('npm executable not found')
 
+    npmInstall = [npm, 'install', '--unsafe-perm']
+    if not dev:
+        npmInstall.append('--production')
+
     wd = wd or constants.PACKAGE_DIR
     env = 'dev' if dev else 'prod'
     quiet = '--no-progress=false' if sys.stdout.isatty() else '--no-progress=true'
     commands = [
-        (npm, 'install', '--unsafe-perm'),
+        npmInstall,
         [npm, 'run', 'build', '--',
          quiet, '--env=%s' % env] + _getPluginBuildArgs(allPlugins, plugins)
     ]

--- a/grunt_tasks/webpack.config.js
+++ b/grunt_tasks/webpack.config.js
@@ -25,7 +25,6 @@ var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 var paths = require('./webpack.paths.js');
 var es2015Preset = require.resolve('babel-preset-es2015');
-var istanbulPlugin = require.resolve('babel-plugin-istanbul');
 
 function fileLoader() {
     return {
@@ -48,6 +47,22 @@ function urlLoader(options) {
         loader.query.mimetype = options.mimetype;
     }
     return loader;
+}
+
+function _coverageConfig() {
+    try {
+        var istanbulPlugin = require.resolve('babel-plugin-istanbul');
+        return {
+            plugins: [[
+                istanbulPlugin, {
+                    exclude: ['**/*.pug', '**/*.jade', 'node_modules/**/*']
+                }
+            ]]
+        };
+    } catch (e) {
+        // We won't have the istanbul plugin installed in a prod env.
+        return {};
+    }
 }
 
 var loaderPaths = [/clients\/web\/src/];
@@ -83,13 +98,7 @@ module.exports = {
                 query: {
                     presets: [es2015Preset],
                     env: {
-                        cover: {
-                            plugins: [[
-                                istanbulPlugin, {
-                                    exclude: ['**/*.pug', '**/*.jade', 'node_modules/**/*']
-                                }
-                            ]]
-                        }
+                        cover: _coverageConfig()
                     }
                 }
             },

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "webpack-dev-server": "^2.1.0-beta.0"
   },
   "scripts": {
+    "postinstall": "node scripts/postNpmInstall.js",
     "build": "grunt init && NODE_PATH=$PWD/node_modules grunt",
     "watch": "NODE_PATH=$PWD/node_modules grunt --watch",
     "lint": "eslint --cache clients/web Gruntfile.js grunt_tasks scripts && pug-lint clients/web/src/templates",

--- a/scripts/postNpmInstall.js
+++ b/scripts/postNpmInstall.js
@@ -1,10 +1,13 @@
 // Remove the webpack-dev-server grunt task since we do not use it
+
 var fs = require('fs');
-var path = require('path');
+var taskFile = null;
 
-var taskFile = path.join(__dirname, '..', 'node_modules', 'grunt-webpack', 'tasks', 'webpack-dev-server.js');
+try {
+    taskFile = require.resolve('grunt-webpack/tasks/webpack-dev-server.js');
+} catch(e) {}
 
-if (fs.existsSync(taskFile)) {
+if (taskFile) {
     console.log('Removing unused task file ' + taskFile);
     fs.unlinkSync(taskFile);
 }

--- a/scripts/postNpmInstall.js
+++ b/scripts/postNpmInstall.js
@@ -1,0 +1,10 @@
+// Remove the webpack-dev-server grunt task since we do not use it
+var fs = require('fs');
+var path = require('path');
+
+var taskFile = path.join(__dirname, '..', 'node_modules', 'grunt-webpack', 'tasks', 'webpack-dev-server.js');
+
+if (fs.existsSync(taskFile)) {
+    console.log('Removing unused task file ' + taskFile);
+    fs.unlinkSync(taskFile);
+}

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ class InstallWithOptions(install):
                     os.path.join(dest, 'clients', 'web', 'src', 'assets'))
         self.mergeDir('grunt_tasks', dest)
         self.mergeDir('plugins', dest)
+        self.mergeDir('scripts', dest)
 
 with open('README.rst') as f:
     readme = f.read()

--- a/tests/cases/install_test.py
+++ b/tests/cases/install_test.py
@@ -237,7 +237,7 @@ class InstallTestCase(base.TestCase):
 
         with mock.patch('subprocess.Popen', return_value=ProcMock()) as p:
             install.install_web()
-            self.assertNotIn('--production', p.mock_calls[0][1][0])
+            self.assertIn('--production', p.mock_calls[0][1][0])
 
         with mock.patch('subprocess.Popen', return_value=ProcMock()) as p:
             install.install_web(PluginOpts(dev=True))
@@ -256,7 +256,7 @@ class InstallTestCase(base.TestCase):
 
             self.assertEqual(len(p.mock_calls), 2)
             self.assertEqual(
-                list(p.mock_calls[0][1][0]), ['npm', 'install', '--unsafe-perm'])
+                list(p.mock_calls[0][1][0]), ['npm', 'install', '--unsafe-perm', '--production'])
             self.assertEqual(
                 list(p.mock_calls[1][1][0]),
                 ['npm', 'run', 'build', '--',


### PR DESCRIPTION
This makes it so that we call `npm install --production` within `girder-install web`, skipping the devDependencies section of npm packages.

There is a bit of a hack here; the `grunt-webpack` package unconditionally includes a `webpack-dev-server` task that we never used anyway, and in the prod environment, that package it tries to import does not exist. It didn't break the build, but it did cause an error message to appear, so in order to suppress the inclusion of that task, we now just delete the included task as a postinstall step.