### PR TITLE
Add girder-hardened role to Ansible examples

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = ENV["VAGRANT_BOX"] || "ubuntu/trusty64"
 
   if Vagrant.has_plugin?("vagrant-cachier")
     config.cache.scope = :box

--- a/devops/ansible/examples/girder-hardened/requirements.yml
+++ b/devops/ansible/examples/girder-hardened/requirements.yml
@@ -1,0 +1,2 @@
+- src: geerlingguy.nginx
+- src: Stouts.mongodb

--- a/devops/ansible/examples/girder-hardened/requirements.yml
+++ b/devops/ansible/examples/girder-hardened/requirements.yml
@@ -1,2 +1,3 @@
 - src: geerlingguy.nginx
 - src: Stouts.mongodb
+- src: jdauphant.ssl-certs

--- a/devops/ansible/examples/girder-hardened/site.yml
+++ b/devops/ansible/examples/girder-hardened/site.yml
@@ -1,0 +1,64 @@
+---
+
+- hosts: all
+  vars:
+    girder_update: no
+    girder_force: no
+    nginx_vhosts:
+      - listen: "8080 default_server"
+        extra_parameters: |
+          location / {
+            proxy_set_header Host $proxy_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_pass http://localhost:8888/;
+            # Must set the following for SSE notifications to work
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            chunked_transfer_encoding off;
+            proxy_read_timeout 600s;
+            proxy_send_timeout 600s;
+          }
+
+  pre_tasks:
+    - name: Update package cache
+      apt:
+        update_cache: yes
+      become: yes
+      become_user: root
+
+  roles:
+    - role: Stouts.mongodb
+      become: yes
+      become_user: root
+    - role: girder
+    - role: geerlingguy.nginx
+      become: yes
+      become_user: root
+
+  post_tasks:
+    - name: Tweak Girder server configurations
+      ini_file:
+        dest="{{ girder_path }}/girder/conf/girder.local.cfg"
+        backup=yes
+        section="{{ item.section }}"
+        option="{{ item.option }}"
+        value="{{ item.value }}"
+      with_items:
+        - { section: "global", option: "server.thread_pool", value: "1000" }
+        - { section: "global", option: "server.socket_port", value: "8888" }
+        - { section: "global", option: "tools.proxy.on", value: "True" }
+        - { section: "server", option: "mode", value: '"production"' }
+
+    - name: restart girder/nginx
+      service:
+        state=restarted
+        name={{ item }}
+      with_items:
+        - girder
+        - nginx
+      become: yes
+      become_user: root

--- a/devops/ansible/examples/girder-hardened/site.yml
+++ b/devops/ansible/examples/girder-hardened/site.yml
@@ -14,6 +14,19 @@
           ssl_certificate_key /etc/ssl/default_server/default_server.key;
           ssl_certificate /etc/ssl/default_server/default_server.pem;
 
+          add_header X-Content-Type-Options nosniff;
+          add_header X-Frame-Options DENY;
+          add_header Content-Security-Policy "style-src 'self' https://fonts.googleapis.com 'sha256-I08hTk63KqFj9IjGtMeORROxIYJYsBEazDOd2hkXWZY='
+                                                                                            'sha256-zB4+dg/iQaGd+pLwCZo03/lJhn/b6UNYzJppzv3EEAc='
+                                                                                            'sha256-h8Ck0CS7cKiFtPMm/8DjdkPXgP8gxqL7G997urcLS28='
+                                                                                            'sha256-MGNMaa1KDEaQ0N9k9XVIdXWtkb9PIkCbTCFGKcQTs7Q=';
+                                              font-src 'self' data: https://fonts.gstatic.com;
+                                              script-src 'self' 'sha256-zB4+dg/iQaGd+pLwCZo03/lJhn/b6UNYzJppzv3EEAc='
+                                                                'sha256-Z36Z11zZSKHfI2n01+6JycFJBmzRbTWWGsVvkXtuvaY=';";
+
+          # add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+          # add_header Public-Key-Pins
+
           location / {
             proxy_set_header Host $proxy_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/devops/ansible/examples/girder-hardened/site.yml
+++ b/devops/ansible/examples/girder-hardened/site.yml
@@ -4,9 +4,16 @@
   vars:
     girder_update: no
     girder_force: no
+    girder_hardened: yes
     nginx_vhosts:
       - listen: "8080 default_server"
+        ssl_certificate_key: "/etc/ssl/default_server/default_server.key"
+        ssl_certificate: "/etc/ssl/default_server/default_server.pem"
         extra_parameters: |
+          ssl on;
+          ssl_certificate_key /etc/ssl/default_server/default_server.key;
+          ssl_certificate /etc/ssl/default_server/default_server.pem;
+
           location / {
             proxy_set_header Host $proxy_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -35,6 +42,10 @@
       become: yes
       become_user: root
     - role: girder
+    - role: jdauphant.ssl-certs
+      ssl_certs_common_name: "default_server"
+      become: yes
+      become_user: root
     - role: geerlingguy.nginx
       become: yes
       become_user: root

--- a/devops/ansible/roles/girder/defaults/main.yml
+++ b/devops/ansible/roles/girder/defaults/main.yml
@@ -6,3 +6,6 @@ girder_version: "master"
 girder_update: yes
 girder_force: yes
 girder_web: yes
+
+# experimental support, will probably break things
+girder_hardened: no

--- a/devops/ansible/roles/girder/templates/daemon/girder.service.j2
+++ b/devops/ansible/roles/girder/templates/daemon/girder.service.j2
@@ -13,5 +13,17 @@ ExecStart={{ girder_virtualenv }}/bin/python -m girder
 ExecStart={{ ansible_python.executable }} -m girder
 {% endif %}
 
+{% if girder_hardened %}
+# Hardened systemd options
+ProtectSystem=full
+ProtectHome=read-only
+ReadWriteDirectories={{ girder_path }} -{{ ansible_user_dir }}/.girder {{ girder_virtualenv|default("") }}
+
+#PrivateTmp=yes
+#PrivateDevices=yes
+
+# As of systemd >= 232, use PrivateUsers option and set ProtectSystem=strict
+{% endif %}
+
 [Install]
 WantedBy=multi-user.target

--- a/devops/ansible/roles/girder/templates/daemon/girder.service.j2
+++ b/devops/ansible/roles/girder/templates/daemon/girder.service.j2
@@ -10,7 +10,7 @@ Restart=always
 {% if girder_virtualenv is defined %}
 ExecStart={{ girder_virtualenv }}/bin/python -m girder
 {% else %}
-ExecStart=python -m girder
+ExecStart={{ ansible_python.executable }} -m girder
 {% endif %}
 
 [Install]


### PR DESCRIPTION
This adds an experimental variable to the ansible role called `girder_hardened` which is disabled by default (nothing in this PR breaks existing code).

What this does is utilize some of the sandbox features of systemd in our existing systemd service file, as well as add a sample playbook which implements many of the headers from the [OWASP Secure Headers Project](https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#tab=Main) to largely reduce the attack surface of things browsers can control (XSS for example).

Some additional details are in the relevant commit messages.