### PR TITLE
Fix initialization of bootstrap collapseable panels

### DIFF
--- a/plugins/item_tasks/web_client/views/ControlsPanel.js
+++ b/plugins/item_tasks/web_client/views/ControlsPanel.js
@@ -20,6 +20,9 @@ var ControlsPanel = Panel.extend({
             id: this.$el.attr('id')
         }));
         this.addAll();
+
+        // initialize collapseable elements
+        this.$('.g-panel-content').collapse({toggle: false});
     },
 
     addOne: function (model) {

--- a/plugins/item_tasks/web_client/views/Panel.js
+++ b/plugins/item_tasks/web_client/views/Panel.js
@@ -14,6 +14,9 @@ var Panel = View.extend({
     },
     render: function () {
         this.$el.html(panel(this.spec));
+
+        // initialize collapseable elements
+        this.$('.g-panel-content').collapse({toggle: false});
     },
     expand: function () {
         this.$('.icon-down-open').attr('class', 'icon-up-open');


### PR DESCRIPTION
This is a fix ported from slicer_cli_web.  The control panels didn't collapse properly on the first click, now they do.