### PR TITLE
Allow null values in metadata, as well as metadata deletion via new endpoint

### DIFF
--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -156,6 +156,8 @@ class Item(Resource):
         .modelParam('id', model='item', level=AccessType.WRITE)
         .jsonParam('metadata', 'A JSON object containing the metadata keys to add',
                    paramType='body')
+        .param('allowNull', 'Whether "null" is allowed as a metadata value.', required=False,
+               dataType='boolean', default=False)
         .errorResponse(('ID was invalid.',
                         'Invalid JSON passed in request body.',
                         'Metadata key name was invalid.'))
@@ -173,7 +175,7 @@ class Item(Resource):
                 raise RestException(
                     'Invalid key %s: keys must not start with the "$" character.' % k)
 
-        return self.model('item').setMetadata(item, metadata)
+        return self.model('item').setMetadata(item, metadata, params['allowNull'])
 
     @autoDescribeRoute(
         Description('Delete metadata fields on an item.')

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -163,7 +163,7 @@ class Item(Resource):
                         'Metadata key name was invalid.'))
         .errorResponse('Write access was denied for the item.', 403)
     )
-    def setMetadata(self, item, metadata, params):
+    def setMetadata(self, item, metadata, allowNull, params):
         # Make sure we let user know if we can't accept a metadata key
         for k in metadata:
             if not k:
@@ -175,7 +175,7 @@ class Item(Resource):
                 raise RestException(
                     'Invalid key %s: keys must not start with the "$" character.' % k)
 
-        return self.model('item').setMetadata(item, metadata, params['allowNull'])
+        return self.model('item').setMetadata(item, metadata, allowNull)
 
     @autoDescribeRoute(
         Description('Delete metadata fields on an item.')

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -182,7 +182,7 @@ class Item(Resource):
         .responseClass('Item')
         .modelParam('id', model='item', level=AccessType.WRITE)
         .jsonParam('fields', 'A JSON list containing the metadata fields to delete',
-                   paramType='body')
+                   paramType='body', requireArray=True)
         .errorResponse(('ID was invalid.',
                         'Invalid JSON passed in request body.',
                         'Metadata key name was invalid.'))

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -24,11 +24,14 @@ from girder.constants import AccessType, TokenScope
 from girder.api import access
 
 
-def validate_field(f):
-    if '.' in f:
-        raise RestException('Invalid key %s: keys must not contain the "." character.' % f)
-    if f[0] == '$':
-        raise RestException('Invalid key %s: keys must not start with the "$" character.' % f)
+def _validateFields(fields):
+    for f in fields:
+        if not f:
+            raise RestException('Key names must not be empty.')
+        if '.' in f:
+            raise RestException('Invalid key %s: keys must not contain the "." character.' % f)
+        if f[0] == '$':
+            raise RestException('Invalid key %s: keys must not start with the "$" character.' % f)
 
 
 class Item(Resource):
@@ -172,11 +175,7 @@ class Item(Resource):
     )
     def setMetadata(self, item, metadata, allowNull, params):
         # Make sure we let user know if we can't accept a metadata key
-        for k in metadata:
-            if not k:
-                raise RestException('Key names must not be empty.')
-
-            validate_field(k)
+        _validateFields(metadata)
 
         return self.model('item').setMetadata(item, metadata, allowNull)
 
@@ -192,11 +191,7 @@ class Item(Resource):
         .errorResponse('Write acess was denied for the item.', 403)
     )
     def deleteMetadata(self, item, fields, params):
-        if not fields:
-            raise RestException('Key names must not be empty.')
-
-        for k in fields:
-            validate_field(k)
+        _validateFields(fields)
 
         return self.model('item').deleteMetadata(item, fields)
 

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -24,6 +24,13 @@ from girder.constants import AccessType, TokenScope
 from girder.api import access
 
 
+def validate_field(f):
+    if '.' in f:
+        raise RestException('Invalid key %s: keys must not contain the "." character.' % f)
+    if f[0] == '$':
+        raise RestException('Invalid key %s: keys must not start with the "$" character.' % f)
+
+
 class Item(Resource):
 
     def __init__(self):
@@ -168,12 +175,8 @@ class Item(Resource):
         for k in metadata:
             if not k:
                 raise RestException('Key names must not be empty.')
