### PR TITLE
Adds an API that lists all jobs to a system admin user

### DIFF
--- a/plugins/jobs/server/job_rest.py
+++ b/plugins/jobs/server/job_rest.py
@@ -29,6 +29,7 @@ class Job(Resource):
         self.resourceName = 'job'
 
         self.route('GET', (), self.listJobs)
+        self.route('GET', ('all',), self.listAllJobs)
         self.route('GET', (':id',), self.getJob)
         self.route('PUT', (':id',), self.updateJob)
         self.route('DELETE', (':id',), self.deleteJob)
@@ -54,6 +55,17 @@ class Job(Resource):
 
         return list(self.model('job', 'jobs').list(
             user=user, offset=offset, limit=limit, sort=sort, currentUser=currentUser))
+
+    @access.admin
+    @filtermodel(model='job', plugin='jobs')
+    @autoDescribeRoute(
+        Description('List all jobs.')
+        .pagingParams(defaultSort='created', defaultSortDir=SortDir.DESCENDING)
+    )
+    def listAllJobs(self, limit, offset, sort, params):
+        currentUser = self.getCurrentUser()
+        return list(self.model('job', 'jobs').listAll(
+            offset=offset, limit=limit, sort=sort, currentUser=currentUser))
 
     @access.public
     @filtermodel(model='job', plugin='jobs')

--- a/plugins/jobs/server/models/job.py
+++ b/plugins/jobs/server/models/job.py
@@ -71,6 +71,22 @@ class Job(AccessControlledModel):
                                                 limit=limit, offset=offset):
             yield r
 
+    def listAll(self, limit=0, offset=0, sort=None, currentUser=None):
+        """
+        List all jobs.
+
+        :param limit: The page limit.
+        :param offset: The page offset
+        :param sort: The sort field.
+        :param currentUser: User for access filtering.
+        """
+        cursor = self.find({}, sort=sort)
+
+        for r in self.filterResultsByPermission(cursor=cursor, user=currentUser,
+                                                level=AccessType.READ,
+                                                limit=limit, offset=offset):
+            yield r
+
     def cancelJob(self, job):
         """
         Revoke/cancel a job. This simply triggers the jobs.cancel event and


### PR DESCRIPTION
Created a new API endpoint `GET /job/all`. This API allows admin user to list all jobs in girder no matter the job is associated with a different user or is an anonymous job. 
For a non-admin user, the API would return an HTTP 403 (Forbidden) status. 
For an anonymous user, the API would return an HTTP 401 (unauthorized) status.