### PR TITLE
Improve log output during web client build

### DIFF
--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -35,6 +35,8 @@ module.exports = function (grunt) {
         return;
     }
 
+    require('colors');
+
     grunt.config.merge({
         default: {
             plugin: {}
@@ -102,7 +104,7 @@ module.exports = function (grunt) {
             config = grunt.file.readYAML(yml);
         }
 
-        console.log(`Configuring plugin ${plugin.magenta} (${cfgFile})`);
+        grunt.log.writeln(`Configuring plugin ${plugin.magenta} (${cfgFile})`);
 
         var doAutoBuild = (
             !_.isObject(config.grunt) ||
@@ -121,10 +123,10 @@ module.exports = function (grunt) {
         var webpackHelperFile = path.resolve(dir, config.webpack && config.webpack.configHelper || 'webpack.helper.js');
         var webpackHelper;
         if (fs.existsSync(webpackHelperFile)) {
-            console.log(`Loading webpack helper from ${webpackHelperFile}`);
+            grunt.log.writeln(`  >> Loading webpack helper from ${webpackHelperFile}`);
             webpackHelper = require(webpackHelperFile);
         } else {
-            console.log('No webpack helper file found.');
+            grunt.verbose.writeln('  >> No webpack helper file found.');
             webpackHelper = function (x) {
                 return x;
             };
@@ -262,8 +264,8 @@ module.exports = function (grunt) {
                 var npmFile = require(path.resolve(dir, config.npm.file));
                 var fields = config.npm.fields || ['devDependencies', 'dependencies', 'optionalDependencies'];
 
-                grunt.log.writeln('Loading NPM dependencies from: ' + config.npm.file);
-                grunt.log.writeln('Using fields: ' + fields.join(', '));
+                grunt.log.writeln('  >> Loading NPM dependencies from: ' + config.npm.file);
+                grunt.log.writeln('  >> Using fields: ' + fields.join(', '));
 
                 fields.forEach(function (field) {
                     _.each(npmFile[field] || {}, function (version, dep) {
@@ -276,9 +278,9 @@ module.exports = function (grunt) {
             // "dependencies" property.
             if (config.npm.dependencies) {
                 if (config.npm.file) {
-                    grunt.log.writeln('Loading additional dependencies');
+                    grunt.log.writeln('  >> Loading additional NPM dependencies');
                 } else {
-                    grunt.log.writeln('Loading dependencies');
+                    grunt.log.writeln('  >> Loading NPM dependencies');
                 }
 
                 _.each(config.npm.dependencies, function (version, dep) {
@@ -287,9 +289,9 @@ module.exports = function (grunt) {
             }
 
             if (config.npm.localNodeModules) {
-                grunt.log.writeln('Installing dependencies to dedicated directory: node_modules_' + plugin);
+                grunt.log.writeln(`  >> Installing NPM dependencies to dedicated directory: node_modules_${plugin}`);
             } else {
-                grunt.log.writeln('Installing dependencies to Girder node_modules directory');
+                grunt.verbose.writeln('  >> Installing NPM dependencies to Girder node_modules directory');
             }
 
             // Invoke the npm installation task.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "event-source": "0.1.1",
     "extract-text-webpack-plugin": "^2.0.0-beta.2",
     "file-loader": "^0.x",
-    "grunt": "~0.4.5",
+    "grunt": "^1.0.1",
     "grunt-cli": "~0.1",
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-stylus": "~0.22.0",


### PR DESCRIPTION
@ronichoudhury PTAL, this makes some minor changes to the log messages you added in your recent branch related to plugin building. These changes were made to improve the visualization of the log output when configuring plugins for building.

* For the new config options, output will only appear if you select a non-default option. If you turn on verbose mode, you will get all the messages as before.
* Status messages about plugin config options are now indented with a leading " >>" to make it visually apparent which plugin config they pertain to.