### PR TITLE
Don't render some Pug comments in HTML

### DIFF
--- a/clients/web/src/templates/layout/layout.pug
+++ b/clients/web/src/templates/layout/layout.pug
@@ -5,8 +5,8 @@
 
 #g-app-progress-container
 
-// Set tabindex on modal element to allow closing modal by pressing Escape. See:
-// - http://getbootstrap.com/javascript/#modals-examples
-// - http://stackoverflow.com/questions/12630156/
+//- Set tabindex on modal element to allow closing modal by pressing Escape. See:
+//- - http://getbootstrap.com/javascript/#modals-examples
+//- - http://stackoverflow.com/questions/12630156/
 #g-dialog-container.modal.fade(tabindex="-1")
 #g-alerts-container


### PR DESCRIPTION
As a follow up to #1873, convert some buffered Pug comments to
unbuffered Pug comments so that they don't appear in the rendered HTML.

See: https://pugjs.org/language/comments.html