### PR TITLE
Add a `girder_clone` option to Girder role

### DIFF
--- a/devops/ansible/roles/girder/README.md
+++ b/devops/ansible/roles/girder/README.md
@@ -20,6 +20,7 @@ Role Variables
 | girder_path                | no       | $HOME/girder | Path to download and build Girder in.                                                   |
 | girder_version             | no       | master       | Git commit-ish for fetching Girder.                                                     |
 | girder_virtualenv          | no       | none         | Path to a Python virtual environment to install Girder in.                              |
+| girder_clone               | no       | yes          | Whether provisioning should clone Girder into `girder_path`.                            |
 | girder_update              | no       | yes          | Whether provisioning should fetch new versions via git.                                 |
 | girder_force               | no       | yes          | Whether provisioning should discard modified files in the working directory.            |
 | girder_web                 | no       | yes          | Whether to build the Girder web client.                                                 |

--- a/devops/ansible/roles/girder/defaults/main.yml
+++ b/devops/ansible/roles/girder/defaults/main.yml
@@ -5,6 +5,7 @@ girder_path: "{{ ansible_user_dir }}/girder"
 girder_version: "master"
 girder_update: yes
 girder_force: yes
+girder_clone: yes
 girder_web: yes
 girder_start: yes
 girder_enabled: yes

--- a/devops/ansible/roles/girder/tasks/girder.yml
+++ b/devops/ansible/roles/girder/tasks/girder.yml
@@ -41,6 +41,7 @@
     version: "{{ girder_version }}"
     update: "{{ girder_update|default(omit) }}"
     force: "{{ girder_force|default(omit) }}"
+    clone: "{{ girder_clone|default(omit) }}"
   register: vc
 
 - set_fact:


### PR DESCRIPTION
This is needed for deployment situations where I want to clone the Girder repo myself and want the role not to worry about cloning/updating/etc.