### PR TITLE
Add self-describing JSON

### DIFF
--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -189,7 +189,7 @@ girderTest.createCollection = function (collName, collDesc, createFolderName) {
         if (createFolderName) {
             waitsFor(function () {
                 return $('.g-create-subfolder').length > 0;
-            }, 'hierarchy widget to laod');
+            }, 'hierarchy widget to load');
 
             runs(function () {
                 return $('.g-create-subfolder').click();

--- a/plugins/item_tasks/plugin_tests/mock_worker.py
+++ b/plugins/item_tasks/plugin_tests/mock_worker.py
@@ -27,6 +27,28 @@ def simulateConfigure(job):
     req.raise_for_status()
 
 
+def simulateJsonConfigure(job):
+    """Simulate worker configuring a docker JSON item task"""
+    output = job['kwargs']['outputs']['_stdout']
+    jobInfo = job['kwargs']['jobInfo']
+
+    with open(os.path.join(os.path.dirname(__file__), 'specs.json'), 'rb') as f:
+        spec = f.read()
+
+    # Write the JSON output back to the server
+    req = requests.request(
+        method=output['method'], url=output['url'], headers=output['headers'],
+        params=output['params'], data=spec)
+    req.raise_for_status()
+
+    # Update the job to mark it as finished
+    req = requests.request(
+        method=jobInfo['method'], url=jobInfo['url'], headers=jobInfo['headers'], params={
+            'status': girder.plugins.jobs.constants.JobStatus.SUCCESS
+        })
+    req.raise_for_status()
+
+
 def simulateRun(job):
     """Simulate worker running a docker item task"""
     pass
@@ -35,6 +57,8 @@ def simulateRun(job):
 def mockedSchedule(self, job, *args, **kwargs):
     if job['type'] == 'item_task.slicer_cli':
         simulateConfigure(job)
+    elif job['type'] == 'item_task.json_description':
+        simulateJsonConfigure(job)
     elif job['type'] == 'item_task':
         simulateRun(job)
     else:

--- a/plugins/item_tasks/plugin_tests/spec.json
+++ b/plugins/item_tasks/plugin_tests/spec.json
@@ -1,0 +1,6 @@
+{
+  "description": "Single spec description",
+  "mode": "docker",
+  "inputs": [],
+  "outputs": []
+}

--- a/plugins/item_tasks/plugin_tests/specs.json
+++ b/plugins/item_tasks/plugin_tests/specs.json
@@ -1,0 +1,14 @@
+[
+  {
+    "description": "Task 1 description",
+    "mode": "docker",
+    "inputs": [],
+    "outputs": []
+  },
+  {
+    "description": "Task 2 description",
+    "mode": "docker",
+    "inputs": [],
+    "outputs": []
+  }
+]

--- a/plugins/item_tasks/plugin_tests/tasks.js
+++ b/plugins/item_tasks/plugin_tests/tasks.js
@@ -181,3 +181,69 @@ describe('Run the item task', function () {
         });
     });
 });
+
+describe('Auto-configure the JSON item task folder', function () {
+    it('go to collection page', function () {
+        $('ul.g-global-nav .g-nav-link[g-target="collections"]').click();
+    });
+
+    it('create collection and folder', girderTest.createCollection('json task test', '', 'tasks'));
+
+    it('navigate to the folder', function () {
+        runs(function () {
+            $('.g-folder-list-link').click();
+        });
+
+        waitsFor(function () {
+            return $('.g-empty-parent-message:visible').length > 0;
+        }, 'folder empty list to appear');
+    });
+
+    it('run configuration job', function () {
+        $('.g-folder-actions-button').click();
+        $('.g-folder-actions-menu .g-create-docker-tasks').click();
+
+        girderTest.waitForDialog();
+
+        runs(function () {
+            $('.modal-dialog .g-configure-docker-image').val('me/my_image:latest');
+            $('.modal-dialog button.btn.btn-success[type="submit"]').click();
+        });
+
+        waitsFor(function () {
+            return $('.g-job-info-key').length > 0;
+        }, 'navigation to the configuration job');
+
+        waitsFor(function () {
+            return $('.g-job-status-badge').attr('status') === 'success';
+        }, 'job success status', 10000);
+    });
+});
+
+
+describe('Navigate to the new JSON task', function () {
+    it('navigate to task', function () {
+        $('.g-nav-link[g-target="item_tasks"]').click();
+
+        waitsFor(function (){
+            return $('.g-execute-task-link').length > 0;
+        }, 'task list to be rendered');
+
+        runs(function () {
+            expect($('.g-execute-task-link').length).toBe(3);
+            expect($('.g-execute-task-link').eq(0).text()).toBe('me/my_image:latest 0');
+            expect($('.g-execute-task-link').eq(1).text()).toBe('me/my_image:latest 1');
+            window.location.assign($('a.g-execute-task-link').eq(0).attr('href'));
+        });
+
+        waitsFor(function () {
+            return $('.g-task-description-container').length > 0;
+        }, 'task run view to display');
+
+        runs(function () {
+            expect($('.g-task-description-container').text()).toContain(
+                'Task 1 description');
+            expect($('.g-inputs-container').length).toBe(0);
+        });
+    });
+});

