### PR TITLE
Address XSS issues reported by snyk.io. See #1892

### DIFF
--- a/clients/web/test/spec/dateTimeWidgetSpec.js
+++ b/clients/web/test/spec/dateTimeWidgetSpec.js
@@ -149,12 +149,12 @@ describe('Test DateTimeWidget', function () {
 
         it('get date as string when set in UTC', function () {
             widget.setDate('2015-02-01T12:00Z');
-            expect(widget.dateString()).toBe('2015-02-01T12:00:00+00:00');
+            expect(widget.dateString()).toBe('2015-02-01T12:00:00Z');
         });
 
         it('get date as string when set with UTC offset', function () {
             widget.setDate('2015-02-01T12:00-05:00');
-            expect(widget.dateString()).toBe('2015-02-01T17:00:00+00:00');
+            expect(widget.dateString()).toBe('2015-02-01T17:00:00Z');
         });
 
         it('get date as string when not set', function () {
@@ -394,18 +394,18 @@ describe('Test DateTimeRangeWidget', function () {
 
         it('get dates as string when set in UTC', function () {
             widget.setFromDate('2015-02-01T12:00Z');
-            expect(widget.fromDateString()).toBe('2015-02-01T12:00:00+00:00');
+            expect(widget.fromDateString()).toBe('2015-02-01T12:00:00Z');
 
             widget.setToDate('2015-03-01T12:00Z');
-            expect(widget.toDateString()).toBe('2015-03-01T12:00:00+00:00');
+            expect(widget.toDateString()).toBe('2015-03-01T12:00:00Z');
         });
 
         it('get dates as string when set with UTC offset', function () {
             widget.setFromDate('2015-02-01T12:00-05:00');
-            expect(widget.fromDateString()).toBe('2015-02-01T17:00:00+00:00');
+            expect(widget.fromDateString()).toBe('2015-02-01T17:00:00Z');
 
             widget.setToDate('2015-03-01T12:00-05:00');
-            expect(widget.toDateString()).toBe('2015-03-01T17:00:00+00:00');
+            expect(widget.toDateString()).toBe('2015-03-01T17:00:00Z');
         });
 
         it('get dates as string when not set', function () {

--- a/girder/api/api_docs.mako
+++ b/girder/api/api_docs.mako
@@ -43,15 +43,17 @@
           class="swagger-ui-wrap docs-swagger-container">
       </div>
     </div>
+    <script src="${staticRoot}/built/swagger/lib/object-assign-pollyfill.js"></script>
     <script src="${staticRoot}/built/swagger/lib/jquery-1.8.0.min.js"></script>
     <script src="${staticRoot}/built/swagger/lib/jquery.slideto.min.js"></script>
     <script src="${staticRoot}/built/swagger/lib/jquery.wiggle.min.js"></script>
     <script src="${staticRoot}/built/swagger/lib/jquery.ba-bbq.min.js"></script>
-    <script src="${staticRoot}/built/swagger/lib/handlebars-2.0.0.js"></script>
-    <script src="${staticRoot}/built/swagger/lib/underscore-min.js"></script>
+    <script src="${staticRoot}/built/swagger/lib/handlebars-4.0.5.js"></script>
+    <script src="${staticRoot}/built/swagger/lib/lodash.min.js"></script>
     <script src="${staticRoot}/built/swagger/lib/backbone-min.js"></script>
     <script src="${staticRoot}/built/swagger/swagger-ui.min.js"></script>
-    <script src="${staticRoot}/built/swagger/lib/highlight.7.3.pack.js"></script>
+    <script src="${staticRoot}/built/swagger/lib/highlight.9.1.0.pack.js"></script>
+    <script src="${staticRoot}/built/swagger/lib/highlight.9.1.0.pack_extended.js"></script>
     <script src='${staticRoot}/built/swagger/lib/jsoneditor.min.js'></script>
     <script src='${staticRoot}/built/swagger/lib/marked.js'></script>
     <script src="${staticRoot}/girder-swagger.js"></script>

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "style-loader": "^0.13.1",
     "stylus": "^0.54.5",
     "stylus-loader": "^2.1.1",
-    "swagger-ui": "2.1.4",
+    "swagger-ui": "2.2.10",
     "toposort": "^1.0.0",
     "underscore": "~1.8.3",
     "url-loader": "^0.5.7",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bootstrap-switch": "3.3.2",
     "colors": "1.1.2",
     "css-loader": "^0.26.1",
-    "eonasdan-bootstrap-datetimepicker": "~4.15",
+    "eonasdan-bootstrap-datetimepicker": "~4.17",
     "event-source": "0.1.1",
     "extract-text-webpack-plugin": "^2.0.0-rc.0",
     "file-loader": "^0.10.0",


### PR DESCRIPTION
This PR updates:
* the version of swagger-ui to the latest release of the 2.x serie.
* the version oeonasdan-bootstrap-datetimepicker from 4.15 to 4.17

### Swagger UI

It address the following XSS issues reported by https://snyk.io/test/github/girder/girder

XSS in Consumes/Produces Parameter
* require >= 2.1.5
* https://snyk.io/vuln/npm:swagger-ui:20160720

XSS in key names:
* require >= 2.2.1
* https://snyk.io/vuln/npm:swagger-ui:20160721

XSS via Content-type header
* requires >= 2.1.5
* https://snyk.io/vuln/npm:swagger-ui:20160725

Cross-site Scripting (XSS)
* requires >= 2.2.3
* https://snyk.io/vuln/npm:swagger-ui:20160901

Updates to apply to api_docs.mako were identified using:

```
git clone git@github.com:swagger-api/swagger-ui.git && cd $_
git diff v2.1.4 v2.2.10 -- dist/index.html
```

### eonasdan-bootstrap-datetimepicker

This PR updates the package that indirectly updates moment package
to a version >= 2.15.2 that is not affected by these potential client side
DDOS issues:

Regular Expression Denial of Service
* requires > 2.11.2
* https://snyk.io/vuln/npm:moment:20160126

Regular Expression Denial of Service
* requires >= 2.15.2
* https://snyk.io/vuln/npm:moment:20161019