### PR TITLE
requirements: Require functools32 only if using python <= 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ bcrypt==2.0.0
 boto==2.40.0
 cffi==1.8.3
 CherryPy==6.0.1
-functools32==3.2.3.post2
+functools32==3.2.3.post2; python_version <= '2.7'
 jsonschema==2.6.0
 Mako==1.0.4
 pymongo==3.2.2


### PR DESCRIPTION
This commit fixes a regression introduced in 2206517 (Add new
requirements into requirements.txt)

It addresses the following error reported when installing requirements
when using python 3.5:

```
$ pip install -U -r requirements-dev.txt -r requirements.txt
Ignoring shutilwhich: markers 'python_version < "3.3"' don't match your environment
Ignoring snakebite: markers 'python_version < "3.0"' don't match your environment
Ignoring hachoir-core: markers 'python_version < "3.0"' don't match your environment
Ignoring hachoir-metadata: markers 'python_version < "3.0"' don't match your environment
Ignoring hachoir-parser: markers 'python_version < "3.0"' don't match your environment
Requirement already up-to-date: coverage==4.1.0 in /home/jcfr/.virtualenvs/girder_env/lib/python3.5/site-packages (from -r requirements-dev.txt (line 2))
Requirement already up-to-date: flake8==2.5.4 in /home/jcfr/.virtualenvs/girder_env/lib/python3.5/site-packages (from -r requirements-dev.txt (line 3))
[...]
Requirement already up-to-date: CherryPy==6.0.1 in /home/jcfr/.virtualenvs/girder_env/lib/python3.5/site-packages (from -r requirements.txt (line 5))
Collecting functools32==3.2.3.post2 (from -r requirements.txt (line 6))
  Using cached functools32-3.2.3-2.zip
    Complete output from command python setup.py egg_info:
    This backport is for Python 2.7 only.

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-br7thpgg/functools32/
```