### PR TITLE
Implement an "npm install" option for Webpack-built plugins

### DIFF
--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -729,6 +729,18 @@ Each type needs to be installed differently due to how node manages external pac
   isolated. By default, the ``localNodeModules`` is set to ``false`` and the
   dependencies will be installed to Girder's own ``node_modules`` directory.
 
+  The final alternative for Webpack-built plugins is to set the ``npm.install``
+  configuration property to ``true``; this will cause the build system to run
+  ``npm install`` in the plugin directory. This may have certain benefits for
+  plugin development, such as allowing plugin sources to import modules without
+  the alias prefix as described above (though, this alias would still be
+  available for use by other plugins that want to access your plugin's
+  dependencies). Additionally, if your plugin is installed without using
+  symlinks, then you will still have access to Girder's Node dependencies (see
+  this [GitHub conversation](https://github.com/nodejs/node/issues/3402) for a
+  discussion of why symlinked directories will not allow for the usual Node
+  import semantics).
+
   If instead you are using a custom Grunt build with a Gruntfile, the
   dependencies should be installed into your plugin's **node_modules** directory
   by providing a `package.json <https://docs.npmjs.com/files/package.json>`_

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -274,6 +274,17 @@ module.exports = function (grunt) {
         });
 
         grunt.registerTask('npm-install', 'Install plugin NPM dependencies', function (plugin, localNodeModules) {
+            if (localNodeModules === 'install') {
+                var args = ['--color=always', 'install'];
+
+                var child = child_process.spawnSync('npm', args, {
+                    cwd: path.resolve(dir),
+                    stdio: 'inherit'
+                });
+
+                return child.status === 0;
+            }
+
             // Start building the list of arguments to the NPM executable.
             //
             // We want color output embedded in the Grunt output.
@@ -299,6 +310,11 @@ module.exports = function (grunt) {
         });
 
         function addDependencies(deps, localNodeModules) {
+            if (arguments.length === 0) {
+              grunt.config.set('default.npm-install:' + plugin + ':install', {});
+              return;
+            }
+
             // install any additional npm packages during init
             var npm = (
                 _(deps || {})
@@ -315,7 +331,10 @@ module.exports = function (grunt) {
             }
         }
 
-        if (config.npm) {
+        if (config.npm && config.npm.install) {
+            grunt.log.writeln('  >> Installing NPM dependencies in-place from: ' + path.resolve(dir, 'package.json'));
+            addDependencies();
+        } else if (config.npm) {
             var modules = {};
 
             // If the config contains a "file" section, load NPM dependencies

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -274,10 +274,11 @@ module.exports = function (grunt) {
         });
 
         grunt.registerTask('npm-install', 'Install plugin NPM dependencies', function (plugin, localNodeModules) {
+            var args, child;
             if (localNodeModules === 'install') {
-                var args = ['--color=always', 'install'];
+                args = ['--color=always', 'install'];
 
-                var child = child_process.spawnSync('npm', args, {
+                child = child_process.spawnSync('npm', args, {
                     cwd: path.resolve(dir),
                     stdio: 'inherit'
                 });
@@ -288,7 +289,7 @@ module.exports = function (grunt) {
             // Start building the list of arguments to the NPM executable.
             //
             // We want color output embedded in the Grunt output.
-            var args = ['--color=always'];
+            args = ['--color=always'];
 
             // If the plugin requested to install the dependencies in its own
             // dedicated directory, set the prefix option.
@@ -302,7 +303,7 @@ module.exports = function (grunt) {
             args = args.concat(['install'], modules);
 
             // Launch the child process.
-            var child = child_process.spawnSync('npm', args, {
+            child = child_process.spawnSync('npm', args, {
                 stdio: 'inherit'
             });
 
@@ -311,8 +312,8 @@ module.exports = function (grunt) {
 
         function addDependencies(deps, localNodeModules) {
             if (arguments.length === 0) {
-              grunt.config.set('default.npm-install:' + plugin + ':install', {});
-              return;
+                grunt.config.set('default.npm-install:' + plugin + ':install', {});
+                return;
             }
 
             // install any additional npm packages during init


### PR DESCRIPTION
The idea is to let the Webpack build process install the plugin's dependencies in its own directory, via an ordinary `npm install` invocation (much the same as what is already recommended for Gruntfile-built plugins).

I believe this approach may be strictly superior to the `node_modules_<plugin>` approach previously implemented:
- It uses no non-standard directories, and does only standard-looking things
- It eliminates the in-plugin need to use a bulky node alias (e.g. `import foo from girder_plugins/plugin/node/foo')
    - (the build process still supplies the alias, so sibling plugins will be able to gain access to the plugin's sources and dependencies as needed)
- It enables "dependency cascading" or whatever the correct term is (i.e., the plugin can invoke its own dependencies, but also have access to Girder's by invoking them in the same form)

The one downside: symlinking directories into a Node-built project doesn't work the way Unix programmers might expect. For my own use case I bit the bullet and decided to only support the non-symlink mode of plugin installation. If Node ever fixes this problem in a principled way, this downside will disappear.

Depends on #1720 to prevent Girder loaders from being applied to sources in plugin's `node_modules` directory.