### PR TITLE
Re-implements the GUI for Collection Creation Policy on System Configuration page

### DIFF
--- a/clients/web/src/models/CollectionCreationPolicyModel.js
+++ b/clients/web/src/models/CollectionCreationPolicyModel.js
@@ -1,0 +1,25 @@
+import _ from 'underscore';
+import AccessControlledModel from 'girder/models/AccessControlledModel';
+import { restRequest } from 'girder/rest';
+
+var CollectionCreationPolicyModel = AccessControlledModel.extend({
+    resourceName: 'system/setting/collection_creation_policy',
+    fetchAccess: function () {
+        return restRequest({
+            path: this.resourceName + '/access',
+            type: 'GET'
+        }).done(_.bind(function (resp) {
+            if (resp.access) {
+                this.set(resp);
+            } else {
+                this.set('access', resp);
+            }
+            this.trigger('g:accessFetched');
+            return resp;
+        }, this)).error(_.bind(function (err) {
+            this.trigger('g:error', err);
+        }, this));
+    }
+});
+
+export default CollectionCreationPolicyModel;

--- a/clients/web/src/models/CollectionCreationPolicyModel.js
+++ b/clients/web/src/models/CollectionCreationPolicyModel.js
@@ -9,11 +9,7 @@ var CollectionCreationPolicyModel = AccessControlledModel.extend({
             path: this.resourceName + '/access',
             type: 'GET'
         }).done(_.bind(function (resp) {
-            if (resp.access) {
-                this.set(resp);
-            } else {
-                this.set('access', resp);
-            }
+            this.set('access', resp);
             this.trigger('g:accessFetched');
             return resp;
         }, this)).error(_.bind(function (err) {

--- a/clients/web/src/models/CollectionCreationPolicyModel.js
+++ b/clients/web/src/models/CollectionCreationPolicyModel.js
@@ -1,4 +1,3 @@
-import _ from 'underscore';
 import AccessControlledModel from 'girder/models/AccessControlledModel';
 import { restRequest } from 'girder/rest';
 
@@ -8,13 +7,13 @@ var CollectionCreationPolicyModel = AccessControlledModel.extend({
         return restRequest({
             path: this.resourceName + '/access',
             type: 'GET'
-        }).done(_.bind(function (resp) {
+        }).done(resp => {
             this.set('access', resp);
             this.trigger('g:accessFetched');
             return resp;
-        }, this)).error(_.bind(function (err) {
+        }).error(err => {
             this.trigger('g:error', err);
-        }, this));
+        });
     }
 });
 

--- a/clients/web/src/stylesheets/body/systemConfig.styl
+++ b/clients/web/src/stylesheets/body/systemConfig.styl
@@ -1,6 +1,10 @@
 .g-settings-form
   margin-top 10px
 
+  .bootstrap-switch-handle-on,
+  .bootstrap-switch-handle-off
+      word-wrap normal
+
 #g-core-collection-create-policy
   font-family monospace
   margin-bottom 3px
@@ -14,9 +18,9 @@
   margin-bottom 10px
   padding 10px
 
-  :first-child
+  > :first-child
     margin-top 0
-  :last-child
+  > :last-child
     margin-bottom 0
   .g-settings-form-container
     background-color darken($bgColor, 3%)
@@ -27,6 +31,14 @@
 .g-collection-create-policy-container
   // this class is deprecated
   @extend .g-settings-form-container
+
+  .access-widget-container
+    width: 420px
+    margin-top: 15px;
+
+    .g-grant-access-container
+      div.form-group
+        margin-bottom: 0
 
   .g-search-container
     .g-search-wrapper, input[type="text"]

--- a/clients/web/src/stylesheets/body/systemConfig.styl
+++ b/clients/web/src/stylesheets/body/systemConfig.styl
@@ -33,12 +33,12 @@
   @extend .g-settings-form-container
 
   .access-widget-container
-    width: 420px
-    margin-top: 15px;
+    width 420px
+    margin-top 15px
 
     .g-grant-access-container
       div.form-group
