### PR TITLE
Fix closing alert notifications by clicking 'x'

### DIFF
--- a/clients/web/src/views/App.js
+++ b/clients/web/src/views/App.js
@@ -29,6 +29,7 @@ import 'girder/stylesheets/layout/layout.styl';
 import 'girder/utilities/jquery/girderModal';
 
 import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap/js/alert';
 
 var App = View.extend({
     /**


### PR DESCRIPTION
Fix closing alert notifications by clicking 'x' by ensuring that
Bootstrap's data API code for alerts is included. Without this, elements
that have the 'data-dismiss="alert"' attribute aren't dismissed when the
close button is clicked because the click event handler isn't installed.

Fixes #1870.