### PR TITLE
Teach UploadWidget to provide newly created file IDs

### DIFF
--- a/clients/web/src/views/widgets/UploadWidget.js
+++ b/clients/web/src/views/widgets/UploadWidget.js
@@ -266,6 +266,7 @@ var UploadWidget = View.extend({
                 ? this.parent : new FileModel();
 
         this.currentFile.on('g:upload.complete', function () {
+            this.files[this.currentIndex].id = this.currentFile.id;
             this.currentIndex += 1;
             this.uploadNextFile();
         }, this).on('g:upload.chunkSent', function (info) {


### PR DESCRIPTION
The g:uploadFinished event passes an array of files to its callbacks.
These files now contain their newly created IDs.