### PR TITLE
Improve girder cli

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -173,7 +173,8 @@ class GirderClient(object):
             if not apiRoot:
                 apiRoot = self.DEFAULT_API_ROOT
             # If needed, prepend '/'
-            apiRoot = '/' + apiRoot if apiRoot[0] != '/' else apiRoot
+            if not apiRoot.startswith('/'):
+                apiRoot = '/' + apiRoot
 
             self.scheme = scheme or self.DEFAULT_SCHEME
             self.host = host or self.DEFAULT_HOST

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -166,7 +166,9 @@ class GirderClient(object):
             to pass 443 for the port
         :param cacheSettings: Settings to use with the diskcache library, or
             None to disable caching.
-        :param progressReporterCls: the progress reporter class to instantiate.
+        :param progressReporterCls: the progress reporter class to instantiate. This class
+            is expected to be a context manager with a constructor accepting `label` and
+            `length` keyword arguments and an `update` method accepting a `chunkSize` argument.
             This defaults to :class:`_NoopProgressReporter`.
         """
         if apiUrl is None:

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -196,7 +196,9 @@ class GirderClient(object):
             None to disable caching.
         :param progressReporterCls: the progress reporter class to instantiate. This class
             is expected to be a context manager with a constructor accepting `label` and
-            `length` keyword arguments and an `update` method accepting a `chunkSize` argument.
+            `length` keyword arguments, an `update` method accepting a `chunkSize` argument and
+            a class attribute `reportProgress` set to True (It can conveniently be
+            initialized using `sys.stdout.isatty()`).
             This defaults to :class:`_NoopProgressReporter`.
         """
         if apiUrl is None:

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -151,9 +151,9 @@ class GirderClient(object):
             if apiRoot is None:
                 apiRoot = '/api/v1'
 
-            self.scheme = scheme or 'http'
+            self.scheme = scheme or 'https'
             self.host = host or 'localhost'
-            self.port = port or (443 if scheme == 'https' else 80)
+            self.port = port or (443 if self.scheme == 'https' else 80)
 
             self.urlBase = '%s://%s:%s%s' % (
                 self.scheme, self.host, str(self.port), apiRoot)

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -89,7 +89,7 @@ class HttpError(Exception):
 
 
 class _NoopProgressReporter(object):
-    def __init__(self, label="", length=0):
+    def __init__(self, label='', length=0):
         self.label = label
         self.length = length
 
@@ -166,7 +166,7 @@ class GirderClient(object):
             to pass 443 for the port
         :param cacheSettings: Settings to use with the diskcache library, or
             None to disable caching.
-        :param progressReporterCls: the progress reported class to instantiate.
+        :param progressReporterCls: the progress reporter class to instantiate.
             This defaults to :class:`_NoopProgressReporter`.
         """
         if apiUrl is None:

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -148,8 +148,10 @@ class GirderClient(object):
             None to disable caching.
         """
         if apiUrl is None:
-            if apiRoot is None:
-                apiRoot = '/api/v1'
+            if not apiRoot:
+                apiRoot = 'api/v1'
+            # If needed, prepend '/'
+            apiRoot = '/' + apiRoot if apiRoot[0] != '/' else apiRoot
 
             self.scheme = scheme or 'https'
             self.host = host or 'localhost'

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -799,14 +799,14 @@ class GirderClient(object):
             # Used for fast non-multipart upload
             class _ProgressBytesIO(six.BytesIO):
                 def read(self, _size):
-                    _chunk = super(_ProgressBytesIO, self).read(_size)
+                    _chunk = six.BytesIO.read(self, _size)
                     reporter.update(len(_chunk))
                     return _chunk
 
             # Used for deprecated multipart upload
             class _ProgressMultiPartEncoder(MultipartEncoder):
                 def read(self, _size):
-                    _chunk = super(_ProgressMultiPartEncoder, self).read(_size)
+                    _chunk = MultipartEncoder.read(self, _size)
                     reporter.update(len(_chunk))
                     return _chunk
 

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -89,6 +89,8 @@ class HttpError(Exception):
 
 
 class _NoopProgressReporter(object):
+    reportProgress = False
+
     def __init__(self, label='', length=0):
         self.label = label
         self.length = length
@@ -1301,7 +1303,8 @@ class GirderClient(object):
         :param reuseExisting: boolean indicating whether to accept an existing item
             of the same name in the same location, or create a new one instead
         """
-        print('Uploading Item from %s' % localFile)
+        if not self.progressReporterCls.reportProgress:
+            print('Uploading Item from %s' % localFile)
         if not dryRun:
             currentItem = self.loadOrCreateItem(
                 os.path.basename(localFile), parentFolderId, reuseExisting)

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -123,6 +123,11 @@ class GirderClient(object):
     # The current maximum chunk size for uploading file chunks
     MAX_CHUNK_SIZE = 1024 * 1024 * 64
 
+    DEFAULT_API_ROOT = 'api/v1'
+    DEFAULT_HOST = 'localhost'
+    DEFAULT_PORT = 443
+    DEFAULT_SCHEME = 'https'
+
     def __init__(self, host=None, port=None, apiRoot=None, scheme=None, apiUrl=None,
                  cacheSettings=None):
         """
@@ -149,13 +154,14 @@ class GirderClient(object):
         """
         if apiUrl is None:
             if not apiRoot:
-                apiRoot = 'api/v1'
+                apiRoot = self.DEFAULT_API_ROOT
             # If needed, prepend '/'
             apiRoot = '/' + apiRoot if apiRoot[0] != '/' else apiRoot
 
-            self.scheme = scheme or 'https'
-            self.host = host or 'localhost'
-            self.port = port or (443 if self.scheme == 'https' else 80)
+            self.scheme = scheme or self.DEFAULT_SCHEME
+            self.host = host or self.DEFAULT_HOST
+            self.port = port or (
+                self.DEFAULT_PORT if self.scheme == 'https' else 80)
 
             self.urlBase = '%s://%s:%s%s' % (
                 self.scheme, self.host, str(self.port), apiRoot)

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -42,7 +42,8 @@ class GirderCli(GirderClient):
             this blank to be prompted.
         """
         super(GirderCli, self).__init__(
-            host=host, port=port, apiRoot=apiRoot, scheme=scheme, apiUrl=apiUrl)
+            host=host, port=port, apiRoot=apiRoot, scheme=scheme, apiUrl=apiUrl,
+            progressReporterCls=click.progressbar)
         interactive = password is None
 
         if apiKey:

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -115,8 +115,8 @@ def _lookup_parent_type(client, object_id):
                 raise (sys.exc_info()[0], sys.exc_info()[1], sys.exc_info()[2])  # noqa: E999
 
 
