### PR TITLE
Non-multipart file upload

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -312,7 +312,7 @@ class GirderClient(object):
             as the key/value pairs in the request parameters.
         :type parameters: dict
         :param data: A dictionary, bytes or file-like object to send in the body.
-        :param files: A dictonary of 'name' => file-like-objects for multipart encoding upload.
+        :param files: A dictionary of 'name' => file-like-objects for multipart encoding upload.
         :type files: dict
         :param json: A JSON object to send in the request body.
         :type json: dict
@@ -760,8 +760,7 @@ class GirderClient(object):
 
             if self.getServerVersion() >= ['2', '2']:
                 uploadObj = self.post(
-                    'file/chunk?offset=%d&uploadId=%s' % (offset, uploadId),
-                    data=six.BytesIO(chunk))
+                    'file/chunk?offset=%d&uploadId=%s' % (offset, uploadId), data=chunk)
             else:
                 # Prior to version 2.2 the server only supported multipart uploads
                 parameters = {

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -292,22 +292,6 @@ class GirderClient(object):
 
         return self._serverApiDescription
 
-    def _serverSupportsNonMultiPartUpload(self, useCached=True):
-        """
-        Returns whether it supports the more efficient non multipart upload.
-
-        It internally fetches the API server description and check if the
-        ``file/chunk`` endpoint
-
-        :param useCached: Whether to return the previously fetched value. Set
-            to False to force a re-fetch of the description from the server.
-        :type useCached: bool
-        :return: boolean indicating if the server supports the feature or not.
-        """
-        description = self.getServerAPIDescription(useCached)
-        params = description["paths"]["/file/chunk"]["post"]["parameters"]
-        return "chunk" not in [param["name"] for param in params]
-
     def sendRestRequest(self, method, path, parameters=None, data=None, files=None, json=None):
         """
         This method looks up the appropriate method, constructs a request URL
@@ -774,7 +758,7 @@ class GirderClient(object):
             if isinstance(chunk, six.text_type):
                 chunk = chunk.encode('utf8')
 
-            if self._serverSupportsNonMultiPartUpload():
+            if self.getServerVersion() >= ['2', '2']:
                 uploadObj = self.post(
                     'file/chunk?offset=%d&uploadId=%s' % (offset, uploadId),
                     data=six.BytesIO(chunk))

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -684,15 +684,9 @@ class GirderClient(object):
                     'an object with an id. Got instead: ' + json.dumps(obj))
 
         for chunk, startbyte in self._fileChunker(filepath, filesize):
-            parameters = {
-                'offset': startbyte,
-                'uploadId': uploadId
-            }
-            filedata = {
-                'chunk': chunk
-            }
-            path = 'file/chunk'
-            obj = self.post(path, parameters=parameters, files=filedata)
+            obj = self.post(
+                'file/chunk?offset=%d&uploadId=%s' % (startbyte, uploadId),
+                data=six.BytesIO(chunk))
 
             if '_id' not in obj:
                 raise Exception(
@@ -725,14 +719,11 @@ class GirderClient(object):
             if not data:
                 break
 
-            params = {
-                'offset': offset,
-                'uploadId': uploadId
-            }
-            files = {
-                'chunk': data
-            }
-            uploadObj = self.post('file/chunk', parameters=params, files=files)
+            if isinstance(data, six.text_type):
+                data = data.encode('utf8')
+
+            uploadObj = self.post(
+                'file/chunk?offset=%d&uploadId=%s' % (offset, uploadId), data=six.BytesIO(data))
             offset += len(data)
 
             if '_id' not in uploadObj:

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -234,7 +234,7 @@ class GirderClient(object):
 
     def getServerVersion(self, useCached=True):
         """
-        Fetch server API version. By default, caches the version on this class
+        Fetch server API version. By default, caches the version
         such that future calls to this function do not make another request to
         the server.
 

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -166,7 +166,7 @@ class GirderClient(object):
         self.token = ''
         self._folderUploadCallbacks = []
         self._itemUploadCallbacks = []
-        self._serverVersion = None
+        self._serverApiDescription = {}
         self.incomingMetadata = {}
         self.localMetadata = {}
 
@@ -243,10 +243,54 @@ class GirderClient(object):
         :type useCached: bool
         :return: The API version as a list (e.g. ``['1', '0', '0']``)
         """
-        if not self._serverVersion or not useCached:
-            self._serverVersion = self.get('system/version')['apiVersion'].split('.')
+        return self.getServerAPIDescription(useCached)["info"]["version"].split('.')
 
-        return self._serverVersion
+    def getServerAPIDescription(self, useCached=True):
+        """
+        Fetch server RESTful API description.
+
+        :param useCached: Whether to return the previously fetched value. Set
+            to False to force a re-fetch of the description from the server.
+        :type useCached: bool
+        :return: The API descriptions as a dict.
+
+        For example: ::
+
+            {
+                "basePath": "/api/v1",
+                "definitions": {},
+                "host": "girder.example.com",
+                "info": {
+                    "title": "Girder REST API",
+                    "version": "X.Y.Z"
+                },
+                "paths": {
+                    "/api_key": {
+                        "get": {
+                            "description": "Only site administrators [...]",
+                            "operationId": "api_key_listKeys",
+                            "parameters": [
+                                {
+                                    "description": "ID of the user whose keys to list.",
+                                    "in": "query",
+                                    "name": "userId",
+                                    "required": false,
+                                    "type": "string"
+                                },
+                                ...
+                            ]
+                        }.
+                        ...
+                    }
+                ...
+                }
+            }
+
+        """
+        if not self._serverApiDescription or not useCached:
+            self._serverApiDescription = self.get('describe')
+
+        return self._serverApiDescription
 
     def sendRestRequest(self, method, path, parameters=None, data=None, files=None, json=None):
         """

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -788,16 +788,16 @@ class GirderClient(object):
         offset = 0
         uploadId = uploadObj['_id']
         while True:
-            data = stream.read(min(self.MAX_CHUNK_SIZE, (size - offset)))
+            chunk = stream.read(min(self.MAX_CHUNK_SIZE, (size - offset)))
 
-            if not data:
+            if not chunk:
                 break
 
-            if isinstance(data, six.text_type):
-                data = data.encode('utf8')
+            if isinstance(chunk, six.text_type):
+                chunk = chunk.encode('utf8')
 
-            uploadObj = self._sendChunk(offset, uploadId, data)
-            offset += len(data)
+            uploadObj = self._sendChunk(offset, uploadId, chunk)
+            offset += len(chunk)
 
             if callable(progressCallback):
                 progressCallback({

--- a/clients/web/src/models/FileModel.js
+++ b/clients/web/src/models/FileModel.js
@@ -230,16 +230,11 @@ var FileModel = Model.extend({
         var blob = file[sliceFn](this.startByte, endByte);
         var model = this;
 
-        var fd = new FormData();
-        fd.append('offset', this.startByte);
-        fd.append('uploadId', uploadId);
-        fd.append('chunk', blob);
-
         restRequest({
-            path: 'file/chunk',
+            path: `file/chunk?offset=${this.startByte}&uploadId=${uploadId}`,
             type: 'POST',
             dataType: 'json',
-            data: fd,
+            data: blob,
             contentType: false,
             processData: false,
             success: function (resp) {

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -818,33 +818,8 @@ function _prepareTestUpload() {
     girderTest.getCallbackSuffix();
 
     (function (impl) {
-        FormData.prototype.append = function (name, value, filename) {
-            this.vals = this.vals || {};
-            if (filename) {
-                this.vals[name + '_filename'] = value;
-            }
-            this.vals[name] = value;
-            impl.call(this, name, value, filename);
-        };
-    }(FormData.prototype.append));
-
-    (function (impl) {
         XMLHttpRequest.prototype.send = function (data) {
-            if (data && data instanceof FormData) {
-                var newdata = new FormData();
-                newdata.append('offset', data.vals.offset);
-                newdata.append('uploadId', data.vals.uploadId);
-                var len = data.vals.chunk.size;
-                if (girderTest._uploadData.length &&
-                    girderTest._uploadData.length === len &&
-                    !girderTest._uploadDataExtra) {
-                    newdata.append('chunk', girderTest._uploadData);
-                } else {
-                    newdata.append('chunk', new Array(
-                        len + 1 + girderTest._uploadDataExtra).join('-'));
-                }
-                data = newdata;
-            } else if (data && data instanceof Blob) {
+            if (data && data instanceof Blob) {
                 if (girderTest._uploadDataExtra) {
                     /* Our mock S3 server will take extra data, so break it
                      * by adding a faulty copy header.  This will throw an

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -26,6 +26,7 @@ from ..rest import Resource, RestException, filtermodel
 from ...constants import AccessType, TokenScope
 from girder.models.model_base import AccessException, GirderException
 from girder.api import access
+from girder.utility import RequestBodyStream
 from girder.utility.progress import ProgressContext
 
 
@@ -176,21 +177,17 @@ class File(Resource):
 
     @access.user(scope=TokenScope.DATA_WRITE)
     @autoDescribeRoute(
-        Description('Upload a chunk of a file with multipart/form-data.')
-        .consumes('multipart/form-data')
+        Description('Upload a chunk of a file.')
         .modelParam('uploadId', paramType='formData')
         .param('offset', 'Offset of the chunk in the file.', dataType='integer',
                paramType='formData')
-        .param('chunk', 'The actual bytes of the chunk. For external upload '
-               'behaviors, this may be set to an opaque string that will be '
-               'handled by the assetstore adapter.', dataType='file')
         .errorResponse(('ID was invalid.',
                         'Received too many bytes.',
                         'Chunk is smaller than the minimum size.'))
         .errorResponse('You are not the user who initiated the upload.', 403)
         .errorResponse('Failed to store upload.', 500)
     )
-    def readChunk(self, upload, offset, chunk, params):
+    def readChunk(self, upload, offset, params):
         """
         After the temporary upload record has been created (see initUpload),
         the bytes themselves should be passed up in ordered chunks. The user
@@ -198,7 +195,20 @@ class File(Resource):
         the writer of the chunk is the same as the person who initiated the
         upload. The passed offset is a verification mechanism for ensuring the
         server and client agree on the number of bytes sent/received.
+
+        This method accepts both the legacy multipart content encoding, as
+        well as passing offset and uploadId as query parameters and passing
+        the chunk as the body, which is the recommended method.
+
+        Multipart uploads are @deprecated as of v2.2.0.
         """
+        if 'chunk' in params:
+            chunk = params['chunk']
+            if isinstance(chunk, cherrypy._cpreqbody.Part):
+                chunk = chunk.file
+        else:
+            chunk = RequestBodyStream(cherrypy.request.body)
+
         user = self.getCurrentUser()
 
         if upload['userId'] != user['_id']:
@@ -209,10 +219,7 @@ class File(Resource):
                 'Server has received %s bytes, but client sent offset %s.' % (
                     upload['received'], offset))
         try:
-            if isinstance(chunk, cherrypy._cpreqbody.Part):
-                return self.model('upload').handleChunk(upload, chunk.file, filter=True, user=user)
-            else:
-                return self.model('upload').handleChunk(upload, chunk, filter=True, user=user)
+            return self.model('upload').handleChunk(upload, chunk, filter=True, user=user)
         except IOError as exc:
             if exc.errno == errno.EACCES:
                 raise Exception('Failed to store upload.')

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -19,6 +19,7 @@
 
 import cherrypy
 import errno
+import os
 import six
 
 from ..describe import Description, autoDescribeRoute, describeRoute
@@ -205,7 +206,11 @@ class File(Resource):
         if 'chunk' in params:
             chunk = params['chunk']
             if isinstance(chunk, cherrypy._cpreqbody.Part):
-                chunk = chunk.file
+                # Seek is the only obvious way to get the length of the part
+                chunk.file.seek(0, os.SEEK_END)
+                size = chunk.file.tell()
+                chunk.file.seek(0, os.SEEK_SET)
+                chunk = RequestBodyStream(chunk.file, size=size)
         else:
             chunk = RequestBodyStream(cherrypy.request.body)
 

--- a/girder/utility/__init__.py
+++ b/girder/utility/__init__.py
@@ -142,3 +142,17 @@ class JsonEncoder(json.JSONEncoder):
         elif isinstance(obj, datetime.datetime):
             return obj.replace(tzinfo=pytz.UTC).isoformat()
         return str(obj)
+
+
+class RequestBodyStream(object):
+    """
+    Wraps a cherrypy request body into a more abstract file-like object.
+    """
+    def __init__(self, stream):
+        self.stream = stream
+
+    def read(self, *args, **kwargs):
+        return self.stream.read(*args, **kwargs)
+
+    def close(self, *args, **kwargs):
+        pass

--- a/girder/utility/__init__.py
+++ b/girder/utility/__init__.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 ###############################################################################
 
+import cherrypy
 import datetime
 import dateutil.parser
 import errno
@@ -148,11 +149,23 @@ class RequestBodyStream(object):
     """
     Wraps a cherrypy request body into a more abstract file-like object.
     """
-    def __init__(self, stream):
+    def __init__(self, stream, size=None):
         self.stream = stream
+        self.size = size
 
     def read(self, *args, **kwargs):
         return self.stream.read(*args, **kwargs)
 
     def close(self, *args, **kwargs):
         pass
+
+    def getSize(self):
+        """
+        Returns the size of the body data wrapped by this class. For
+        multipart encoding, this is the size of the part. For sending
+        as the body, this is the Content-Length header.
+        """
+        if self.size is not None:
+            return self.size
+
+        return int(cherrypy.request.headers['Content-Length'])

--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -21,7 +21,7 @@ import six
 from girder.api.rest import setResponseHeader
 from girder.constants import SettingKey
 from girder.models.model_base import ValidationException
-from girder.utility import progress
+from girder.utility import progress, RequestBodyStream
 from .model_importer import ModelImporter
 
 
@@ -218,7 +218,7 @@ class AbstractAssetstoreAdapter(ModelImporter):
         :type chunk: a file-like object or a string
         :returns: the length of the chunk if known, or None.
         """
-        if isinstance(chunk, six.BytesIO):
+        if isinstance(chunk, (six.BytesIO, RequestBodyStream)):
             return
         elif hasattr(chunk, "fileno"):
             return os.fstat(chunk.fileno()).st_size

--- a/girder/utility/gridfs_assetstore_adapter.py
+++ b/girder/utility/gridfs_assetstore_adapter.py
@@ -185,7 +185,7 @@ class GridFsAssetstoreAdapter(AbstractAssetstoreAdapter):
             self.chunkColl.delete_many({
                 'uuid': upload['chunkUuid'],
                 'n': {'$gte': startingN}
-            }, multi=True)
+            })
             raise
 
         # Persist the internal state of the checksum

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -17,6 +17,8 @@
 #  limitations under the License.
 ###############################################################################
 
+import boto
+import httmock
 import io
 import json
 import mock
@@ -33,8 +35,7 @@ from girder.constants import SettingKey
 from girder.models import getDbConnection
 from girder.models.model_base import AccessException
 from girder.utility.filesystem_assetstore_adapter import DEFAULT_PERMS
-from girder.utility.s3_assetstore_adapter import (makeBotoConnectParams,
-                                                  S3AssetstoreAdapter)
+from girder.utility.s3_assetstore_adapter import makeBotoConnectParams, S3AssetstoreAdapter
 from six.moves import urllib
 
 
@@ -760,7 +761,7 @@ class FileTestCase(base.TestCase):
     @moto.mock_s3bucket_path
     def testS3Assetstore(self):
         botoParams = makeBotoConnectParams('access', 'secret')
-        mock_s3.createBucket(botoParams, 'b')
+        bucket = mock_s3.createBucket(botoParams, 'b')
 
         self.model('assetstore').remove(self.model('assetstore').getCurrent())
         assetstore = self.model('assetstore').createS3Assetstore(
@@ -789,8 +790,7 @@ class FileTestCase(base.TestCase):
             path='/file/chunk', user=self.user, fields=fields, files=files)
         self.assertStatus(resp, 400)
         self.assertEqual(
-            resp.json['message'],
-            'Uploads of this length must be sent in a single chunk.')
+            resp.json['message'], 'Uploads of this length must be sent in a single chunk.')
 
         # Attempting to send second chunk with incorrect offset should fail
         fields = [('offset', 100), ('uploadId', uploadId)]
@@ -799,20 +799,41 @@ class FileTestCase(base.TestCase):
             path='/file/chunk', user=self.user, fields=fields, files=files)
         self.assertStatus(resp, 400)
         self.assertEqual(
-            resp.json['message'],
-            'Server has received 0 bytes, but client sent offset 100.')
+            resp.json['message'], 'Server has received 0 bytes, but client sent offset 100.')
 
         # Request offset from server (simulate a resume event)
-        resp = self.request(path='/file/offset', method='GET', user=self.user,
-                            params={'uploadId': uploadId})
+        resp = self.request(
+            path='/file/offset', method='GET', user=self.user, params={'uploadId': uploadId})
         self.assertStatusOk(resp)
+
+        @httmock.all_requests
+        def mockChunkUpload(url, request):
+            """
+            We used to be able to use moto to mock the sending of chunks to
+            S3, however we now no longer use the boto API to do so internally,
+            and must mock this out at the level of requests.
+            """
+            if url.netloc != 's3.amazonaws.com':
+                raise Exception('Unexpected request to host ' + url.netloc)
+
+            body = request.body.read(65536)  # sufficient for now, we have short bodies
+
+            # Actually set the key in moto
+            self.assertEqual(url.path[:3], '/b/')
+            key = boto.s3.key.Key(bucket=bucket, name=url.path[3:])
+            key.set_contents_from_string(body)
+
+            return {
+                'status_code': 200
+            }
 
         # Trying to send too many bytes should fail
         currentOffset = resp.json['offset']
         fields = [('offset', resp.json['offset']), ('uploadId', uploadId)]
         files = [('chunk', 'hello.txt', "extra_"+chunk2+"_bytes")]
-        resp = self.multipartRequest(
-            path='/file/chunk', user=self.user, fields=fields, files=files)
+        with httmock.HTTMock(mockChunkUpload):
+            resp = self.multipartRequest(
+                path='/file/chunk', user=self.user, fields=fields, files=files)
         self.assertStatus(resp, 400)
         self.assertEqual(resp.json, {
             'type': 'validation',
@@ -820,16 +841,17 @@ class FileTestCase(base.TestCase):
         })
 
         # The offset should not have changed
-        resp = self.request(path='/file/offset', method='GET', user=self.user,
-                            params={'uploadId': uploadId})
+        resp = self.request(
+            path='/file/offset', method='GET', user=self.user, params={'uploadId': uploadId})
         self.assertStatusOk(resp)
         self.assertEqual(resp.json['offset'], currentOffset)
 
         # Send all in one chunk
         files = [('chunk', 'hello.txt', chunk1 + chunk2)]
         fields = [('offset', 0), ('uploadId', uploadId)]
-        resp = self.multipartRequest(
-            path='/file/chunk', user=self.user, fields=fields, files=files)
+        with httmock.HTTMock(mockChunkUpload):
+            resp = self.multipartRequest(
+                path='/file/chunk', user=self.user, fields=fields, files=files)
         self.assertStatusOk(resp)
 
         file = self.model('file').load(resp.json['_id'], force=True)
@@ -842,7 +864,7 @@ class FileTestCase(base.TestCase):
         # Make sure metadata is updated in S3 when file info changes
         # (moto API doesn't cover this at all, so we manually mock.)
         with mock.patch('boto.s3.key.Key.set_remote_metadata') as m:
-            resp = self.request(
+            self.request(
                 '/file/%s' % str(file['_id']), method='PUT', params={
                     'mimeType': 'application/csv',
                     'name': 'new name'
@@ -876,8 +898,9 @@ class FileTestCase(base.TestCase):
         files = [('chunk', 'hello.txt', chunk1)]
 
         # Send the first chunk, should now work
-        resp = self.multipartRequest(
-            path='/file/chunk', user=self.user, fields=fields, files=files)
+        with httmock.HTTMock(mockChunkUpload):
+            resp = self.multipartRequest(
+                path='/file/chunk', user=self.user, fields=fields, files=files)
         self.assertStatusOk(resp)
 
         resp = self.request(path='/file/offset', user=self.user, params={
@@ -890,11 +913,12 @@ class FileTestCase(base.TestCase):
         moto.s3.models.UPLOAD_PART_MIN_SIZE = 5
 
         # Send the second chunk
-        resp = self.request(
-            path='/file/chunk', method='POST', user=self.user, body=chunk2, params={
-                'offset': resp.json['offset'],
-                'uploadId': uploadId
-            }, type='text/plain')
+        with httmock.HTTMock(mockChunkUpload):
+            resp = self.request(
+                path='/file/chunk', method='POST', user=self.user, body=chunk2, params={
+                    'offset': resp.json['offset'],
+                    'uploadId': uploadId
+                }, type='text/plain')
         self.assertStatusOk(resp)
 
         file = resp.json

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -890,10 +890,11 @@ class FileTestCase(base.TestCase):
         moto.s3.models.UPLOAD_PART_MIN_SIZE = 5
 
         # Send the second chunk
-        files = [('chunk', 'hello.txt', chunk2)]
-        fields = [('offset', resp.json['offset']), ('uploadId', uploadId)]
-        resp = self.multipartRequest(
-            path='/file/chunk', user=self.user, fields=fields, files=files)
+        resp = self.request(
+            path='/file/chunk', method='POST', user=self.user, body=chunk2, params={
+                'offset': resp.json['offset'],
+                'uploadId': uploadId
+            }, type='text/plain')
         self.assertStatusOk(resp)
 
         file = resp.json

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 ###############################################################################
 
+import girder
 import girder_client
 import json
 import mock
@@ -625,3 +626,27 @@ class PythonClientTestCase(base.TestCase):
         uploadedFile = self.client.uploadFileToItem(item['_id'], path, filename='g1')
 
         self.assertEqual(uploadedFile['name'], 'g1')
+
+    def testGetServerVersion(self):
+
+        # track system/version API calls
+        hits = []
+
+        @httmock.urlmatch(path=r'.*/system/version$')
+        def mock(url, request):
+            hits.append(url)
+
+        expected_version = girder.constants.VERSION['apiVersion']
+
+        with httmock.HTTMock(mock):
+            self.assertEqual(
+                ".".join(self.client.getServerVersion()), expected_version)
+            self.assertEqual(len(hits), 1)
+
+            self.assertEqual(
+                ".".join(self.client.getServerVersion()), expected_version)
+            self.assertEqual(len(hits), 1)
+
+            self.assertEqual(
+                ".".join(self.client.getServerVersion(useCached=False)), expected_version)
+            self.assertEqual(len(hits), 2)

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -317,15 +317,15 @@ class PythonClientTestCase(base.TestCase):
             self.assertEqual(file['mimeType'], 'text/plain')
 
     def testUploadNonMultipartVersionGreaterOrEqual22(self):
-        for version in ["2.2.0", "2.2.1", "2.3", "3.0", "3.1"]:
+        for version in ['2.2.0', '2.2.1', '2.3', '3.0', '3.1']:
             with mock.patch.object(
-                    self.client, 'getServerVersion', return_value=version.split(".")):
+                    self.client, 'getServerVersion', return_value=version.split('.')):
                 self._testUploadMethod(expected_non_multipart_hits=1, expected_multipart_hits=0)
 
     def testUploadMultipartVersionLess22(self):
-        for version in ["1.4.1", "1.6.0", "2.1.0", "2.1.9"]:
+        for version in ['1.4.1', '1.6.0', '2.1.0', '2.1.9']:
             with mock.patch.object(
-                    self.client, 'getServerVersion', return_value=version.split(".")):
+                    self.client, 'getServerVersion', return_value=version.split('.')):
                 self._testUploadMethod(expected_non_multipart_hits=0, expected_multipart_hits=1)
 
     def _testUploadMethod(self, expected_non_multipart_hits=0, expected_multipart_hits=0):
@@ -610,9 +610,9 @@ class PythonClientTestCase(base.TestCase):
         item = self.client.createItem(self.publicFolder['_id'],
                                       itemName)
 
-        testPath = "user/%s/%s/%s" % (self.user['login'],
+        testPath = 'user/%s/%s/%s' % (self.user['login'],
                                       self.publicFolder['name'], itemName)
-        testInvalidPath = "user/%s/%s/%s" % (self.user['login'],
+        testInvalidPath = 'user/%s/%s/%s' % (self.user['login'],
                                              self.publicFolder['name'],
                                              'RogueOne')
 
@@ -710,15 +710,15 @@ class PythonClientTestCase(base.TestCase):
 
         with httmock.HTTMock(mock):
             self.assertEqual(
-                ".".join(self.client.getServerVersion()), expected_version)
+                '.'.join(self.client.getServerVersion()), expected_version)
             self.assertEqual(len(hits), 1)
 
             self.assertEqual(
-                ".".join(self.client.getServerVersion()), expected_version)
+                '.'.join(self.client.getServerVersion()), expected_version)
             self.assertEqual(len(hits), 1)
 
             self.assertEqual(
-                ".".join(self.client.getServerVersion(useCached=False)), expected_version)
+                '.'.join(self.client.getServerVersion(useCached=False)), expected_version)
             self.assertEqual(len(hits), 2)
 
     def testGetServerAPIDescription(self):
@@ -731,11 +731,11 @@ class PythonClientTestCase(base.TestCase):
             hits.append(url)
 
         def checkDescription(description):
-            self.assertEqual(description["basePath"], "/api/v1")
-            self.assertEqual(description["definitions"], {})
-            self.assertEqual(description["info"]["title"], "Girder REST API")
-            self.assertEqual(description["info"]["version"], girder.constants.VERSION['apiVersion'])
-            self.assertGreater(len(description["paths"]), 0)
+            self.assertEqual(description['basePath'], '/api/v1')
+            self.assertEqual(description['definitions'], {})
+            self.assertEqual(description['info']['title'], 'Girder REST API')
+            self.assertEqual(description['info']['version'], girder.constants.VERSION['apiVersion'])
+            self.assertGreater(len(description['paths']), 0)
 
         with httmock.HTTMock(mock):
             checkDescription(self.client.getServerAPIDescription())

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -629,10 +629,10 @@ class PythonClientTestCase(base.TestCase):
 
     def testGetServerVersion(self):
 
-        # track system/version API calls
+        # track describe API calls
         hits = []
 
-        @httmock.urlmatch(path=r'.*/system/version$')
+        @httmock.urlmatch(path=r'.*/describe$')
         def mock(url, request):
             hits.append(url)
 
@@ -649,4 +649,30 @@ class PythonClientTestCase(base.TestCase):
 
             self.assertEqual(
                 ".".join(self.client.getServerVersion(useCached=False)), expected_version)
+            self.assertEqual(len(hits), 2)
+
+    def testGetServerAPIDescription(self):
+
+        # track system/version APIi calls
+        hits = []
+
+        @httmock.urlmatch(path=r'.*/describe$')
+        def mock(url, request):
+            hits.append(url)
+
+        def checkDescription(description):
+            self.assertEqual(description["basePath"], "/api/v1")
+            self.assertEqual(description["definitions"], {})
+            self.assertEqual(description["info"]["title"], "Girder REST API")
+            self.assertEqual(description["info"]["version"], girder.constants.VERSION['apiVersion'])
+            self.assertGreater(len(description["paths"]), 0)
+
+        with httmock.HTTMock(mock):
+            checkDescription(self.client.getServerAPIDescription())
+            self.assertEqual(len(hits), 1)
+
+            checkDescription(self.client.getServerAPIDescription())
+            self.assertEqual(len(hits), 1)
+
+            checkDescription(self.client.getServerAPIDescription(useCached=False))
             self.assertEqual(len(hits), 2)

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -316,7 +316,15 @@ class PythonClientTestCase(base.TestCase):
                 size=size, parentType='folder')
             self.assertEqual(file['mimeType'], 'text/plain')
 
-    def testUploadReference(self):
+    def testUploadReferenceWithMultipart(self):
+        with mock.patch.object(self.client, 'getServerVersion', return_value=['2', '1', '0']):
+            self._testUploadReference()
+
+    def testUploadReferenceWithNonMultipart(self):
+        with mock.patch.object(self.client, 'getServerVersion', return_value=['2', '2', '0']):
+            self._testUploadReference()
+
+    def _testUploadReference(self):
         eventList = []
 
         def processEvent(event):
@@ -378,7 +386,15 @@ class PythonClientTestCase(base.TestCase):
         file = self.client.uploadFileToItem(item['_id'], testPath)
         self.assertEqual(file['mimeType'], 'text/plain')
 
-    def testUploadContent(self):
+    def testUploadContentWithMultipart(self):
+        with mock.patch.object(self.client, 'getServerVersion', return_value=['2', '1', '0']):
+            self._testUploadContent()
+
+    def testUploadContentWithoutMultipart(self):
+        with mock.patch.object(self.client, 'getServerVersion', return_value=['2', '2', '0']):
+            self._testUploadContent()
+
+    def _testUploadContent(self):
         path = os.path.join(self.libTestDir, 'sub0', 'f')
         size = os.path.getsize(path)
         with open(path) as fh:
@@ -602,7 +618,15 @@ class PythonClientTestCase(base.TestCase):
         self.assertEqual(resp['type'], 'validation')
         self.assertEqual(resp['message'], 'Path not found: %s' % (testInvalidPath))
 
-    def testUploadWithPath(self):
+    def testUploadWithPathWithMultipart(self):
+        with mock.patch.object(self.client, 'getServerVersion', return_value=['2', '1', '0']):
+            self._testUploadWithPath()
+
+    def testUploadWithPathWithoutMultipart(self):
+        with mock.patch.object(self.client, 'getServerVersion', return_value=['2', '2', '0']):
+            self._testUploadWithPath()
+
+    def _testUploadWithPath(self):
         testUser = self.model('user').createUser(
             firstName='Jeffrey', lastName='Abrams', login='jjabrams',
             password='password', email='jjabrams@email.com')
@@ -617,7 +641,15 @@ class PythonClientTestCase(base.TestCase):
             parentType='folder', parent=parent,
             user=testUser, limit=0)], ['sub0', 'sub1', 'sub2'])
 
-    def testUploadFileWithDifferentName(self):
+    def testUploadFileWithDifferentNameWithMultipart(self):
+        with mock.patch.object(self.client, 'getServerVersion', return_value=['2', '1', '0']):
+            self._testUploadFileWithDifferentName()
+
+    def testUploadFileWithDifferentNameWithoutMultipart(self):
+        with mock.patch.object(self.client, 'getServerVersion', return_value=['2', '2', '0']):
+            self._testUploadFileWithDifferentName()
+
+    def _testUploadFileWithDifferentName(self):
         itemName = 'MyStash'
         item = self.client.createItem(self.publicFolder['_id'],
                                       itemName)


### PR DESCRIPTION
This mode has a couple significant advantages:

1. It's much faster -- the cherrypy server does not need to
   expend resources searching the body for multipart chunk
   delimiters.
2. The cherrypy server does not write the file part to disk,
   and the request handler is invoked immediately rather than
   waiting for the whole request body. This removes the
   noticeable pause during uploading when the chunk was being
   processed.

@Xarthisius this fixes the issue you noticed with uploads being slow.