### PR TITLE
Import S3 upload handler via FileModel

### DIFF
--- a/clients/web/src/models/FileModel.js
+++ b/clients/web/src/models/FileModel.js
@@ -4,6 +4,7 @@ import FolderModel from 'girder/models/FolderModel';
 import ItemModel from 'girder/models/ItemModel';
 import Model from 'girder/models/Model';
 import { restRequest, uploadHandlers, getUploadChunkSize } from 'girder/rest';
+import 'girder/utilities/S3UploadHandler';  // imported for side effect
 
 var FileModel = Model.extend({
     resourceName: 'file',


### PR DESCRIPTION
This makes it so that any downstreams that use the FileModel or
the UploadWidget will also support direct-to-S3 uploads, since
unfortunately this module has to be imported for a side effect.

Refs https://github.com/girder/covalic/issues/220