### PR TITLE
Return girderToken via OAuth callback

### DIFF
--- a/plugins/oauth/server/rest.py
+++ b/plugins/oauth/server/rest.py
@@ -145,6 +145,10 @@ class OAuth(Resource):
             'user': user
         })
 
-        self.sendAuthTokenCookie(user)
+        girderToken = self.sendAuthTokenCookie(user)
+        try:
+            redirect = redirect.format(girderToken=str(girderToken['_id']))
+        except KeyError:
+            pass  # in case there's another {} that's not handled by format
 
         raise cherrypy.HTTPRedirect(redirect)


### PR DESCRIPTION
Long time ago I discussed with @zachmullen [how to properly pass girder token to a 3rd party web application](https://gitter.im/girder/girder?at=586bd2e9aa6be0472f014480). The consensus was to check whether redirect url contains a specific placeholder and replace it with token if it exists.

This is my first attempt at implementing that functionality. It's gonna need docs update and tests.