### PR TITLE
Explicitly list webpack resolve.extensions

### DIFF
--- a/grunt_tasks/webpack.config.js
+++ b/grunt_tasks/webpack.config.js
@@ -207,6 +207,7 @@ module.exports = {
         alias: {
             'girder': paths.web_src
         },
+        extensions: ['.js'],
         modules: [
             paths.clients_web,
             paths.plugins,


### PR DESCRIPTION
The default value works, but makes it difficult/confusing for
downstream plugins that attempt to alter this value; doing so
can break core building in unexpected ways. After this change,
downstreams can augment this by simply push()ing the value.

@opadron PTAL