### PR TITLE
Missing _ import in dialog.js

### DIFF
--- a/clients/web/src/dialog.js
+++ b/clients/web/src/dialog.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import _ from 'underscore';
 import Backbone from 'backbone';
 
 import router from 'girder/router';

--- a/clients/web/src/views/layout/LoginView.js
+++ b/clients/web/src/views/layout/LoginView.js
@@ -1,3 +1,4 @@
+import _ from 'underscore';
 import View from 'girder/views/View';
 import events from 'girder/events';
 import { handleClose, handleOpen } from 'girder/dialog';

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "babel-plugin-istanbul": "^2.0.1",
     "eslint": "^3.3.1",
-    "eslint-config-girder": "^1.0.0",
+    "eslint-config-girder": "^2.0.0",
     "eslint-config-semistandard": "^6.0.2",
     "eslint-config-standard": "^5.3.5",
     "eslint-plugin-backbone": "^2.0.2",


### PR DESCRIPTION
This isn't a problem for the main girder app since `window._` is set there. However, for other apps that link against `girder_lib`, it's problematic if _ is not in global scope.