### PR TITLE
Filter results by flags

### DIFF
--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -1264,9 +1264,8 @@ class AccessControlledModel(Model):
                                   removeKeys=(), flags=None):
         """
         Given a database result cursor, this generator will yield only the
-        results that the user has the given level of access on, respecting the
-        limit and offset specified. It can also only yield results for which the
-        user has certain access flags.
+        results that the user has the given level of access and specified access flags on,
+        respecting the limit and offset specified.
 
         :param cursor: The database cursor object from "find()".
         :param user: The user to check policies against.
@@ -1281,6 +1280,7 @@ class AccessControlledModel(Model):
                            matching document.
         :type removeKeys: list
         :param flags: A flag or set of flags to test.
+        :type flags: flag identifier, or a list/set/tuple of them
         """
         if flags:
             def hasAccess(doc):

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -1280,6 +1280,7 @@ class AccessControlledModel(Model):
         :param removeKeys: List of keys that should be removed from each
                            matching document.
         :type removeKeys: list
+        :param flags: A flag or set of flags to test.
         """
         if flags:
             def hasAccess(doc):

--- a/girder/utility/acl_mixin.py
+++ b/girder/utility/acl_mixin.py
@@ -119,7 +119,7 @@ class AccessControlMixin(object):
         return self.model(self.resourceColl).requireAccessFlags(resource, user, flags)
 
     def filterResultsByPermission(self, cursor, user, level, limit, offset,
-                                  removeKeys=()):
+                                  removeKeys=(), flags=None):
         """
         Yields filtered results from the cursor based on the access control
         existing for the resourceParent.
@@ -139,13 +139,16 @@ class AccessControlMixin(object):
 
             # if the resourceId is not cached, check for permission "level"
             # and set the cache
-            resource = self.model(self.resourceColl).load(resourceId,
-                                                          force=True)
-            resourceAccessCache[resourceId] = \
-                self.model(self.resourceColl).hasAccess(
-                    resource, user=user, level=level)
+            resource = self.model(self.resourceColl).load(resourceId, force=True)
+            val = self.model(self.resourceColl).hasAccess(
+                resource, user=user, level=level)
 
-            return resourceAccessCache[resourceId]
+            if flags:
+                val = val and self.model(self.resourceColl).hasAccessFlags(
+                    resource, user=user, flags=flags)
+
+            resourceAccessCache[resourceId] = val
+            return val
 
         endIndex = offset + limit if limit else None
         filteredCursor = six.moves.filter(hasAccess, cursor)

--- a/girder/utility/acl_mixin.py
+++ b/girder/utility/acl_mixin.py
@@ -118,7 +118,7 @@ class AccessControlMixin(object):
         resource = self.model(self.resourceColl).load(doc[self.resourceParent], force=True)
         return self.model(self.resourceColl).requireAccessFlags(resource, user, flags)
 
-    def filterResultsByPermission(self, cursor, user, level, limit, offset,
+    def filterResultsByPermission(self, cursor, user, level, limit=0, offset=0,
                                   removeKeys=(), flags=None):
         """
         Yields filtered results from the cursor based on the access control

--- a/tests/cases/system_test.py
+++ b/tests/cases/system_test.py
@@ -642,3 +642,19 @@ class SystemTestCase(base.TestCase):
 
         # Testing with flags=None should give sensible behavior
         folderModel.requireAccessFlags(folder, user=None, flags=None)
+
+        # Test filtering results by access flags (both ACModel and AclMixin)
+        for model, doc in ((folderModel, folder), (itemModel, item)):
+            cursor = model.find({})
+            self.assertGreater(len(list(cursor)), 0)
+
+            cursor = model.find({})
+            filtered = list(model.filterResultsByPermission(
+                cursor, user=None, level=AccessType.READ, flags='my_key'))
+            self.assertEqual(len(filtered), 0)
+
+            cursor = model.find({})
+            filtered = list(model.filterResultsByPermission(
+                cursor, user=self.users[1], level=AccessType.READ, flags=('my_key', 'admin_flag')))
+            self.assertEqual(len(filtered), 1)
+            self.assertEqual(filtered[0]['_id'], doc['_id'])


### PR DESCRIPTION
@mgrauer you should probably be the one to QA this since you QA'd the original permission flags work. This fills in a gap in our access flag functionality, namely within `filterResultsByPermission`.