### PR TITLE
fontello.zip sometimes fails to download

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -70,7 +70,6 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-contrib-symlink');
     grunt.loadNpmTasks('grunt-gitinfo');
-    grunt.loadNpmTasks('grunt-curl');
     grunt.loadNpmTasks('grunt-zip');
     grunt.loadNpmTasks('grunt-file-creator');
     grunt.loadNpmTasks('grunt-webpack');

--- a/grunt_tasks/fontello.js
+++ b/grunt_tasks/fontello.js
@@ -3,6 +3,7 @@ module.exports = function (grunt) {
     var path = require('path');
 
     var archivePath = 'clients/web/static/built/fontello.zip';
+    var srcUrl = 'https://data.kitware.com/api/v1/file/57c5d1fc8d777f10f269dece/download';
 
     grunt.config.merge({
         unzip: {
@@ -44,15 +45,13 @@ module.exports = function (grunt) {
     } else {
         // Download font archive from data.kitware.com
         grunt.config.merge({
-            curl: {
+            shell: {
                 fontello: {
-                    src: 'https://data.kitware.com/api/v1/file/57c5d1fc8d777f10f269dece/download',
-                    dest: archivePath
+                    command: 'curl "' + srcUrl + '" -o "' + archivePath + '"'
                 }
             },
-
             init: {
-                'curl:fontello': {},
+                'shell:fontello': {},
                 'unzip:fontello': {
                     dependencies: ['curl:fontello']
                 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "grunt-contrib-uglify": "0.11.0",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-contrib-symlink": "~1.0.0",
-    "grunt-curl": "^2.2.0",
     "grunt-zip": "~0.17.1",
     "grunt-shell": "1.3.1",
     "grunt-gitinfo": "~0.1.0",


### PR DESCRIPTION
When running the grunt tasks (such as via `npm install`), fontello.zip is downloaded from data.kitware.com.  Frequently, this fails, and an error of ` Corrupted zip : can't find end of central directory` is emitted when the file is unzipped.  Rerunning the task will often succeed (it has the same chance of failure as the initial run).

Anecdotally, this seems to happen more often when running in a VM or docker environment.

This appears to be caused by nodejs's `request` module emitting a finished event before the file is fully flushed to disk via a stream made with `fs.createWriteStream`.  This happens in the `grunt-curl` task (which, misleadingly, doesn't use `curl`), and also happens with the same frequency if the `request` module is used alone.

As a solution, we can shell out to the actual `curl` command.  We already require curl as a dependency, according to our docs.

If there is a preferred way to do this, I'd be happy to switch to a different method.