-def _common_parameters(path_exists=False, path_writable=True,
-                       additional_parent_types=['collection', 'user']):
+def _CommonParameters(path_exists=False, path_writable=True,
+                      additional_parent_types=['collection', 'user']):
     parent_types = ['folder'] + additional_parent_types
     parent_type_cls = _DeprecatedOption
     parent_type_default = 'folder'
@@ -149,7 +149,7 @@ _short_help = 'Download files from Girder'
 
 
 @main.command('download', short_help=_short_help, help='%s\n\n%s' % (_short_help, _common_help))
-@_common_parameters(additional_parent_types=['collection', 'user', 'item'])
+@_CommonParameters(additional_parent_types=['collection', 'user', 'item'])
 @click.pass_obj
 def _download(gc, parent_type, parent_id, local_folder):
     if parent_type == 'auto':
@@ -164,7 +164,7 @@ _short_help = 'Synchronize local folder with remote Girder folder'
 
 
 @main.command('localsync', short_help=_short_help, help='%s\n\n%s' % (_short_help, _common_help))
-@_common_parameters(additional_parent_types=[])
+@_CommonParameters(additional_parent_types=[])
 @click.pass_obj
 def _localsync(gc, parent_type, parent_id, local_folder):
     if parent_type != 'folder':
@@ -178,7 +178,7 @@ _short_help = 'Upload files to Girder'
 
 
 @main.command('upload', short_help=_short_help, help='%s\n\n%s' % (_short_help, _common_help))
