### PR TITLE
Fix typo in role assetstore types

### DIFF
--- a/devops/ansible/roles/girder/library/girder.py
+++ b/devops/ansible/roles/girder/library/girder.py
@@ -1636,7 +1636,7 @@ class GirderClientModule(GirderClient):
 
     assetstore_types = {
         "filesystem": 0,
-        "girdfs": 1,
+        "gridfs": 1,
         "s3": 2,
         "hdfs": "hdfs",
         "database": "database"


### PR DESCRIPTION
GridFS assetstore types cannot currently be specified without this fix, since the name `girdfs` does not match the `dict` key elsewhere in this script (`gridfs`).