### PR TITLE
Add codecov badge and badges to readthedocs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-|logo| Girder |build-status| |docs-status| |license-badge| |gitter-badge|
-=========================================================================
+|logo| Girder |build-status| |docs-status| |license-badge| |gitter-badge| |codecov-badge|
+=========================================================================================
 
 **Data Management Platform**
 
@@ -28,3 +28,7 @@ We'd love for you to `contribute to Girder <CONTRIBUTING.md>`_.
 .. |gitter-badge| image:: https://badges.gitter.im/Join Chat.svg
     :target: https://gitter.im/girder/girder?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
     :alt: Gitter Chat
+
+.. |codecov-badge| image:: https://img.shields.io/codecov/c/github/girder/girder.svg
+    :target: https://codecov.io/gh/girder/girder
+    :alt: Coverage Status

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,28 @@
 Girder: a data management platform
 ==================================
 
+|build-status| |license-badge| |gitter-badge| |codecov-badge| |github-badge|
+
+.. |build-status| image:: https://circleci.com/gh/girder/girder.png?style=shield
+    :target: https://circleci.com/gh/girder/girder
+    :alt: Build Status
+
+.. |license-badge| image:: https://raw.githubusercontent.com/girder/girder/badges/docs/license.png
+    :target: https://pypi.python.org/pypi/girder
+    :alt: License
+
+.. |gitter-badge| image:: https://badges.gitter.im/Join Chat.svg
+    :target: https://gitter.im/girder/girder?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+    :alt: Gitter Chat
+
+.. |codecov-badge| image:: https://img.shields.io/codecov/c/github/girder/girder.svg
+    :target: https://codecov.io/gh/girder/girder
+    :alt: Coverage Status
+
+.. |github-badge| image:: https://img.shields.io/github/stars/girder/girder.svg?style=social&label=GitHub
+    :target: https://github.com/girder/girder
+    :alt: GitHub
+
 What is Girder?
 ---------------
 


### PR DESCRIPTION
The readthedocs badges are the same as the README except that instead of a badge pointing to the documentation (since they are already on the documentation page) there is a GitHub badge.