### PR TITLE
Improve error checking when user attempts to upload a directory

### DIFF
--- a/clients/web/src/views/widgets/UploadWidget.js
+++ b/clients/web/src/views/widgets/UploadWidget.js
@@ -176,7 +176,15 @@ var UploadWidget = View.extend({
         this.$('.g-drop-zone')
             .removeClass('g-dropzone-show')
             .html(`<i class="icon-docs"/> ${this._browseText}`);
-        this.files = e.originalEvent.dataTransfer.files;
+
+        var dataTransfer = e.originalEvent.dataTransfer;
+
+        // Require all dropped items to be files
+        if (!_.every(dataTransfer.items, _.bind(this._isFile, this))) {
+            this.$('.g-upload-error-message').html('Only files may be uploaded.');
+            return;
+        }
+        this.files = dataTransfer.files;
 
         if (!this.multiFile && this.files.length > 1) {
             // If in single-file mode and the user drops multiple files,
@@ -307,6 +315,27 @@ var UploadWidget = View.extend({
             }
             this.currentFile.upload(this.parent, this.files[this.currentIndex], null, otherParams);
         }
+    },
+
+    /**
+     * Check whether a DataTransferItem from a drag and drop operation
+     * represents a file, as opposed to a directory, URI, string, or other
+     * entity.
+     * @param {DataTransferItem} item - The item from a drag and drop operation.
+     * @returns {boolean} True if item represents a file.
+     */
+    _isFile: function (item) {
+        var getAsEntry = item.getAsEntry;
+        if (!_.isFunction(getAsEntry)) {
+            getAsEntry = item.webkitGetAsEntry;
+        }
+        if (!_.isFunction(getAsEntry)) {
+            // Unsupported; assume item is file
+            return true;
+        }
+
+        var entry = getAsEntry.call(item);
+        return entry && entry.isFile;
     }
 });
 

--- a/clients/web/src/views/widgets/UploadWidget.js
+++ b/clients/web/src/views/widgets/UploadWidget.js
@@ -180,7 +180,7 @@ var UploadWidget = View.extend({
         var dataTransfer = e.originalEvent.dataTransfer;
 
         // Require all dropped items to be files
-        if (!_.every(dataTransfer.items, _.bind(this._isFile, this))) {
+        if (!_.every(dataTransfer.items, (item) => this._isFile(item))) {
             this.$('.g-upload-error-message').html('Only files may be uploaded.');
             return;
         }

--- a/clients/web/test/spec/dataSpec.js
+++ b/clients/web/test/spec/dataSpec.js
@@ -746,6 +746,87 @@ describe('Create a data hierarchy', function () {
         girderTest.testUploadDrop(10, 2);
     });
 
+    it('attempt to upload a directory by dropping', function () {
+        waitsFor(function () {
+            return $('.g-upload-here-button').length > 0;
+        }, 'the upload here button to appear');
+
+        runs(function () {
+            $('.g-upload-here-button').click();
+        });
+
+        waitsFor(function () {
+            return $('.g-drop-zone:visible').length > 0 &&
+                $('.modal-dialog:visible').length > 0;
+        }, 'the upload dialog to appear');
+
+        var files = [
+            {
+                name: 'file1',
+                size: 1024
+            },
+            {
+                name: 'file2',
+                size: 1024
+            },
+            {
+                name: 'dir',
+                size: 4096
+            }
+        ];
+
+        var items = [
+            // Mock DataTransferItem that doesn't support the webkitGetAsEntry
+            // method
+            {
+            },
+            // Mock DataTransferItem that represents a file
+            {
+                webkitGetAsEntry: function () {
+                    return { isFile: true };
+                }
+            },
+            // Mock DataTransferItem that represents a directory
+            {
+                webkitGetAsEntry: function () {
+                    return { isFile: false };
+                }
+            }
+        ];
+
+        var selector = '.g-drop-zone';
+        var dropActiveSelector = '.g-dropzone-show:visible';
+
+        runs(function () {
+            $(selector).trigger($.Event('dragenter', {originalEvent: {dataTransfer: {}}}));
+        });
+
+        waitsFor(function () {
+            return $(dropActiveSelector).length > 0;
+        }, 'the drop bullseye to appear');
+
+        runs(function () {
+            $(selector).trigger($.Event('drop', {originalEvent: {
+                dataTransfer: {
+                    files: files,
+                    items: items
+                }}}));
+        });
+
+        waitsFor(function () {
+            return $(dropActiveSelector).length === 0;
+        }, 'the drop bullseye to disappear');
+
+        waitsFor(function () {
+            return $('.g-upload-error-message').text().length > 0;
+        }, 'the error message to be displayed');
+
+        runs(function () {
+            expect($('.g-upload-error-message').text().indexOf(
+                'Only files may be uploaded') >= 0).toBe(true);
+        });
+    });
+
     it('logout from second user', girderTest.logout('logout from second user'));
 });
 


### PR DESCRIPTION
Add functionality to the upload widget to check whether every dropped
item is a file. Display an error message when the check fails.

Note that the implementaion uses the DataTransferItem.webkitGetAsEntry()
method, which has not yet been standardized, but first tries to use the
suggested future standard method name getAsEntry(). See
https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem.

Fixes #1489.