### PR TITLE
Add a method for authenticating Girder Client with an existing token

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -323,7 +323,7 @@ class GirderClient(object):
             resp = self.post('api_key/token', parameters={
                 'key': apiKey
             })
-            self.token = resp['authToken']['token']
+            self.setToken(resp['authToken']['token'])
         else:
             if interactive:
                 if username is None:
@@ -343,7 +343,16 @@ class GirderClient(object):
             if 'authToken' not in resp:
                 raise AuthenticationError()
 
-            self.token = resp['authToken']['token']
+            self.setToken(resp['authToken']['token'])
+
+    def setToken(self, token):
+        """
+        Set a token on the GirderClient instance. This is useful in the case
+        where the client has already been given a valid token, such as a remote job.
+
+        :param token: A string containing the existing Girder token
+        """
+        self.token = token
 
     def getServerVersion(self, useCached=True):
         """


### PR DESCRIPTION
This change seems pretty pedantic looking at it now, but I would rather have a setter that we guarantee backwards compatibility support for in the event that the logic around the `token` property ever changes. It also serves as documentation for the correct way to use Girder client given the user already has a token.

Fixes #803 