-            if '.' in k:
-                raise RestException(
-                    'Invalid key %s: keys must not contain the "." character.' % k)
-            if k[0] == '$':
-                raise RestException(
-                    'Invalid key %s: keys must not start with the "$" character.' % k)
+
+            validate_field(k)
 
         return self.model('item').setMetadata(item, metadata, allowNull)
 
@@ -193,12 +196,7 @@ class Item(Resource):
             raise RestException('Key names must not be empty.')
 
         for k in fields:
-            if '.' in k:
-                raise RestException(
-                    'Invalid key %s: keys must not contain the "." character.' % k)
-            if k[0] == '$':
-                raise RestException(
-                    'Invalid key %s: keys must not start with the "$" character.' % k)
+            validate_field(k)
 
         return self.model('item').deleteMetadata(item, fields)
 

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -319,7 +319,8 @@ class Item(acl_mixin.AccessControlMixin, Model):
             item['meta'] = {}
 
         for field in fields:
-            del item['meta'][field]
+            if field in item['meta']:
+                del item['meta'][field]
 
         item['updated'] = datetime.datetime.utcnow()
 

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -334,8 +334,7 @@ class Item(acl_mixin.AccessControlMixin, Model):
             item['meta'] = {}
 
         for field in fields:
-            if field in item['meta']:
-                del item['meta'][field]
+            item['meta'].pop(field, None)
 
         item['updated'] = datetime.datetime.utcnow()
 

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -284,7 +284,7 @@ class Item(acl_mixin.AccessControlMixin, Model):
         # Validate and save the item
         return self.save(item)
 
-    def setMetadata(self, item, metadata, allowNull):
+    def setMetadata(self, item, metadata, allowNull=False):
         """
         Set metadata on an item.  A `ValidationException` is thrown in the
         cases where the metadata JSON object is badly formed, or if any of the

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -295,6 +295,9 @@ class Item(acl_mixin.AccessControlMixin, Model):
         :param metadata: A dictionary containing key-value pairs to add to
                      the items meta field
         :type metadata: dict
+        :param allowNull: Whether to allow `null` values to be set in the item's
+                     metadata. If set to `False` or omitted, a `null` value will cause that
+                     metadata field to be deleted.
         :returns: the item document
         """
         if 'meta' not in item:
@@ -315,6 +318,18 @@ class Item(acl_mixin.AccessControlMixin, Model):
         return self.save(item)
 
     def deleteMetadata(self, item, fields):
+        """
+        Delete metadata on an item. A `ValidationException` is thrown if the
+        metadata field names contain a period ('.') or begin with a dollar sign
+        ('$').
+
+        :param item: The item to delete metadata from.
+        :type item: dict
+        :param fields: An array containing the field names to deleete from the
+                   item's meta field
+        :type field: list
+        :returns: the item document
+        """
         if 'meta' not in item:
             item['meta'] = {}
 

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -313,6 +313,19 @@ class Item(acl_mixin.AccessControlMixin, Model):
         # Validate and save the item
         return self.save(item)
 
+    def deleteMetadata(self, item, fields):
+        print fields
+        if 'meta' not in item:
+            item['meta'] = {}
+
+        for field in fields:
+            del item['meta'][field]
+
+        item['updated'] = datetime.datetime.utcnow()
+
+        # Validate and save the item
+        return self.save(item)
+
     def parentsToRoot(self, item, user=None, force=False):
         """
         Get the path to traverse to a root of the hierarchy.

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -305,7 +305,7 @@ class Item(acl_mixin.AccessControlMixin, Model):
 
         # Remove metadata fields that were set to null (use items in py3)
         if not allowNull:
-            toDelete = [k for k, v in six.viewitems(item['meta']) if v is None]
+            toDelete = [k for k, v in six.viewitems(metadata) if v is None]
             for key in toDelete:
                 del item['meta'][key]
 

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -284,7 +284,7 @@ class Item(acl_mixin.AccessControlMixin, Model):
         # Validate and save the item
         return self.save(item)
 
-    def setMetadata(self, item, metadata):
+    def setMetadata(self, item, metadata, allowNull):
         """
         Set metadata on an item.  A `ValidationException` is thrown in the
         cases where the metadata JSON object is badly formed, or if any of the
@@ -304,9 +304,10 @@ class Item(acl_mixin.AccessControlMixin, Model):
         item['meta'].update(six.viewitems(metadata))
 
         # Remove metadata fields that were set to null (use items in py3)
