### PR TITLE
Move some path functions from the resource api to the path utilities module.

### DIFF
--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -145,26 +145,6 @@ class Resource(BaseResource):
     def lookup(self, path, test, params):
         return path_util.lookUpPath(path, self.getCurrentUser(), test)['document']
 
-    def _getResourceName(self, type, doc):
-        if type == 'user':
-            return doc['login']
-        elif type in ('file', 'item', 'folder', 'user', 'collection'):
-            return doc['name']
-        else:
-            raise RestException('Invalid resource type.')
-
-    def _getResourceParent(self, type, doc):
-        if type == 'file':
-            return doc['itemId'], 'item'
-        elif type == 'item':
-            return doc['folderId'], 'folder'
-        elif type == 'folder':
-            return doc['parentId'], doc['parentCollection']
-        else:
-            raise RestException(
-                'Invalid resource type.'
-            )
-
     @access.public(scope=TokenScope.DATA_READ)
     @autoDescribeRoute(
         Description('Get path of a resource.')
@@ -175,21 +155,11 @@ class Resource(BaseResource):
         .errorResponse('Read access was denied for the resource.', 403)
     )
     def path(self, id, type, params):
-        path = []
-        while True:
-            doc = self._getResource(id, type)
-            if doc is None:
-                raise RestException('Invalid resource id.')
-            name = self._getResourceName(type, doc)
-            path.insert(0, name)
-
-            if type in ('file', 'item', 'folder'):
-                id, type = self._getResourceParent(type, doc)
-            else:
-                break
-
-        path.insert(0, type)
-        return '/' + path_util.join(path)
+        user = self.getCurrentUser()
+        doc = self._getResource(id, type)
+        if doc is None:
+            raise RestException('Invalid resource id.')
+        return path_util.getResourcePath(type, doc, user=user)
 
     @access.cookie(force=True)
     @access.public(scope=TokenScope.DATA_READ)

--- a/girder/utility/path.py
+++ b/girder/utility/path.py
@@ -20,7 +20,8 @@
 """This module contains utility methods for parsing girder path strings."""
 
 import re
-from girder.models.model_base import AccessException, ValidationException
+from ..constants import AccessType
+from ..models.model_base import AccessException, GirderException, ValidationException
 from .model_importer import ModelImporter
 
 
@@ -124,7 +125,7 @@ def lookUpToken(token, parentType, parent):
         parentType, parent.get('name', parent.get('_id')), token))
 
 
-def lookUpPath(path, user=None, test=False, filter=True):
+def lookUpPath(path, user=None, test=False, filter=True, force=False):
     """
     Look up a resource in the data hierarchy by path.
 
@@ -136,6 +137,8 @@ def lookUpPath(path, user=None, test=False, filter=True):
     :type test: bool
     :param filter: Whether the returned model should be filtered.
     :type filter: bool
+    :param force: if True, don't validate the access.
+    :type force: bool
     """
     path = path.lstrip('/')
     pathArray = split(path)
@@ -172,9 +175,11 @@ def lookUpPath(path, user=None, test=False, filter=True):
 
     try:
         document = parent
-        ModelImporter.model(model).requireAccess(document, user)
+        if not force:
+            ModelImporter.model(model).requireAccess(document, user)
         for token in pathArray[2:]:
             document, model = lookUpToken(token, model, document)
+        if not force:
             ModelImporter.model(model).requireAccess(document, user)
     except (ValidationException, AccessException):
         # We should not distinguish the response between access and validation errors so that
@@ -195,3 +200,50 @@ def lookUpPath(path, user=None, test=False, filter=True):
         'model': model,
         'document': document
     }
+
+
+def getResourceName(type, doc):
+    """
+    Get the name of a resource that can be put in a path,
+
+    :param type: the resource model type.
+    :param doc: the resource document.
+    :return: the name of the resource.
+    """
+    if type == 'user':
+        return doc['login']
+    elif type in ('file', 'item', 'folder', 'user', 'collection'):
+        return doc['name']
+    else:
+        raise GirderException('Invalid resource type.')
+
+
+def getResourcePath(type, doc, user=None, force=False):
+    """
+    Get the path for a resource.
+
+    :param type: the resource model type.
+    :param doc: the resource document.
+    :param user: user with correct privileges to access path
+    :param force: if True, don't validate the access.
+    :returns: the path to the resource.
+    """
+    path = []
+    while True:
+        path.insert(0, getResourceName(type, doc))
+        if type == 'file':
+            parentModel = 'item'
+            parentId = doc['itemId']
+        elif type == 'item':
+            parentModel = 'folder'
+            parentId = doc['folderId']
+        elif type == 'folder':
+            parentModel = doc['parentCollection']
+            parentId = doc['parentId']
+        else:
+            break
+        doc = ModelImporter.model(parentModel).load(
+            id=parentId, user=user, level=AccessType.READ, force=force)
+        type = parentModel
+    path.insert(0, type)
+    return '/' + join(path)

--- a/girder/utility/path.py
+++ b/girder/utility/path.py
@@ -207,8 +207,11 @@ def getResourceName(type, doc):
     Get the name of a resource that can be put in a path,
 
     :param type: the resource model type.
+    :type type: str
     :param doc: the resource document.
+    :type doc: dict
     :return: the name of the resource.
+    :rtype: str
     """
     if type == 'user':
         return doc['login']
@@ -223,10 +226,15 @@ def getResourcePath(type, doc, user=None, force=False):
     Get the path for a resource.
 
     :param type: the resource model type.
+    :type type: str
     :param doc: the resource document.
+    :type doc: dict
     :param user: user with correct privileges to access path
+    :type user: dict or None
     :param force: if True, don't validate the access.
-    :returns: the path to the resource.
+    :type force: bool
+    :return: the path to the resource.
+    :rtype: str
     """
     path = []
     while True:


### PR DESCRIPTION
Add a force option to lookUpPath.

Note that our resource paths are not guaranteed to be unique: an item can have multiple files with the same name.  Perhaps we should also allow resource paths that use resource IDs.