### PR TITLE
Disable extract-text-loader-plugin

### DIFF
--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -653,15 +653,11 @@ girderTest.addScripts = function (scripts) {
 };
 
 /**
- * Import a CSS file into the runtime context.
+ * Import a CSS file into the runtime context. Now that we
+ * no longer have CSS files per plugin, this is a no-op.
+ * @deprecated TODO remove in next major version
  */
-girderTest.importStylesheet = function (css) {
-    $('<link/>', {
-        rel: 'stylesheet',
-        type: 'text/css',
-        href: css
-    }).appendTo('head');
-};
+girderTest.importStylesheet = $.noop;
 
 /**
  * For the current folder, check if it is public or private and take an action.

--- a/girder/utility/webroot.mako
+++ b/girder/utility/webroot.mako
@@ -6,11 +6,7 @@
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Droid+Sans:400,700">
     <link rel="stylesheet" href="${staticRoot}/built/fontello/css/fontello.css">
     <link rel="stylesheet" href="${staticRoot}/built/fontello/css/animation.css">
-    <link rel="stylesheet" href="${staticRoot}/built/girder_lib.min.css">
     <link rel="icon" type="image/png" href="${staticRoot}/img/Girder_Favicon.png">
-    % for plugin in pluginCss:
-    <link rel="stylesheet" href="${staticRoot}/built/plugins/${plugin}/plugin.min.css">
-    % endfor
   </head>
   <body>
     <div id="g-global-info-apiroot" class="hide">${apiRoot}</div>

--- a/girder/utility/webroot.py
+++ b/girder/utility/webroot.py
@@ -78,8 +78,7 @@ class Webroot(WebrootBase):
     """
     def __init__(self, templatePath=None):
         if not templatePath:
-            templatePath = os.path.join(constants.PACKAGE_DIR,
-                                        'utility', 'webroot.mako')
+            templatePath = os.path.join(constants.PACKAGE_DIR, 'utility', 'webroot.mako')
         super(Webroot, self).__init__(templatePath)
 
         self.vars = {
@@ -92,11 +91,9 @@ class Webroot(WebrootBase):
     def _renderHTML(self):
         self.vars['pluginCss'] = []
         self.vars['pluginJs'] = []
-        builtDir = os.path.join(constants.STATIC_ROOT_DIR, 'clients', 'web',
-                                'static', 'built', 'plugins')
+        builtDir = os.path.join(
+            constants.STATIC_ROOT_DIR, 'clients', 'web', 'static', 'built', 'plugins')
         for plugin in self.vars['plugins']:
-            if os.path.exists(os.path.join(builtDir, plugin, 'plugin.min.css')):
-                self.vars['pluginCss'].append(plugin)
             if os.path.exists(os.path.join(builtDir, plugin, 'plugin.min.js')):
                 self.vars['pluginJs'].append(plugin)
 

--- a/grunt_tasks/build.js
+++ b/grunt_tasks/build.js
@@ -18,7 +18,6 @@ var path = require('path');
 var _ = require('underscore');
 
 var webpack = require('webpack');
-var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var webpackGlobalConfig = require('./webpack.config.js');
 var paths = require('./webpack.paths.js');
 
@@ -103,10 +102,6 @@ module.exports = function (grunt) {
                     new webpack.DllPlugin({
                         path: path.join(paths.web_built, '[name]-manifest.json'),
                         name: '[name]'
-                    }),
-                    new ExtractTextPlugin({
-                        filename: '[name].min.css',
-                        allChunks: true
                     })
                 ]
             },
@@ -118,10 +113,6 @@ module.exports = function (grunt) {
                     new webpack.DllReferencePlugin({
                         context: '.',
                         manifest: path.join(paths.web_built, 'girder_lib-manifest.json')
-                    }),
-                    new ExtractTextPlugin({
-                        filename: '[name].min.css',
-                        allChunks: true
                     })
                 ]
             }

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -23,7 +23,6 @@ module.exports = function (grunt) {
     var path = require('path');
     var child_process = require('child_process'); // eslint-disable-line camelcase
 
-    var ExtractTextPlugin = require('extract-text-webpack-plugin');
     var webpack = require('webpack');
     var paths = require('./webpack.paths.js');
 
@@ -230,10 +229,6 @@ module.exports = function (grunt) {
                         new webpack.DllReferencePlugin({
                             context: '.',
                             manifest: path.join(paths.web_built, 'girder_lib-manifest.json')
-                        }),
-                        new ExtractTextPlugin({
-                            filename: `${output}.min.css`,
-                            allChunks: true
                         })
                     ]
                 };

--- a/grunt_tasks/webpack.config.js
+++ b/grunt_tasks/webpack.config.js
@@ -21,9 +21,6 @@
  */
 var path = require('path');
 var webpack = require('webpack');