-        margin-bottom: 0
+        margin-bottom 0
 
   .g-search-container
     .g-search-wrapper, input[type="text"]

--- a/clients/web/src/templates/body/systemConfiguration.pug
+++ b/clients/web/src/templates/body/systemConfiguration.pug
@@ -55,11 +55,16 @@ form.g-settings-form(role="form")
             selected=((settings['core.add_to_group_policy'] ||
           defaults['core.add_to_group_policy']) === "yesmod"))
           | Yes, by group administrators and moderators unless disabled per group
-    .g-collection-create-policy-container.g-settings-form-container
-      label(for="g-core-collection-create-policy") Collection creation policy
-      textarea#g-core-collection-create-policy.form-control
-        = JSON.stringify(settings['core.collection_create_policy'] || defaults['core.collection_create_policy'], null, 4)
-      .g-search-container
+    .g-collection-create-policy-container
+      label 
+        | Collection creation policy
+      p.
+        Allow additional users and groups to create collection.
+      input.g-plugin-switch(type="checkbox",
+          checked="checked", data-size="mini", data-on-color="primary")
+      .access-widget-container
+      textarea#g-core-collection-create-policy(style={'display':'none'})
+        = JSON.stringify(settings['core.collection_create_policy'] || defaults['core.collection_create_policy'])
     .form-group
       label(for="g-core-user-default-folders") Create default folders for new users
       select#g-core-user-default-folders.form-control.input-sm

--- a/clients/web/src/templates/body/systemConfiguration.pug
+++ b/clients/web/src/templates/body/systemConfiguration.pug
@@ -56,14 +56,13 @@ form.g-settings-form(role="form")
           defaults['core.add_to_group_policy']) === "yesmod"))
           | Yes, by group administrators and moderators unless disabled per group
     .g-collection-create-policy-container
-      label 
-        | Collection creation policy
+      label Collection creation policy
       p.
         Allow additional users and groups to create collection.
       input.g-plugin-switch(type="checkbox",
           checked="checked", data-size="mini", data-on-color="primary")
       .access-widget-container
-      textarea#g-core-collection-create-policy(style={'display':'none'})
+      textarea#g-core-collection-create-policy.hide
         = JSON.stringify(settings['core.collection_create_policy'] || defaults['core.collection_create_policy'])
     .form-group
       label(for="g-core-user-default-folders") Create default folders for new users

--- a/clients/web/src/templates/widgets/accessEditor.pug
+++ b/clients/web/src/templates/widgets/accessEditor.pug
@@ -12,9 +12,9 @@ include accessEditorMixins
           i.icon-sitemap
         = model.name()
     .modal-body.g-access-modal-body
-      +privacyEditor(modelType)
+      if !hidePrivacyEditor
+        +privacyEditor(modelType)
       +permissionsEditor
-
       if !hideRecurseOption
         +recurseOption(modelType)
 

--- a/clients/web/src/templates/widgets/accessEditorNonModal.pug
+++ b/clients/web/src/templates/widgets/accessEditorNonModal.pug
@@ -1,6 +1,7 @@
 include accessEditorMixins
 
-+privacyEditor(modelType)
+if !hidePrivacyEditor
+  +privacyEditor(modelType)
 +permissionsEditor
 
 if !hideRecurseOption

--- a/clients/web/src/templates/widgets/accessEntry.pug
+++ b/clients/web/src/templates/widgets/accessEntry.pug
@@ -7,12 +7,13 @@ div(class=`g-${type}-access-entry`, resourceid=entry.id)
       .g-desc-title= entry.title
       .g-desc-subtitle= entry.subtitle
   .g-access-col-right
