### PR TITLE
[WIP] Dynamic linking between plugin bundles

### DIFF
--- a/girder/utility/webroot.mako
+++ b/girder/utility/webroot.mako
@@ -8,6 +8,9 @@
     <link rel="stylesheet" href="${staticRoot}/built/fontello/css/animation.css">
     <link rel="stylesheet" href="${staticRoot}/built/girder_lib.min.css">
     <link rel="icon" type="image/png" href="${staticRoot}/img/Girder_Favicon.png">
+    % for plugin in pluginLibCss:
+    <link rel="stylesheet" href="${staticRoot}/built/plugins/${plugin}/plugin_lib.min.css">
+    % endfor
     % for plugin in pluginCss:
     <link rel="stylesheet" href="${staticRoot}/built/plugins/${plugin}/plugin.min.css">
     % endfor
@@ -27,6 +30,9 @@
             girder.events.trigger('g:appload.after');
         });
     </script>
+    % for plugin in pluginLibJs:
+    <script src="${staticRoot}/built/plugins/${plugin}/plugin_lib.min.js"></script>
+    % endfor
     % for plugin in pluginJs:
     <script src="${staticRoot}/built/plugins/${plugin}/plugin.min.js"></script>
     % endfor

--- a/girder/utility/webroot.mako
+++ b/girder/utility/webroot.mako
@@ -8,9 +8,6 @@
     <link rel="stylesheet" href="${staticRoot}/built/fontello/css/animation.css">
     <link rel="stylesheet" href="${staticRoot}/built/girder_lib.min.css">
     <link rel="icon" type="image/png" href="${staticRoot}/img/Girder_Favicon.png">
-    % for plugin in pluginLibCss:
-    <link rel="stylesheet" href="${staticRoot}/built/plugins/${plugin}/plugin_lib.min.css">
-    % endfor
     % for plugin in pluginCss:
     <link rel="stylesheet" href="${staticRoot}/built/plugins/${plugin}/plugin.min.css">
     % endfor
@@ -30,9 +27,6 @@
             girder.events.trigger('g:appload.after');
         });
     </script>
-    % for plugin in pluginLibJs:
-    <script src="${staticRoot}/built/plugins/${plugin}/plugin_lib.min.js"></script>
-    % endfor
     % for plugin in pluginJs:
     <script src="${staticRoot}/built/plugins/${plugin}/plugin.min.js"></script>
     % endfor

--- a/girder/utility/webroot.py
+++ b/girder/utility/webroot.py
@@ -22,6 +22,7 @@ import mako
 import os
 
 from girder import constants
+from girder.utility import config
 
 
 class WebrootBase(object):
@@ -41,6 +42,7 @@ class WebrootBase(object):
         self.indexHtml = None
 
         self.vars = {}
