### PR TITLE
Upgrade remarkable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "json-loader": "^0.5.4",
     "jsoneditor": "4.1.2",
     "nib": "^1.1.0",
-    "remarkable": "1.6.2",
+    "remarkable": "1.7.1",
     "sprintf-js": "1.0.x",
     "style-loader": "^0.13.1",
     "stylus": "^0.54.5",


### PR DESCRIPTION
The version of remarkable we were using contained an XSS vulnerability documented here: https://nodesecurity.io/advisories/319

I've verified that this was broken before and that this upgrade fixes the issue.