-    select.form-control.input-sm
-      option(value=accessTypes.READ, selected=(entry.level === accessTypes.READ ? 'selected' : null)) Can view
-      option(value=accessTypes.WRITE, selected=(entry.level === accessTypes.WRITE ? 'selected' : null)) Can edit
-      option(value=accessTypes.ADMIN, selected=(entry.level === accessTypes.ADMIN ? 'selected' : null)) Is owner
+    if !hideAccessType
+      select.form-control.input-sm
+        option(value=accessTypes.READ, selected=(entry.level === accessTypes.READ ? 'selected' : null)) Can view
+        option(value=accessTypes.WRITE, selected=(entry.level === accessTypes.WRITE ? 'selected' : null)) Can edit
+        option(value=accessTypes.ADMIN, selected=(entry.level === accessTypes.ADMIN ? 'selected' : null)) Is owner
     .g-access-action-container
-      if _.keys(flagList).length
+      if !noAccessFlag && _.keys(flagList).length
         a.g-action-manage-flags(title="Access flags")
           i.icon-flag
         .g-flags-popover-container.hide(resourcetype=type, resourceid=entry.id, title="Access flags")

--- a/clients/web/test/spec/adminSpec.js
+++ b/clients/web/test/spec/adminSpec.js
@@ -99,6 +99,14 @@ describe('Test the settings page', function () {
     });
     it('Use search to update collection create policy', function () {
         runs(function () {
+            $('.g-collection-create-policy-container .g-plugin-switch').click();
+        });
+
+        waitsFor(function () {
+            return $('.g-collection-create-policy-container .access-widget-container .g-grant-access-container').length > 0;
+        }, 'access widget to load');
+
+        runs(function () {
             $('.g-collection-create-policy-container .g-search-field').val('admin')
                 .trigger('input');
         });
@@ -112,8 +120,24 @@ describe('Test the settings page', function () {
         });
 
         waitsFor(function () {
-            return JSON.parse($('#g-core-collection-create-policy').val()).users.length === 1;
-        }, 'policy value to update');
+            return $('.g-collection-create-policy-container .access-widget-container #g-ac-list-users').children().length === 1;
+        }, 'access list to populate');
+
+        runs(function () {
+            $('.g-collection-create-policy-container .access-widget-container #g-ac-list-users .g-user-access-entry .icon-cancel').click();
+        });
+
+        waitsFor(function () {
+            return $('.g-collection-create-policy-container .access-widget-container #g-ac-list-users').children().length === 0;
+        }, 'policy value to be cleared');
+
+        runs(function () {
+            $('.g-collection-create-policy-container .g-plugin-switch').click();
+        });
+
+        waitsFor(function () {
+            return $('.g-collection-create-policy-container .access-widget-container .g-grant-access-container').length === 0;
+        }, 'access widget unload');
     });
 
     it('logout and check for redirect to front page from settings page', function () {

--- a/clients/web/test/spec/adminSpec.js
+++ b/clients/web/test/spec/adminSpec.js
@@ -39,6 +39,11 @@ describe('Create an admin and non-admin user', function () {
     it('No admin console when logging in as a normal user', function () {
         expect($('.g-global-nav-li span').text()).not.toContain('Admin console');
     });
+
+    it('go to groups page', girderTest.goToGroupsPage());
+
+    it('Create a public group',
+       girderTest.createGroup('pubGroup', 'public group', true));
 });
 
 describe('Test the settings page', function () {
@@ -113,7 +118,7 @@ describe('Test the settings page', function () {
 
         waitsFor(function () {
             return $('.g-collection-create-policy-container .g-search-result').length > 0;
-        }, 'search result to appear');
+        }, 'search result to appear for a user');
 
         runs(function () {
             $('.g-collection-create-policy-container .g-search-result>a').click();
@@ -121,7 +126,27 @@ describe('Test the settings page', function () {
 
         waitsFor(function () {
             return $('.g-collection-create-policy-container .access-widget-container #g-ac-list-users').children().length === 1;
-        }, 'access list to populate');
+        }, 'access list to populate with one user');
+
+        runs(function () {
+            $('.g-collection-create-policy-container .g-search-field').val('pubGroup').trigger('input');
+        });
+
+        waitsFor(function () {
+            return $('.g-collection-create-policy-container .g-search-result .icon-users').length > 0;
+        }, 'search result to appear for a group');
+
+        runs(function () {
+            $('.g-collection-create-policy-container .g-search-result>a').click();
+        });
+
+        waitsFor(function () {
+            return $('.g-collection-create-policy-container .access-widget-container #g-ac-list-groups').children().length === 1;
+        }, 'access list to populate with one group');
+
+        runs(function () {
+            $('.g-submit-settings').click();
+        });
 
         runs(function () {
             $('.g-collection-create-policy-container .access-widget-container #g-ac-list-users .g-user-access-entry .icon-cancel').click();

--- a/clients/web/test/spec/customWidgetsSpec.js
+++ b/clients/web/test/spec/customWidgetsSpec.js
@@ -115,8 +115,8 @@
 
             waitsFor(function () {
                 return $('.g-hierarchy-widget').length > 0 &&
-                    $('.g-folder-list-link').length > 0 &&
-                    $('.g-item-list-link').length > 0;
+                       $('.g-folder-list-link').length > 0 &&
+                       $('.g-item-list-link').length > 0;
             }, 'the hierarchy widget to display');
 
             runs(function () {

--- a/clients/web/test/spec/customWidgetsSpec.js
+++ b/clients/web/test/spec/customWidgetsSpec.js
@@ -115,8 +115,8 @@
 
             waitsFor(function () {
                 return $('.g-hierarchy-widget').length > 0 &&
-                       $('.g-folder-list-link').length > 0 &&
-                       $('.g-item-list-link').length > 0;
+                    $('.g-folder-list-link').length > 0 &&
+                    $('.g-item-list-link').length > 0;
             }, 'the hierarchy widget to display');
 
             runs(function () {
@@ -603,6 +603,32 @@
                 expect(adminCheckbox.is(':disabled')).toBe(true);
                 expect(openCheckbox.is(':disabled')).toBe(false);
             });
+        });
+
+        it('test hide component options', function () {
+            runs(function () {
+                // create the widget will all hide options
+                widget.destroy();
+                widget = new girder.views.widgets.AccessWidget({
+                    el: 'body',
+                    modal: false,
+                    model: folder,
+                    modelType: 'folder',
+                    parentView: null,
+                    hideRecurseOption: true,
+                    hideSaveButton: true,
+                    hidePrivacyEditor: true,
+                    hideAccessType: true,
+                    noAccessFlag: true
+                });
+            });
+
+            waitsFor(function () {
+                return widget.$('#g-ac-list-users').children().length === 1 &&
+                    widget.$('.g-public-container').length === 0 &&
+                    widget.$('.g-recursive-container').length === 0 &&
+                    widget.$('.g-user-access-entry select').length === 0;
+            }, 'check if all component are hidden');
         });
     });
 

--- a/tests/cases/system_test.py
+++ b/tests/cases/system_test.py
@@ -472,7 +472,6 @@ class SystemTestCase(base.TestCase):
             }
         })
 
-        group = self.model('group').createGroup('test group', creator=self.users[1])
         self.users[1] = self.model('user').load(self.users[1]['_id'], force=True)
         user = self.users[1]
 
@@ -503,7 +502,7 @@ class SystemTestCase(base.TestCase):
                 'flags': ['my_key', 'not a registered flag']
             }],
             'groups': [{
-                'id': group['_id'],
+                'id': self.group['_id'],
                 'level': AccessType.ADMIN,
                 'flags': ['my_key']
             }]
@@ -543,7 +542,7 @@ class SystemTestCase(base.TestCase):
                 'flags': ['admin_flag']
             }],
             'groups': [{
-                'id': group['_id'],
+                'id': self.group['_id'],
                 'level': AccessType.ADMIN,
                 'flags': ['admin_flag']
             }]
