### PR TITLE
Enable esdoc for automated web client documentation

### DIFF
--- a/.esdoc.json
+++ b/.esdoc.json
@@ -1,0 +1,4 @@
+{
+  "source": "./clients/web/src",
+  "destination": "./docs/_build/esdoc"
+}

--- a/circle.yml
+++ b/circle.yml
@@ -31,3 +31,11 @@ test:
   override:
     - ~/girder/cmake/run_circleci.sh:
         parallel: true
+
+deployment:
+  master:
+    branch: master
+    owner: girder
+    commands:
+      - npm run esdoc
+      - curl 'https://doc.esdoc.org/api/create' -X POST --data-urlencode "gitUrl=git@github.com:girder/girder.git"

--- a/clients/web/src/dialog.js
+++ b/clients/web/src/dialog.js
@@ -54,14 +54,15 @@ function handleOpen(name, options, nameId) {
 
 /**
  * Prompt the user to confirm an action.
- * @param [text] The text to prompt the user with.
- * @param [yesText] The text for the confirm button.
- * @param [yesClass] Class string to apply to the confirm button.
- * @param [noText] The text for the no/cancel button.
- * @param [escapedHtml] If you want to render the text as HTML rather than
+ * @param {Object} [params] Parameters controlling this function's behavior.
+ * @param {String} [params.text] The text to prompt the user with.
+ * @param {String} [params.yesText] The text for the confirm button.
+ * @param {String} [params.yesClass] Class string to apply to the confirm button.
+ * @param {String} [params.noText] The text for the no/cancel button.
+ * @param {Boolean} [params.escapedHtml] If you want to render the text as HTML rather than
  *        plain text, set this to true to acknowledge that you have escaped any
  *        user-created data within the text to prevent XSS exploits.
- * @param confirmCallback Callback function when the user confirms the action.
+ * @param {Function} [params.confirmCallback]Callback function when the user confirms the action.
  */
 function confirm(params) {
     params = _.extend({

--- a/clients/web/src/rest.js
+++ b/clients/web/src/rest.js
@@ -13,7 +13,7 @@ var uploadChunkSize = 1024 * 1024 * 64; // 64MB
 /**
  * Set the root path to the API.
  *
- * @param path The full root path for the API.
+ * @param root The full root path for the API.
  */
 function setApiRoot(root) {
     apiRoot = root;
@@ -21,7 +21,7 @@ function setApiRoot(root) {
 
 /** Set the root path to the static content.
  *
- * @param path The full root path for the static content.
+ * @param root The full root path for the static content.
  */
 function setStaticRoot(root) {
     staticRoot = root;

--- a/docs/api-docs.rst
+++ b/docs/api-docs.rst
@@ -205,6 +205,12 @@ Constants
 Clients
 -------
 
+Web client
+^^^^^^^^^^
+
+Documentation for Girder's web client library is built and hosted by esdoc and can be found
+`here <https://doc.esdoc.org/github.com/girder/girder>`_.
+
 jQuery Plugins
 ^^^^^^^^^^^^^^
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "devDependencies": {
     "babel-plugin-istanbul": "^2.0.1",
+    "esdoc": "^0.5.2",
     "eslint": "^3.3.1",
     "eslint-config-girder": "^2.0.0",
     "eslint-config-semistandard": "^6.0.2",
@@ -75,6 +76,7 @@
     "build": "grunt init && NODE_PATH=$PWD/node_modules grunt",
     "watch": "NODE_PATH=$PWD/node_modules grunt --watch",
     "lint": "eslint --cache clients/web Gruntfile.js grunt_tasks scripts clients/web/test && pug-lint clients/web/src/templates",
-    "docs": "grunt docs"
+    "docs": "grunt docs",
+    "esdoc": "esdoc"
   }
 }


### PR DESCRIPTION
@Purg your question earlier made me look into this, and this library seems like a good choice for handling this.

@girder/developers once this is merged to master, we *should* have our JS docs built and hosted for us on https://doc.esdoc.org/