### PR TITLE
Fix race condition in item_tasks.tasks test

### DIFF
--- a/plugins/item_tasks/plugin_tests/tasks_test.py
+++ b/plugins/item_tasks/plugin_tests/tasks_test.py
@@ -285,8 +285,7 @@ class TasksTest(base.TestCase):
         self.assertIn('itemTaskTempToken', job)
 
         from girder.plugins.jobs.constants import JobStatus
-        job['status'] = JobStatus.SUCCESS
-        job = jobModel.save(job)
+        job = jobModel.updateJob(job, status=JobStatus.SUCCESS)
 
         self.assertNotIn('itemTaskTempToken', job)
         self.assertIn('itemTaskBindings', job)


### PR DESCRIPTION
We were clobbering our job model by saving it on the test
main thread after it had been saved on the async events thread.