--- a/plugins/item_tasks/plugin_tests/tasks_test.py
+++ b/plugins/item_tasks/plugin_tests/tasks_test.py
@@ -2,7 +2,6 @@ import json
 import mock
 import os
 import time
-import urllib
 
 from girder.constants import AccessType
 from tests import base
@@ -27,7 +26,6 @@ class TasksTest(base.TestCase):
             login='user1', firstName='user', lastName='1', email='u@u.com', password='123456')
         folders = self.model('folder').childFolders(self.admin, parentType='user', user=self.admin)
         self.privateFolder, self.publicFolder = list(folders)
-
 
     def testJsonSpec(self):
         # Create a new folder that will contain the tasks
@@ -112,7 +110,6 @@ class TasksTest(base.TestCase):
         parsedSpec['pull_image'] = False
         parsedSpec['docker_image'] = 'johndoe/foo:v5'
         self.assertEqual(item['meta']['itemTaskSpec'], parsedSpec)
-
 
     def testSlicerCli(self):
         # Create a new item that will become a task

--- a/plugins/item_tasks/server/rest.py
+++ b/plugins/item_tasks/server/rest.py
@@ -389,7 +389,8 @@ class ItemTask(Resource):
     @autoDescribeRoute(
         Description('Create item tasks under a folder using a list of JSON specifications.')
         .modelParam('id', model='folder', force=True)
-        .jsonParam('json', 'The JSON specifications as a list or a single specification object.', paramType='body')
+        .jsonParam('json', 'The JSON specifications as a list or a single object.',
+                   paramType='body')
         .param('image', 'The docker image name.', required=True, strip=True)
         .param('pullImage', 'Whether the image should be pulled from a docker registry. ' +
                'Set to false to use local images only.',

--- a/plugins/item_tasks/server/rest.py
+++ b/plugins/item_tasks/server/rest.py
@@ -2,6 +2,7 @@ import json
 import six
 
 from girder import events
+from girder import logger
 from girder.api import access
 from girder.api.describe import autoDescribeRoute, Description
 from girder.api.rest import ensureTokenScopes, filtermodel, Resource, RestException, getApiUrl
@@ -21,6 +22,8 @@ class ItemTask(Resource):
         self.route('POST', (':id', 'execution'), self.executeTask)
         self.route('POST', (':id', 'slicer_cli_description'), self.runSlicerCliDescription)
         self.route('PUT', (':id', 'slicer_cli_xml'), self.setSpecFromXml)
+        self.route('POST', (':id', 'json_description'), self.runJsonTasksDescription)
+        self.route('PUT', (':id', 'add_json_specs'), self.addJsonSpecs)
 
     @access.public
     @autoDescribeRoute(
@@ -320,3 +323,90 @@ class ItemTask(Resource):
             'itemTaskSpec': itemTaskSpec,
             'isItemTask': True
         })
+
+    @access.admin(scope=constants.TOKEN_SCOPE_AUTO_CREATE_CLI)
+    @autoDescribeRoute(
+        Description('Create item task specs based on a docker image.')
+        .notes('This operates on an existing folder, adding item tasks '
+               'using introspection of a docker image.')
+        .modelParam('id', 'The ID of the folder that the task specs will be added to.',
+                    model='folder', level=AccessType.WRITE)
+        .param('image', 'The docker image name.', required=True, strip=True)
+        .param('pullImage', 'Whether the image should be pulled from a docker registry. ' +
+               'Set to false to use local images only.',
+               dataType='boolean', required=False, default=True)
+    )
+    def runJsonTasksDescription(self, folder, image, pullImage, params):
+        jobModel = self.model('job', 'jobs')
+        token = self.model('token').createToken(
+            days=3, scope='item_task.set_task_spec.%s' % folder['_id'],
+            user=self.getCurrentUser())
+        job = jobModel.createJob(
+            title='Read docker task specs: %s' % image, type='item_task.json_description',
+            handler='worker_handler', user=self.getCurrentUser())
+
+        job.update({
+            'itemTaskId': folder['_id'],
+            'kwargs': {
+                'task': {
+                    'mode': 'docker',
+                    'docker_image': image,
+                    'container_args': [],
+                    'pull_image': pullImage,
+                    'outputs': [{
+                        'id': '_stdout',
+                        'format': 'text'
+                    }],
+                },
+                'outputs': {
+                    '_stdout': {
+                        'mode': 'http',
+                        'method': 'PUT',
+                        'format': 'text',
+                        'url': '/'.join((getApiUrl(), self.resourceName,
+                                         str(folder['_id']), 'add_json_specs')),
+                        'headers': {'Girder-Token': token['_id']},
+                        'params': {
+                            'pullImage': pullImage
+                        }
+                    }
+                },
+                'jobInfo': utils.jobInfoSpec(job),
+                'validate': False,
+                'auto_convert': False,
+                'cleanup': True
+            }
+        })
+
+        job = jobModel.save(job)
+        jobModel.scheduleJob(job)
+        return job
+
+    @access.token
+    @autoDescribeRoute(
+        Description('Create item tasks under a folder using a list of JSON specifications.')
+        .modelParam('id', model='folder', force=True)
+        .jsonParam('json', 'The JSON specs.', paramType='body')
+        .param('pullImage', 'Whether the image should be pulled from a docker registry. ' +
+               'Set to false to use local images only.',
+               dataType='boolean', required=False, default=True),
+        hide=True
+    )
+    def addJsonSpecs(self, folder, json, pullImage, params):
+        self.ensureTokenScopes('item_task.set_task_spec.%s' % folder['_id'])
+        token = self.getCurrentToken()
+        user = self.model('user').load(token['userId'], force=True)
+        for itemTaskSpec in json:
+            logger.info('Configuring item "%s"' % itemTaskSpec['name'])
+            item = self.model('item').createItem(
+                name=itemTaskSpec['name'],
+                creator=user,
+                folder=folder,
+                description=itemTaskSpec.get('description', ''),
+                reuseExisting=True)
+            logger.info(pullImage)
+            logger.info(params)
+            itemTaskSpec['pull_image'] = pullImage
+            self.model('item').setMetadata(item, {
+                'itemTaskSpec': itemTaskSpec
+            })

--- a/plugins/item_tasks/web_client/main.js
+++ b/plugins/item_tasks/web_client/main.js
@@ -52,7 +52,6 @@ import hierarchyMenuModTemplate from './templates/hierarchyMenuMod.pug';
 wrap(HierarchyWidget, 'render', function (render) {
     render.call(this);
     this.$('.g-folder-actions-menu .dropdown-header').after(hierarchyMenuModTemplate({
-        _: _,
         parentType: this.parentModel.get('_modelType'),
         currentUser: getCurrentUser()
     }));

--- a/plugins/item_tasks/web_client/main.js
+++ b/plugins/item_tasks/web_client/main.js
@@ -5,6 +5,7 @@ import './routes';
 import { getCurrentUser } from 'girder/auth';
 import { wrap } from 'girder/utilities/PluginUtils';
 import GlobalNavView from 'girder/views/layout/GlobalNavView';
+import HierarchyWidget from 'girder/views/widgets/HierarchyWidget';
 import ItemView from 'girder/views/body/ItemView';
 import { registerPluginNamespace } from 'girder/pluginUtils';
 
@@ -45,6 +46,29 @@ ItemView.prototype.events['click .g-configure-item-task'] = function () {
         });
     }
     this.configureTaskDialog.render();
+};
+
+import hierarchyMenuModTemplate from './templates/hierarchyMenuMod.pug';
+wrap(HierarchyWidget, 'render', function (render) {
+    render.call(this);
+    this.$('.g-folder-actions-menu .dropdown-header').after(hierarchyMenuModTemplate({
+        _: _,
+        parentType: this.parentModel.get('_modelType'),
+        currentUser: getCurrentUser()
+    }));
+    return this;
+});
+
+import ConfigureTasksDialog from './views/ConfigureTasksDialog';
+HierarchyWidget.prototype.events['click .g-create-docker-tasks'] = function () {
+    if (!this.configureTasksDialog) {
+        this.configureTasksDialog = new ConfigureTasksDialog({
+            model: this.parentModel,
+            parentView: this,
+            el: $('#g-dialog-container')
+        });
+    }
+    this.configureTasksDialog.render();
 };
 
 // Show task inputs and outputs on job details view

