### PR TITLE
fix missing initialization parameters in hierarchy-widget

### DIFF
--- a/clients/web/src/views/widgets/HierarchyWidget.js
+++ b/clients/web/src/views/widgets/HierarchyWidget.js
@@ -539,7 +539,8 @@ var HierarchyWidget = View.extend({
                     checkboxes: this._checkboxes,
                     downloadLinks: this._downloadLinks,
                     viewLinks: this._viewLinks,
-                    itemFilter: this._itemFilter
+                    itemFilter: this._itemFilter,
+                    showSizes: this._showSizes
                 });
             } else {
                 this._initFolderViewSubwidgets();

--- a/clients/web/src/views/widgets/HierarchyWidget.js
+++ b/clients/web/src/views/widgets/HierarchyWidget.js
@@ -526,7 +526,8 @@ var HierarchyWidget = View.extend({
         this.folderListView.initialize({
             parentType: parent.resourceName,
             parentId: parent.get('_id'),
-            checkboxes: this._checkboxes
+            checkboxes: this._checkboxes,
+            folderFilter: this._itemFilter
         });
 
         this.updateChecked();
@@ -535,7 +536,10 @@ var HierarchyWidget = View.extend({
             if (this.itemListView) {
                 this.itemListView.initialize({
                     folderId: parent.get('_id'),
-                    checkboxes: this._checkboxes
+                    checkboxes: this._checkboxes,
+                    downloadLinks: this._downloadLinks,
+                    viewLinks: this._viewLinks,
+                    itemFilter: this._itemFilter
                 });
             } else {
                 this._initFolderViewSubwidgets();


### PR DESCRIPTION
Fixes a minor oversight from #1729 where subcomponents were being reinitialized without passing some of the newly added options along, causing incorrect behavior.