### PR TITLE
Fix downloading GridFS files with offsets.

### DIFF
--- a/girder/utility/gridfs_assetstore_adapter.py
+++ b/girder/utility/gridfs_assetstore_adapter.py
@@ -262,7 +262,7 @@ class GridFsAssetstoreAdapter(AbstractAssetstoreAdapter):
             for chunk in cursor:
                 chunkLen = len(chunk['data'])
 
-                if position + chunkLen > endByte:
+                if position + chunkLen - co > endByte:
                     chunkLen = endByte - position + co
                     shouldBreak = True
 


### PR DESCRIPTION
If the offset within a GridFS file download is within the second to last chunk, a partial download may result because the last chunk would never be accessed.