-@_common_parameters(path_exists=True, path_writable=False)
+@_CommonParameters(path_exists=True, path_writable=False)
 @click.option('--leaf-folders-as-items', is_flag=True,
               help='upload all files in leaf folders to a single Item named after the folder')
 @click.option('--reuse', is_flag=True,

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -99,6 +99,7 @@ def _common_parameters(path_exists=False, path_writable=True,
                        additional_parent_types=['collection', 'user']):
     parent_types = ['folder'] + additional_parent_types
     parent_type_cls = click.Option if len(additional_parent_types) > 0 else _DeprecatedOption
+
     def wrap(func):
         decorators = [
             click.option('--parent-type', default='folder', show_default=True, cls=parent_type_cls,
@@ -122,10 +123,13 @@ _short_help = 'Download files from Girder'
 
 
 @main.command('download', short_help=_short_help, help='%s\n\n%s' % (_short_help, _common_help))
-@_common_parameters()
+@_common_parameters(additional_parent_types=['collection', 'user', 'item'])
 @click.pass_obj
 def _download(gc, parent_type, parent_id, local_folder):
-    gc.downloadResource(parent_id, local_folder, parent_type)
+    if parent_type == 'item':
+        gc.downloadItem(parent_id, local_folder)
+    else:
+        gc.downloadResource(parent_id, local_folder, parent_type)
 
 
 _short_help = 'Synchronize local folder with remote Girder folder'

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -108,7 +108,9 @@ def _common_parameters(func):
                      help='type of Girder parent target',
                      type=click.Choice(['collection', 'folder', 'user'])),
         click.argument('parent_id'),
-        click.argument('local_folder'),
+        click.argument(
+            'local_folder',
+            type=click.Path(exists=False, dir_okay=True, writable=True, readable=True)),
     ]
     for decorator in reversed(decorators):
         func = decorator(func)

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -54,10 +54,10 @@ class _DeprecatedOption(click.Option):
         pass
 
 
-CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+_CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 
-@click.group(context_settings=CONTEXT_SETTINGS)
+@click.group(context_settings=_CONTEXT_SETTINGS)
 @click.option('--api-url', default=None,
               help='RESTful API URL '
                    '(e.g https://girder.example.com:443/%s)' % GirderClient.DEFAULT_API_ROOT)
@@ -116,24 +116,20 @@ _common_help = 'PARENT_ID is the id of the Girder parent target and ' \
 _short_help = 'Download files from Girder'
 
 
-@main.command(
-    'download',
-    short_help=_short_help, help='%s\n\n%s' % (_short_help, _common_help))
+@main.command('download', short_help=_short_help, help='%s\n\n%s' % (_short_help, _common_help))
 @_common_parameters
 @click.pass_obj
-def download(gc, parent_type, parent_id, local_folder):
+def _download(gc, parent_type, parent_id, local_folder):
     gc.downloadResource(parent_id, local_folder, parent_type)
 
 
 _short_help = 'Synchronize local folder with remote Girder folder'
 
 
-@main.command(
-    'localsync',
-    short_help=_short_help, help='%s\n\n%s' % (_short_help, _common_help))
+@main.command('localsync', short_help=_short_help, help='%s\n\n%s' % (_short_help, _common_help))
 @_common_parameters
 @click.pass_obj
-def localsync(gc, parent_type, parent_id, local_folder):
+def _localsync(gc, parent_type, parent_id, local_folder):
     if parent_type != 'folder':
         raise Exception('localsync command only accepts parent-type of folder')
     gc.loadLocalMetadata(local_folder)
@@ -144,9 +140,7 @@ def localsync(gc, parent_type, parent_id, local_folder):
 _short_help = 'Upload files to Girder'
 
 
-@main.command(
-    'upload',
-    short_help=_short_help, help='%s\n\n%s' % (_short_help, _common_help))
+@main.command('upload', short_help=_short_help, help='%s\n\n%s' % (_short_help, _common_help))
 @_common_parameters
 @click.option('--leaf-folders-as-items', is_flag=True,
               help='upload all files in leaf folders to a single Item named after the folder')
@@ -157,8 +151,8 @@ _short_help = 'Upload files to Girder'
 @click.option('--blacklist', default='',
               help='comma-separated list of filenames to ignore')
 @click.pass_obj
-def upload(gc, parent_type, parent_id, local_folder,
-           leaf_folders_as_items, reuse, blacklist, dry_run):
+def _upload(gc, parent_type, parent_id, local_folder,
+            leaf_folders_as_items, reuse, blacklist, dry_run):
     gc.upload(
         local_folder, parent_id, parent_type,
         leafFoldersAsItems=leaf_folders_as_items, reuseExisting=reuse,

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -64,9 +64,39 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.option('--api-root', default=GirderClient.DEFAULT_API_ROOT,
               help='relative path to the Girder REST API', show_default=True)
 @click.pass_context
-def main(ctx, username, password,
+def main(ctx, username, password,  # noqa: D301
          api_key, api_url, scheme, host, port, api_root):
-    """Perform common Girder CLI operations."""
+    """Perform common Girder CLI operations.
+
+    The CLI is particularly suited to upload (or download) large, nested
+    hierarchy of data to (or from) Girder from (or into) a local directory.
+
+    \b
+    Specifying the Girder Instance
+    ------------------------------
+
+    The easiest way to do so is to pass the host name using the ``host``
+    argument. For example:
+
+      girder-cli --host data.kitware.com <command> ...
+
+    In case, you are experimenting with an instance not serving content
+    using https, specifying the full URL to the REST API using the
+    ``api-url`` argument is the easiest. For example:
+
+      girder-cli --api-url http://localhost:8080/api/v1 <command> ...
+
+    \b
+    Specifying credentials
+    ----------------------
+
+    The recommended way is to generate an api key and specify the
+    ``api-key`` argument.
+
+    The client also supports ``username`` and ``password`` args. If only the
+    ``username`` is specified, the client will prompt the user to interactively
+    input his/her password.
+    """
     ctx.obj = GirderCli(
         username, password, host=host, port=port, apiRoot=api_root,
         scheme=scheme, apiUrl=api_url, apiKey=api_key)

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -18,7 +18,7 @@
 ###############################################################################
 
 import click
-from click._compat import _default_text_stdout, isatty
+import sys
 import types
 from girder_client import GirderClient, HttpError
 
@@ -68,7 +68,7 @@ class GirderCli(GirderClient):
             bar.format_pos = types.MethodType(formatPos, bar)
             return bar
 
-        _progressBar.reportProgress = isatty(_default_text_stdout())
+        _progressBar.reportProgress = sys.stdout.isatty()
 
         super(GirderCli, self).__init__(
             host=host, port=port, apiRoot=apiRoot, scheme=scheme, apiUrl=apiUrl,

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -146,7 +146,7 @@ def _lookup_parent_type(client, object_id):
 
 
 def _CommonParameters(path_exists=False, path_writable=True,
-                      additional_parent_types=('collection', 'user')):
+                      additional_parent_types=('collection', 'user'), path_default=None):
     parent_types = ['folder'] + list(additional_parent_types)
     parent_type_cls = _HiddenOption
     parent_type_default = 'folder'
@@ -164,7 +164,9 @@ def _CommonParameters(path_exists=False, path_writable=True,
             click.argument(
                 'local_folder',
                 type=click.Path(exists=path_exists, dir_okay=True,
-                                writable=path_writable, readable=True)),
+                                writable=path_writable, readable=True),
+                default=path_default
+            ),
         ]
         for decorator in reversed(decorators):
             func = decorator(func)
@@ -178,8 +180,9 @@ _common_help = 'PARENT_ID is the id of the Girder parent target and ' \
 _short_help = 'Download files from Girder'
 
 
-@main.command('download', short_help=_short_help, help='%s\n\n%s' % (_short_help, _common_help))
-@_CommonParameters(additional_parent_types=['collection', 'user', 'item'])
+@main.command('download', short_help=_short_help, help='%s\n\n%s' % (
+    _short_help, _common_help.replace('LOCAL_FOLDER', 'LOCAL_FOLDER (default: ".")')))
+@_CommonParameters(additional_parent_types=['collection', 'user', 'item'], path_default='.')
 @click.pass_obj
 def _download(gc, parent_type, parent_id, local_folder):
     if parent_type == 'auto':

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -95,12 +95,14 @@ def main(ctx, username, password, api_key, api_url, scheme, host, port, api_root
         scheme=scheme, apiUrl=api_url, apiKey=api_key)
 
 
-def _common_parameters(path_exists=False, path_writable=True):
+def _common_parameters(path_exists=False, path_writable=True,
+                       additional_parent_types=['collection', 'user']):
+    parent_types = ['folder'] + additional_parent_types
+    parent_type_cls = click.Option if len(additional_parent_types) > 0 else _DeprecatedOption
     def wrap(func):
         decorators = [
-            click.option('--parent-type', default='folder', show_default=True,
-                         help='type of Girder parent target',
-                         type=click.Choice(['collection', 'folder', 'user'])),
+            click.option('--parent-type', default='folder', show_default=True, cls=parent_type_cls,
+                         help='type of Girder parent target', type=click.Choice(parent_types)),
             click.argument('parent_id'),
             click.argument(
                 'local_folder',
@@ -130,7 +132,7 @@ _short_help = 'Synchronize local folder with remote Girder folder'
 
 
 @main.command('localsync', short_help=_short_help, help='%s\n\n%s' % (_short_help, _common_help))
-@_common_parameters()
+@_common_parameters(additional_parent_types=[])
 @click.pass_obj
 def _localsync(gc, parent_type, parent_id, local_folder):
     if parent_type != 'folder':

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -98,7 +98,7 @@ def main(ctx, username, password, api_key, api_url, scheme, host, port, api_root
 def _common_parameters(path_exists=False, path_writable=True):
     def wrap(func):
         decorators = [
-            click.option('--parent-type', default='folder',
+            click.option('--parent-type', default='folder', show_default=True,
                          help='type of Girder parent target',
                          type=click.Choice(['collection', 'folder', 'user'])),
             click.argument('parent_id'),

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -50,9 +50,13 @@ class GirderCli(GirderClient):
             self.authenticate(username, password, interactive=interactive)
 
 
-class _DeprecatedOption(click.Option):
+class _HiddenOption(click.Option):
     def get_help_record(self, ctx):
         pass
+
+
+class _DeprecatedOption(_HiddenOption):
+    pass
 
 
 _CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
@@ -113,7 +117,7 @@ def _lookup_parent_type(client, object_id):
 def _CommonParameters(path_exists=False, path_writable=True,
                       additional_parent_types=('collection', 'user')):
     parent_types = ['folder'] + list(additional_parent_types)
-    parent_type_cls = _DeprecatedOption
+    parent_type_cls = _HiddenOption
     parent_type_default = 'folder'
     if len(additional_parent_types) > 0:
         parent_types.append('auto')

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -53,13 +53,13 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
-@click.option('--username', default=None)
-@click.option('--password', default=None)
 @click.option('--api-key', default=None)
+@click.option('--host', default=GirderClient.DEFAULT_HOST, show_default=True)
 @click.option('--api-url', default=None,
               help='full URL to the RESTful API of a Girder server')
+@click.option('--username', default=None)
+@click.option('--password', default=None)
 @click.option('--scheme', default=GirderClient.DEFAULT_SCHEME, show_default=True)
-@click.option('--host', default=GirderClient.DEFAULT_HOST, show_default=True)
 @click.option('--port', default=GirderClient.DEFAULT_PORT, show_default=True)
 @click.option('--api-root', default=GirderClient.DEFAULT_API_ROOT,
               help='relative path to the Girder REST API', show_default=True)

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -39,9 +39,14 @@ class GirderCli(GirderClient):
         :param password: password to authenticate to Girder instance, leave
             this blank to be prompted.
         """
+        def _progressBar(*args, **kwargs):
+            bar = click.progressbar(*args, **kwargs)
+            bar.bar_template = "[%(bar)s]  %(info)s  %(label)s"
+            return bar
+
         super(GirderCli, self).__init__(
             host=host, port=port, apiRoot=apiRoot, scheme=scheme, apiUrl=apiUrl,
-            progressReporterCls=click.progressbar)
+            progressReporterCls=_progressBar)
         interactive = password is None
 
         if apiKey:

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -17,8 +17,6 @@
 #  limitations under the License.
 ###############################################################################
 
-import sys
-
 import click
 from girder_client import GirderClient, HttpError
 
@@ -85,7 +83,7 @@ def main(ctx, username, password, api_key, api_url, scheme, host, port, api_root
     The CLI is particularly suited to upload (or download) large, nested
     hierarchy of data to (or from) Girder from (or into) a local directory.
 
-    The recommended way to use credentials is to first generate an api key
+    The recommended way to use credentials is to first generate an API key
     and then specify the ``api-key`` argument or set the ``GIRDER_API_KEY``
     environment variable.
 
@@ -109,15 +107,12 @@ def _lookup_parent_type(client, object_id):
         except HttpError as exc_info:
             if exc_info.status == 400:
                 continue
-            if sys.version_info[0] >= 3:
-                raise exc_info.with_traceback(sys.exc_info()[2])
-            else:
-                raise (sys.exc_info()[0], sys.exc_info()[1], sys.exc_info()[2])  # noqa: E999
+            raise
 
 
 def _CommonParameters(path_exists=False, path_writable=True,
-                      additional_parent_types=['collection', 'user']):
-    parent_types = ['folder'] + additional_parent_types
+                      additional_parent_types=('collection', 'user')):
+    parent_types = ['folder'] + list(additional_parent_types)
     parent_type_cls = _DeprecatedOption
     parent_type_default = 'folder'
     if len(additional_parent_types) > 0:

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -49,50 +49,42 @@ class GirderCli(GirderClient):
             self.authenticate(username, password, interactive=interactive)
 
 
+class _DeprecatedOption(click.Option):
+    def get_help_record(self, ctx):
+        pass
+
+
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
-@click.option('--api-key', envvar='GIRDER_API_KEY', default=None,
-              help='setting GIRDER_API_KEY env. variable is supported')
-@click.option('--host', default=GirderClient.DEFAULT_HOST, show_default=True)
 @click.option('--api-url', default=None,
-              help='full URL to the RESTful API of a Girder server')
+              help='RESTful API URL '
+                   '(e.g https://girder.example.com:443/%s)' % GirderClient.DEFAULT_API_ROOT)
+@click.option('--api-key', envvar='GIRDER_API_KEY', default=None,
+              help='[default: GIRDER_API_KEY env. variable]')
 @click.option('--username', default=None)
 @click.option('--password', default=None)
-@click.option('--scheme', default=GirderClient.DEFAULT_SCHEME, show_default=True)
-@click.option('--port', default=GirderClient.DEFAULT_PORT, show_default=True)
+# Deprecated options
+@click.option('--host', default=GirderClient.DEFAULT_HOST, show_default=True,
+              cls=_DeprecatedOption)
+@click.option('--scheme', default=GirderClient.DEFAULT_SCHEME, show_default=True,
+              cls=_DeprecatedOption)
+@click.option('--port', default=GirderClient.DEFAULT_PORT, show_default=True,
+              cls=_DeprecatedOption)
 @click.option('--api-root', default=GirderClient.DEFAULT_API_ROOT,
-              help='relative path to the Girder REST API', show_default=True)
+              help='relative path to the Girder REST API', show_default=True,
+              cls=_DeprecatedOption)
 @click.pass_context
-def main(ctx, username, password,  # noqa: D301
-         api_key, api_url, scheme, host, port, api_root):
+def main(ctx, username, password, api_key, api_url, scheme, host, port, api_root):
     """Perform common Girder CLI operations.
 
     The CLI is particularly suited to upload (or download) large, nested
     hierarchy of data to (or from) Girder from (or into) a local directory.
 
-    \b
-    Specifying the Girder Instance
-    ------------------------------
-
-    The easiest way to do so is to pass the host name using the ``host``
-    argument. For example:
-
-      girder-cli --host data.kitware.com <command> ...
-
-    In case, you are experimenting with an instance not serving content
-    using https, specifying the full URL to the REST API using the
-    ``api-url`` argument is the easiest. For example:
-
-      girder-cli --api-url http://localhost:8080/api/v1 <command> ...
-
-    \b
-    Specifying credentials
-    ----------------------
-
-    The recommended way is to generate an api key and specify the
-    ``api-key`` argument or set the ``GIRDER_API_KEY`` environment variable.
+    The recommended way to use credentials is to first generate an api key
+    and then specify the ``api-key`` argument or set the ``GIRDER_API_KEY``
+    environment variable.
 
     The client also supports ``username`` and ``password`` args. If only the
     ``username`` is specified, the client will prompt the user to interactively

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -58,11 +58,11 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.option('--api-key', default=None)
 @click.option('--api-url', default=None,
               help='full URL to the RESTful API of a Girder server')
-@click.option('--scheme', default=None)
-@click.option('--host', default=None)
-@click.option('--port', default=None)
-@click.option('--api-root', default=None,
-              help='relative path to the Girder REST API')
+@click.option('--scheme', default=GirderClient.DEFAULT_SCHEME, show_default=True)
+@click.option('--host', default=GirderClient.DEFAULT_HOST, show_default=True)
+@click.option('--port', default=GirderClient.DEFAULT_PORT, show_default=True)
+@click.option('--api-root', default=GirderClient.DEFAULT_API_ROOT,
+              help='relative path to the Girder REST API', show_default=True)
 @click.pass_context
 def main(ctx, username, password,
          api_key, api_url, scheme, host, port, api_root):

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -18,6 +18,7 @@
 ###############################################################################
 
 import click
+from click._compat import _default_text_stdout, isatty
 from girder_client import GirderClient, HttpError
 
 
@@ -43,6 +44,8 @@ class GirderCli(GirderClient):
             bar = click.progressbar(*args, **kwargs)
             bar.bar_template = "[%(bar)s]  %(info)s  %(label)s"
             return bar
+
+        _progressBar.reportProgress = isatty(_default_text_stdout())
 
         super(GirderCli, self).__init__(
             host=host, port=port, apiRoot=apiRoot, scheme=scheme, apiUrl=apiUrl,

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -53,7 +53,8 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
-@click.option('--api-key', default=None)
+@click.option('--api-key', envvar='GIRDER_API_KEY', default=None,
+              help='setting GIRDER_API_KEY env. variable is supported')
 @click.option('--host', default=GirderClient.DEFAULT_HOST, show_default=True)
 @click.option('--api-url', default=None,
               help='full URL to the RESTful API of a Girder server')
@@ -91,7 +92,7 @@ def main(ctx, username, password,  # noqa: D301
     ----------------------
 
     The recommended way is to generate an api key and specify the
-    ``api-key`` argument.
+    ``api-key`` argument or set the ``GIRDER_API_KEY`` environment variable.
 
     The client also supports ``username`` and ``password`` args. If only the
     ``username`` is specified, the client will prompt the user to interactively

--- a/clients/python/requirements.txt
+++ b/clients/python/requirements.txt
@@ -1,3 +1,4 @@
+click==6.7
 diskcache==1.6.7
 requests==2.10.0
 six==1.10.0

--- a/clients/python/requirements.txt
+++ b/clients/python/requirements.txt
@@ -1,4 +1,5 @@
 click==6.7
 diskcache==1.6.7
 requests==2.10.0
+requests_toolbelt==0.7.1
 six==1.10.0

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -52,7 +52,8 @@ setup(
         'Environment :: Console',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2'
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3'
     ],
     packages=find_packages(exclude=('tests.*', 'tests')),
     install_requires=install_reqs,

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -22,6 +22,7 @@ import re
 from setuptools import setup, find_packages
 
 install_reqs = [
+    'click>=6.7',
     'diskcache',
     'requests>=2.4.2',
     'requests_toolbelt',

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -24,6 +24,7 @@ from setuptools import setup, find_packages
 install_reqs = [
     'diskcache',
     'requests>=2.4.2',
+    'requests_toolbelt',
     'six'
 ]
 with open('README.rst') as f:

--- a/docs/python-client.rst
+++ b/docs/python-client.rst
@@ -83,7 +83,7 @@ Setting the ``GIRDER_API_KEY`` environment variable is also supported: ::
 
 The client also supports ``username`` and ``password`` args. If only the
 ``username`` is specified, the client will prompt the user to interactively
-input his/her password.
+input their password.
 
 Upload a local file hierarchy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/python-client.rst
+++ b/docs/python-client.rst
@@ -175,14 +175,16 @@ the local folder `download_folder`::
 Auto-detecting parent-type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Both download and upload commands accept a `--parent-type` argument allowing to specify
-the type (folder, collection, user, or item) associated with the chosen object id.
+Both download and upload commands accept a `--parent-type` argument allowing the users
+to specify the type (folder, collection, user, or item) associated with the chosen
+object id.
 
-If the argument is omitted, the client will conveniently tries to autodetect the type
+If the argument is omitted, the client will conveniently try to autodetect the type
 by iteratively invoking the `resource/%id/path?type=%type` API end point and checking
 if a resource is found.
 
-Note that relying on auto-detection induces an extra time cost.
+Note that relying on auto-detection incurs extra network requests, which will slow down
+the script, so it should be avoided for time-sensitive operations.
 
 Synchronize local folder with a Folder hierarchy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/python-client.rst
+++ b/docs/python-client.rst
@@ -45,15 +45,15 @@ pip, you can use the special ``girder-cli`` executable: ::
 
 Otherwise you can equivalently just invoke the module directly: ::
 
-    python -m girder_client <subcommand> <arguments>
+    python -m girder_client <command> <arguments>
 
-To see all available subcommands, run: ::
+To see all available commands, run: ::
 
     girder-cli --help
 
-For help with a specific subcommand, run: ::
+For help with a specific command, run: ::
 
-    girder-cli <subcommand> --help
+    girder-cli <command> --help
 
 Specifying the Girder Instance
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -63,7 +63,7 @@ you wish to connect to. The easiest way to do so is to pass the full URL to the
 REST API of the Girder instance you wish to connect to using the ``api-url``
 argument to ``girder-cli``. For example: ::
 
-    girder-cli --api-url http://localhost:8080/api/v1 <subcommand> ...
+    girder-cli --api-url http://localhost:8080/api/v1 <command> ...
 
 You may also specify the URL in parts, using the ``host`` argument, and optional
 ``scheme``, ``port``, and ``api-root`` args. ::

--- a/docs/python-client.rst
+++ b/docs/python-client.rst
@@ -71,7 +71,7 @@ and optional ``scheme``, ``port``, and ``api-root`` args.
 Specifying credentials
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The recommended way is to generate an :ref:`api key <api_keys>` and specify
+The recommended way is to generate an :ref:`API key <api_keys>` and specify
 the ``api-key`` argument. ::
 
     girder-cli --api-url https://girder.example.com:443/api/v1  --api-key abcdefghijklmopqrstuvwxyz012345678901234 ...

--- a/docs/python-client.rst
+++ b/docs/python-client.rst
@@ -164,6 +164,13 @@ with id `54f8ac238d777f69813604af` under the local folder `download_folder` ::
 
     girder-cli download --parent-type user 54b6d40b8926486c0cbca364 download_folder
 
+Item
+""""
+
+To download the file(s) associated with a Girder Item with if `58b8eb798d777f0aef5d0f78` under
+the local folder `download_folder`::
+
+    girder-cli download --parent-type item 8b8eb798d777f0aef5d0f78 download_folder
 
 Synchronize local folder with a Folder hierarchy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/python-client.rst
+++ b/docs/python-client.rst
@@ -172,6 +172,18 @@ the local folder `download_folder`::
 
     girder-cli download --parent-type item 8b8eb798d777f0aef5d0f78 download_folder
 
+Auto-detecting parent-type
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Both download and upload commands accept a `--parent-type` argument allowing to specify
+the type (folder, collection, user, or item) associated with the chosen object id.
+
+If the argument is omitted, the client will conveniently tries to autodetect the type
+by iteratively invoking the `resource/%id/path?type=%type` API end point and checking
+if a resource is found.
+
+Note that relying on auto-detection induces an extra time cost.
+
 Synchronize local folder with a Folder hierarchy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/python-client.rst
+++ b/docs/python-client.rst
@@ -20,6 +20,19 @@ directory of Girder, you can install the client via pip: ::
 
     pip install girder-client
 
+
+After installing the client via pip and if you are using ``bash``,
+auto-completion can easily be enabled executing:
+
+::
+
+    eval "$(_GIRDER_CLI_COMPLETE=source girder-cli)"
+
+For convenience, adding this line at the end of ``.bashrc`` will make sure
+auto-completion is always available.
+
+For more details, see http://click.pocoo.org/6/bashcomplete/
+
 The Command Line Interface
 --------------------------
 

--- a/docs/python-client.rst
+++ b/docs/python-client.rst
@@ -82,6 +82,11 @@ the ``api-key`` argument. ::
 
     girder-cli --host girder.example.com  --api-key abcdefghijklmopqrstuvwxyz012345678901234 ...
 
+Setting the ``GIRDER_API_KEY`` environment variable is also supported: ::
+
+    export GIRDER_API_KEY=abcdefghijklmopqrstuvwxyz012345678901234
+    girder-cli --host girder.example.com ...
+
 The client also supports ``username`` and ``password`` args. If only the
 ``username`` is specified, the client will prompt the user to interactively
 input his/her password.

--- a/docs/python-client.rst
+++ b/docs/python-client.rst
@@ -136,15 +136,34 @@ separated list to the ``--blacklist`` arg ::
 .. note: The girder_client can upload to an S3 Assetstore when uploading to a Girder server
          that is version 1.3.0 or later.
 
-Download a Folder hierarchy into a local folder
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Download a hierarchy of data into a local folder
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Folder
+""""""
 
 To download a Girder Folder hierarchy rooted at Folder id
 `54b6d40b8926486c0cbca364` under the local folder `download_folder` ::
 
     girder-cli download 54b6d40b8926486c0cbca364 download_folder
 
-Downloading is only supported from a parent type of Folder.
+
+Collection
+""""""""""
+
+To download the Girder Folder hierarchies associated with a Girder Collection
+with id `57b5c9e58d777f126827f5a1` under the local folder `download_folder` ::
+
+    girder-cli download --parent-type collection 57b5c9e58d777f126827f5a1 download_folder
+
+User
+""""
+
+To download the Girder Folder hierarchies associated with a Girder User
+with id `54f8ac238d777f69813604af` under the local folder `download_folder` ::
+
+    girder-cli download --parent-type user 54b6d40b8926486c0cbca364 download_folder
+
 
 Synchronize local folder with a Folder hierarchy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/python-client.rst
+++ b/docs/python-client.rst
@@ -74,6 +74,18 @@ Or... ::
 
     girder-cli --host girder.example.com --scheme https --port 443 --api-root /api/v1 ...
 
+Specifying credentials
+^^^^^^^^^^^^^^^^^^^^^^
+
+The recommended way is to generate an :ref:`api key <api_keys>` and specify
+the ``api-key`` argument. ::
+
+    girder-cli --host girder.example.com  --api-key abcdefghijklmopqrstuvwxyz012345678901234 ...
+
+The client also supports ``username`` and ``password`` args. If only the
+``username`` is specified, the client will prompt the user to interactively
+input his/her password.
+
 Upload a local file hierarchy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/python-client.rst
+++ b/docs/python-client.rst
@@ -65,8 +65,10 @@ argument to ``girder-cli``. For example: ::
 
     girder-cli --api-url http://localhost:8080/api/v1 <command> ...
 
-For backward compatibility, you may also specify the URL in parts, using the ``host`` argument,
-and optional ``scheme``, ``port``, and ``api-root`` args.
+.. deprecated:: 2.2
+
+  Instead of using ``api-url`` argument, you may also specify the URL in parts, using the
+  ``host`` argument, and optional ``scheme``, ``port``, and ``api-root`` args.
 
 Specifying credentials
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/python-client.rst
+++ b/docs/python-client.rst
@@ -257,4 +257,5 @@ Further Examples and Function Level Documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: girder_client
+    :special-members: __init__
     :members:

--- a/docs/python-client.rst
+++ b/docs/python-client.rst
@@ -65,14 +65,8 @@ argument to ``girder-cli``. For example: ::
 
     girder-cli --api-url http://localhost:8080/api/v1 <command> ...
 
-You may also specify the URL in parts, using the ``host`` argument, and optional
-``scheme``, ``port``, and ``api-root`` args. ::
-
-    girder-cli --host girder.example.com ...
-
-Or... ::
-
-    girder-cli --host girder.example.com --scheme https --port 443 --api-root /api/v1 ...
+For backward compatibility, you may also specify the URL in parts, using the ``host`` argument,
+and optional ``scheme``, ``port``, and ``api-root`` args.
 
 Specifying credentials
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -80,12 +74,12 @@ Specifying credentials
 The recommended way is to generate an :ref:`api key <api_keys>` and specify
 the ``api-key`` argument. ::
 
-    girder-cli --host girder.example.com  --api-key abcdefghijklmopqrstuvwxyz012345678901234 ...
+    girder-cli --api-url https://girder.example.com:443/api/v1  --api-key abcdefghijklmopqrstuvwxyz012345678901234 ...
 
 Setting the ``GIRDER_API_KEY`` environment variable is also supported: ::
 
     export GIRDER_API_KEY=abcdefghijklmopqrstuvwxyz012345678901234
-    girder-cli --host girder.example.com ...
+    girder-cli --api-url https://girder.example.com:443/api/v1 ...
 
 The client also supports ``username`` and ``password`` args. If only the
 ``username`` is specified, the client will prompt the user to interactively

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -304,3 +304,9 @@ key, it will immediately delete all active tokens created with that key, and als
 stop that key from being able to create new tokens until you activate it once again.
 Alternatively, you can delete the key altogether, which will make the key and any
 tokens created with it never work again.
+
+
+Using Girder CLI to Upload and Download data
+============================================
+
+See :ref:`python-client`

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -271,6 +271,8 @@ User
 ``Users`` have ``ADMIN`` access on themselves, and have ``READ`` access on other
 ``Users``.
 
+.. _api_keys:
+
 API keys
 --------
 

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -59,7 +59,7 @@ class Resource(BaseResource):
                'prefix-based search.', enum=('text', 'prefix'), required=False,
                default='text')
         .jsonParam('types', 'A JSON list of resource types to search for, e.g. '
-                   "'user', 'folder', 'item'.", requireArray=True)
+                   '["user", "folder", "item"].', requireArray=True)
         .param('level', 'Minimum required access level.', required=False,
                dataType='integer', default=AccessType.READ)
         .pagingParams(defaultSort=None, defaultLimit=10)

--- a/plugins/metadata_extractor/plugin_tests/client_metadata_extractor_test.py
+++ b/plugins/metadata_extractor/plugin_tests/client_metadata_extractor_test.py
@@ -47,7 +47,8 @@ class ClientMetadataExtractorTestCase(MetadataExtractorTestCase):
 
         from girder_client import GirderClient
 
-        client = GirderClient('localhost', int(os.environ['GIRDER_PORT']))
+        client = GirderClient(
+            'localhost', int(os.environ['GIRDER_PORT']), scheme='http')
         client.authenticate(self.user['login'], self.password)
         extractor = ClientMetadataExtractor(client, self.path, self.item['_id'])
         extractor.extractMetadata()

--- a/tests/cases/py_client/cli_test.py
+++ b/tests/cases/py_client/cli_test.py
@@ -194,8 +194,23 @@ class PythonCliTestCase(base.TestCase):
         self.assertTrue(os.path.isdir(os.path.join(downloadDir, 'my_folder')))
         shutil.rmtree(downloadDir, ignore_errors=True)
 
+        # Test download of the collection auto-detecting parent-type
+        ret = invokeCli(('download', '/collection/my_collection',
+                         downloadDir), username='mylogin', password='password')
+        self.assertEqual(ret['exitVal'], 0)
+        self.assertTrue(os.path.isdir(os.path.join(downloadDir, 'my_folder')))
+        shutil.rmtree(downloadDir, ignore_errors=True)
+
         # Test download of a user
         ret = invokeCli(('download', '--parent-type=user', '/user/mylogin',
+                         downloadDir), username='mylogin', password='password')
+        self.assertEqual(ret['exitVal'], 0)
+        self.assertTrue(
+            os.path.isfile(os.path.join(downloadDir, 'Public', 'testdata', 'hello.txt')))
+        shutil.rmtree(downloadDir, ignore_errors=True)
+
+        # Test download of a user auto-detecting parent-type
+        ret = invokeCli(('download', '/user/mylogin',
                          downloadDir), username='mylogin', password='password')
         self.assertEqual(ret['exitVal'], 0)
         self.assertTrue(
@@ -207,6 +222,14 @@ class PythonCliTestCase(base.TestCase):
         item_id = items[0]['_id']
         item_name = items[0]['name']
         ret = invokeCli(('download', '--parent-type=item', '%s' % item_id,
+                         downloadDir), username='mylogin', password='password')
+        self.assertEqual(ret['exitVal'], 0)
+        self.assertTrue(
+            os.path.isfile(os.path.join(downloadDir, item_name)))
+        shutil.rmtree(downloadDir, ignore_errors=True)
+
+        # Test download of an item auto-detecting parent-type
+        ret = invokeCli(('download', '%s' % item_id,
                          downloadDir), username='mylogin', password='password')
         self.assertEqual(ret['exitVal'], 0)
         self.assertTrue(

--- a/tests/cases/py_client/cli_test.py
+++ b/tests/cases/py_client/cli_test.py
@@ -120,7 +120,7 @@ class PythonCliTestCase(base.TestCase):
         self.assertNotEqual(ret['exitVal'], 0)
 
         ret = invokeCli(('-h',))
-        self.assertIn('usage: girder-cli', ret['stdout'])
+        self.assertIn('Usage: girder-cli', ret['stdout'])
         self.assertEqual(ret['exitVal'], 0)
 
     def testUploadDownload(self):

--- a/tests/cases/py_client/cli_test.py
+++ b/tests/cases/py_client/cli_test.py
@@ -58,7 +58,9 @@ def invokeCli(argv, username='', password='', useApiUrl=False):
         apiUrl = 'http://localhost:%s/api/v1' % os.environ['GIRDER_PORT']
         argsList = ['girder-client', '--api-url', apiUrl]
     else:
-        argsList = ['girder-client', '--port', os.environ['GIRDER_PORT']]
+        argsList = ['girder-client',
+                    '--scheme', 'http',
+                    '--port', os.environ['GIRDER_PORT']]
 
     if username:
         argsList += ['--username', username]

--- a/tests/cases/py_client/cli_test.py
+++ b/tests/cases/py_client/cli_test.py
@@ -237,6 +237,16 @@ class PythonCliTestCase(base.TestCase):
             filename = os.path.join(downloadDir, fname)
             self.assertEqual(os.path.getmtime(filename), old_mtimes[fname])
 
+        # Check that localsync command do not show '--parent-type' option help
+        ret = invokeCli(('localsync', '--help'))
+        self.assertNotIn('--parent-type', ret['stdout'])
+        self.assertEqual(ret['exitVal'], 0)
+
+        # Check that localsync command still accepts '--parent-type' argument
+        ret = invokeCli(('localsync', '--parent-type', 'folder', str(subfolder['_id']),
+                         downloadDir), username='mylogin', password='password')
+        self.assertEqual(ret['exitVal'], 0)
+
     def testLeafFoldersAsItems(self):
         localDir = os.path.join(os.path.dirname(__file__), 'testdata')
         args = ['upload', str(self.publicFolder['_id']), localDir, '--leaf-folders-as-items']

--- a/tests/cases/py_client/cli_test.py
+++ b/tests/cases/py_client/cli_test.py
@@ -202,6 +202,17 @@ class PythonCliTestCase(base.TestCase):
             os.path.isfile(os.path.join(downloadDir, 'Public', 'testdata', 'hello.txt')))
         shutil.rmtree(downloadDir, ignore_errors=True)
 
+        # Test download of an item
+        items = list(self.model('folder').childItems(folder=subfolder))
+        item_id = items[0]['_id']
+        item_name = items[0]['name']
+        ret = invokeCli(('download', '--parent-type=item', '%s' % item_id,
+                         downloadDir), username='mylogin', password='password')
+        self.assertEqual(ret['exitVal'], 0)
+        self.assertTrue(
+            os.path.isfile(os.path.join(downloadDir, item_name)))
+        shutil.rmtree(downloadDir, ignore_errors=True)
+
         def _check_upload(ret):
             self.assertEqual(ret['exitVal'], 0)
             six.assertRegex(

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -342,9 +342,10 @@ class PythonClientTestCase(base.TestCase):
 
         def mock_post(*args, **kwargs):
             if 'data' in kwargs:
-                non_multipart.append(1)
-            elif 'parameters' in kwargs and 'files' in kwargs:
-                multipart.append(1)
+                if 'parameters' in kwargs:
+                    multipart.append(1)
+                else:
+                    non_multipart.append(1)
             return original_post(*args, **kwargs)
 
         with mock.patch.object(self.client, 'post', new=mock_post):

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -72,7 +72,8 @@ class PythonClientTestCase(base.TestCase):
             os.mkdir(subDirName)
             writeFile(subDirName)
 
-        self.client = girder_client.GirderClient(port=os.environ['GIRDER_PORT'])
+        self.client = girder_client.GirderClient(
+            port=os.environ['GIRDER_PORT'], scheme='http')
 
         # Register a user
         self.password = 'password'
@@ -504,7 +505,9 @@ class PythonClientTestCase(base.TestCase):
         # create another client with caching enabled
         cacheSettings = {'directory': os.path.join(self.libTestDir, 'cache')}
         client = girder_client.GirderClient(
-            port=os.environ['GIRDER_PORT'], cacheSettings=cacheSettings)
+            port=os.environ['GIRDER_PORT'],
+            scheme="http",
+            cacheSettings=cacheSettings)
         client.authenticate(self.user['login'], self.password)
         self.assertNotEqual(client.cache, None)
 

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -574,7 +574,10 @@ class PythonClientTestCase(base.TestCase):
         }
 
         def _patchJson(url, request):
-            patchRequest['valid'] = json.loads(request.body.decode('utf8')) == jsonBody
+            body = request.body
+            if isinstance(body, six.binary_type):
+                body = body.decode('utf8')
+            patchRequest['valid'] = json.loads(body) == jsonBody
 
             return httmock.response(200, {}, {}, request=request)
 


### PR DESCRIPTION
This PR aims at improving the user overall user experience associated with the Girder CLI.

### Why ?

As a user, I initially got frustrated with the behaviour of the CLI. I couldn't figure out the correct combination of scheme, host, ... and had to do some guess work.

Here is my take at improving the user experience.

### Details

* Documentation
  * Reference Girder CLI documentation from the user documentation
  * Add a "Specifying Credentials" section to the python client documentation
* girder client
  * allow api-key to be specified using `GIRDER_API_KEY` env. variable
  * api-root can be specified as `api/v1` or `/api/v1`
  * scheme defaults to `https` allowing to simply specify the host when using production instance supporting https
  * display default value in help string
  * support auto-completion when using bash
  * report download and upload progress (for both multipart and non-multipart implementation)
  * download local folder now default to current directory

* girder client (deprecated functionalities)
  * specifying URL by part is now deprecated


* Internal
  * Introduce dependency to [click python library](http://pocco-click.readthedocs.io/en/latest/). A modern and flexible command line parser.
  * Introduce dependency to [toolbelt](https://toolbelt.readthedocs.io/en/latest/uploading-data.html#monitoring-your-streaming-multipart-upload) so that progress for multipart upload is reported.


### What is next ? 

* <s>Progress reporting leveraging the facilities offered by [click](http://pocco-click.readthedocs.io/en/latest/utils.html#showing-progress-bars)</s>
* Better error message in case of error. No need to report a stack trace when authentication failed or a folder if do not exist