### PR TITLE
Fix minor XSS vulnerability in human-readable REST HTML output

### DIFF
--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 ###############################################################################
 
+import cgi
 import cherrypy
 import collections
 import datetime
@@ -485,8 +486,9 @@ def _createResponse(val):
         elif accept.value == 'text/html':  # pragma: no cover
             # Pretty-print and HTML-ify the response for the browser
             setResponseHeader('Content-Type', 'text/html')
-            resp = json.dumps(val, indent=4, sort_keys=True, allow_nan=False,
-                              separators=(',', ': '), cls=JsonEncoder)
+            resp = cgi.escape(json.dumps(
+                val, indent=4, sort_keys=True, allow_nan=False, separators=(',', ': '),
+                cls=JsonEncoder))
             resp = resp.replace(' ', '&nbsp;').replace('\n', '<br />')
             resp = '<div style="font-family:monospace;">%s</div>' % resp
             return resp.encode('utf8')


### PR DESCRIPTION
Thanks to @jjomier for finding this with a pen-testing tool. This is not a major security vulnerability since none of our end user clients would ever encounter it (except perhaps via following a malicious link), but it is a legitimate XSS vector. To see the problem, using your web browser, go to, e.g.

    http://localhost:8080/api/v1/item/some%3Cb%3Efoo%3C/b%3E%3Ci%3Ebar%3C/i%3E

Scope: only when using a web browser to invoke an API route directly (i.e. the `Accept` header is set to `text/html`.