### PR TITLE
Add plugin node_modules to search path for modules and loaders

### DIFF
--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -226,6 +226,16 @@ module.exports = function (grunt) {
                         path: path.join(paths.web_built, 'plugins', plugin),
                         filename: `${output}.min.js`
                     },
+                    resolve: {
+                      modules: [
+                        path.resolve(dir, 'node_modules')
+                      ]
+                    },
+                    resolveLoader: {
+                      modules: [
+                        path.resolve(dir, 'node_modules')
+                      ]
+                    },
                     plugins: [
                         new webpack.DllReferencePlugin({
                             context: '.',

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -227,14 +227,14 @@ module.exports = function (grunt) {
                         filename: `${output}.min.js`
                     },
                     resolve: {
-                      modules: [
-                        path.resolve(dir, 'node_modules')
-                      ]
+                        modules: [
+                            path.resolve(dir, 'node_modules')
+                        ]
                     },
                     resolveLoader: {
-                      modules: [
-                        path.resolve(dir, 'node_modules')
-                      ]
+                        modules: [
+                            path.resolve(dir, 'node_modules')
+                        ]
                     },
                     plugins: [
                         new webpack.DllReferencePlugin({


### PR DESCRIPTION
This enables an ultra simple mode of plugin development, consisting in the following setup/build steps:
1. Clone the Girder repository.
2. Run `npm install` in the Girder root directory.
2. Move into the plugins directory and clone your plugin repository (see below for why to do it this way).
3. Move into the cloned plugin directory and run `npm install`.
4. Move back into the Girder root directory and run an appropriate `npm run build` command.

Done this way, you can simply `require()` NPM modules from your plugin code without using any lengthy aliases to access that plugin's own node_modules content. This brings plugin development much closer to "regular web development", without any need for special aliases, etc. It also allows the developer to simply list NPM dependencies for the plugin in package.json rather than some other special place, which in turn allows any NPM hooks in use for the plugin to simply work.

The only concession that needs to be made is that you cannot use a symlink in the plugins directory to your plugin's source directory. This is because of a catastrophic error in NPM that has now been frozen as official behavior, where the Node module resolution algorithm considers the parent of a symlinked directory to be the parent of the *target* directory, rather than the directory that contains the symlink. If someone wants to maintain a separate directory in a projects directory somewhere, they could always reverse the usual order of the symlink, pointing to the "live" version inside the plugins directory and working out of the symlinked directory. Unfortunately there seems to be no way around this, but it is also not a huge concession to make in exchange for the much simplified development environment that results.