### PR TITLE
Adjust the host in the swagger document.

### DIFF
--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -457,7 +457,7 @@ class Describe(Resource):
 
                 paths[route] = pathItem
 
-        apiUrl = getApiUrl()
+        apiUrl = getApiUrl(preferReferer=True)
         urlParts = getUrlParts(apiUrl)
         host = urlParts.netloc
         basePath = urlParts.path

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -59,26 +59,34 @@ def getUrlParts(url=None):
     return urllib.parse.urlparse(url)
 
 
-def getApiUrl(url=None):
+def getApiUrl(url=None, preferReferer=False):
     """
     In a request thread, call this to get the path to the root of the REST API.
     The returned path does *not* end in a forward slash.
 
     :param url: URL from which to extract the base URL. If not specified, uses
         the server root system setting. If that is not specified, uses `cherrypy.url()`
+    :param preferReferer: if no url is specified, this is true, and this is in
+        a cherrypy request that has a referer header that contains the api
+        string, use that referer as the url.
     """
+    apiStr = '/api/v1'
+
     if not url:
-        root = ModelImporter.model('setting').get(SettingKey.SERVER_ROOT)
-        if root:
-            return posixpath.join(root, config.getConfig()['server']['api_root'].lstrip('/'))
+        if preferReferer and apiStr in cherrypy.request.headers.get('referer', ''):
+            url = cherrypy.request.headers['referer']
+        else:
+            root = ModelImporter.model('setting').get(SettingKey.SERVER_ROOT)
+            if root:
+                return posixpath.join(root, config.getConfig()['server']['api_root'].lstrip('/'))
 
     url = url or cherrypy.url()
-    idx = url.find('/api/v1')
+    idx = url.find(apiStr)
 
     if idx < 0:
         raise GirderException('Could not determine API root in %s.' % url)
 
-    return url[:idx + 7]
+    return url[:idx + len(apiStr)]
 
 
 def iterBody(length=READ_BUFFER_LEN, strictLength=False):

--- a/tests/cases/api_describe_test.py
+++ b/tests/cases/api_describe_test.py
@@ -169,6 +169,18 @@ class ApiDescribeTestCase(base.TestCase):
             'description',
             resp.json['paths']['/group']['get']['responses']['200'])
 
+    def testApiDescribeReferred(self):
+        resp = self.request(path='/describe', method='GET')
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json['basePath'], '/api/v1')
+        self.assertEqual(resp.json['host'], '127.0.0.1')
+        resp = self.request(
+            path='/describe', method='GET',
+            additionalHeaders=[('Referer', 'http://somewhere.com/alternate/api/v1')])
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json['basePath'], '/alternate/api/v1')
+        self.assertEqual(resp.json['host'], 'somewhere.com')
+
     def testRoutesExist(self):
         # Check that the resources and operations exist
         resp = self.request(path='/describe', method='GET')


### PR DESCRIPTION
When serving the api describe endpoint, try to use the referrer to set the host and basePath in the swagger document.  This is well-formed from most web browsers, and will properly work inside and outside of a proxy.  For requests that don't send a Referer [sic] header, use the existing method.  Without this, proxies will only have the right value in Swagger if the tools.proxy.base value is set, if the api root is not placed on a different path by the proxy, and if the proxy is accessed as described by the tools.proxy.base value (which might be different inside and outside of a vpn, for instance).