### PR TITLE
girder_cli: Report progress with 2 digit precision when using python 2.7

### DIFF
--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -51,7 +51,8 @@ class GirderCli(GirderClient):
                 if length == 0:
                     return '%.2f' % length
                 unit = ''
-                units = ['K', 'M', 'G', 'P']
+                # See https://en.wikipedia.org/wiki/Binary_prefix
+                units = ['k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
                 while True:
                     if length <= 1024 or len(units) == 0:
                         break

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -53,10 +53,10 @@ class GirderCli(GirderClient):
                 unit = ''
                 units = ['K', 'M', 'G', 'P']
                 while True:
-                    if int(length / 1024) == 0 or len(units) == 0:
+                    if length <= 1024 or len(units) == 0:
                         break
                     unit = units.pop(0)
-                    length /= 1024
+                    length /= 1024.
                 return '%.2f%s' % (length, unit)
 
             def formatPos(_self):


### PR DESCRIPTION
This commit explicitly divides by a float number to support python version
that do not implement PEP238 by default.

See https://www.python.org/dev/peps/pep-0238/

Reported-by: "zach.mullen" <zach.mullen@kitware.com>