### PR TITLE
Store OAuth headers in the user document

### DIFF
--- a/plugins/oauth/plugin_tests/oauth_test.py
+++ b/plugins/oauth/plugin_tests/oauth_test.py
@@ -352,7 +352,10 @@ class OauthTest(base.TestCase):
                         'lastName': self.adminUser['lastName'],
                         'oauth': {
                             'provider': 'google',
-                            'id': '5326'
+                            'id': '5326',
+                            'authHeaders': {
+                                'Authorization': 'Bearer google_existing_test_token',
+                            }
                         }
                     }
                 },
@@ -368,7 +371,10 @@ class OauthTest(base.TestCase):
                         'lastName': 'Creed',
                         'oauth': {
                             'provider': 'google',
-                            'id': 'the1best'
+                            'id': 'the1best',
+                            'authHeaders': {
+                                'Authorization': 'Bearer google_new_test_token',
+                            }
                         }
                     }
                 }
@@ -530,7 +536,11 @@ class OauthTest(base.TestCase):
                         'lastName': self.adminUser['lastName'],
                         'oauth': {
                             'provider': 'github',
-                            'id': '2399'
+                            'id': '2399',
+                            'authHeaders': {
+                                'Authorization': 'token github_existing_test_token',
+                                'Accept': 'application/json'
+                            }
                         }
                     }
                 },
@@ -547,7 +557,11 @@ class OauthTest(base.TestCase):
                         'lastName': 'Drago',
                         'oauth': {
                             'provider': 'github',
-                            'id': 1985
+                            'id': 1985,
+                            'authHeaders': {
+                                'Authorization': 'token github_new_test_token',
+                                'Accept': 'application/json'
+                            }
                         }
                     }
                 }
@@ -760,7 +774,11 @@ class OauthTest(base.TestCase):
                         'lastName': self.adminUser['lastName'],
                         'oauth': {
                             'provider': 'globus',
-                            'id': '2399'
+                            'id': '2399',
+                            'authHeaders': {
+                                'Authorization': 'Bearer globus_existing_test_token',
+                                'Accept': 'application/json'
+                            }
                         }
                     }
                 },
@@ -775,7 +793,11 @@ class OauthTest(base.TestCase):
                         'lastName': 'Drago',
                         'oauth': {
                             'provider': 'globus',
-                            'id': 1985
+                            'id': 1985,
+                            'authHeaders': {
+                                'Authorization': 'Bearer globus_new_test_token',
+                                'Accept': 'application/json'
+                            }
                         }
                     }
                 }
@@ -937,7 +959,11 @@ class OauthTest(base.TestCase):
                         'lastName': self.adminUser['lastName'],
                         'oauth': {
                             'provider': 'linkedin',
-                            'id': '42kD-5H'
+                            'id': '42kD-5H',
+                            'authHeaders': {
+                                'Authorization': 'Bearer linkedin_existing_test_token',
+                                'Accept': 'application/json'
+                            }
                         }
                     }
                 },
@@ -953,7 +979,11 @@ class OauthTest(base.TestCase):
                         'lastName': 'Lang',
                         'oauth': {
                             'provider': 'linkedin',
-                            'id': '634pity-fool4'
+                            'id': '634pity-fool4',
+                            'authHeaders': {
+                                'Authorization': 'Bearer linkedin_new_test_token',
+                                'Accept': 'application/json'
+                            }
                         }
                     }
                 }
@@ -1113,7 +1143,11 @@ class OauthTest(base.TestCase):
                         'lastName': self.adminUser['lastName'],
                         'oauth': {
                             'provider': 'bitbucket',
-                            'id': '2399'
+                            'id': '2399',
+                            'authHeaders': {
+                                'Authorization': 'Bearer bitbucket_existing_test_token',
+                                'Accept': 'application/json'
+                            }
                         }
                     }
                 },
@@ -1130,7 +1164,11 @@ class OauthTest(base.TestCase):
                         'lastName': 'Drago',
                         'oauth': {
                             'provider': 'bitbucket',
-                            'id': 1983
+                            'id': 1983,
+                            'authHeaders': {
+                                'Authorization': 'Bearer bitbucket_existing_test_token',
+                                'Accept': 'application/json'
+                            }
                         }
                     }
                 }
@@ -1310,7 +1348,11 @@ class OauthTest(base.TestCase):
                         'lastName': self.adminUser['lastName'],
                         'oauth': {
                             'provider': 'box',
-                            'id': '2481632'
+                            'id': '2481632',
+                            'authHeaders': {
+                                'Authorization': 'Bearer box_existing_test_token',
+                                'Accept': 'application/json'
+                            }
                         }
                     }
                 },