--- a/plugins/item_tasks/web_client/models/WidgetModel.js
+++ b/plugins/item_tasks/web_client/models/WidgetModel.js
@@ -138,7 +138,7 @@ var WidgetModel = Backbone.Model.extend({
         } else if (this.isInteger()) {
             out = this._validateInteger(value);
         }
-        if (this.isEnumeration() && !this.get('values').includes(this._normalizeValue(value))) {
+        if (this.isEnumeration() && !_.contains(this.get('values'), this._normalizeValue(value))) {
             out = 'Invalid value choice';
         }
         return out;
@@ -250,13 +250,13 @@ var WidgetModel = Backbone.Model.extend({
      * True if the value should be coerced as a number.
      */
     isNumeric: function () {
-        return [
+        return _.contains([
             'range',
             'number',
             'number-vector',
             'number-enumeration',
             'number-enumeration-multiple'
-        ].includes(this.get('type'));
+        ], this.get('type'));
     },
 
     /**
@@ -277,12 +277,12 @@ var WidgetModel = Backbone.Model.extend({
      * True if the value is a 3 component vector.
      */
     isVector: function () {
-        return [
+        return _.contains([
             'number-vector',
             'number-enumeration-multiple',
             'string-vector',
             'string-enumeration-multiple'
-        ].includes(this.get('type'));
+        ], this.get('type'));
     },
 
     /**
@@ -296,12 +296,12 @@ var WidgetModel = Backbone.Model.extend({
      * True if the value should be chosen from one of several "values".
      */
     isEnumeration: function () {
-        return [
+        return _.contains([
             'number-enumeration',
             'number-enumeration-multiple',
             'string-enumeration',
             'string-enumeration-multiple'
-        ].includes(this.get('type'));
+        ], this.get('type'));
     },
 
     /**

--- a/plugins/item_tasks/web_client/models/WidgetModel.js
+++ b/plugins/item_tasks/web_client/models/WidgetModel.js
@@ -58,7 +58,7 @@ var WidgetModel = Backbone.Model.extend({
         // normalize enumerated values
         if (_.has(hash, 'values')) {
             try {
-                hash.values = _.map(hash.values, _.bind(this.normalize, this));
+                hash.values = _.map(hash.values, _.bind(this._normalizeValue, this));
             } catch (e) {
                 console.warn('Could not normalize value in "' + hash.values + '"'); // eslint-disable-line no-console
             }
@@ -138,7 +138,7 @@ var WidgetModel = Backbone.Model.extend({
         } else if (this.isInteger()) {
             out = this._validateInteger(value);
         }
-        if (this.isEnumeration() && !_.contains(this.get('values'), this.normalize(value))) {
+        if (this.isEnumeration() && !this.get('values').includes(this._normalizeValue(value))) {
             out = 'Invalid value choice';
         }
         return out;
@@ -250,10 +250,13 @@ var WidgetModel = Backbone.Model.extend({
      * True if the value should be coerced as a number.
      */
     isNumeric: function () {
-        return _.contains(
-            ['range', 'number', 'number-vector', 'number-enumeration'],
-            this.get('type')
-        );
+        return [
+            'range',
+            'number',
+            'number-vector',
+            'number-enumeration',
+            'number-enumeration-multiple'
+        ].includes(this.get('type'));
     },
 
     /**
@@ -274,10 +277,12 @@ var WidgetModel = Backbone.Model.extend({
      * True if the value is a 3 component vector.
      */
     isVector: function () {
-        return _.contains(
-            ['number-vector', 'string-vector'],
-            this.get('type')
-        );
+        return [
+            'number-vector',
+            'number-enumeration-multiple',
+            'string-vector',
+            'string-enumeration-multiple'
+        ].includes(this.get('type'));
     },
 
     /**
@@ -291,10 +296,12 @@ var WidgetModel = Backbone.Model.extend({
      * True if the value should be chosen from one of several "values".
      */
     isEnumeration: function () {
-        return _.contains(
-            ['number-enumeration', 'string-enumeration'],
-            this.get('type')
-        );
+        return [
+            'number-enumeration',
+            'number-enumeration-multiple',
+            'string-enumeration',
+            'string-enumeration-multiple'
+        ].includes(this.get('type'));
     },
 
     /**
@@ -335,7 +342,9 @@ var WidgetModel = Backbone.Model.extend({
         'number-vector',
         'string-vector',
         'number-enumeration',
+        'number-enumeration-multiple',
         'string-enumeration',
+        'string-enumeration-multiple',
         'file',
         'directory',
         'new-file',

--- a/plugins/item_tasks/web_client/templates/configureTasks.pug
+++ b/plugins/item_tasks/web_client/templates/configureTasks.pug
@@ -1,0 +1,28 @@
+.modal-dialog
+  .modal-content
+    form.g-configure-docker-form.modal-form(role="form")
+      .modal-header
+        button.close(data-dismiss="modal", aria-hidden="true", type="button") &times;
+        h4.modal-title Auto-configure task items
+        .g-dialog-subtitle
+          i.icon-folder
+          = folder.name()
+      .modal-body
+        p.
+          Running this will pull and run the specified docker image in order
+          to introspect its task specification output. Once that output
+          is parsed, the information will be transformed into metadata on new
+          items under this folder, which can then be run as tasks via the worker.
+        .form-group
+          label Docker image identifier
+          input.g-configure-docker-image.form-control.input-sm
+        .checkbox
+          label
+            input.g-configure-docker-pull-image(type="checkbox", checked=true)
+            | Pull image from docker registry.
+        .g-validation-failed-message
+      .modal-footer
+        a.btn.btn-default(data-dismiss="modal") Close
+        button.btn.btn-success(type="submit")
+          i.icon-play
+          |  Run

--- a/plugins/item_tasks/web_client/templates/enumerationMultiWidget.pug
+++ b/plugins/item_tasks/web_client/templates/enumerationMultiWidget.pug
@@ -1,0 +1,6 @@
+extends ./widget.pug
+
+block input
+  select.form-control(id=id, name=title, multiple='multiple', size=10)
+    each v in values
+      option(selected=value.includes(v))= v

--- a/plugins/item_tasks/web_client/templates/hierarchyMenuMod.pug
+++ b/plugins/item_tasks/web_client/templates/hierarchyMenuMod.pug
@@ -1,0 +1,9 @@
+- var itemsAdded = false
+if parentType == 'folder' && currentUser && currentUser.get('admin')
+  - itemsAdded = true
+  li(role="presentation")
+    a.g-create-docker-tasks(role="menuitem")
+      i.icon-cube
+      | Add tasks
+if itemsAdded
+  li.divider(role="presentation")

--- a/plugins/item_tasks/web_client/templates/hierarchyMenuMod.pug
+++ b/plugins/item_tasks/web_client/templates/hierarchyMenuMod.pug
@@ -1,5 +1,5 @@
 - var itemsAdded = false
-if parentType == 'folder' && currentUser && currentUser.get('admin')
+if parentType === 'folder' && currentUser && currentUser.get('admin')
   - itemsAdded = true
   li(role="presentation")
     a.g-create-docker-tasks(role="menuitem")

--- a/plugins/item_tasks/web_client/views/ConfigureTasksDialog.js
+++ b/plugins/item_tasks/web_client/views/ConfigureTasksDialog.js
@@ -24,7 +24,6 @@ var ConfigureTasksDialog = View.extend({
                 data,
                 error: null
             }).done((job) => {
-                console.log(job);
                 router.navigate(`job/${job._id}`, {trigger: true});
             }).error((resp) => {
                 this.$('.g-validation-failed-message').text(resp.responseJSON.message);

--- a/plugins/item_tasks/web_client/views/ConfigureTasksDialog.js
+++ b/plugins/item_tasks/web_client/views/ConfigureTasksDialog.js
@@ -1,0 +1,42 @@
+import { restRequest } from 'girder/rest';
+import router from 'girder/router';
+import View from 'girder/views/View';
+import template from '../templates/configureTasks.pug';
+import 'girder/utilities/jquery/girderModal';
+
+var ConfigureTasksDialog = View.extend({
+    events: {
+        'submit .g-configure-docker-form': function (e) {
+            e.preventDefault();
+            this.$('.g-validation-failed-message').empty();
+
+            var image = this.$('.g-configure-docker-image').val().trim();
+            var data = {
+                pullImage: this.$('.g-configure-docker-pull-image').is(':checked')
+            };
+            if (image) {
+                data.image = image;
+            }
+
+            restRequest({
+                path: `item_task/${this.model.id}/json_description`,
+                type: 'POST',
+                data,
+                error: null
+            }).done((job) => {
+                console.log(job);
+                router.navigate(`job/${job._id}`, {trigger: true});
+            }).error((resp) => {
+                this.$('.g-validation-failed-message').text(resp.responseJSON.message);
+            });
+        }
+    },
+
+    render: function () {
+        this.$el.html(template({
+            folder: this.model
+        })).girderModal(this);
+    }
+});
+
+export default ConfigureTasksDialog;

--- a/plugins/item_tasks/web_client/views/ControlWidget.js
+++ b/plugins/item_tasks/web_client/views/ControlWidget.js
@@ -7,6 +7,7 @@ import { getCurrentUser } from 'girder/auth';
 import booleanWidget from '../templates/booleanWidget.pug';
 import colorWidget from '../templates/colorWidget.pug';
 import enumerationWidget from '../templates/enumerationWidget.pug';
+import enumerationMultiWidget from '../templates/enumerationMultiWidget.pug';
 import fileWidget from '../templates/fileWidget.pug';
 import rangeWidget from '../templates/rangeWidget.pug';
 import widget from '../templates/widget.pug';
@@ -89,8 +90,14 @@ var ControlWidget = View.extend({
         'string-enumeration': {
             template: enumerationWidget
         },
+        'string-enumeration-multiple': {
+            template: enumerationMultiWidget
+        },
         'number-enumeration': {
             template: enumerationWidget
+        },
+        'number-enumeration-multiple': {
+            template: enumerationMultiWidget
         },
         file: {
             template: fileWidget

--- a/tests/base.py
+++ b/tests/base.py
@@ -438,29 +438,33 @@ class TestCase(unittest.TestCase, model_importer.ModelImporter):
         :type appPrefix: str
         :returns: The cherrypy response object from the request.
         """
-        if not params:
-            params = {}
-
         headers = [('Host', '127.0.0.1'), ('Accept', 'application/json')]
         qs = fd = None
 
         if additionalHeaders:
             headers.extend(additionalHeaders)
-        if method in ['POST', 'PUT', 'PATCH'] or body:
-            if isinstance(body, six.text_type):
-                body = body.encode('utf8')
-            qs = urllib.parse.urlencode(params).encode('utf8')
-            if type is None:
-                headers.append(('Content-Type',
-                                'application/x-www-form-urlencoded'))
-            else:
-                headers.append(('Content-Type', type))
-                qs = body
-            headers.append(('Content-Length', '%d' % len(qs)))
-            fd = BytesIO(qs)
-            qs = None
-        elif params:
+
+        if isinstance(body, six.text_type):
+            body = body.encode('utf8')
+
+        if params:
             qs = urllib.parse.urlencode(params)
+
+        if params and body:
+            # In this case, we are forced to send params in query string
+            fd = BytesIO(body)
+            headers.append(('Content-Type', type))
+            headers.append(('Content-Length', '%d' % len(body)))
+        elif method in ['POST', 'PUT', 'PATCH'] or body:
+            if type:
+                qs = body
+            elif params:
+                qs = qs.encode('utf8')
+
+            headers.append(('Content-Type', type or 'application/x-www-form-urlencoded'))
+            headers.append(('Content-Length', '%d' % len(qs or b'')))
+            fd = BytesIO(qs or b'')
+            qs = None
 
         app = cherrypy.tree.apps[appPrefix]
         request, response = app.get_serving(


### PR DESCRIPTION
Adds the ability for a JSON-based self-describing container to add all of its tasks to a folder. See https://github.com/Kitware/pysciencedock#usage-through-girder to see how to use this to import a set of tasks. I just pushed a `kitware/pysciencedock` up so it should work without needing to build the docker image manually.