### PR TITLE
Support building web client plugins that are symlinked into plugins dir

### DIFF
--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -205,7 +205,18 @@ module.exports = function (grunt) {
                 for (var i = 0; i < numLoaders; i++) {
                     var selector = 'webpack.options.module.loaders.' + i + '.include';
                     var loaders = grunt.config.get(selector);
-                    grunt.config.set(selector, loaders.concat([path.resolve(dir)]));
+                    var pluginPath = path.resolve(dir);
+                    var realPath = fs.realpathSync(dir);
+                    var loaderIncludes = [pluginPath];
+
+                    // We add the plugin path to the include list for the loaders, and also
+                    // add the realpath (i.e. following symlinks) to workaround an issue where
+                    // webpack doesn't resolve symlinked include directories correctly.
+                    if (realPath !== pluginPath) {
+                        loaderIncludes.push(realPath);
+                    }
+
+                    grunt.config.set(selector, loaders.concat(loaderIncludes));
                 }
             }
 


### PR DESCRIPTION
@ronichoudhury PTAL. This fixes the issue where certain plugins failed to build if they were symlinked into the directory, namely those that want to modify the core girder web client using the standard girder webpack loaders, i.e. they have no custom webpack configuration.