### PR TITLE
Make the staticRoot relative to the api_root.

### DIFF
--- a/girder/utility/server.py
+++ b/girder/utility/server.py
@@ -135,14 +135,14 @@ def configureServer(test=False, plugins=None, curConfig=None):
     # Make the staticRoot relative to the api_root, if possible.  The api_root
     # could be relative or absolute, but it needs to be in an absolute form for
     # relpath to behave as expected.  We always expect the api_root to
-    # contain at least two ocmponents, but the reference from static needs to
+    # contain at least two components, but the reference from static needs to
     # be from only the first component.
-    api_root_base = os.path.split(os.path.join('/', curConfig['server']['api_root']))[0]
+    apiRootBase = os.path.split(os.path.join('/', curConfig['server']['api_root']))[0]
 
     root.api.v1.updateHtmlVars({
         'apiRoot': curConfig['server']['api_root'],
         'staticRoot': os.path.relpath(routeTable[constants.GIRDER_STATIC_ROUTE_ID],
-                                      api_root_base)
+                                      apiRootBase)
     })
 
     root, appconf, _ = plugin_utilities.loadPlugins(

--- a/girder/utility/server.py
+++ b/girder/utility/server.py
@@ -132,9 +132,17 @@ def configureServer(test=False, plugins=None, curConfig=None):
         'plugins': plugins
     })
 
+    # Make the staticRoot relative to the api_root, if possible.  The api_root
+    # could be relative or absolute, but it needs to be in an absolute form for
+    # relpath to behave as expected.  We always expect the api_root to
+    # contain at least two ocmponents, but the reference from static needs to
+    # be from only the first component.
+    api_root_base = os.path.split(os.path.join('/', curConfig['server']['api_root']))[0]
+
     root.api.v1.updateHtmlVars({
         'apiRoot': curConfig['server']['api_root'],
-        'staticRoot': routeTable[constants.GIRDER_STATIC_ROUTE_ID],
+        'staticRoot': os.path.relpath(routeTable[constants.GIRDER_STATIC_ROUTE_ID],
+                                      api_root_base)
     })
 
     root, appconf, _ = plugin_utilities.loadPlugins(


### PR DESCRIPTION
This seems kind of clunky, but allows proxies to refer appropriately to the swagger docs both inside and outside of a proxy.

This resolves issue #1054.