### PR TITLE
Fix stylus loader bug that caused builds to hang

### DIFF
--- a/grunt_tasks/webpack.config.js
+++ b/grunt_tasks/webpack.config.js
@@ -110,12 +110,8 @@ module.exports = {
                 include: loaderPaths,
                 loaders: ExtractTextPlugin.extract({
                     fallbackLoader: 'style-loader',
-                    loader: ['css-loader', {
-                        loader: 'stylus-loader',
-                        query: {
-                            'resolve url': true
-                        }
-                    }]
+                    // stylus loader query must be a string for now
+                    loader: ['css-loader', 'stylus-loader?resolve url=true']
                 })
             },
             // CSS


### PR DESCRIPTION
This was fixed in https://github.com/shama/stylus-loader/pull/166 but
has not yet been merged and released. This is the only way I
discovered to workaround this issue.

A longer term solution would be to change our webpack configuration to
the new structure, but that's more than I want to undertake right now.