### PR TITLE
Revert to working version of extract-text-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "css-loader": "^0.23.1",
     "eonasdan-bootstrap-datetimepicker": "~4.15",
     "event-source": "0.1.1",
-    "extract-text-webpack-plugin": "^2.0.0-beta.2",
+    "extract-text-webpack-plugin": "2.0.0-beta.5",
     "file-loader": "^0.x",
     "grunt": "^1.0.1",
     "grunt-cli": "~0.1",


### PR DESCRIPTION
@mgrauer PTAL

This fixes our build breakage, which is caused by an upstream breakage in extract-text-webpack-plugin as of v2.0.0-rc.0.