### PR TITLE
Ensure buttons are initially disabled

### DIFF
--- a/clients/web/src/templates/body/assetstores.pug
+++ b/clients/web/src/templates/body/assetstores.pug
@@ -81,7 +81,7 @@
           else
             .g-assetstore-button-container(title="You must delete all files from the assetstore before you can delete the assetstore.")
               button.g-delete-assetstore.btn.btn-sm.btn-danger.disabled(
-                  cid=assetstore.cid) Delete
+                  cid=assetstore.cid, disabled) Delete
           if !assetstore.get('current') && !assetstore.get('readOnly')
             button.g-set-current.btn.btn-sm.btn-primary(
               cid=assetstore.cid) Set as current

--- a/clients/web/src/templates/widgets/uploadWidgetMixins.pug
+++ b/clients/web/src/templates/widgets/uploadWidgetMixins.pug
@@ -26,6 +26,6 @@ mixin g-upload-widget-progress
   .g-upload-error-message.g-validation-failed-message
 
 mixin g-upload-widget-start-button
-  button.g-start-upload.btn.btn-small.btn-primary.disabled(type="submit")
+  button.g-start-upload.btn.btn-small.btn-primary.disabled(type="submit", disabled)
     i.icon-upload
     |  Start Upload


### PR DESCRIPTION
Set the disabled attribute on some buttons to ensure that the buttons
are initially disabled. Applying the 'disabled' class visually disables
the button, but setting the attribute functionally disables the button.
This is consistent with the implementation of girderEnable().