### PR TITLE
Don't show old events when reopening an event stream

### DIFF
--- a/clients/web/src/utilities/EventStream.js
+++ b/clients/web/src/utilities/EventStream.js
@@ -56,7 +56,7 @@ prototype.open = function () {
 
         // Set the "since" argument to filter out notifications
         // that have already been sent to this client.
-        var since = parseInt(localStorage.getItem('sseTimestamp'));
+        var since = parseInt(window.localStorage.getItem('sseTimestamp'));
         if (since >= 0) {
             params.since = since;
         }
@@ -73,7 +73,7 @@ prototype.open = function () {
                 stream.trigger('g:error', e);
                 return;
             }
-            localStorage.setItem('sseTimestamp', obj._girderTime);
+            window.localStorage.setItem('sseTimestamp', obj._girderTime);
             stream.trigger('g:event.' + obj.type, obj);
         };
         this._stopHeartbeat = false;

--- a/tests/cases/notification_test.py
+++ b/tests/cases/notification_test.py
@@ -100,6 +100,18 @@ class NotificationTestCase(base.TestCase):
             progress.interval = 1000
             progress.update(current=3)
 
+            # The message should contain a timestamp
+            self.assertIn('_girderTime', messages[0])
+            self.assertIsInstance(messages[0]['_girderTime'], int)
+
+            # Test that the "since" parameter correctly filters out messages
+            since = messages[0]['_girderTime'] + 1
+            resp = self.request(path='/notification/stream', method='GET',
+                                user=user, token=token, isJson=False,
+                                params={'timeout': 0, 'since': since})
+            messages = self.getSseMessages(resp)
+            self.assertEqual(len(messages), 0)
+
         # Exiting the context manager should flush the most recent update.
         resp = self.request(path='/notification/stream', method='GET',
                             user=user, token=token, isJson=False,


### PR DESCRIPTION
There are two components to this:

1. The addition of a `since` parameter to `/notification/stream`.  This is unix time stamp that filters out notifications before this time.
2. The server time is injected into all the notification messages and stored into `localStorage`.  This value (if present) is passed to the server when opening a new stream.

The second component is a little convoluted, but is designed to get around the issue of synchronization between the client and server clocks.  This fixes the immediate issue of being bombarded by notifications when reconnecting the stream, but further improvements could be made to make notifications more easily dismissable.

Fixes #1866