### PR TITLE
Do not invoke watch with --all-plugins

### DIFF
--- a/girder/utility/install.py
+++ b/girder/utility/install.py
@@ -189,10 +189,15 @@ def install_web(opts=None):
     elif opts.watch:
         _runWatchCmd('npm', 'run', 'watch')
     elif opts.watch_plugin:
+        staticPlugins = plugin_utilities.getToposortedPlugins(
+            [opts.watch_plugin], ignoreMissing=True,
+            keys=('dependencies', 'staticWebDependencies'))
+        staticPlugins = [p for p in staticPlugins if p != opts.watch_plugin]
+
         _runWatchCmd(
-            'npm', 'run', 'watch', '--', '--all-plugins', 'webpack:%s_%s' % (
-                opts.plugin_prefix, opts.watch_plugin)
-        )
+            'npm', 'run', 'watch', '--', '--plugins=%s' % opts.watch_plugin,
+            '--configure-plugins=%s' % ','.join(staticPlugins),
+            'webpack:%s_%s' % (opts.plugin_prefix, opts.watch_plugin))
     else:
         runWebBuild(
             dev=opts.development, npm=opts.npm, allPlugins=opts.all_plugins,

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -33,14 +33,18 @@ module.exports = function (grunt) {
 
     if (_.isString(plugins) && plugins) {
         plugins = plugins.split(',');
-    } else if (!buildAll) {
-        return;
+    } else {
+        plugins = [];
     }
 
     if (_.isString(configurePlugins) && configurePlugins) {
         configurePlugins = configurePlugins.split(',');
     } else {
         configurePlugins = [];
+    }
+
+    if (!buildAll && !plugins.length && !configurePlugins.length) {
+        return;
     }
 
     require('colors');

--- a/tests/cases/install_test.py
+++ b/tests/cases/install_test.py
@@ -286,7 +286,8 @@ class InstallTestCase(base.TestCase):
             self.assertEqual(len(p.mock_calls), 1)
             self.assertEqual(
                 list(p.mock_calls[0][1][0]),
-                ['npm', 'run', 'watch', '--', '--all-plugins', 'webpack:plugin_jobs']
+                ['npm', 'run', 'watch', '--', '--plugins=jobs', '--configure-plugins=',
+                 'webpack:plugin_jobs']
             )
 
         # Keyboard interrupt should be handled gracefully


### PR DESCRIPTION
Bugfix: all-plugins caused plugins that depend on special loaders
(e.g. the dicom_viewer plugin) to be configured; if they were
not also built, errors were thrown due to their dependencies not
being installed. The solution is to only configure dependent plugins
during the watch task.

@jeffbaumes PTAL, this should fix the bug you ran into when running watch-plugin yesterday.