### PR TITLE
Allow celery queue selection for worker tasks

### DIFF
--- a/plugins/worker/plugin_tests/worker_test.py
+++ b/plugins/worker/plugin_tests/worker_test.py
@@ -141,7 +141,8 @@ class WorkerTestCase(base.TestCase):
             title='title', type='foo', handler='worker_handler',
             user=self.admin, public=False, args=(), kwargs={},
             otherFields={
-                'celeryTaskName': 'some_other.task'
+                'celeryTaskName': 'some_other.task',
+                'celeryQueue': 'my_other_q'
             })
 
         job['kwargs'] = {
@@ -166,3 +167,5 @@ class WorkerTestCase(base.TestCase):
             self.assertEqual(len(sendTaskCalls), 1)
             self.assertEqual(sendTaskCalls[0][1], (
                 'some_other.task', job['args'], job['kwargs']))
+            self.assertIn('queue', sendTaskCalls[0][2])
+            self.assertEqual(sendTaskCalls[0][2]['queue'], 'my_other_q')

--- a/plugins/worker/server/__init__.py
+++ b/plugins/worker/server/__init__.py
@@ -82,7 +82,8 @@ def schedule(event):
         task = job.get('celeryTaskName', 'girder_worker.run')
 
         # Send the task to celery
-        asyncResult = getCeleryApp().send_task(task, job['args'], job['kwargs'])
+        asyncResult = getCeleryApp().send_task(
+            task, job['args'], job['kwargs'], queue=job.get('celeryQueue'))
 
         # Set the job status to queued and record the task ID from celery.
         ModelImporter.model('job', 'jobs').updateJob(job, status=JobStatus.QUEUED, otherFields={
@@ -123,4 +124,5 @@ def load(info):
     events.bind('jobs.schedule', 'worker', schedule)
     events.bind('jobs.status.validate', 'worker', validateJobStatus)
 
-    ModelImporter.model('job', 'jobs').exposeFields(AccessType.SITE_ADMIN, {'celeryTaskId'})
+    ModelImporter.model('job', 'jobs').exposeFields(
+        AccessType.SITE_ADMIN, {'celeryTaskId', 'celeryQueue'})


### PR DESCRIPTION
ping @jonathan-owens This allows tasks scheduled on the worker to optionally specify what celery queue to be placed on.

@cjh1 and/or @kotfic PTAL