@@ -560,7 +559,7 @@ class SystemTestCase(base.TestCase):
                 'flags': ['my_key', 'admin_flag']
             }],
             'groups': [{
-                'id': group['_id'],
+                'id': self.group['_id'],
                 'level': AccessType.ADMIN,
                 'flags': ['admin_flag']
             }]
@@ -638,7 +637,7 @@ class SystemTestCase(base.TestCase):
         self.assertFalse(folderModel.hasAccessFlags(folder, self.users[1], flags='my_key'))
 
         folder = folderModel.setGroupAccess(
-            folder, group, level=AccessType.READ, save=True, force=True, flags='my_key')
+            folder, self.group, level=AccessType.READ, save=True, force=True, flags='my_key')
         folderModel.requireAccessFlags(folder, user=self.users[1], flags='my_key')
 
         # Testing with flags=None should give sensible behavior

--- a/tests/cases/system_test.py
+++ b/tests/cases/system_test.py
@@ -665,3 +665,18 @@ class SystemTestCase(base.TestCase):
 
         settingModel.set(SettingKey.SERVER_ROOT, 'https://somedomain.org/foo')
         self.assertEqual(getApiUrl(), 'https://somedomain.org/foo/api/v1')
+
+    def testCollectionCreationPolicySettingAndItsAccessAPI(self):
+        resp = self.request(path='/system/setting', method='PUT', params={
+            'list': json.dumps([
+                {'key': SettingKey.COLLECTION_CREATE_POLICY, 'value': json.dumps({
+                    'open': True,
+                    'users': [str(self.users[0]['_id'])]
+                })}
+            ])
+        }, user=self.users[0])
+
+        resp = self.request(path='/system/setting/collection_creation_policy/access',
+                            method='GET', user=self.users[0])
+        self.assertEqual(resp.json['users'][0]['id'], str(self.users[0]['_id']))
+        self.assertEqual(resp.json['users'][0]['login'], str(self.users[0]['login']))

