### PR TITLE
Adds an optional URL field to plugin config to be used on Admin Plugin page

### DIFF
--- a/clients/web/src/templates/body/plugins.pug
+++ b/clients/web/src/templates/body/plugins.pug
@@ -22,7 +22,10 @@
           experimental=(experimental ? "true" : undefined),
           data-on-color=(experimental ? "warning" : "primary"))
       .g-plugin-name
-        span= plugin.value.name
+        if plugin.value.url
+          a(href=plugin.value.url, target='_blank')= plugin.value.name
+        else
+          span= plugin.value.name
         if plugin.value.version
           span.g-plugin-version Version #{plugin.value.version}
         if experimental

--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -30,7 +30,7 @@ our example, we'll just use JSON. ::
     touch cats/plugin.json
 
 The plugin config file should specify a human-readable name and description for your
-plugin, and can optionally contain a list of other plugins that your plugin
+plugin, and can optionally contains a URL to a documentation, a list of other plugins that your plugin
 depends on. If your plugin has dependencies, the other plugins will be
 enabled whenever your plugin is enabled. The contents of plugin.json for our
 example will be:
@@ -43,6 +43,7 @@ example will be:
     {
     "name": "My Cats Plugin",
     "description": "Allows users to manage their cats.",
+    "url": "http://girder.readthedocs.io/en/latest/plugin/mycat.html"
     "version": "1.0.0",
     "dependencies": ["other_plugin"]
     }

--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -29,11 +29,11 @@ our example, we'll just use JSON. ::
 
     touch cats/plugin.json
 
-The plugin config file should specify a human-readable name and description for your
-plugin, and can optionally contains a URL to a documentation, a list of other plugins that your plugin
-depends on. If your plugin has dependencies, the other plugins will be
-enabled whenever your plugin is enabled. The contents of plugin.json for our
-example will be:
+The plugin config file should specify a human-readable name and description for 
+your plugin. It can also optionally contain a URL to documentation and 
+a list of other plugins that your plugin depends on. If your plugin has 
+dependencies, the other plugins will be enabled whenever your plugin is enabled. 
+The contents of plugin.json for our example will be:
 
 .. note:: If you have both ``plugin.json`` and ``plugin.yml`` files in the directory, the
    ``plugin.json`` will take precedence.

--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -41,11 +41,11 @@ example will be:
 .. code-block:: json
 
     {
-    "name": "My Cats Plugin",
-    "description": "Allows users to manage their cats.",
-    "url": "http://girder.readthedocs.io/en/latest/plugin/mycat.html"
-    "version": "1.0.0",
-    "dependencies": ["other_plugin"]
+        "name": "My Cats Plugin",
+        "description": "Allows users to manage their cats.",
+        "url": "http://girder.readthedocs.io/en/latest/plugin/mycat.html",
+        "version": "1.0.0",
+        "dependencies": ["other_plugin"]
     }
 
 .. note:: Some plugins depend on other plugins, but only for building web client code, not

