### PR TITLE
Cannot modify plugin globals via static imports

### DIFF
--- a/plugins/worker/web_client/JobStatus.js
+++ b/plugins/worker/web_client/JobStatus.js
@@ -1,3 +1,6 @@
+// Since plugins are not dynamically linked against other plugin libraries,
+// we have to modify the runtime global JobStatus, rather than importing it
+// here statically, which would only modify a local copy.
 girder.plugins.jobs.JobStatus.registerStatus({
     WORKER_FETCHING_INPUT: {
         value: 820,

--- a/plugins/worker/web_client/JobStatus.js
+++ b/plugins/worker/web_client/JobStatus.js
@@ -1,6 +1,4 @@
-import JobStatus from 'girder_plugins/jobs/JobStatus';
-
-JobStatus.registerStatus({
+girder.plugins.jobs.JobStatus.registerStatus({
     WORKER_FETCHING_INPUT: {
         value: 820,
         text: 'Fetching input',

--- a/plugins/worker/web_client/main.js
+++ b/plugins/worker/web_client/main.js
@@ -1,5 +1,3 @@
 import './routes';
-import './stylesheets/jobDetailsWidget.styl'; // unclear what it is really used for
-
-// Extends and overrides API
+import './stylesheets/jobDetailsWidget.styl';
 import './JobStatus';


### PR DESCRIPTION
This is the issue I referred to in #1703.

The problem is, when statically importing symbols from one plugin to another, at runtime these objects are copies, not the same global object. The point of this line in the worker plugin is to modify a shared object (JobStatus), whereas it was only modifying its own copy, which broke the job rendering page.

I'm not sure of the best pattern to address cases like these where we want to mutate some global state in an upstream plugin, but we can't do it via static imports. My attempts to make plugins generate their own DLLs and link against one another didn't yield great results, and seemed to be leading to a nightmare of engineering maintenance.