### PR TITLE
Ensure that there is an index on the created field for job.

### DIFF
--- a/plugins/jobs/server/models/job.py
+++ b/plugins/jobs/server/models/job.py
@@ -34,7 +34,7 @@ class Job(AccessControlledModel):
             ('userId', SortDir.ASCENDING),
             ('created', SortDir.DESCENDING)
         )
-        self.ensureIndices([(compoundSearchIndex, {})])
+        self.ensureIndices([(compoundSearchIndex, {}), 'created'])
 
         self.exposeFields(level=AccessType.READ, fields={
             'title', 'type', 'created', 'interval', 'when', 'status',


### PR DESCRIPTION
With the admin list-all-jobs option, the list will fail if the job collection is too big.  This fixes that.