### PR TITLE
Fixes enter key causing page refresh in Search Control

### DIFF
--- a/clients/web/src/views/widgets/SearchFieldWidget.js
+++ b/clients/web/src/views/widgets/SearchFieldWidget.js
@@ -57,6 +57,7 @@ var SearchFieldWidget = View.extend({
                     list.eq(pos).addClass('g-search-selected');
                 }
             } else if (code === 13) { /* enter */
+                e.preventDefault();
                 var link = this.$('.g-search-result.g-search-selected>a');
                 if (link.length) {
                     this._resultClicked(link);


### PR DESCRIPTION
This PR is for issue https://github.com/girder/girder/issues/1739.
The issue is caused by the fact there could be `<form>` wrapping the Search Control, Pressing enter key inside a form triggers a form submit an event, which, by default, causes the page to have a form POST refresh. 
As @zachmullen said in the issue, `preventDefault` will fix it.