--- a/girder/utility/plugin_utilities.py
+++ b/girder/utility/plugin_utilities.py
@@ -314,6 +314,7 @@ def findAllPlugins():
         allPlugins[plugin] = {
             'name': data.get('name', plugin),
             'description': data.get('description', ''),
+            'url': data.get('url', ''),
             'version': data.get('version', ''),
             'dependencies': set(data.get('dependencies', [])),
             'staticWebDependencies': set(data.get('staticWebDependencies', []))

--- a/plugins/authorized_upload/plugin.yml
+++ b/plugins/authorized_upload/plugin.yml
@@ -1,2 +1,3 @@
 name: Authorized upload
 description: Allows registered users to authorize file uploads on their behalf via a secure one-use URL.
+url: http://girder.readthedocs.io/en/latest/plugins.html#authorized-uploads

--- a/plugins/autojoin/plugin.json
+++ b/plugins/autojoin/plugin.json
@@ -1,5 +1,6 @@
 {
     "name": "Auto Join",
     "description": "Automatically assign new users to groups based on their email domain",
+    "url": "http://girder.readthedocs.io/en/latest/plugins.html#auto-join",
     "version": "0.1.0"
 }

--- a/plugins/curation/plugin.json
+++ b/plugins/curation/plugin.json
@@ -1,5 +1,6 @@
 {
     "name": "Curation",
     "description": "Manage curation workflows for folders.",
+    "url": "http://girder.readthedocs.io/en/latest/plugins.html#curation",
     "version": "0.1.0"
 }

--- a/plugins/dicom_viewer/plugin.json
+++ b/plugins/dicom_viewer/plugin.json
@@ -1,6 +1,7 @@
 {
     "name": "DICOM Viewer",
     "description": "View DICOM images in the browser",
+    "url": "http://girder.readthedocs.io/en/latest/plugins.html#dicom-viewer",
     "version": "0.1.0",
     "npm": {
         "dependencies": {

--- a/plugins/geospatial/plugin.json
+++ b/plugins/geospatial/plugin.json
@@ -1,5 +1,6 @@
 {
     "name": "Geospatial",
     "description": "Enables the storage and querying of GeoJSON formatted geospatial data",
+    "url": "http://girder.readthedocs.io/en/latest/plugins.html#geospatial",
     "version": "0.1.0"
 }

--- a/plugins/google_analytics/plugin.json
+++ b/plugins/google_analytics/plugin.json
@@ -1,5 +1,6 @@
 {
     "name": "Google Analytics",
     "description": "Allow the tracking of page views via Google Analytics.",
+    "url": "http://girder.readthedocs.io/en/latest/plugins.html#google-analytics",
     "version": "0.1.1"
 }

--- a/plugins/gravatar/plugin.yml
+++ b/plugins/gravatar/plugin.yml
@@ -1,3 +1,4 @@
 name: Gravatar portraits
 description: Adds Gravatar URLs for users.
+url: http://girder.readthedocs.io/en/latest/plugins.html#gravatar-portraits
 version: 1.0.0

--- a/plugins/hdfs_assetstore/plugin.yml
+++ b/plugins/hdfs_assetstore/plugin.yml
@@ -3,5 +3,6 @@ description: >
     This plugin adds a new assetstore type to the system that proxies files for
     the Hadoop Distributed Filesystem (HDFS). This also allows files on a
     pre-existing HDFS instance to be imported into the Girder data hierarchy.
+url: http://girder.readthedocs.io/en/latest/plugins.html#hdfs-assetstore
 version: 1.0.0
 python3: false

--- a/plugins/homepage/plugin.json
+++ b/plugins/homepage/plugin.json
@@ -1,5 +1,6 @@
 {
     "name": "Homepage",
     "description": "Customize the homepage using Markdown.",
+    "url": "http://girder.readthedocs.io/en/latest/plugins.html#homepage",
     "version": "1.0.0"
 }

--- a/plugins/item_tasks/plugin.yml
+++ b/plugins/item_tasks/plugin.yml
@@ -1,5 +1,6 @@
 name: Item tasks
 description: Allows items in Girder to be used as specifications for tasks to be run on the worker.
+url: http://girder.readthedocs.io/en/latest/plugins.html#item-tasks
 dependencies:
   - worker
 npm:

--- a/plugins/jobs/plugin.yml
+++ b/plugins/jobs/plugin.yml
@@ -1,3 +1,4 @@
 name: Jobs
 description: A general purpose plugin for managing offline jobs.
+url: http://girder.readthedocs.io/en/latest/plugins.html#jobs
 version: 2.0.0

--- a/plugins/metadata_extractor/plugin.json
+++ b/plugins/metadata_extractor/plugin.json
@@ -1,6 +1,7 @@
 {
     "name": "Metadata extractor",
     "description": "Enables the extraction of metadata from uploaded files",
+    "url": "http://girder.readthedocs.io/en/latest/plugins.html#metadata-extractor",
     "version": "0.1.0",
     "python3": false
 }

--- a/plugins/oauth/plugin.json
+++ b/plugins/oauth/plugin.json
@@ -1,5 +1,6 @@
 {
     "name": "OAuth2 login",
     "description": "Allow users to login via supported OAuth2 providers.",
+    "url": "http://girder.readthedocs.io/en/latest/plugins.html#oauth-login",
     "version": "2.1.0"
 }

--- a/plugins/provenance/plugin.json
+++ b/plugins/provenance/plugin.json
@@ -1,5 +1,6 @@
 {
 "name": "Provenance tracker",
 "description": "Tracks provenance of items in Girder",
+"url": "http://girder.readthedocs.io/en/latest/plugins.html#provenance-tracker",
 "version": "0.1.1"
 }

--- a/plugins/worker/plugin.json
+++ b/plugins/worker/plugin.json
@@ -1,6 +1,7 @@
 {
     "name": "Remote worker",
     "description": "Distributed offline processing engine built on celery.",
+    "url": "http://girder.readthedocs.io/en/latest/plugins.html#remote-worker",
     "version": "0.1.0",
     "dependencies": ["jobs"]
 }


### PR DESCRIPTION
This is a small improvement came out of a discussion on documentation.

This PR simply adds an optional URL field to plugin config. If an URL exist for a plugin. The plugin name will be rendered as an anchor element with a href to the URL. When clicked, a new page to that URL will be open.

Currently, the URL is static, and there is no validation.
Please feel free to suggest if there are additional features we need with this change.

-------

![chrome_2017-03-07_15-32-29](https://cloud.githubusercontent.com/assets/3123478/23677232/4c69b3bc-034d-11e7-9e5c-cef1a8b28d0a.png)


