### PR TITLE
Fix girder-client python doc build on RTD

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,7 @@ class Mock(object):
         else:
             return Mock()
 
-MOCK_MODULES = ['bcrypt']
+MOCK_MODULES = ['bcrypt', 'diskcache']
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = Mock()
 


### PR DESCRIPTION
This had broken silently because the setup.py install of
girder_client is not run, and the build process tried to
import diskcache via girder_client.