### PR TITLE
Do not build esdoc on Circle, only on ESDoc hosting

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -37,5 +37,4 @@ deployment:
     branch: master
     owner: girder
     commands:
-      - npm run esdoc
       - curl 'https://doc.esdoc.org/api/create' -X POST --data-urlencode "gitUrl=git@github.com:girder/girder.git"


### PR DESCRIPTION
It uses ES6 features that are too new for the version of
node we use for testing on Circle.

