### PR TITLE
Remove the Webpack url-loader

### DIFF
--- a/grunt_tasks/webpack.config.js
+++ b/grunt_tasks/webpack.config.js
@@ -36,20 +36,6 @@ function fileLoader() {
     };
 }
 
-function urlLoader(options) {
-    options = options || {};
-    var loader = {
-        loader: 'url-loader',
-        query: {
-            limit: 4096
-        }
-    };
-    if (options.mimetype) {
-        loader.query.mimetype = options.mimetype;
-    }
-    return loader;
-}
-
 function _coverageConfig() {
     try {
         var istanbulPlugin = require.resolve('babel-plugin-istanbul');
@@ -151,7 +137,6 @@ module.exports = {
                 test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
                 include: loaderPathsNodeModules,
                 loaders: [
-                    urlLoader({ mimetype: 'application/font-woff' }),
                     fileLoader()
                 ]
             },
@@ -160,7 +145,6 @@ module.exports = {
                 test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,
                 include: loaderPathsNodeModules,
                 loaders: [
-                    urlLoader({ mimetype: 'application/font-woff2' }),
                     fileLoader()
                 ]
             },
@@ -169,7 +153,6 @@ module.exports = {
                 test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
                 include: loaderPathsNodeModules,
                 loaders: [
-                    urlLoader({ mimetype: 'application/octet-stream' }),
                     fileLoader()
                 ]
             },
@@ -186,7 +169,6 @@ module.exports = {
                 test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
                 include: loaderPathsNodeModules,
                 loaders: [
-                    urlLoader({ mimetype: 'image/svg+xml' }),
                     fileLoader()
                 ]
             }


### PR DESCRIPTION
The 'url-loader' provides a wrapper around 'file-loader', so the two loaders should not be chained together. This bug was not discovered, as Girder was not loading any '.woff', '.ttf', or '.svg' files with Webpack.

Rather than fix the chaining bug, this just removes the url-loader, as its use is probably a premature optimization. Using url-loader will theoretically improve first-load performance, but makes it more difficult for user agents to cache assets and will interfere with the effectiveness of HTTP2 in the future.