### PR TITLE
Fix an issue getting the access level of an item.

### DIFF
--- a/clients/web/src/models/ItemModel.js
+++ b/clients/web/src/models/ItemModel.js
@@ -26,10 +26,11 @@ var ItemModel = Model.extend({
             callback(this.get('_accessLevel'));
             return this.get('_accessLevel');
         } else {
-            this.parent = new FolderModel();
-            this.parent.set({
+            var parent = new FolderModel();
+            parent.set({
                 _id: this.get('folderId')
             }).once('g:fetched', function () {
+                this.parent = parent;
                 this.set('_accessLevel', this.parent.getAccessLevel());
                 callback(this.get('_accessLevel'));
             }, this).fetch();

--- a/clients/web/src/views/widgets/HierarchyWidget.js
+++ b/clients/web/src/views/widgets/HierarchyWidget.js
@@ -215,6 +215,7 @@ var HierarchyWidget = View.extend({
         this.itemListView = new ItemListWidget({
             itemFilter: this._itemFilter,
             folderId: this.parentModel.get('_id'),
+            accessLevel: this.parentModel.getAccessLevel(),
             checkboxes: this._checkboxes,
             downloadLinks: this._downloadLinks,
             viewLinks: this._viewLinks,

--- a/clients/web/src/views/widgets/ItemListWidget.js
+++ b/clients/web/src/views/widgets/ItemListWidget.js
@@ -31,6 +31,7 @@ var ItemListWidget = View.extend({
           _.has(settings, 'viewLinks') ? settings.viewLinks : true);
         this._showSizes = (
           _.has(settings, 'showSizes') ? settings.showSizes : true);
+        this.accessLevel = settings.accessLevel;
 
         new LoadingAnimation({
             el: this.$el,
@@ -42,6 +43,11 @@ var ItemListWidget = View.extend({
         this.collection.filterFunc = settings.itemFilter;
 
         this.collection.on('g:changed', function () {
+            if (this.accessLevel !== undefined) {
+                this.collection.each((model) => {
+                    model.set('_accessLevel', this.accessLevel);
+                });
+            }
             this.render();
             this.trigger('g:changed');
         }, this).fetch({ folderId: settings.folderId });
@@ -85,6 +91,9 @@ var ItemListWidget = View.extend({
      * Insert an item into the collection and re-render it.
      */
     insertItem: function (item) {
+        if (this.accessLevel !== undefined) {
+            item.set('_accessLevel', this.accessLevel);
+        }
         this.collection.add(item);
         this.trigger('g:changed');
         this.render();


### PR DESCRIPTION
Also, allow an access level to be passed to the item list widget so that access levels don't have to be retrieved.  This is used by the Hierarchy Widget.

If the access level of an item is unknown, the parent of the item (a folder) is retrieved.  If the access level was requested again while the parent was still being fetched, `undefined` would be returned instead of waiting for the fetch to complete.  Now, a new fetch is started.  This is wasteful, and further improvements could be to wait for the first fetch to complete or to share a single parent item between all of the items in a collection.  The fetch is avoided completely for the Hierarchy Widget by assigning an access level when the item list is created.