@@ -1326,7 +1368,11 @@ class OauthTest(base.TestCase):
                         'lastName': 'Drago',
                         'oauth': {
                             'provider': 'box',
-                            'id': '1985'
+                            'id': '1985',
+                            'authHeaders': {
+                                'Authorization': 'Bearer box_new_test_token',
+                                'Accept': 'application/json'
+                            }
                         }
                     }
                 }

--- a/plugins/oauth/server/__init__.py
+++ b/plugins/oauth/server/__init__.py
@@ -42,7 +42,13 @@ def validateProvidersEnabled(doc):
     constants.PluginSettings.GITHUB_CLIENT_SECRET,
     constants.PluginSettings.LINKEDIN_CLIENT_SECRET,
     constants.PluginSettings.BITBUCKET_CLIENT_SECRET,
-    constants.PluginSettings.BOX_CLIENT_SECRET
+    constants.PluginSettings.BOX_CLIENT_SECRET,
+    constants.PluginSettings.GOOGLE_STORE_TOKEN,
+    constants.PluginSettings.GLOBUS_STORE_TOKEN,
+    constants.PluginSettings.GITHUB_STORE_TOKEN,
+    constants.PluginSettings.LINKEDIN_STORE_TOKEN,
+    constants.PluginSettings.BITBUCKET_STORE_TOKEN,
+    constants.PluginSettings.BOX_STORE_TOKEN
 })
 def validateOtherSettings(event):
     pass

--- a/plugins/oauth/server/constants.py
+++ b/plugins/oauth/server/constants.py
@@ -24,18 +24,24 @@ class PluginSettings:
 
     GOOGLE_CLIENT_ID = 'oauth.google_client_id'
     GOOGLE_CLIENT_SECRET = 'oauth.google_client_secret'
+    GOOGLE_STORE_TOKEN = 'oauth.google_store_token'
 
     GLOBUS_CLIENT_ID = 'oauth.globus_client_id'
     GLOBUS_CLIENT_SECRET = 'oauth.globus_client_secret'
+    GLOBUS_STORE_TOKEN = 'oauth.globus_store_token'
 
     GITHUB_CLIENT_ID = 'oauth.github_client_id'
     GITHUB_CLIENT_SECRET = 'oauth.github_client_secret'
+    GITHUB_STORE_TOKEN = 'oauth.github_store_token'
 
     LINKEDIN_CLIENT_ID = 'oauth.linkedin_client_id'
     LINKEDIN_CLIENT_SECRET = 'oauth.linkedin_client_secret'
+    LINKEDIN_STORE_TOKEN = 'oauth.linkedin_store_token'
 
     BITBUCKET_CLIENT_ID = 'oauth.bitbucket_client_id'
     BITBUCKET_CLIENT_SECRET = 'oauth.bitbucket_client_secret'
+    BITBUCKET_STORE_TOKEN = 'oauth.bitbucket_store_token'
 
     BOX_CLIENT_ID = 'oauth.box_client_id'
     BOX_CLIENT_SECRET = 'oauth.box_client_secret'
+    BOX_STORE_TOKEN = 'oauth.box_store_token'

--- a/plugins/oauth/server/providers/__init__.py
+++ b/plugins/oauth/server/providers/__init__.py
@@ -30,6 +30,7 @@ from .box import Box
 def addProvider(provider):
     idMap[provider.getProviderName()] = provider
 
+
 idMap = collections.OrderedDict()
 
 

--- a/plugins/oauth/server/providers/bitbucket.py
+++ b/plugins/oauth/server/providers/bitbucket.py
@@ -39,6 +39,10 @@ class Bitbucket(ProviderBase):
         return self.model('setting').get(
             constants.PluginSettings.BITBUCKET_CLIENT_SECRET)
 
