### PR TITLE
Move local node_modules under main node_modules dir

### DIFF
--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -84,6 +84,10 @@ module.exports = function (grunt) {
         grunt.config.merge(cfg);
     };
 
+    var getPluginLocalNodePath = function (plugin) {
+        return path.resolve(path.join('node_modules', `girder_plugin_${plugin}`));
+    };
+
     var configurePluginForBuilding = function (dir) {
         var plugin = path.basename(dir);
         var json = path.resolve(dir, 'plugin.json');
@@ -138,7 +142,7 @@ module.exports = function (grunt) {
         // just a standalone web client.
         var output = config.webpack && config.webpack.output || 'plugin';
 
-        var pluginNodeDir = path.resolve(process.cwd(), 'node_modules_' + plugin, 'node_modules');
+        var pluginNodeDir = path.join(getPluginLocalNodePath(plugin), 'node_modules');
 
         // Add webpack target and name resolution for this plugin if
         // web_client/main.js (or user-specified name) exists.
@@ -258,7 +262,7 @@ module.exports = function (grunt) {
             // If the plugin requested to install the dependencies in its own
             // dedicated directory, set the prefix option.
             if (localNodeModules === 'true') {
-                args = args.concat(['--prefix', path.resolve('node_modules_' + plugin)]);
+                args = args.concat(['--prefix', getPluginLocalNodePath(plugin)]);
             }
 
             // Get the list of the packages to install and append them to the


### PR DESCRIPTION
This moves the local node_modules under the main node_modules dir. This has the advantage of allowing the search path to be visible via relative paths at config time, and also makes these directories automatically gitignored.