### PR TITLE
Allow vagrant playbooks to require asset build

### DIFF
--- a/devops/ansible/examples/girder-configure-lib/site.yml
+++ b/devops/ansible/examples/girder-configure-lib/site.yml
@@ -4,6 +4,7 @@
   vars:
     girder_update: no
     girder_force: no
+    girder_always_build_assets: yes
   pre_tasks:
     - name: Update package cache
       apt:

--- a/devops/ansible/examples/girder-dev-environment/site.yml
+++ b/devops/ansible/examples/girder-dev-environment/site.yml
@@ -5,6 +5,7 @@
     girder_update: no
     girder_force: no
     girder_virtualenv: "{{ ansible_user_dir }}/.virtualenvs/girder"
+    girder_always_build_assets: yes
   pre_tasks:
     - name: Update package cache
       apt:

--- a/devops/ansible/examples/girder-external-mongo/site.yml
+++ b/devops/ansible/examples/girder-external-mongo/site.yml
@@ -4,6 +4,7 @@
   vars:
     girder_update: no
     girder_force: no
+    girder_always_build_assets: yes
   pre_tasks:
     - name: Update package cache
       apt:

--- a/devops/ansible/examples/girder-nginx/site.yml
+++ b/devops/ansible/examples/girder-nginx/site.yml
@@ -4,6 +4,7 @@
   vars:
     girder_update: no
     girder_force: no
+    girder_always_build_assets: yes
     nginx_vhosts:
       - listen: "8080 default_server"
         extra_parameters: |

--- a/devops/ansible/roles/girder/README.md
+++ b/devops/ansible/roles/girder/README.md
@@ -15,14 +15,15 @@ This is intended to be run on a clean Ubuntu 14.04 or 16.04 system.
 Role Variables
 --------------
 
-| parameter         | required | default      | comments                                                                     |
-| ----------------- | -------- | ------------ | ---------------------------------------------------------------------------- |
-| girder_path       | no       | $HOME/girder | Path to download and build Girder in.                                        |
-| girder_version    | no       | master       | Git commit-ish for fetching Girder.                                          |
-| girder_virtualenv | no       | none         | Path to a Python virtual environment to install Girder in.                   |
-| girder_update     | no       | yes          | Whether provisioning should fetch new versions via git.                      |
-| girder_force      | no       | yes          | Whether provisioning should discard modified files in the working directory. |
-| girder_web        | no       | yes          | Whether to build the Girder web client.                                      |
+| parameter                  | required | default      | comments                                                                                |
+| -------------------------- | -------- | ------------ | --------------------------------------------------------------------------------------- |
+| girder_path                | no       | $HOME/girder | Path to download and build Girder in.                                                   |
+| girder_version             | no       | master       | Git commit-ish for fetching Girder.                                                     |
+| girder_virtualenv          | no       | none         | Path to a Python virtual environment to install Girder in.                              |
+| girder_update              | no       | yes          | Whether provisioning should fetch new versions via git.                                 |
+| girder_force               | no       | yes          | Whether provisioning should discard modified files in the working directory.            |
+| girder_web                 | no       | yes          | Whether to build the Girder web client.                                                 |
+| girder_always_build_assets | no       | no           | Whether to always rebuild client side assets (has no effect if girder_web is disabled). |
 
 Examples
 --------

--- a/devops/ansible/roles/girder/defaults/main.yml
+++ b/devops/ansible/roles/girder/defaults/main.yml
@@ -6,3 +6,6 @@ girder_version: "master"
 girder_update: yes
 girder_force: yes
 girder_web: yes
+
+# the default is to only build assets when the git step results in new files
+girder_always_build_assets: no

--- a/devops/ansible/roles/girder/handlers/main.yml
+++ b/devops/ansible/roles/girder/handlers/main.yml
@@ -1,7 +1,0 @@
----
-
-- name: Build Girder (web)
-  command: "{{ girder_install_executable|default('girder-install') }} web"
-  args:
-    chdir: "{{ girder_path }}"
-  when: "{{ girder_web }}"

--- a/devops/ansible/roles/girder/tasks/girder.yml
+++ b/devops/ansible/roles/girder/tasks/girder.yml
@@ -23,4 +23,6 @@
     update: "{{ girder_update|default(omit) }}"
     force: "{{ girder_force|default(omit) }}"
   register: vc
-  notify: Build Girder (web)
+
+- set_fact:
+    girder_files_updated: "{{ vc.changed }}"

--- a/devops/ansible/roles/girder/tasks/main.yml
+++ b/devops/ansible/roles/girder/tasks/main.yml
@@ -36,3 +36,11 @@
   when: girder_virtualenv is defined
 
 - include: daemon.yml
+
+- name: Build Girder (web)
+  command: "{{ girder_install_executable|default('girder-install') }} web"
+  args:
+    chdir: "{{ girder_path }}"
+  # ensure that the install is one that uses web assets and
+  # the assets are always supposed to be rebuilt, or the files have changed (from git)
+  when: girder_web and (girder_always_build_assets or girder_files_updated)

--- a/devops/ansible/start_girder_in_screen.sh
+++ b/devops/ansible/start_girder_in_screen.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-/usr/bin/screen -d -m /bin/bash -c '/usr/bin/python -m girder 2>&1 | tee /home/vagrant/girder_output.log'

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -42,10 +42,13 @@ A shortcut to going through the installation steps for development is to use
 `VirtualBox <https://www.virtualbox.org>`_ virtual machine. To setup this
 environment run ``vagrant up`` in the root of the repository. This will spin up
 and provision a virtual machine, provided you have Vagrant and VirtualBox
-installed. Once this process is complete, you can run ``vagrant ssh`` in order
-to start Girder. There is a helper script in the Vagrant home directory that
-will start Girder in a detached screen session. You may want to run a similar
-process to run one of the watch commands detailed above.
+installed. Vagrant uses `Ansible <https://ansible.com>`_ for provisioning Girder and its various
+dependencies.
+
+.. seealso::
+
+   For more information on provisioning Girder, see :doc:`provisioning`.
+
 
 Utilities
 ---------


### PR DESCRIPTION
Fixes #1796 

@msmolens PTAL

In a nutshell, these were working correctly for production machines: only ever rebuild if a git clone/pull results in changed files. However with Vagrant, since the repo is mounted and we don't pull (in fear of messing up a devs working tree), there never are any changed files, and the code is never rebuilt.