### PR TITLE
Simplify Globus OAuth provider module

### DIFF
--- a/plugins/oauth/requirements.txt
+++ b/plugins/oauth/requirements.txt
@@ -1,2 +1,0 @@
-cryptography==1.4
-PyJWT==1.4.2

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ extras_reqs = {
     'geospatial': ['geojson'],
     'item_tasks': ['ctk-cli'],
     'thumbnails': ['Pillow', 'pydicom', 'numpy'],
-    'worker': ['celery'],
+    'worker': ['celery']
 }
 all_extra_reqs = itertools.chain.from_iterable(extras_reqs.values())
 extras_reqs['plugins'] = list(set(all_extra_reqs))

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,6 @@ extras_reqs = {
     'item_tasks': ['ctk-cli'],
     'thumbnails': ['Pillow', 'pydicom', 'numpy'],
     'worker': ['celery'],
-    'oauth': ['pyjwt', 'cryptography']
 }
 all_extra_reqs = itertools.chain.from_iterable(extras_reqs.values())
 extras_reqs['plugins'] = list(set(all_extra_reqs))


### PR DESCRIPTION
Instead of parsing the JWT identity token, we now explicitly call an endpoint providing a basic user information. This drops the additional requirement on *cryptography* and *pyjwt*.