### PR TITLE
Fixes #1774 Ensure static/built dir exists

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,6 +59,15 @@ module.exports = function (grunt) {
         grunt.config.set('girderDir', '.');
     }
 
+    // Ensure our build directory exists
+    try {
+        fs.mkdirSync('clients/web/static/built');
+    } catch (e) {
+        if (e.code !== 'EEXIST') {
+            throw e;
+        }
+    }
+
     /**
      * Load task modules inside `grunt_tasks`.
      */


### PR DESCRIPTION
@manthey PTAL, the addition of the curl download step caused the build to break in our package installed environments because it ran at a time when the `built` directory did not yet exist.