### PR TITLE
Support static-only plugin dependencies

### DIFF
--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -47,6 +47,12 @@ example will be:
     "dependencies": ["other_plugin"]
     }
 
+.. note:: Some plugins depend on other plugins, but only for building web client code, not
+    at runtime. For these cases, rather than the ``dependencies`` field, use the
+    ``staticWebDependencies`` field instead. This will allow the plugin to import web
+    code from the other plugin, but will not require the other plugin to be built or enabled
+    at runtime.
+
 This information will appear in the web client administration console, and
 administrators will be able to enable and disable it there. Whenever plugins
 are enabled or disabled, a server restart is required in order for the

--- a/girder/utility/install.py
+++ b/girder/utility/install.py
@@ -308,8 +308,6 @@ def main():
     web.add_argument('--all-plugins', action='store_true',
                      help='build all available plugins rather than just enabled ones')
     web.add_argument('--plugins', default='', help='comma-separated list of plugins to build')
-    web.add_argument('--configure-plugins', default='',
-                     help='comma-separated list of plugins to configure for static linking')
     web.add_argument('--watch', action='store_true',
                      help='watch for changes and rebuild girder core library in dev mode')
     web.add_argument('--watch-plugin', default='',

--- a/girder/utility/plugin_utilities.py
+++ b/girder/utility/plugin_utilities.py
@@ -92,10 +92,17 @@ def loadPlugins(plugins, root, appconf, apiRoot=None, buildDag=True):
     return root, appconf, apiRoot
 
 
-def getToposortedPlugins(plugins, ignoreMissing=False):
+def getToposortedPlugins(plugins, ignoreMissing=False, keys=('dependencies',)):
     """
     Given a set of plugins to load, construct the full DAG of required plugins
     to load and yields them in toposorted order.
+
+    :param ignoreMissing: Normally if one of the plugins specified does not exist,
+        this raises a ValidationError. Set this to False to suppress that and instead
+        print an error message and continue.
+    :type ignoreMissing: bool
+    :param keys: Keys that should be used to determine dependencies.
+    :type keys: list of str
     """
     plugins = set(plugins)
 
@@ -112,7 +119,9 @@ def getToposortedPlugins(plugins, ignoreMissing=False):
             else:
                 raise ValidationException(message)
 
-        deps = allPlugins[plugin]['dependencies']
+        deps = set()
+        for key in keys:
+            deps |= allPlugins[plugin][key]
         dag[plugin] = deps
 
         for dep in deps:
@@ -306,7 +315,8 @@ def findAllPlugins():
             'name': data.get('name', plugin),
             'description': data.get('description', ''),
             'version': data.get('version', ''),
-            'dependencies': set(data.get('dependencies', []))
+            'dependencies': set(data.get('dependencies', [])),
+            'staticWebDependencies': set(data.get('staticWebDependencies', []))
         }
     return allPlugins
 

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -28,12 +28,19 @@ module.exports = function (grunt) {
     var paths = require('./webpack.paths.js');
 
     var buildAll = grunt.option('all-plugins');
+    var configurePlugins = grunt.option('configure-plugins');
     var plugins = grunt.option('plugins');
 
     if (_.isString(plugins) && plugins) {
         plugins = plugins.split(',');
     } else if (!buildAll) {
         return;
+    }
+
+    if (_.isString(configurePlugins) && configurePlugins) {
+        configurePlugins = configurePlugins.split(',');
+    } else {
+        configurePlugins = [];
     }
 
     require('colors');
@@ -89,7 +96,7 @@ module.exports = function (grunt) {
         return path.resolve(path.join('node_modules', `girder_plugin_${plugin}`));
     };
 
-    var configurePluginForBuilding = function (dir) {
+    var configurePluginForBuilding = function (dir, buildPlugin) {
         var plugin = path.basename(dir);
         var json = path.resolve(dir, 'plugin.json');
         var yml = path.resolve(dir, 'plugin.yml');
@@ -109,7 +116,8 @@ module.exports = function (grunt) {
             config = grunt.file.readYAML(yml);
         }
 
-        grunt.log.writeln(`Configuring plugin ${plugin.magenta} (${cfgFile})`);
+        var buildText = `build=${buildPlugin ? 'ON'.green : 'OFF'.red}`;
+        grunt.log.writeln(`Configuring plugin ${plugin.magenta} (${cfgFile}, ${buildText})`);
 
         var doAutoBuild = (
             !_.isObject(config.grunt) ||
@@ -183,27 +191,8 @@ module.exports = function (grunt) {
                 nodeDir: pluginNodeDir
             };
 
-            grunt.config.merge({
+            var configOpts = {
                 webpack: {
-                    [`${output}_${plugin}`]: {
-                        entry: {
-                            [helperConfig.pluginEntry]: [main]
-                        },
-                        output: {
-                            path: path.join(paths.web_built, 'plugins', plugin),
-                            filename: `${output}.min.js`
-                        },
-                        plugins: [
-                            new customWebpackPlugins.DllReferenceByPathPlugin({
-                                context: '.',
-                                manifest: path.join(paths.web_built, 'girder_lib-manifest.json')
-                            }),
-                            new ExtractTextPlugin({
-                                filename: `${output}.min.css`,
-                                allChunks: true
-                            })
-                        ]
-                    },
                     options: {
                         // Add an import alias to the global config for this plugin
                         resolve: {
@@ -224,15 +213,35 @@ module.exports = function (grunt) {
                         }
                     }
                 }
-            });
+            };
 
-            grunt.config.merge({
-                default: {
+            if (buildPlugin) {
+                configOpts.webpack[`${output}_${plugin}`] = {
+                    entry: {
+                        [helperConfig.pluginEntry]: [main]
+                    },
+                    output: {
+                        path: path.join(paths.web_built, 'plugins', plugin),
+                        filename: `${output}.min.js`
+                    },
+                    plugins: [
+                        new customWebpackPlugins.DllReferenceByPathPlugin({
+                            context: '.',
+                            manifest: path.join(paths.web_built, 'girder_lib-manifest.json')
+                        }),
+                        new ExtractTextPlugin({
+                            filename: `${output}.min.css`,
+                            allChunks: true
+                        })
+                    ]
+                };
+                configOpts.default = {
                     [`webpack:${output}_${plugin}`]: {
                         dependencies: ['build'] // plugin builds must run after core build
                     }
-                }
-            });
+                };
+            }
+            grunt.config.merge(configOpts);
 
             // If the plugin config has no webpack section, no defaultLoaders
             // property in the webpack section, or the defaultLoaders is
@@ -376,15 +385,20 @@ module.exports = function (grunt) {
         }
     };
 
+    // Glob for plugins and configure each one to be built
     if (buildAll) {
         // Glob for plugins and configure each one to be built
         grunt.file.expand(grunt.config.get('pluginDir') + '/*').forEach(function (dir) {
-            configurePluginForBuilding(path.resolve(dir));
+            configurePluginForBuilding(path.resolve(dir), true);
         });
     } else {
+        // Configure only the plugins that were requested via --configure-plugins
+        configurePlugins.forEach(function (name) {
+            configurePluginForBuilding(path.resolve(grunt.config.get('pluginDir'), name), false);
+        });
         // Build only the plugins that were requested via --plugins
         plugins.forEach(function (name) {
-            configurePluginForBuilding(path.resolve(grunt.config.get('pluginDir'), name));
+            configurePluginForBuilding(path.resolve(grunt.config.get('pluginDir'), name), true);
         });
     }
 

--- a/tests/cases/install_test.py
+++ b/tests/cases/install_test.py
@@ -303,9 +303,13 @@ class InstallTestCase(base.TestCase):
             install.install_web(PluginOpts(plugins='has_static_deps'))
 
             self.assertEqual(len(p.mock_calls), 2)
-            self.assertEqual(list(p.mock_calls[1][1][0]), [
+            self.assertEqual(list(p.mock_calls[1][1][0][:-1]), [
                 'npm', 'run', 'build', '--', '--no-progress=true', '--env=prod',
                 '--plugins=has_static_deps',
-                '--configure-plugins=has_webroot,does_nothing,test_plugin,has_deps'
             ])
-
+            lastArg = p.mock_calls[1][1][0][-1]
+            six.assertRegex(self, lastArg, '--configure-plugins=.*')
+            self.assertEqual(
+                set(lastArg.split('=')[-1].split(',')), {
+                    'does_nothing', 'has_deps', 'has_webroot', 'test_plugin'
+                })

--- a/tests/test_plugins/has_static_deps/plugin.yml
+++ b/tests/test_plugins/has_static_deps/plugin.yml
@@ -1,0 +1,3 @@
+staticWebDependencies:
+  - has_webroot
+  - has_deps


### PR DESCRIPTION
Some plugins will want to use web code from other plugins, but do not depend on them at runtime. This adds a new field to `plugin.yml` called `staticWebDependencies` in which such dependencies can now be expressed.

The motivating example for this is the dependency between item_tasks and slicer_cli_web.