+        self.config = config.getConfig()
 
     def updateHtmlVars(self, vars):
         """
@@ -54,7 +56,7 @@ class WebrootBase(object):
         return mako.template.Template(self.template).render(**self.vars)
 
     def GET(self, **params):
-        if self.indexHtml is None:
+        if self.indexHtml is None or self.config['server']['mode'] == 'development':
             self.indexHtml = self._renderHTML()
 
         return self.indexHtml
@@ -92,18 +94,11 @@ class Webroot(WebrootBase):
     def _renderHTML(self):
         self.vars['pluginCss'] = []
         self.vars['pluginJs'] = []
-        self.vars['pluginLibJs'] = []
-        self.vars['pluginLibCss'] = []
-
         builtDir = os.path.join(constants.STATIC_ROOT_DIR, 'clients', 'web',
                                 'static', 'built', 'plugins')
         for plugin in self.vars['plugins']:
-            if os.path.exists(os.path.join(builtDir, plugin, 'plugin_lib.min.css')):
-                self.vars['pluginLibCss'].append(plugin)
             if os.path.exists(os.path.join(builtDir, plugin, 'plugin.min.css')):
                 self.vars['pluginCss'].append(plugin)
-            if os.path.exists(os.path.join(builtDir, plugin, 'plugin_lib.min.js')):
-                self.vars['pluginLibJs'].append(plugin)
             if os.path.exists(os.path.join(builtDir, plugin, 'plugin.min.js')):
                 self.vars['pluginJs'].append(plugin)
 

--- a/girder/utility/webroot.py
+++ b/girder/utility/webroot.py
@@ -92,11 +92,18 @@ class Webroot(WebrootBase):
     def _renderHTML(self):
         self.vars['pluginCss'] = []
         self.vars['pluginJs'] = []
+        self.vars['pluginLibJs'] = []
+        self.vars['pluginLibCss'] = []
+
         builtDir = os.path.join(constants.STATIC_ROOT_DIR, 'clients', 'web',
                                 'static', 'built', 'plugins')
         for plugin in self.vars['plugins']:
+            if os.path.exists(os.path.join(builtDir, plugin, 'plugin_lib.min.css')):
+                self.vars['pluginLibCss'].append(plugin)
             if os.path.exists(os.path.join(builtDir, plugin, 'plugin.min.css')):
                 self.vars['pluginCss'].append(plugin)
+            if os.path.exists(os.path.join(builtDir, plugin, 'plugin_lib.min.js')):
+                self.vars['pluginLibJs'].append(plugin)
             if os.path.exists(os.path.join(builtDir, plugin, 'plugin.min.js')):
                 self.vars['pluginJs'].append(plugin)
 

--- a/grunt_tasks/build.js
+++ b/grunt_tasks/build.js
@@ -103,7 +103,6 @@ module.exports = function (grunt) {
                 },
                 output: {
                     library: '[name]'
-
                 },
                 plugins: [
                     // Remove this if it turns out we don't want to use it for every bundle target.

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -22,6 +22,7 @@ module.exports = function (grunt) {
     var fs = require('fs');
     var path = require('path');
     var child_process = require('child_process'); // eslint-disable-line camelcase
+    var webpack = require('webpack');
 
     var ExtractTextPlugin = require('extract-text-webpack-plugin');
     var customWebpackPlugins = require('./webpack.plugins.js');
@@ -142,13 +143,140 @@ module.exports = function (grunt) {
         // the user can control whether this is a "Girder client extension" or
         // just a standalone web client.
         var output = config.webpack && config.webpack.output || 'plugin';
-
+        var dllPlugins = config.webpack && config.webpack.dllPlugins || [];
         var pluginNodeDir = path.join(getPluginLocalNodePath(plugin), 'node_modules');
 
         // Add webpack target and name resolution for this plugin if
         // web_client/main.js (or user-specified name) exists.
         var webClient = path.resolve(dir + '/web_client');
         var mains = config.webpack && config.webpack.main || {};
+        var libs = config.webpack && config.webpack.libs || {};
+
+        if (_.isString(libs)) {
+            // If main was specified as a string, convert to an object
+            libs = {
+                [output]: libs
+            };
+        } else if (_.isEmpty(libs)) {
+            // By default, use web_client/index.js if it exists.
+            var libJs = path.join(webClient, 'index.js');
+
+            if (fs.existsSync(libJs)) {
+                libs = {
+                    [output]: libJs
+                };
+            }
+        }
+
+        _.each(libs, (lib, output) => {
+            output = `${output}_lib`;
+
+            if (!path.isAbsolute(lib)) {
+                lib = path.join(dir, lib);
+            }
+            if (!fs.existsSync(lib)) {
+                throw new Error(`Library entry point file ${lib} not found.`);
+            }
+
+            var helperConfig = {
+                plugin,
+                output,
+                main: lib,
+                pluginEntry: `plugins/${plugin}/${output}`,
+                pluginDir: dir,
+                nodeDir: pluginNodeDir
+            };
+
+            var dllReferencePlugins = dllPlugins.map(function () {
+                return new customWebpackPlugins.DllReferenceByPathPlugin({
+                    context: '.',
+                    manifest: path.join(paths.web_built, 'plugins', plugin, 'plugin_lib-manifest.json')
+                });
+            });
+
+            grunt.config.merge({
+                webpack: {
+                    [`${output}_${plugin}`]: {
+                        entry: {
+                            [helperConfig.pluginEntry]: [lib]
+                        },
+                        output: {
+                            library: `girder_${output}_${plugin}`,
+                            path: path.join(paths.web_built, 'plugins', plugin),
+                            filename: `${output}.min.js`
+                        },
+                        plugins: dllReferencePlugins.concat([
+                            new customWebpackPlugins.DllReferenceByPathPlugin({
+                                context: '.',
+                                manifest: path.join(paths.web_built, 'girder_lib-manifest.json')
+                            }),
+                            new webpack.DllPlugin({
+                                path: path.join(paths.web_built, 'plugins', plugin, `${output}-manifest.json`),
+                                name: `girder_${output}_${plugin}`
+                            }),
+                            new ExtractTextPlugin({
+                                filename: `${output}.min.css`,
+                                allChunks: true
+                            })
+                        ])
+                    },
+                    options: {
+                        // Add an import alias to the global config for this plugin
+                        resolve: {
+                            alias: {
+                                [`girder_plugins/${plugin}/node`]: pluginNodeDir,
+                                [`girder_plugins/${plugin}`]: webClient
+                            },
+                            modules: [
+                                path.resolve(process.cwd(), 'node_modules'),
+                                pluginNodeDir
+                            ]
+                        },
+                        resolveLoader: {
+                            modules: [
+                                path.resolve(process.cwd(), 'node_modules'),
+                                pluginNodeDir
+                            ]
+                        }
+                    }
+                }
+            });
+
+            grunt.config.merge({
+                default: {
+                    [`webpack:${output}_${plugin}`]: {
+                        dependencies: ['build'] // plugin builds must run after core build
+                    }
+                }
+            });
+
+            // If the plugin config has no webpack section, no defaultLoaders
+            // property in the webpack section, or the defaultLoaders is
+            // explicitly set to anything besides false, then augment the
+            // webpack loader configurations with the plugin source directory.
+            if (!config.webpack || config.webpack.defaultLoaders === undefined || config.webpack.defaultLoaders !== false) {
+                var numLoaders = grunt.config.get('webpack.options.module.loaders').length;
+                for (var i = 0; i < numLoaders; i++) {
+                    var selector = 'webpack.options.module.loaders.' + i + '.include';
+                    var loaders = grunt.config.get(selector) || [];
+                    var pluginPath = path.resolve(dir);
+                    var realPath = fs.realpathSync(dir);
+                    var loaderIncludes = [pluginPath];
+
+                    // We add the plugin path to the include list for the loaders, and also
+                    // add the realpath (i.e. following symlinks) to workaround an issue where
+                    // webpack doesn't resolve symlinked include directories correctly.
+                    if (realPath !== pluginPath) {
+                        loaderIncludes.push(realPath);
+                    }
+
+                    grunt.config.set(selector, loaders.concat(loaderIncludes));
+                }
+            }
+
+            var newConfig = webpackHelper(grunt.config.get('webpack.options'), helperConfig);
+            grunt.config.set('webpack.options', newConfig);
+        });
 
         if (_.isString(mains)) {
             // If main was specified as a string, convert to an object
@@ -183,6 +311,20 @@ module.exports = function (grunt) {
                 nodeDir: pluginNodeDir
             };
 
+            var dllReferencePlugins = dllPlugins.map(function (otherPlugin) {
+                return new customWebpackPlugins.DllReferenceByPathPlugin({
+                    context: '.',
+                    manifest: path.join(paths.web_built, 'plugins', otherPlugin, 'plugin_lib-manifest.json')
+                });
+            });
+
+            if (!_.isEmpty(libs)) {
+                dllReferencePlugins.push(new customWebpackPlugins.DllReferenceByPathPlugin({
+                    context: '.',
+                    manifest: path.join(paths.web_built, 'plugins', plugin, 'plugin_lib-manifest.json')
+                }));
+            }
+
             grunt.config.merge({
                 webpack: {
                     [`${output}_${plugin}`]: {
@@ -193,7 +335,7 @@ module.exports = function (grunt) {
                             path: path.join(paths.web_built, 'plugins', plugin),
                             filename: `${output}.min.js`
                         },
-                        plugins: [
+                        plugins: dllReferencePlugins.concat([
                             new customWebpackPlugins.DllReferenceByPathPlugin({
                                 context: '.',
                                 manifest: path.join(paths.web_built, 'girder_lib-manifest.json')
@@ -202,7 +344,7 @@ module.exports = function (grunt) {
                                 filename: `${output}.min.css`,
                                 allChunks: true
                             })
-                        ]
+                        ])
                     },
                     options: {
                         // Add an import alias to the global config for this plugin

--- a/plugins/jobs/plugin_tests/jobsSpec.js
+++ b/plugins/jobs/plugin_tests/jobsSpec.js
@@ -1,12 +1,11 @@
-/* globals girderTest, describe, expect, it, runs, waitsFor  */
+/* globals girderTest, describe, expect, it, runs, waitsFor, girder, _ */
 
 girderTest.addCoveredScripts([
-    '/clients/web/static/built/plugins/jobs/plugin_lib.min.js',
     '/clients/web/static/built/plugins/jobs/plugin.min.js'
 ]);
 
 girderTest.importStylesheet(
-    '/static/built/plugins/jobs/plugin_lib.min.css'
+    '/static/built/plugins/jobs/plugin.min.css'
 );
 
 girder.events.trigger('g:appload.before');
@@ -51,7 +50,7 @@ $(function () {
                     this.trigger('g:fetched');
                 };
 
-                girder.router.navigate('job/foo', {trigger: true});
+                girder.router.navigate('job/foo', { trigger: true });
                 girder.plugins.jobs.models.JobModel.prototype.fetch = oldFetch;
 
                 expect($('.g-monospace-viewer[property="kwargs"]').length).toBe(0);
@@ -113,7 +112,25 @@ $(function () {
 
     describe('Unit test the job list widget.', function () {
         it('Show a job list widget.', function () {
-            var jobs, rows;
+            var jobs, rows, widget;
+
+            girderTest.createUser(
+                'admin', 'admin@email.com', 'Quota', 'Admin', 'testpassword')();
+
+            runs(function () {
+                widget = new girder.plugins.jobs.views.JobListWidget({
+                    el: $('#g-app-body-container'),
+                    filter: {},
+                    parentView: app,
+                    showGraphs: true,
+                    showFilters: true,
+                    showPageSizeSelector: true
+                }).render();
+
+                expect($('.g-jobs-list-table>tbody>tr').length).toBe(0);
+            });
+
+            girderTest.waitForLoad();
 
             runs(function () {
                 jobs = _.map([1, 2, 3], function (i) {
@@ -127,15 +144,6 @@ $(function () {
                     });
                 });
 
-                var widget = new girder.plugins.jobs.views.JobListWidget({
-                    el: $('#g-app-body-container'),
-                    filter: {},
-                    parentView: app
-                }).render();
-
-                expect($('.g-jobs-list-table>tbody>tr').length).toBe(0);
-
-                // Add the jobs to the collection
                 widget.collection.add(jobs);
             });
 
@@ -163,255 +171,261 @@ $(function () {
 
             // Table row should update automatically
             waitsFor(function () {
-                return $('td.g-job-status-cell', rows[2]).text() === 'Error';
-            });
-        });
-        it('Job list widget filter by status.', function () {
-          var jobs, rows, widget, evt = {};
+                return $($('.g-jobs-list-table>tbody>tr').get(2)).find('td.g-job-status-cell').text() === 'Error';
+            }, 'Third row status change to Error');
 
-          runs(function () {
-              jobs = _.map([1, 2, 3], function (i) {
-                  return new girder.plugins.jobs.models.JobModel({
-                      _id: 'foo' + i,
-                      title: 'My batch job ' + i,
-                      status: i,
-                      updated: '2015-01-12T12:00:0' + i,
-                      created: '2015-01-12T12:00:0' + i,
-                      when: '2015-01-12T12:00:0' + i
-                  });
-              });
-
-              widget = new girder.plugins.jobs.views.JobListWidget({
-                  el: $('#g-app-body-container'),
-                  filter: {},
-                  parentView: app
-              }).render();
-
-              expect($('.g-jobs-list-table>tbody>tr').length).toBe(0);
-
-              // Add the jobs to the collection
-              widget.collection.add(jobs);
-          });
-
-          waitsFor(function () {
-              return $('.g-jobs-list-table>tbody>tr').length === 3;
-          }, 'job list to auto-reload when collection is updated')
-
-          runs(function () {
-              // Make sure we are in reverse chronological order
-              rows = $('.g-jobs-list-table>tbody>tr');
-              expect($(rows[0]).text()).toContain('My batch job 3');
-              expect($(rows[0]).text()).toContain('Success');
-              expect($(rows[1]).text()).toContain('My batch job 2');
-              expect($(rows[1]).text()).toContain('Running');
-              expect($(rows[2]).text()).toContain('My batch job 1');
-              expect($(rows[2]).text()).toContain('Queued');
-
-              // Trigger event to filter out jobs in state 1 and 2
-              evt[girder.plugins.jobs.JobStatus.text(1)] = false
-              evt[girder.plugins.jobs.JobStatus.text(2)] = false
-              evt[girder.plugins.jobs.JobStatus.text(3)] = true
-              widget.filterStatusMenuWidget.trigger('g:triggerCheckBoxMenuChanged', evt);
-          });
-
-          // Table should now only contain jobs in state 3
-          waitsFor(function () {
-              return $('.g-jobs-list-table>tbody>tr').length === 1;
-          }, 'job list to be filtered');
-
-          runs(function () {
-            // Make sure we only get the successful jobs ( state 3 )
-            rows = $('.g-jobs-list-table>tbody>tr');
-            expect($(rows[0]).text()).toContain('My batch job 3');
-            expect($(rows[0]).text()).toContain('Success');
-
-            // Trigger event to include jobs in state 1 and 2
-            evt[girder.plugins.jobs.JobStatus.text(1)] = true
-            evt[girder.plugins.jobs.JobStatus.text(2)] = true
-            widget.filterStatusMenuWidget.trigger('g:triggerCheckBoxMenuChanged', evt);
-          });
-
-          // Table should now have all the jobs again
-          waitsFor(function () {
-              return $('.g-jobs-list-table>tbody>tr').length === 3;
-          }, 'job list to be filtered');
-
-          runs(function () {
-            rows = $('.g-jobs-list-table>tbody>tr');
-            expect($(rows[0]).text()).toContain('My batch job 3');
-            expect($(rows[0]).text()).toContain('Success');
-            expect($(rows[1]).text()).toContain('My batch job 2');
-            expect($(rows[1]).text()).toContain('Running');
-            expect($(rows[2]).text()).toContain('My batch job 1');
-            expect($(rows[2]).text()).toContain('Queued');
-          });
-      });
-      it('Job list widget filter by type.', function () {
-        var jobs, rows, widget, evt;
-
-        runs(function () {
-            jobs = _.map(['one', 'two', 'three'], function (t, i) {
-                return new girder.plugins.jobs.models.JobModel({
-                    _id: 'foo' + i,
-                    title: 'My batch job ' + i,
-                    status: i,
-                    type: t,
-                    updated: '2015-01-12T12:00:0' + i,
-                    created: '2015-01-12T12:00:0' + i,
-                    when: '2015-01-12T12:00:0' + i
+            runs(function () {
+                girder.utilities.eventStream.trigger('g:event.job_created', {
+                    data: {
+                        _id: 'foo' + 4,
+                        title: 'My batch job ' + 4,
+                        status: 4,
+                        updated: '2015-01-12T12:00:0' + 4,
+                        created: '2015-01-12T12:00:0' + 4,
+                        when: '2015-01-12T12:00:0' + 4
+                    }
                 });
             });
 
-            widget = new girder.plugins.jobs.views.JobListWidget({
-                el: $('#g-app-body-container'),
-                filter: {},
-                parentView: app
-            }).render();
-
-            expect($('.g-jobs-list-table>tbody>tr').length).toBe(0);
-
-            // Add the jobs to the collection
-            widget.collection.add(jobs);
+            waitsFor(function () {
+                return $('.g-no-job-record').is(':visible');
+            }, 'job list to auto-reload when job_created is triggered');
         });
 
-        waitsFor(function () {
-            return $('.g-jobs-list-table>tbody>tr').length === 3;
-        }, 'job list to auto-reload when collection is updated')
+        it('Job list widget filter by status & type.', function () {
+            var widget;
+            runs(function () {
+                widget = new girder.plugins.jobs.views.JobListWidget({
+                    el: $('#g-app-body-container'),
+                    filter: {},
+                    parentView: app,
+                    showGraphs: true,
+                    showFilters: true,
+                    showPageSizeSelector: true
+                }).render();
 
-        runs(function () {
-            rows = $('.g-jobs-list-table>tbody>tr');
-            expect($(rows[0]).text()).toContain('My batch job 2');
-            expect($(rows[0]).text()).toContain('three');
-            expect($(rows[1]).text()).toContain('My batch job 1');
-            expect($(rows[1]).text()).toContain('two');
-            expect($(rows[2]).text()).toContain('My batch job 0');
-            expect($(rows[2]).text()).toContain('one');
+                expect($('.g-jobs-list-table>tbody>tr').length).toBe(0);
 
-            // Trigger event to filter out jobs of type 'two' and 'three'
-            evt = {
-                one: true,
-                two: false,
-                three: false
-            };
-            widget.filterTypeMenuWidget.trigger('g:triggerCheckBoxMenuChanged', evt);
+                // programmatically set value
+                widget.typeFilterWidget.setItems({
+                    'type A': true,
+                    'type B': true,
+                    'type C': false
+                });
+
+                // one item should be unchecked
+                expect(
+                    widget.$('.g-job-filter-container .type .dropdown ul li input[type="checkbox"]').toArray().reduce(function (total, input) {
+                        return total + ($(input).is(':checked') ? 1 : 0);
+                    }, 0)
+                ).toBe(2);
+
+                widget.$('.g-job-filter-container .type .dropdown ul li input').first().click();
+
+                expect(
+                    widget.$('.g-job-filter-container .type .dropdown ul li input[type="checkbox"]').toArray().reduce(function (total, input) {
+                        return total + ($(input).is(':checked') ? 1 : 0);
+                    }, 0)
+                ).toBe(1);
+
+                widget.$('.g-job-filter-container .type .dropdown .g-job-checkall input').click();
+
+                // all should be checked after clicking Check all
+                expect(
+                    widget.$('.g-job-filter-container .type .dropdown ul li input[type="checkbox"]').toArray().reduce(function (total, input) {
+                        return total + ($(input).is(':checked') ? 1 : 0);
+                    }, 0)
+                ).toBe(3);
+                expect($('.g-job-filter-container .type .dropdown .g-job-checkall input').is(':checked')).toBe(true);
+
+                widget.$('.g-job-filter-container .status .dropdown .g-job-checkall input').click();
+
+                expect(
+                    widget.$('.g-job-filter-container .status .dropdown ul li input[type="checkbox"]').toArray().reduce(function (total, input) {
+                        return total + ($(input).is(':checked') ? 1 : 0);
+                    }, 0)
+                ).toBe(0);
+
+                widget.$('.g-page-size').val(50).trigger('change');
+                expect(widget.collection.pageLimit).toBe(50);
+            });
         });
 
-        // Table should now only contain jobs of type 'one'
-        waitsFor(function () {
-            return $('.g-jobs-list-table>tbody>tr').length === 1;
-        }, 'job list to be filtered');
+        it('Trigger click event.', function () {
+            var jobs, widget;
 
-        runs(function () {
-          // Make sure we only get the jobs of type 'one'
-          rows = $('.g-jobs-list-table>tbody>tr');
-          expect($(rows[0]).text()).toContain('My batch job 0');
-          expect($(rows[0]).text()).toContain('one');
+            runs(function () {
+                widget = new girder.plugins.jobs.views.JobListWidget({
+                    el: $('#g-app-body-container'),
+                    parentView: app,
+                    filter: {},
+                    triggerJobClick: true,
+                    showGraphs: true,
+                    showFilters: true,
+                    showPageSizeSelector: true
+                }).render();
 
-          // Trigger event to include jobs of type 'two' and 'three'
-          evt['two'] = true
-          evt['three'] = true
-          widget.filterTypeMenuWidget.trigger('g:triggerCheckBoxMenuChanged', evt);
+                expect($('.g-jobs-list-table>tbody>tr').length).toBe(0);
+            });
+
+            girderTest.waitForLoad();
+
+            runs(function () {
+                jobs = _.map([1, 2, 3], function (i) {
+                    return new girder.plugins.jobs.models.JobModel({
+                        _id: 'foo' + i,
+                        title: 'My batch job ' + i,
+                        status: i,
+                        updated: '2015-01-12T12:00:0' + i,
+                        created: '2015-01-12T12:00:0' + i,
+                        when: '2015-01-12T12:00:0' + i
+                    });
+                });
+
+                widget.collection.add(jobs);
+            });
+
+            waitsFor(function () {
+                return $('.g-jobs-list-table>tbody>tr').length === 3;
+            }, 'job list to auto-reload when collection is updated');
+
+            runs(function () {
+                var fired = false;
+                widget.on('g:jobClicked', function () {
+                    fired = true;
+                });
+                widget.$('.g-job-trigger-link').click();
+                expect(fired).toBe(true);
+            });
         });
 
-        // Table should now have all the jobs again
-        waitsFor(function () {
-            return $('.g-jobs-list-table>tbody>tr').length === 3;
-        }, 'job list to be filtered');
+        it('job list widget in all jobs mode', function () {
+            var widget;
 
-        runs(function () {
-          rows = $('.g-jobs-list-table>tbody>tr');
-          expect($(rows[0]).text()).toContain('My batch job 2');
-          expect($(rows[0]).text()).toContain('three');
-          expect($(rows[1]).text()).toContain('My batch job 1');
-          expect($(rows[1]).text()).toContain('two');
-          expect($(rows[2]).text()).toContain('My batch job 0');
-          expect($(rows[2]).text()).toContain('one');
+            runs(function () {
+                widget = new girder.plugins.jobs.views.JobListWidget({
+                    el: $('#g-app-body-container'),
+                    parentView: app,
+                    filter: {},
+                    allJobsMode: true,
+                    showGraphs: true,
+                    showFilters: true,
+                    showPageSizeSelector: true
+                });
+
+                expect(widget.collection.resourceName).toEqual('job/all');
+
+                girderTest.logout('logout from admin')();
+
+                girderTest.createUser(
+                    'user1', 'user@email.com', 'Quota', 'User', 'testpassword')();
+            });
+
+            girderTest.waitForLoad();
+
+            runs(function () {
+                widget = new girder.plugins.jobs.views.JobListWidget({
+                    el: $('#g-app-body-container'),
+                    parentView: app,
+                    allJobsMode: true,
+                    showGraphs: true,
+                    showFilters: true,
+                    showPageSizeSelector: true
+                });
+            });
+            girderTest.waitForLoad();
+
+            waitsFor(function () {
+                return widget.$('.g-jobs-list-table tr').length === 0;
+            }, 'no record show be shown');
         });
-      });
 
-      it('Job list widget filter by status & type.', function () {
-        var jobs, rows, widget, statusEvt = {}, typeEvt = {};
-        runs(function () {
-            jobs = _.map(['one', 'two', 'three'], function (t, i) {
-                return new girder.plugins.jobs.models.JobModel({
-                    _id: 'foo' + i,
-                    title: 'My batch job ' + i,
-                    status: i+1,
-                    type: t,
-                    updated: '2015-01-12T12:00:0' + i,
-                    created: '2015-01-12T12:00:0' + i,
-                    when: '2015-01-12T12:00:0' + i
+        it('timing history and time chart', function () {
+            var jobs, widget;
+            runs(function () {
+                widget = new girder.plugins.jobs.views.JobListWidget({
+                    el: $('#g-app-body-container'),
+                    filter: {},
+                    parentView: app,
+                    showGraphs: true,
+                    showFilters: true,
+                    showPageSizeSelector: true
+                }).render();
+            });
+
+            girderTest.waitForLoad();
+
+            runs(function () {
+                jobs = _.map(['one', 'two', 'three'], function (t, i) {
+                    return new girder.plugins.jobs.models.JobModel({
+                        _id: 'foo' + i,
+                        title: 'My batch job ' + i,
+                        status: 4,
+                        type: t,
+                        timestamps: [
+                            {
+                                'status': 1,
+                                'time': '2017-03-10T18:31:59.008Z'
+                            },
+                            {
+                                'status': 2,
+                                'time': '2017-03-10T18:32:06.190Z'
+                            },
+                            {
+                                'status': 4,
+                                'time': '2017-03-10T18:32:34.760Z'
+                            }
+                        ],
+                        updated: '2017-03-10T18:32:34.760Z',
+                        created: '2017-03-10T18:31:59.008Z',
+                        when: '2017-03-10T18:31:59.008Z'
+                    });
+                });
+
+                widget.collection.add(jobs);
+
+                $('.g-jobs.nav.nav-tabs li a[name="timing-history"]').tab('show');
+            });
+
+            waitsFor(function () {
+                return widget.$('.g-jobs-graph svg .mark-rect.timing rect').length;
+            }, 'timing history graph to render');
+
+            runs(function () {
+                $('.g-jobs.nav.nav-tabs li a[name="time"]').tab('show');
+            });
+
+            waitsFor(function () {
+                return widget.$('.g-jobs-graph svg .mark-symbol.circle path').length;
+            }, 'time graph to render');
+
+            runs(function () {
+                $('.g-job-filter-container .timing .dropdown .g-job-checkall input').click();
+            });
+
+            waitsFor(function () {
+                return !widget.$('.g-jobs-graph svg .mark-symbol.circle path').length;
+            }, 'graph to clear');
+        });
+
+        it('job list widget without graphs, filter, and page size selector', function () {
+            var widget;
+
+            runs(function () {
+                widget = new girder.plugins.jobs.views.JobListWidget({
+                    el: $('#g-app-body-container'),
+                    parentView: app,
+                    filter: {}
                 });
             });
 
-            widget = new girder.plugins.jobs.views.JobListWidget({
-                el: $('#g-app-body-container'),
-                filter: {},
-                parentView: app
-            }).render();
+            girderTest.waitForLoad();
 
-
-            expect($('.g-jobs-list-table>tbody>tr').length).toBe(0);
-
-            // Add the jobs to the collection
-            widget.collection.add(jobs);
+            runs(function () {
+                expect(widget.$('.g-jobs.nav.nav-tabs').length).toBe(0);
+                expect(widget.$('.g-job-filter-container').length).toBe(0);
+                expect(widget.$('.g-page-size-container').length).toBe(0);
+            });
         });
-
-        waitsFor(function () {
-            return $('.g-jobs-list-table>tbody>tr').length === 3;
-        }, 'job list to auto-reload when collection is updated')
-
-        runs(function () {
-            rows = $('.g-jobs-list-table>tbody>tr');
-            expect($(rows[0]).text()).toContain('My batch job 2');
-            expect($(rows[0]).text()).toContain('three');
-            expect($(rows[1]).text()).toContain('My batch job 1');
-            expect($(rows[1]).text()).toContain('two');
-            expect($(rows[2]).text()).toContain('My batch job 0');
-            expect($(rows[2]).text()).toContain('one');
-
-            // Trigger event to filter out jobs of type 'two' and 'three'
-            typeEvt = {
-                one: true,
-                two: false,
-                three: false
-            };
-            widget.filterTypeMenuWidget.trigger('g:triggerCheckBoxMenuChanged', typeEvt);
-
-            // Trigger event to filter out jobs in state 1 and 3
-            statusEvt[girder.plugins.jobs.JobStatus.text(1)] = false
-            statusEvt[girder.plugins.jobs.JobStatus.text(2)] = true
-            statusEvt[girder.plugins.jobs.JobStatus.text(3)] = false
-            widget.filterStatusMenuWidget.trigger('g:triggerCheckBoxMenuChanged', statusEvt);
-        });
-
-        // Table should be empty
-        waitsFor(function () {
-            return $('.g-jobs-list-table>tbody>tr').length === 0;
-        }, 'job list to be filtered');
-
-        runs(function () {
-
-          // Trigger event to include jobs of type 'one'
-          typeEvt['one'] = true
-          widget.filterTypeMenuWidget.trigger('g:triggerCheckBoxMenuChanged', typeEvt);
-
-          // Trigger event to include jobs in state 1
-          statusEvt[girder.plugins.jobs.JobStatus.text(1)] = true
-          widget.filterStatusMenuWidget.trigger('g:triggerCheckBoxMenuChanged', statusEvt);
-        });
-
-        // Table should have one job
-        waitsFor(function () {
-            return $('.g-jobs-list-table>tbody>tr').length === 1;
-        }, 'job list to be filtered');
-
-        runs(function () {
-          rows = $('.g-jobs-list-table>tbody>tr');
-          expect($(rows[0]).text()).toContain('My batch job 0');
-          expect($(rows[0]).text()).toContain('one');
-          expect($(rows[0]).text()).toContain('1');
-        });
-      });
     });
 });

--- a/plugins/jobs/plugin_tests/jobsSpec.js
+++ b/plugins/jobs/plugin_tests/jobsSpec.js
@@ -1,11 +1,12 @@
 /* globals girderTest, describe, expect, it, runs, waitsFor  */
 
 girderTest.addCoveredScripts([
+    '/clients/web/static/built/plugins/jobs/plugin_lib.min.js',
     '/clients/web/static/built/plugins/jobs/plugin.min.js'
 ]);
 
 girderTest.importStylesheet(
-    '/static/built/plugins/jobs/plugin.min.css'
+    '/static/built/plugins/jobs/plugin_lib.min.css'
 );
 
 girder.events.trigger('g:appload.before');

--- a/plugins/worker/plugin.json
+++ b/plugins/worker/plugin.json
@@ -2,5 +2,8 @@
     "name": "Remote worker",
     "description": "Distributed offline processing engine built on celery.",
     "version": "0.1.0",
-    "dependencies": ["jobs"]
+    "dependencies": ["jobs"],
+    "webpack": {
+        "dllPlugins": ["jobs"]
+    }
 }

--- a/plugins/worker/web_client/JobStatus.js
+++ b/plugins/worker/web_client/JobStatus.js
@@ -1,9 +1,6 @@
-// Since plugins are not dynamically linked against other plugin libraries,
-// we have to modify the runtime global JobStatus, rather than importing it
-// here statically, which would only modify a local copy.
+import JobStatus from 'girder_plugins/jobs/JobStatus';
 
-/*global girder*/
-girder.plugins.jobs.JobStatus.registerStatus({
+JobStatus.registerStatus({
     WORKER_FETCHING_INPUT: {
         value: 820,
         text: 'Fetching input',


### PR DESCRIPTION
This solves the problem I've been running into where plugin code imported statically gets a copy of a module rather than referencing a single global version of it. This is because webpack does not normally link modules across multiple bundles. The way to do so is to use the DllPlugin and DllReferencePlugin together.

As before, plugins containing `web_client/main.js` will have `plugin.min.js` and `plugin.min.css` built as an entrypoint bundle from main.js. In addition to that behavior, plugins containing `web_client/index.js` will have a second bundle built as a DLL module. If this DLL module is built, the `main.js` bundle will import plugin symbols from the DLL module

Benefits of this approach:

1. Only one copy of all shared modules.
2. We already do this in core, so this behavior is consistent.

Downsides:

1. Webroot files could previously simply import `plugin.min.*` and that would be sufficient to load the plugin. Now, they must also import `plugin_lib.min.*` if they exist. So, this could break some existing custom webroots that rely on loading plugins.
2. The `girder-install web --watch-plugin` command, and our watch commands in general, can only watch a single webpack bundle at a time. If a developer is attempting to watch a plugin that contains both a DLL bundle and an entry bundle, they'll have to figure out which of the two bundles to watch, or run two processes at once. So, instead of `girder-install web --watch-plugin jobs`, they'll have to run some modified version of that command, either `girder-install web --watch-plugin lib_jobs`, or we could add a new option like `girder-install web --watch-plugin-lib jobs`.

TODO

- [ ] Merge #1738 and rebase this.
- [ ] Write docs.
- [ ] Refactor new plugin.js code to reduce duplication.
- [ ] Don't require explicit listing of DLL references between plugins in plugin.json.
- [ ] Add webroot utility to abstract the process of importing plugin code into the template.