### PR TITLE
Stop displaying tracebacks on static mount points

### DIFF
--- a/girder/utility/server.py
+++ b/girder/utility/server.py
@@ -219,7 +219,10 @@ def setup(test=False, plugins=None, curConfig=None):
                         {'/':
                          {'tools.staticdir.on': True,
                           'tools.staticdir.dir': os.path.join(constants.STATIC_ROOT_DIR,
-                                                              'clients/web/static')}})
+                                                              'clients/web/static'),
+                          'request.show_tracebacks': appconf['/']['request.show_tracebacks'],
+                          'response.headers.server': 'Girder %s' % __version__,
+                          'error_page.default': _errorDefault}})
 
     # Mount API (special case)
     # The API is always mounted at /api AND at api relative to the Girder root


### PR DESCRIPTION
Static paths have always been mounted with only the options for
serving static directories. This commit causes the static mountpoint
to share the relevant configuration with the application mountpoint,
namely request.show_tracebacks, response.headers.server, and error_page.default.

I think that ideally we should strive to share the same (or very similar) environment configuration code that CherryPy core [offers](http://docs.cherrypy.org/en/latest/config.html#environments).