### PR TITLE
girder-client: Improve handling of URL part arguments. Fixes #1890

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -168,8 +168,32 @@ class GirderClient(object):
 
     DEFAULT_API_ROOT = 'api/v1'
     DEFAULT_HOST = 'localhost'
-    DEFAULT_PORT = 443
-    DEFAULT_SCHEME = 'https'
+    DEFAULT_LOCALHOST_PORT = 8080
+    DEFAULT_HTTP_PORT = 80
+    DEFAULT_HTTPS_PORT = 443
+
+    @staticmethod
+    def getDefaultPort(hostname, scheme):
+        """Get default port based on the hostname.
+        Returns `GirderClient.DEFAULT_HTTPS_PORT` if scheme is `https`, otherwise
+        returns `GirderClient.DEFAULT_LOCALHOST_PORT` if `hostname` is `localhost`,
+        and finally returns `GirderClient.DEFAULT_HTTP_PORT`.
+        """
+        if scheme == "https":
+            return GirderClient.DEFAULT_HTTPS_PORT
+        if hostname == "localhost":
+            return GirderClient.DEFAULT_LOCALHOST_PORT
+        return GirderClient.DEFAULT_HTTP_PORT
+
+    @staticmethod
+    def getDefaultScheme(hostname):
+        """Get default scheme based on the hostname.
+        Returns `http` if `hostname` is `localhost` otherwise returns `https`.
+        """
+        if hostname == "localhost":
+            return "http"
+        else:
+            return "https"
 
     def __init__(self, host=None, port=None, apiRoot=None, scheme=None, apiUrl=None,
                  cacheSettings=None, progressReporterCls=None):
@@ -201,6 +225,9 @@ class GirderClient(object):
             initialized using `sys.stdout.isatty()`).
             This defaults to :class:`_NoopProgressReporter`.
         """
+        self.host = None
+        self.scheme = None
+        self.port = None
         if apiUrl is None:
             if not apiRoot:
                 apiRoot = self.DEFAULT_API_ROOT
@@ -208,10 +235,9 @@ class GirderClient(object):
             if not apiRoot.startswith('/'):
                 apiRoot = '/' + apiRoot
 
-            self.scheme = scheme or self.DEFAULT_SCHEME
             self.host = host or self.DEFAULT_HOST
-            self.port = port or (
-                self.DEFAULT_PORT if self.scheme == 'https' else 80)
+            self.scheme = scheme or GirderClient.getDefaultScheme(self.host)
+            self.port = port or GirderClient.getDefaultPort(self.host, self.scheme)
 
             self.urlBase = '%s://%s:%s%s' % (
                 self.scheme, self.host, str(self.port), apiRoot)

--- a/docs/python-client.rst
+++ b/docs/python-client.rst
@@ -65,10 +65,9 @@ argument to ``girder-cli``. For example: ::
 
     girder-cli --api-url http://localhost:8080/api/v1 <command> ...
 
-.. deprecated:: 2.2
 
-  Instead of using ``api-url`` argument, you may also specify the URL in parts, using the
-  ``host`` argument, and optional ``scheme``, ``port``, and ``api-root`` args.
+Instead of using ``api-url`` argument, you may also specify the URL in parts, using the
+``host`` argument, and optional ``scheme``, ``port``, and ``api-root`` args.
 
 Specifying credentials
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/plugins/metadata_extractor/plugin_tests/client_metadata_extractor_test.py
+++ b/plugins/metadata_extractor/plugin_tests/client_metadata_extractor_test.py
@@ -47,8 +47,7 @@ class ClientMetadataExtractorTestCase(MetadataExtractorTestCase):
 
         from girder_client import GirderClient
 
-        client = GirderClient(
-            'localhost', int(os.environ['GIRDER_PORT']), scheme='http')
+        client = GirderClient('localhost', int(os.environ['GIRDER_PORT']))
         client.authenticate(self.user['login'], self.password)
         extractor = ClientMetadataExtractor(client, self.path, self.item['_id'])
         extractor.extractMetadata()

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -47,6 +47,7 @@ def setUpModule():
 def tearDownModule():
     base.stopServer()
 
+
 chunk1, chunk2 = ('hello ', 'world')
 chunkData = chunk1.encode('utf8') + chunk2.encode('utf8')
 

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -72,8 +72,7 @@ class PythonClientTestCase(base.TestCase):
             os.mkdir(subDirName)
             writeFile(subDirName)
 
-        self.client = girder_client.GirderClient(
-            port=os.environ['GIRDER_PORT'], scheme='http')
+        self.client = girder_client.GirderClient(port=os.environ['GIRDER_PORT'])
 
         # Register a user
         self.password = 'password'
@@ -506,9 +505,7 @@ class PythonClientTestCase(base.TestCase):
         # create another client with caching enabled
         cacheSettings = {'directory': os.path.join(self.libTestDir, 'cache')}
         client = girder_client.GirderClient(
-            port=os.environ['GIRDER_PORT'],
-            scheme="http",
-            cacheSettings=cacheSettings)
+            port=os.environ['GIRDER_PORT'], cacheSettings=cacheSettings)
         client.authenticate(self.user['login'], self.password)
         self.assertNotEqual(client.cache, None)
 


### PR DESCRIPTION
This commit follows up on PR #1823 by improving the handling
of `--host`, `--port` and `--scheme` URL part arguments.

### Better default values

By default, hostname defaults to "localhost" with scheme and port
being respectively "http" and "8080".

If value of "--host" is different from "localhost" , scheme and port
respectively default to "https" and "443".

And finally, if hostname is different from "localhost", and "--scheme"
is "http", port is "80.

This behavior allows to accommodate both
developer trying to use the instance locally or user trying to manage
data served from secured servers.

Also partially reverts 6d56e6f (girder_client: Change default "scheme" to
"https" and fix logic setting port). Since default values are better
handled, there is no need to explicitly set the scheme to "http" within
tests.
### Better error message

The client reports a clear message when both `--api-url` and
any the URL part arguments are specified. For example:

```
$ girder-cli --port 4242 --api-url http://localhost:8080/api/v1 ...
Usage: girder-cli [OPTIONS] COMMAND [ARGS]...

Error: Option "--api-url" and option "--host" are mutually exclusive.
```

### Better help message

URL by part argument are now documented in the CLI help under
"Advanced Options".


```
$ girder-cli --help
Usage: girder-cli [OPTIONS] COMMAND [ARGS]...

  Perform common Girder CLI operations.

  The CLI is particularly suited to upload (or download) large, nested
  hierarchy of data to (or from) Girder from (or into) a local directory.

  The recommended way to use credentials is to first generate an API key and
  then specify the ``api-key`` argument or set the ``GIRDER_API_KEY``
  environment variable.

  The client also supports ``username`` and ``password`` args. If only the
  ``username`` is specified, the client will prompt the user to
  interactively input his/her password.

Options:
  --api-url TEXT   RESTful API URL (e.g https://girder.example.com:443/api/v1)
  --api-key TEXT   [default: GIRDER_API_KEY env. variable]
  --username TEXT
  --password TEXT
  -h, --help       Show this message and exit.

Advanced Options:
  --host TEXT      [default: localhost]
  --scheme TEXT    [default: http if localhost else https]
  --port TEXT      [default: 8080 if localhost else 443]
  --api-root TEXT  relative path to the Girder REST API  [default: api/v1]

Commands:
  download   Download files from Girder
  localsync  Synchronize local folder with remote Girder folder
  upload     Upload files to Girder
```