### PR TITLE
Stop caching index HTML when server mode is development

### DIFF
--- a/girder/utility/webroot.py
+++ b/girder/utility/webroot.py
@@ -22,6 +22,7 @@ import mako
 import os
 
 from girder import constants
+from girder.utility import config
 
 
 class WebrootBase(object):
@@ -41,6 +42,7 @@ class WebrootBase(object):
         self.indexHtml = None
 
         self.vars = {}
+        self.config = config.getConfig()
 
     def updateHtmlVars(self, vars):
         """
@@ -54,7 +56,7 @@ class WebrootBase(object):
         return mako.template.Template(self.template).render(**self.vars)
 
     def GET(self, **params):
-        if self.indexHtml is None:
+        if self.indexHtml is None or self.config['server']['mode'] == 'development':
             self.indexHtml = self._renderHTML()
 
         return self.indexHtml


### PR DESCRIPTION
Previously, we were always caching indexHtml. This meant that if a
new file were added (pluginCss or pluginJs) it wouldn't be reflected
(even after rebuilding with npm) unless the webserver was
restarted. This commit stops caching indexHtml if the Girder
installation is in development mode.

Fixes #1859 