--- a/tests/cases/system_test.py
+++ b/tests/cases/system_test.py
@@ -68,6 +68,8 @@ class SystemTestCase(base.TestCase):
             'usr%s' % num, 'passwd', 'tst', 'usr', 'u%s@u.com' % num)
             for num in [0, 1]]
 
+        self.group = self.model('group').createGroup('test group', creator=self.users[1])
+
     def tearDown(self):
         # Restore the state of the plugins configuration
         conf = config.getConfig()
@@ -671,7 +673,8 @@ class SystemTestCase(base.TestCase):
             'list': json.dumps([
                 {'key': SettingKey.COLLECTION_CREATE_POLICY, 'value': json.dumps({
                     'open': True,
-                    'users': [str(self.users[0]['_id'])]
+                    'users': [str(self.users[0]['_id'])],
+                    'groups': [str(self.group['_id'])]
                 })}
             ])
         }, user=self.users[0])
@@ -680,3 +683,4 @@ class SystemTestCase(base.TestCase):
                             method='GET', user=self.users[0])
         self.assertEqual(resp.json['users'][0]['id'], str(self.users[0]['_id']))
         self.assertEqual(resp.json['users'][0]['login'], str(self.users[0]['login']))
+        self.assertEqual(resp.json['groups'][0]['id'], str(self.group['_id']))


### PR DESCRIPTION
@zachmullen pointed out the current GUI for editing Collection Creation Policy (CCP) is could use a more user-friendly GUI. Since the current AccessWidget is handling adding users and groups to a list, as suggested by @zachmullen and @manthey, I added few more options to AccessWidget to support the use case for CCP.
A server-side API is added for AccessWidget for retrieving corresponding names of user id and group id.

When CCP enabled
![chrome_2017-03-01_13-46-52](https://cloud.githubusercontent.com/assets/3123478/23475915/04d0716e-fe87-11e6-968f-444085681f81.png)

When it's not enabled
![chrome_2017-03-01_13-47-19](https://cloud.githubusercontent.com/assets/3123478/23475927/0bd42c30-fe87-11e6-938d-ee1a377264fc.png)

