### PR TITLE
Obfuscate underlying HTTP Server

### DIFF
--- a/girder/utility/error.mako
+++ b/girder/utility/error.mako
@@ -1,0 +1,3 @@
+<h2>${status}</h2>
+<p>${message}</p>
+<p><i>Powered by <a href="https://girder.readthedocs.io">Girder</a></i></p>

--- a/girder/utility/server.py
+++ b/girder/utility/server.py
@@ -30,12 +30,8 @@ from girder.utility import plugin_utilities, model_importer
 from girder.utility import config
 from . import webroot
 
-# TODO make a pretty error page someday.
-_errorTemplate = """
-<h1>${status}</h1>
-<p>${message}</p>
-<p><i>Girder server version ${version}</i></p>
-"""
+with open(os.path.join(os.path.dirname(__file__), 'error.mako')) as f:
+    _errorTemplate = f.read()
 
 
 def _errorDefault(status, message, *args, **kwargs):
@@ -43,8 +39,7 @@ def _errorDefault(status, message, *args, **kwargs):
     This is used to render error pages outside of the normal Girder app, such as
     404's. This overrides the default cherrypy error pages.
     """
-    return mako.template.Template(_errorTemplate).render(
-        status=status, message=message, version=API_VERSION)
+    return mako.template.Template(_errorTemplate).render(status=status, message=message)
 
 
 def configureServer(test=False, plugins=None, curConfig=None):

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,7 @@ setup(
             'conf/girder.dist.cfg',
             'mail_templates/*.mako',
             'mail_templates/**/*.mako',
-            'utility/webroot.mako',
+            'utility/*.mako',
             'api/api_docs.mako'
         ]
     },

--- a/tests/cases/custom_root_test.py
+++ b/tests/cases/custom_root_test.py
@@ -77,6 +77,12 @@ class CustomRootTestCase(base.TestCase):
         # Api should not be served out of /girder/api/v1
         resp = self.request('/girder/api/v1', prefix='', isJson=False)
         self.assertStatus(resp, 404)
+        body = self.getBody(resp).lower()
+        server = resp.headers['Server'].lower()
+        self.assertNotIn('cherrypy', body)
+        self.assertNotIn('cherrypy', server)
+        self.assertIn('girder', body)
+        self.assertIn('girder', server)
 
         # Test our staticFile method
         resp = self.request('/static_route', prefix='', isJson=False)


### PR DESCRIPTION
Details of our underlying HTTP server were leaking in two known
places; the Server header, and the error pages e.g. 404. This
addresses both of those, replacing cherrypy references with
Girder references.