### PR TITLE
Use only 3 parallel slots in Circle

### DIFF
--- a/cmake/circle_continuous.cmake
+++ b/cmake/circle_continuous.cmake
@@ -25,15 +25,10 @@ if(test_group STREQUAL python)
     PARALLEL_LEVEL 4 RETURN_VALUE res
     INCLUDE_LABEL girder_python
   )
-elseif(test_group STREQUAL static)
-  ctest_test(
-    PARALLEL_LEVEL 4 RETURN_VALUE res
-    INCLUDE_LABEL girder_static_analysis
-  )
 elseif(test_group STREQUAL browser)
   ctest_test(
     PARALLEL_LEVEL 4 RETURN_VALUE res
-    EXCLUDE_LABEL "girder_python|girder_static_analysis"
+    EXCLUDE_LABEL girder_python
   )
   file(RENAME "${CTEST_BINARY_DIRECTORY}/coverage/js_coverage.xml" "${CTEST_BINARY_DIRECTORY}/coverage.xml")
 endif()

--- a/cmake/run_circleci.sh
+++ b/cmake/run_circleci.sh
@@ -13,9 +13,6 @@ case $CIRCLE_NODE_INDEX in
 	2)
 		export TEST_GROUP=browser
 		;;
-	3)
-		export TEST_GROUP=static
-		;;
 	*)
 		echo "Invalid node index"
 		exit 0


### PR DESCRIPTION
We now have 6 containers on Circle. Scaling back to three parallel containers per build will allow us to run two builds at once; by moving the static analysis tests to be with the browser tests, this also shouldn't increase response time for an individual build.