-
-var ExtractTextPlugin = require('extract-text-webpack-plugin');
-
 var paths = require('./webpack.paths.js');
 var es2015Preset = require.resolve('babel-preset-es2015');
 
@@ -108,23 +105,18 @@ module.exports = {
             {
                 test: /\.styl$/,
                 include: loaderPaths,
-                loaders: ExtractTextPlugin.extract({
-                    fallbackLoader: 'style-loader',
-                    loader: ['css-loader', {
-                        loader: 'stylus-loader',
-                        query: {
-                            'resolve url': true
-                        }
-                    }]
-                })
+                loaders: ['style-loader', 'css-loader', {
+                    loader: 'stylus-loader',
+                    query: {
+                        'resolve url': true
+                    }
+                }]
             },
             // CSS
             {
                 test: /\.css$/,
                 include: loaderPathsNodeModules,
-                loaders: ExtractTextPlugin.extract({
-                    fallbackLoader: 'style-loader',
-                    loader: ['css-loader']})
+                loaders: ['style-loader', 'css-loader']
             },
             // Pug
             {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "css-loader": "^0.26.1",
     "eonasdan-bootstrap-datetimepicker": "~4.15",
     "event-source": "0.1.1",
-    "extract-text-webpack-plugin": "^2.0.0-rc.0",
     "file-loader": "^0.10.0",
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",

--- a/plugins/authorized_upload/plugin_tests/authorizedUploadSpec.js
+++ b/plugins/authorized_upload/plugin_tests/authorizedUploadSpec.js
@@ -6,10 +6,6 @@ girderTest.addCoveredScripts([
     '/clients/web/static/built/plugins/authorized_upload/plugin.min.js'
 ]);
 
-girderTest.importStylesheet(
-    '/static/built/plugins/authorized_upload/plugin.min.css'
-);
-
 girderTest.startApp();
 
 describe('Create an authorized upload.', function () {

--- a/plugins/item_tasks/plugin_tests/tasks.js
+++ b/plugins/item_tasks/plugin_tests/tasks.js
@@ -4,10 +4,6 @@ girderTest.addCoveredScripts([
     '/clients/web/static/built/plugins/item_tasks/plugin.min.js'
 ]);
 
-girderTest.importStylesheet('/static/built/plugins/jobs/plugin.min.css');
-girderTest.importStylesheet('/static/built/plugins/worker/plugin.min.css');
-girderTest.importStylesheet('/static/built/plugins/item_tasks/plugin.min.css');
-
 girderTest.startApp();
 
 describe('Create an item task', function () {

--- a/plugins/jobs/plugin_tests/jobsSpec.js
+++ b/plugins/jobs/plugin_tests/jobsSpec.js
@@ -4,10 +4,6 @@ girderTest.addCoveredScripts([
     '/clients/web/static/built/plugins/jobs/plugin.min.js'
 ]);
 
-girderTest.importStylesheet(
-    '/static/built/plugins/jobs/plugin.min.css'
-);
-
 girder.events.trigger('g:appload.before');
 var app = new girder.views.App({
     el: 'body',


### PR DESCRIPTION
It turns out it was roughly doubling our build time, and also
causing builds to hang on certain plugins for reasons we
could not discover. Disabling it seems to be the best option.