### PR TITLE
Add file-like interface for Girder files

### DIFF
--- a/docs/api-docs.rst
+++ b/docs/api-docs.rst
@@ -179,6 +179,13 @@ Folder
 
 Utility
 -------
+
+.. automodule:: girder.utility.assetstore_utilities
+   :members:
+
+.. automodule:: girder.utility.abstract_assetstore_adapter
+   :members:
+
 .. automodule:: girder.utility.model_importer
    :members:
 

--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -357,3 +357,26 @@ class File(acl_mixin.AccessControlMixin, Model):
         """
         # TODO: check underlying assetstore for size?
         return file.get('size', 0), 0
+
+    def open(self, file):
+        """
+        Use this to expose a Girder file as a python file-like object. At the
+        moment, this is a read-only interface, the equivalent of opening a
+        system file with ``'rb'`` mode. This can also be used as a context
+        manager, e.g.:
+
+        >>> with self.model('file').open(file) as fh:
+        >>>    while True:
+        >>>        chunk = fh.read(CHUNK_LEN)
+        >>>        if not chunk:
+        >>>            break
+
+        Using it this way will automatically close the file handle for you when
+        the ``with`` block is left.
+
+        :param file: A Girder file document.
+        :type file: dict
+        :return: A file-like object containing the bytes of the file.
+        :rtype: girder.utility.abstract_assetstore_adapter.FileHandle
+        """
+        return self.getAssetstoreAdapter(file).open(file)

--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -93,11 +93,15 @@ class FileHandle(object):
     def tell(self):
         return self._pos
 
-    def seek(self, offset):
-        self._pos = offset
+    def seek(self, offset, whence=os.SEEK_SET):
+        if whence == os.SEEK_SET:
+            self._pos = offset
+        elif whence == os.SEEK_CUR:
+            self._pos += offset
+        elif whence == os.SEEK_END:
+            self._pos = self._file['size'] - offset
         self._prev = []
         self._stream = self._adapter.downloadFile(self._file, offset=self._pos, headers=False)()
-        return offset
 
     def close(self):
         pass

--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -14,6 +14,7 @@
 #  limitations under the License.
 ###############################################################################
 
+import itertools
 import os
 import re
 import six
@@ -23,6 +24,83 @@ from girder.constants import SettingKey
 from girder.models.model_base import ValidationException
 from girder.utility import progress
 from .model_importer import ModelImporter
+
+
+class FileHandle(object):
+    """
+    This is the base class that is returned for the file-like API into
+    Girder file objects. The ``open`` method of assetstore implementations
+    is responsible for returning an instance of this class or one of its
+    subclasses. This base class implementation is returned by the
+    abstract assetstore adapter, and does not leverage any details of the
+    assetstore implementations.
+
+    These file handles are stateful, and therefore not safe for concurrent
+    access. If used by multiple threads, mutexes should be used.
+
+    :param file: The file object to which this file-like object corresponds.
+    :type file: dict
+    :param adapter: The assetstore adapter corresponding to this file.
+    :type adapter: girder.utility.abstract_assetstore_adapter.AbstractAssetstoreAdapter
+    """
+    def __init__(self, file, adapter):
+        self._file = file
+        self._adapter = adapter
+        self.seek(0)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def read(self, size):
+        """
+        Read *size* bytes from the file data.
+
+        :param size: The number of bytes to read from the current position. The
+            actual number returned could be less than this if the end of the
+            file is reached. An empty response indicates that the file has been
+            completely consumed.
+        :type size: int
+        :rtype: bytes
+        """
+        data = six.BytesIO()
+        length = 0
+        for chunk in itertools.chain(self._prev, self._stream):
+            chunkLen = len(chunk)
+
+            if chunkLen == 0:
+                break
+
+            if length + chunkLen <= size:
+                data.write(chunk)
+                self._prev = []
+                length += chunkLen
+
+                if length + chunkLen == size:
+                    break
+            else:
+                chunkLen = min(size - length, chunkLen)
+                data.write(chunk[:chunkLen])
+                self._prev = [chunk[chunkLen:]]
+                length += chunkLen
+                break
+
+        self._pos += length
+        return data.getvalue()
+
+    def tell(self):
+        return self._pos
+
+    def seek(self, offset):
+        self._pos = offset
+        self._prev = []
+        self._stream = self._adapter.downloadFile(self._file, offset=self._pos, headers=False)()
+        return offset
+
+    def close(self):
+        pass
 
 
 class AbstractAssetstoreAdapter(ModelImporter):
@@ -337,3 +415,16 @@ class AbstractAssetstoreAdapter(ModelImporter):
         :type file: dict
         """
         pass
+
+    def open(self, file):
+        """
+        Exposes a Girder file as a python file-like object. At the
+        moment, this is a read-only interface, the equivalent of opening a
+        system file with 'rb' mode.
+
+        :param file: A Girder file document.
+        :type file: dict
+        :return: A file-like object containing the bytes of the file.
+        :rtype: FileHandle
+        """
+        return FileHandle(file, self)

--- a/girder/utility/assetstore_utilities.py
+++ b/girder/utility/assetstore_utilities.py
@@ -67,7 +67,7 @@ def setAssetstoreAdapter(storeType, cls):
     :param storeType: The assetstore type to create/modify.
     :type storeType: enum | any
     :param cls: The new assetstore adapter class to install in the table. This
-    should be an adapter descending from AbstractAssetstoreAdapter.
+        should be an adapter descending from AbstractAssetstoreAdapter.
     :type cls: AbstractAssetstoreAdapter
     """
     _assetstoreTable[storeType] = cls

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -310,17 +310,26 @@ class FileTestCase(base.TestCase):
                              'text/plain;charset=utf-8')
         self.assertEqual(contents, self.getBody(resp))
 
-        # Test reading via the model layer file-like API
-        with self.model('file').open(file) as handle:
-            self.assertEqual(handle.tell(), 0)
+        def _readFile(handle):
             buf = b''
             while True:
                 chunk = handle.read(32768)
                 buf += chunk
                 if not chunk:
                     break
+            return buf
 
-            self.assertEqual(buf, contents.encode('utf8'))
+        # Test reading via the model layer file-like API
+        contents = contents.encode('utf8')
+        with self.model('file').open(file) as handle:
+            self.assertEqual(handle.tell(), 0)
+            buf = _readFile(handle)
+            self.assertEqual(buf, contents)
+
+            # Test seek
+            handle.seek(2)
+            buf = _readFile(handle)
+            self.assertEqual(buf, contents[2:])
 
     def _testDownloadFolder(self):
         """


### PR DESCRIPTION
Prior to this change, downloading a file involved using the generator interface. This exposes a read-only file-like interface for Girder files, e.g.

```
with self.model('file').open(file) as f:
    while True:
        buf = f.read(BUF_LEN)
        if not buf:
            break
        ...
```

A naive (but still relatively good) implementation of the file-like interface was added to the abstract assetstore adapter, so all assetstore types will get this for free. This PR switches the Girder SFTP service to use this new API, which caused a speedup of more than 2x in non bandwidth-limited environments (on my local machine from a filesystem assetstore, I went from about 30MB/sec to 80MB/sec transfer speeds).

I plan to create an implementation special to the filesystem assetstore that will likely be even faster by just returning a native file handle.