+    def getStoreTokenSetting(self):
+        return self.model('setting').get(
+            constants.PluginSettings.BITBUCKET_STORE_TOKEN)
+
     @classmethod
     def getUrl(cls, state):
         clientId = cls.model('setting').get(
@@ -113,6 +117,7 @@ class Bitbucket(ProviderBase):
         names = (resp.get('display_name') or login).split()
         firstName, lastName = names[0], names[-1]
 
-        user = self._createOrReuseUser(oauthId, email, firstName, lastName,
+        if not self.storeToken:
+            headers = None
+        return self._createOrReuseUser(oauthId, email, firstName, lastName,
                                        headers, userName=login)
-        return user

--- a/plugins/oauth/server/providers/bitbucket.py
+++ b/plugins/oauth/server/providers/bitbucket.py
@@ -113,5 +113,6 @@ class Bitbucket(ProviderBase):
         names = (resp.get('display_name') or login).split()
         firstName, lastName = names[0], names[-1]
 
-        user = self._createOrReuseUser(oauthId, email, firstName, lastName, login)
+        user = self._createOrReuseUser(oauthId, email, firstName, lastName,
+                                       headers, userName=login)
         return user

--- a/plugins/oauth/server/providers/box.py
+++ b/plugins/oauth/server/providers/box.py
@@ -37,6 +37,10 @@ class Box(ProviderBase):
         return self.model('setting').get(
             constants.PluginSettings.BOX_CLIENT_SECRET)
 
+    def getStoreTokenSetting(self):
+        return self.model('setting').get(
+            constants.PluginSettings.BOX_STORE_TOKEN)
+
     @classmethod
     def getUrl(cls, state):
         clientId = cls.model('setting').get(
@@ -92,5 +96,7 @@ class Box(ProviderBase):
 
         names = resp.get('name').split()
         firstName, lastName = names[0], names[-1]
+        if not self.storeToken:
+            headers = None
         return self._createOrReuseUser(oauthId, email, firstName, lastName,
                                        headers)

--- a/plugins/oauth/server/providers/box.py
+++ b/plugins/oauth/server/providers/box.py
@@ -92,4 +92,5 @@ class Box(ProviderBase):
 
         names = resp.get('name').split()
         firstName, lastName = names[0], names[-1]
-        return self._createOrReuseUser(oauthId, email, firstName, lastName)
+        return self._createOrReuseUser(oauthId, email, firstName, lastName,
+                                       headers)

--- a/plugins/oauth/server/providers/github.py
+++ b/plugins/oauth/server/providers/github.py
@@ -39,6 +39,10 @@ class GitHub(ProviderBase):
         return self.model('setting').get(
             constants.PluginSettings.GITHUB_CLIENT_SECRET)
 
+    def getStoreTokenSetting(self):
+        return self.model('setting').get(
+            constants.PluginSettings.GITHUB_STORE_TOKEN)
+
     @classmethod
     def getUrl(cls, state):
         clientId = cls.model('setting').get(
@@ -106,5 +110,7 @@ class GitHub(ProviderBase):
         names = (resp.get('name') or login).split()
         firstName, lastName = names[0], names[-1]
 
+        if not self.storeToken:
+            headers = None
         return self._createOrReuseUser(oauthId, email, firstName, lastName,
                                        headers, userName=login)

--- a/plugins/oauth/server/providers/github.py
+++ b/plugins/oauth/server/providers/github.py
@@ -106,4 +106,5 @@ class GitHub(ProviderBase):
         names = (resp.get('name') or login).split()
         firstName, lastName = names[0], names[-1]
 
-        return self._createOrReuseUser(oauthId, email, firstName, lastName, login)
+        return self._createOrReuseUser(oauthId, email, firstName, lastName,
+                                       headers, userName=login)

--- a/plugins/oauth/server/providers/globus.py
+++ b/plugins/oauth/server/providers/globus.py
@@ -98,4 +98,5 @@ class Globus(ProviderBase):
         firstName = name[0]
         lastName = name[-1]
 
-        return self._createOrReuseUser(oauthId, email, firstName, lastName)
+        return self._createOrReuseUser(oauthId, email, firstName, lastName,
+                                       headers)

--- a/plugins/oauth/server/providers/globus.py
+++ b/plugins/oauth/server/providers/globus.py
@@ -39,6 +39,10 @@ class Globus(ProviderBase):
         return self.model('setting').get(
             constants.PluginSettings.GLOBUS_CLIENT_SECRET)
 
+    def getStoreTokenSetting(self):
+        return self.model('setting').get(
+            constants.PluginSettings.GLOBUS_STORE_TOKEN)
+
     @classmethod
     def getUrl(cls, state):
         clientId = cls.model('setting').get(
@@ -97,6 +101,7 @@ class Globus(ProviderBase):
         name = resp['name'].split()
         firstName = name[0]
         lastName = name[-1]
-
+        if not self.storeToken:
+            headers = None
         return self._createOrReuseUser(oauthId, email, firstName, lastName,
                                        headers)

--- a/plugins/oauth/server/providers/google.py
+++ b/plugins/oauth/server/providers/google.py
@@ -116,5 +116,6 @@ class Google(ProviderBase):
         firstName = resp.get('name', {}).get('givenName', '')
         lastName = resp.get('name', {}).get('familyName', '')
 
-        user = self._createOrReuseUser(oauthId, email, firstName, lastName)
+        user = self._createOrReuseUser(oauthId, email, firstName, lastName,
+                                       headers)
         return user

--- a/plugins/oauth/server/providers/google.py
+++ b/plugins/oauth/server/providers/google.py
@@ -39,6 +39,10 @@ class Google(ProviderBase):
         return self.model('setting').get(
             constants.PluginSettings.GOOGLE_CLIENT_SECRET)
 
+    def getStoreTokenSetting(self):
+        return self.model('setting').get(
+            constants.PluginSettings.GOOGLE_STORE_TOKEN)
+
     @classmethod
     def getUrl(cls, state):
         clientId = cls.model('setting').get(
@@ -116,6 +120,7 @@ class Google(ProviderBase):
         firstName = resp.get('name', {}).get('givenName', '')
         lastName = resp.get('name', {}).get('familyName', '')
 
-        user = self._createOrReuseUser(oauthId, email, firstName, lastName,
+        if not self.storeToken:
+            headers = None
+        return self._createOrReuseUser(oauthId, email, firstName, lastName,
                                        headers)
-        return user

--- a/plugins/oauth/server/providers/linkedin.py
+++ b/plugins/oauth/server/providers/linkedin.py
@@ -39,6 +39,10 @@ class LinkedIn(ProviderBase):
         return self.model('setting').get(
             constants.PluginSettings.LINKEDIN_CLIENT_SECRET)
 
+    def getStoreTokenSetting(self):
+        return self.model('setting').get(
+            constants.PluginSettings.LINKEDIN_STORE_TOKEN)
+
     @classmethod
     def getUrl(cls, state):
         clientId = cls.model('setting').get(
@@ -100,6 +104,7 @@ class LinkedIn(ProviderBase):
         firstName = resp.get('firstName', '')
         lastName = resp.get('lastName', '')
 
-        user = self._createOrReuseUser(oauthId, email, firstName, lastName,
+        if not self.storeToken:
+            headers = None
+        return self._createOrReuseUser(oauthId, email, firstName, lastName,
                                        headers)
-        return user

--- a/plugins/oauth/server/providers/linkedin.py
+++ b/plugins/oauth/server/providers/linkedin.py
@@ -100,5 +100,6 @@ class LinkedIn(ProviderBase):
         firstName = resp.get('firstName', '')
         lastName = resp.get('lastName', '')
 
-        user = self._createOrReuseUser(oauthId, email, firstName, lastName)
+        user = self._createOrReuseUser(oauthId, email, firstName, lastName,
+                                       headers)
         return user

--- a/plugins/oauth/web_client/templates/configView.pug
+++ b/plugins/oauth/web_client/templates/configView.pug
@@ -33,5 +33,9 @@ p Only fill in the information for the OAuth2 providers you wish to enable.
               label.control-label(for=`g-oauth-provider-${provider.id}-client-secret`) #{provider.name} client secret
               input.input-sm.form-control(id=`g-oauth-provider-${provider.id}-client-secret`,
                   type="text", placeholder="Client secret")
+            label.control-label.checkbox-inline(for=`g-oauth-provider-${provider.id}-store-token`)
+              input.checkbox(id=`g-oauth-provider-${provider.id}-store-token`,
+                  type="checkbox")
+              | Keep #{provider.name} access token
             p.g-validation-failed-message(id=`g-oauth-provider-${provider.id}-error-message`)
             input.btn.btn-sm.btn-primary(type="submit", value="Save", provider-id=provider.id)

--- a/plugins/oauth/web_client/views/ConfigView.js
+++ b/plugins/oauth/web_client/views/ConfigView.js
@@ -21,6 +21,9 @@ var ConfigView = View.extend({
             }, {
                 key: 'oauth.' + providerId + '_client_secret',
                 value: this.$('#g-oauth-provider-' + providerId + '-client-secret').val().trim()
+            }, {
+                key: 'oauth.' + providerId + '_store_token',
+                value: this.$('#g-oauth-provider-' + providerId + '-store-token').prop('checked')
             }]);
         }
     },
@@ -83,6 +86,7 @@ var ConfigView = View.extend({
         _.each(this.providerIds, function (id) {
             settingKeys.push('oauth.' + id + '_client_id');
             settingKeys.push('oauth.' + id + '_client_secret');
+            settingKeys.push('oauth.' + id + '_store_token');
         }, this);
 
         restRequest({
@@ -125,6 +129,8 @@ var ConfigView = View.extend({
                     this.settingVals['oauth.' + id + '_client_id']);
                 this.$('#g-oauth-provider-' + id + '-client-secret').val(
                     this.settingVals['oauth.' + id + '_client_secret']);
+                this.$('#g-oauth-provider-' + id + '-store-token').prop(
+                    'checked', this.settingVals['oauth.' + id + '_store_token']);
             }, this);
         }
 


### PR DESCRIPTION
Up till now, the authentication token obtained in the OAuth2 flow wasonly used to get the user's email/name and was immediately discarded. With this change, auth token is stored in the user model metadata and can be conveniently reused for accessing the issuer's resources.