### PR TITLE
Support multiple bundles in the same plugin using config option

### DIFF
--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -508,6 +508,25 @@ above, the value of this property is ``web_client/main.js``):
         }
     }
 
+You may also set ``main`` to an object that maps bundle names to entry points, which is
+helpful for plugins that want to build multiple targets using the same loaders. For example:
+
+.. code-block:: json
+
+    {
+        "name": "MY_PLUGIN",
+        "webpack": {
+            "main": {
+                "plugin": "web_client/main.js",
+                "external": "web_external/main.js"
+            }
+        }
+    }
+
+That will cause both ``plugin.min.*`` and ``external.min.*`` files to appear in the
+built directory. The file paths of the entry points should be specified relative to the
+plugin directory.
+
 Customizing the Webpack Build
 *****************************
 
@@ -523,6 +542,8 @@ to build your plugin.
 The hash passed to the helper function contains the following information:
 
 - ``plugin``: the name of the plugin
+- ``output``: the name of the output bundle, which is "plugin" by default.
+- ``main``: the full path to the entry point file for the bundle.
 - ``pluginEntry``: the webpack entry point for the plugin (e.g.
   ``plugins/MY_PLUGIN/plugin``)
 - ``pluginDir``: the full path to the plugin directory

--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -721,6 +721,9 @@ value. One reasonable choice is ``index``. These plugins can be used to create
 wholly independent web clients that don't explicitly depend on the core Girder
 client being loaded.
 
+.. note:: If you use an object to specify an output to entry point mapping in ``webpack.main``,
+          the ``webpack.output`` value will be ignored if specified.
+
 Executing custom Grunt build steps for your plugin
 **************************************************
 

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -137,25 +137,50 @@ module.exports = function (grunt) {
         // the user can control whether this is a "Girder client extension" or
         // just a standalone web client.
         var output = config.webpack && config.webpack.output || 'plugin';
-        var pluginEntry =  `plugins/${plugin}/${output}`;
 
         var pluginNodeDir = path.resolve(process.cwd(), 'node_modules_' + plugin, 'node_modules');
-        var helperConfig = {
-            plugin: plugin,
-            pluginEntry: pluginEntry,
-            pluginDir: dir,
-            nodeDir: pluginNodeDir
-        };
 
         // Add webpack target and name resolution for this plugin if
         // web_client/main.js (or user-specified name) exists.
         var webClient = path.resolve(dir + '/web_client');
-        var main = config.webpack && config.webpack.main && path.resolve(dir, config.webpack.main) || webClient + '/main.js';
+        var mains = config.webpack && config.webpack.main || {};
 
-        if (fs.existsSync(main)) {
+        if (_.isString(mains)) {
+            // If main was specified as a string, use "plugin" as the target name.
+            mains = {
+                plugin: mains
+            };
+        } else if (_.isEmpty(mains)) {
+            // By default, use web_client/main.js if it exists.
+            var mainJs = path.join(webClient, 'main.js');
+
+            if (fs.existsSync(mainJs)) {
+                mains = {
+                    plugin: mainJs
+                };
+            }
+        };
+
+        _.each(mains, (main, output) => {
+            if (!path.isAbsolute(main)) {
+                main = path.join(dir, main)
+            }
+            if (!fs.existsSync(main)) {
+                throw `Entry point file ${main} not found.`;
+            }
+
+            var helperConfig = {
+                plugin,
+                output,
+                main,
+                pluginEntry: `plugins/${plugin}/${output}`,
+                pluginDir: dir,
+                nodeDir: pluginNodeDir
+            };
+
             grunt.config.merge({
                 webpack: {
-                    [`plugin_${plugin}`]: {
+                    [`${output}_${plugin}`]: {
                         entry: {
                             [helperConfig.pluginEntry]: [main]
                         },
@@ -190,7 +215,7 @@ module.exports = function (grunt) {
 
             grunt.config.merge({
                 default: {
-                    [`webpack:plugin_${plugin}`]: {
+                    [`webpack:${output}_${plugin}`]: {
                         dependencies: ['build'] // plugin builds must run after core build
                     }
                 }
@@ -222,7 +247,7 @@ module.exports = function (grunt) {
 
             var newConfig = webpackHelper(grunt.config.get('webpack.options'), helperConfig);
             grunt.config.set('webpack.options', newConfig);
-        }
+        });
 
         grunt.registerTask('npm-install', 'Install plugin NPM dependencies', function (plugin, localNodeModules) {
             // Start building the list of arguments to the NPM executable.

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -146,9 +146,9 @@ module.exports = function (grunt) {
         var mains = config.webpack && config.webpack.main || {};
 
         if (_.isString(mains)) {
-            // If main was specified as a string, use "plugin" as the target name.
+            // If main was specified as a string, convert to an object
             mains = {
-                plugin: mains
+                [output]: mains
             };
         } else if (_.isEmpty(mains)) {
             // By default, use web_client/main.js if it exists.
@@ -156,17 +156,17 @@ module.exports = function (grunt) {
 
             if (fs.existsSync(mainJs)) {
                 mains = {
-                    plugin: mainJs
+                    [output]: mainJs
                 };
             }
-        };
+        }
 
         _.each(mains, (main, output) => {
             if (!path.isAbsolute(main)) {
-                main = path.join(dir, main)
+                main = path.join(dir, main);
             }
             if (!fs.existsSync(main)) {
-                throw `Entry point file ${main} not found.`;
+                throw new Error(`Entry point file ${main} not found.`);
             }
 
             var helperConfig = {

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -366,7 +366,7 @@ module.exports = function (grunt) {
     if (buildAll) {
         // Glob for plugins and configure each one to be built
         grunt.file.expand(grunt.config.get('pluginDir') + '/*').forEach(function (dir) {
-            configurePluginForBuilding(dir);
+            configurePluginForBuilding(path.resolve(dir));
         });
     } else {
         // Build only the plugins that were requested via --plugins


### PR DESCRIPTION
@ronichoudhury PTAL, this addresses the issue we discussed this morning. I tested this on COVALIC and it works.

Generally speaking, this supports cases like COVALIC where a plugin needs to build both a plugin.min.* to augment the main girder app, as well as its own custom front-end that uses the same loaders.