### PR TITLE
Make webpack file loader work for plugin bundles

### DIFF
--- a/grunt_tasks/build.js
+++ b/grunt_tasks/build.js
@@ -19,6 +19,7 @@ var _ = require('underscore');
 var noptFix = require('nopt-grunt-fix');
 
 var webpack = require('webpack');
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var webpackGlobalConfig = require('./webpack.config.js');
 var paths = require('./webpack.paths.js');
 var customWebpackPlugins = require('./webpack.plugins.js');
@@ -109,6 +110,10 @@ module.exports = function (grunt) {
                     new webpack.DllPlugin({
                         path: path.join(paths.web_built, '[name]-manifest.json'),
                         name: '[name]'
+                    }),
+                    new ExtractTextPlugin({
+                        filename: '[name].min.css',
+                        allChunks: true
                     })
                 ]
             },
@@ -120,6 +125,10 @@ module.exports = function (grunt) {
                     new customWebpackPlugins.DllReferenceByPathPlugin({
                         context: '.',
                         manifest: path.join(paths.web_built, 'girder_lib-manifest.json')
+                    }),
+                    new ExtractTextPlugin({
+                        filename: '[name].min.css',
+                        allChunks: true
                     })
                 ]
             }

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -23,6 +23,7 @@ module.exports = function (grunt) {
     var path = require('path');
     var child_process = require('child_process'); // eslint-disable-line camelcase
 
+    var ExtractTextPlugin = require('extract-text-webpack-plugin');
     var customWebpackPlugins = require('./webpack.plugins.js');
     var paths = require('./webpack.paths.js');
 
@@ -188,10 +189,18 @@ module.exports = function (grunt) {
                         entry: {
                             [helperConfig.pluginEntry]: [main]
                         },
+                        output: {
+                            path: path.join(paths.web_built, 'plugins', plugin),
+                            filename: `${output}.min.js`
+                        },
                         plugins: [
                             new customWebpackPlugins.DllReferenceByPathPlugin({
                                 context: '.',
                                 manifest: path.join(paths.web_built, 'girder_lib-manifest.json')
+                            }),
+                            new ExtractTextPlugin({
+                                filename: `${output}.min.css`,
+                                allChunks: true
                             })
                         ]
                     },

--- a/grunt_tasks/webpack.config.js
+++ b/grunt_tasks/webpack.config.js
@@ -81,11 +81,6 @@ module.exports = {
             jQuery: 'jquery',
             $: 'jquery',
             'window.jQuery': 'jquery'
-        }),
-        new ExtractTextPlugin({
-            filename: '[name].min.css',
-            allChunks: true,
-            disable: false
         })
     ],
     module: {


### PR DESCRIPTION
Prior to this change, plugins that made use of webpack's file loader had their files written into `clients/web/static/built/assets`, but their plugin was written to `clients/web/static/built/plugins/plugin_name/plugin.min.*`, and webpack assumed that they were located in the same directory when generating the relative paths. This made it so none of these static assets (i.e. images) actually loaded into the page. I think this stems from the fact that using a bundle target name that contains slashes relies on seemingly undefined behavior.

The fix for this is to specify a different output path and filename for the plugin bundles rather than relying on the global config option. The same thing was done for the ExtractTextPlugin that is used to generate the CSS files.

@jbeezley I noticed this happening in the colorpicker widget in slicer_cli_web.