### PR TITLE
Support using girderEnable on elements other than <input>

### DIFF
--- a/clients/web/src/utilities/jquery/girderEnable.js
+++ b/clients/web/src/utilities/jquery/girderEnable.js
@@ -9,11 +9,11 @@ $.fn.girderEnable = function (enable) {
     var selection = $(this);
     if (selection.is(':input')) {
         selection.prop('disabled', !enable);
-        if (!enable) {
-            selection.addClass('disabled');
-        } else {
-            selection.removeClass('disabled');
-        }
+    }
+    if (!enable) {
+        selection.addClass('disabled');
+    } else {
+        selection.removeClass('disabled');
     }
     return this;
 };

--- a/clients/web/src/views/widgets/EditApiKeyWidget.js
+++ b/clients/web/src/views/widgets/EditApiKeyWidget.js
@@ -36,7 +36,7 @@ var EditApiKeyWidget = View.extend({
             this.$('.g-validation-failed-message').text('');
         },
 
-        'change .g-scope-selection-container .radio input': function (e) {
+        'change .g-scope-selection-container .radio input': function () {
             var mode = this._getSelectedScopeMode();
             if (mode === 'full') {
                 this.$('.g-custom-scope-checkbox').girderEnable(false)
@@ -82,7 +82,7 @@ var EditApiKeyWidget = View.extend({
                 this.$('#g-api-key-name').val(this.model.get('name'));
                 this.$('#g-api-key-token-duration').val(this.model.get('tokenDuration') || '');
                 if (this.model.get('scope')) {
-                    this.$('#g-scope-mode-custom').attr('checked', 'checked');
+                    this.$('#g-scope-mode-custom').attr('checked', 'checked').trigger('change');
                     this.$('.g-custom-scope-checkbox').girderEnable(true);
                     _.each(this.model.get('scope'), function (scope) {
                         this.$('.g-custom-scope-checkbox[value="' + scope + '"]').attr('checked', 'checked');


### PR DESCRIPTION
I noticed this bug in our API key create/edit dialog. The text was not being shown as enabled when switching to specific-scope mode. This fixes that issue, and more generally, allows `girderEnable` to be used on elements other than input tags.