### PR TITLE
Stop using an exposed webroot for static files

### DIFF
--- a/girder/utility/server.py
+++ b/girder/utility/server.py
@@ -215,7 +215,7 @@ def setup(test=False, plugins=None, curConfig=None):
                                       str(routeTable[constants.GIRDER_ROUTE_ID]), appconf)
 
     # Mount static files
-    cherrypy.tree.mount(BaseWebroot(), routeTable[constants.GIRDER_STATIC_ROUTE_ID],
+    cherrypy.tree.mount(None, routeTable[constants.GIRDER_STATIC_ROUTE_ID],
                         {'/':
                          {'tools.staticdir.on': True,
                           'tools.staticdir.dir': os.path.join(constants.STATIC_ROOT_DIR,
@@ -234,10 +234,6 @@ def setup(test=False, plugins=None, curConfig=None):
         application.merge({'server': {'mode': 'testing'}})
 
     return application
-
-
-class BaseWebroot(object):
-    exposed = True
 
 
 class _StaticFileRoute(object):


### PR DESCRIPTION
Fixes #1796 

Since the `BaseWebroot` is mounted using the staticdir tool, it uses its
own dispatcher and doesn't need its own webroot, see the docs for
`cherrypy.tree.mount`.

Since it was exposed but didn't have any retrieval methods (i.e. GET),
it was expecting to be callable when the static handler wasn't fulfilled
(file not found) and throwing an exception (and a 500).

@msmolens 