### PR TITLE
Imported file move

### DIFF
--- a/girder/models/upload.py
+++ b/girder/models/upload.py
@@ -178,6 +178,10 @@ class Upload(Model):
             file['created'] = datetime.datetime.utcnow()
             file['assetstoreId'] = assetstore['_id']
             file['size'] = upload['size']
+            # If the file was previously import, it is no longer.
+            if file.get('imported'):
+                file['imported'] = False
+
         else:  # Creating a new file record
             if upload.get('attachParent'):
                 item = None

--- a/girder/models/upload.py
+++ b/girder/models/upload.py
@@ -178,7 +178,7 @@ class Upload(Model):
             file['created'] = datetime.datetime.utcnow()
             file['assetstoreId'] = assetstore['_id']
             file['size'] = upload['size']
-            # If the file was previously import, it is no longer.
+            # If the file was previously imported, it is no longer.
             if file.get('imported'):
                 file['imported'] = False
 


### PR DESCRIPTION
If an imported file is moved to another assetstore we need to reset the imported flag. Otherwise, in the case of the filesystem assetstore the download will fail as the appropriate path will not be generated.
