### PR TITLE
Disable writing of output file if build error occurs

### DIFF
--- a/grunt_tasks/webpack.config.js
+++ b/grunt_tasks/webpack.config.js
@@ -81,7 +81,9 @@ module.exports = {
             jQuery: 'jquery',
             $: 'jquery',
             'window.jQuery': 'jquery'
-        })
+        }),
+        // Disable writing the output file if a build error occurs
+        new webpack.NoEmitOnErrorsPlugin()
     ],
     module: {
         loaders: [


### PR DESCRIPTION
This was problematic when rebuilding front-end code on a live production
site e.g. data.kitware.com. If a build error happened for whatever reason,
rather than leaving the current bundle in place, an output file would
be written that contained just the build error, breaking the site.