### PR TITLE
Small documentation improvements on entering virtual environment

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -27,7 +27,7 @@ Enter the virtual environment:
 
 .. code-block:: none
 
-   source ~/girder_env/bin/activate
+   . ~/girder_env/bin/activate
    
 The ``(girder_env)`` prepended to your prompt indicates you have *entered* 
 the virtual environment. Inside the virtual environment you can use ``pip``,

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,8 +23,14 @@ not be moved.  The following command will generate a new directory called
 
    virtualenv ~/girder_env
 
-Now you can run ``source ~/girder_env/bin/activate`` to *enter* the new
-virtual environment.  Inside the virtual environment you can use ``pip``,
+Enter the virtual environment: 
+
+.. code-block:: none
+
+   source ~/girder_env/bin/activate
+   
+The ``(girder_env)`` prepended to your prompt indicates you have *entered* 
+the virtual environment. Inside the virtual environment you can use ``pip``,
 ``python``, and any other python script installed in your path as usual.
 You can exit the virtual environment by running the shell function
 ``deactivate``.  The shell variable ``VIRTUAL_ENV`` will also list the


### PR DESCRIPTION
The documentation was like this
![chrome_2017-04-12_14-40-30](https://cloud.githubusercontent.com/assets/3123478/24973807/278d6180-1f8e-11e7-9718-b7db9156c4c9.png)

I changed to this
![chrome_2017-04-12_14-46-59](https://cloud.githubusercontent.com/assets/3123478/24974018/e69eca28-1f8e-11e7-9829-4a28ecbb21e7.png)

The entering virtual environment wasn't inside a code block, which is a little bit inconsistent with other steps. And, I personally tend to overlook stuff that is not inside code blocks. So I made this change, hoping it would improve the documentation.