### PR TITLE
DB permission should be update when starting  mangoDB on  Ubuntu16.04

### DIFF
--- a/docs/prerequisites.rst
+++ b/docs/prerequisites.rst
@@ -81,6 +81,7 @@ With Ubuntu 16.04, create a systemd init script at
 
 and start it with: ::
 
+  sudo chmod 600 var/lib/mongodb/
   sudo service mongod start
 
 Enable the Node.js APT repository: ::

--- a/docs/prerequisites.rst
+++ b/docs/prerequisites.rst
@@ -81,7 +81,7 @@ With Ubuntu 16.04, create a systemd init script at
 
 and start it with: ::
 
-  sudo chmod 600 var/lib/mongodb/
+  sudo chmod 600 /var/lib/mongodb/
   sudo service mongod start
 
 Enable the Node.js APT repository: ::


### PR DESCRIPTION
You need to ensure that your ‘mongo’ user should has ownership of that file
Job for mongod.service failed because the control process exited with error code.