-        toDelete = [k for k, v in six.viewitems(item['meta']) if v is None]
-        for key in toDelete:
-            del item['meta'][key]
+        if not allowNull:
+            toDelete = [k for k, v in six.viewitems(item['meta']) if v is None]
+            for key in toDelete:
+                del item['meta'][key]
 
         item['updated'] = datetime.datetime.utcnow()
 

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -315,7 +315,6 @@ class Item(acl_mixin.AccessControlMixin, Model):
         return self.save(item)
 
     def deleteMetadata(self, item, fields):
-        print fields
         if 'meta' not in item:
             item['meta'] = {}
 

--- a/tests/cases/item_test.py
+++ b/tests/cases/item_test.py
@@ -423,14 +423,6 @@ class ItemTestCase(base.TestCase):
         item = resp.json
         self.assertNotHasKeys(item['meta'], ['other'])
 
-        # Error when deletion field names are missing.
-        resp = self.request(path='/item/%s/metadata' % item['_id'],
-                            method='DELETE', user=self.users[0],
-                            body=json.dumps([]), type='application/json')
-        self.assertStatus(resp, 400)
-        self.assertEqual(
-            resp.json['message'], 'Key names must not be empty.')
-
         # Error when deletion field names contain a period.
         resp = self.request(path='/item/%s/metadata' % item['_id'],
                             method='DELETE', user=self.users[0],

--- a/tests/cases/item_test.py
+++ b/tests/cases/item_test.py
@@ -395,13 +395,24 @@ class ItemTestCase(base.TestCase):
         item = resp.json
         self.assertEqual(item['meta']['nullVal'], None)
 
+        # Adding an unrelated key should not affect existing keys
+        del metadata['nullVal']
+        metadata['other'] = 'macguffin'
+        resp = self.request(path='/item/%s/metadata' % item['_id'],
+                            method='PUT', user=self.users[0],
+                            body=json.dumps(metadata), type='application/json')
+
+        item = resp.json
+        self.assertEqual(item['meta']['other'], metadata['other'])
+        self.assertEqual(item['meta']['nullVal'], None)
+
         # Test metadata deletion
         resp = self.request(path='/item/%s/metadata' % item['_id'],
                             method='DELETE', user=self.users[0],
-                            body=json.dumps(['nullVal']), type='application/json')
+                            body=json.dumps(['other']), type='application/json')
 
         item = resp.json
-        self.assertNotHasKeys(item['meta'], ['nullVal'])
+        self.assertNotHasKeys(item['meta'], ['other'])
 
         # Make sure metadata cannot be added with invalid JSON
         metadata = {

--- a/tests/cases/item_test.py
+++ b/tests/cases/item_test.py
@@ -385,6 +385,24 @@ class ItemTestCase(base.TestCase):
         self.assertEqual(item['meta']['foo'], metadata['foo'])
         self.assertNotHasKeys(item['meta'], ['test'])
 
+        # Test insertion of null values
+        metadata['nullVal'] = None
+        resp = self.request(path='/item/%s/metadata' % item['_id'],
+                            method='PUT', user=self.users[0],
+                            body=json.dumps(metadata), params={'allowNull': True},
+                            type='application/json')
+
+        item = resp.json
+        self.assertEqual(item['meta']['nullVal'], None)
+
+        # Test metadata deletion
+        resp = self.request(path='/item/%s/metadata' % item['_id'],
+                            method='DELETE', user=self.users[0],
+                            body=json.dumps(['nullVal']), type='application/json')
+
+        item = resp.json
+        self.assertNotHasKeys(item['meta'], ['nullVal'])
+
         # Make sure metadata cannot be added with invalid JSON
         metadata = {
             'test': 'allowed'


### PR DESCRIPTION
This PR does two related things:
- Adds a `DELETE /item/<id>/metadata` endpoint, whose request body is a JSON list of key names to delete from the metadata
- Adds a boolean `allowNull` parameter to `PUT /item/<id>/metadata`, which allows for `null`-valued metadata fields

To be clear, this does not change the default behavior of the `PUT` endpoint.

I bundled these together to prepare for an eventual breaking change where the `allowNull` behavior is made the only mode of operation for `PUT`, and the `DELETE` endpoint is always used to remove metadata (as discussed in #1628).

Thanks @zachmullen for discussing this with me, including providing the idea for `allowNull`.

Closes #1628
