### PR TITLE
Always include API version in system/version response

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -332,7 +332,9 @@ class GirderClient(object):
         :type useCached: bool
         :return: The API version as a list (e.g. ``['1', '0', '0']``)
         """
-        return self.getServerAPIDescription(useCached)["info"]["version"].split('.')
+        description = self.getServerAPIDescription(useCached)
+        version = description.get('info', {}).get('version')
+        return version.split('.') if version else None
 
     def getServerAPIDescription(self, useCached=True):
         """

--- a/girder/__init__.py
+++ b/girder/__init__.py
@@ -26,15 +26,14 @@ import six
 import sys
 import traceback
 
-
-from girder.constants import LOG_ROOT, MAX_LOG_SIZE, LOG_BACKUP_COUNT, \
-    TerminalColor
+from girder.constants import LOG_ROOT, MAX_LOG_SIZE, LOG_BACKUP_COUNT, TerminalColor, VERSION
 from girder.utility import config, mkdir
 
 __version__ = '2.2.0'
 __license__ = 'Apache 2.0'
 
 
+VERSION['apiVersion'] = __version__
 _quiet = False
 
 


### PR DESCRIPTION
This fixes a bug when the girder web client does not exist. In that
case, the API_VERSION value is set to null, even though there's no
reason for us not to report it since it's known in the backend.

This commit changes the behavior by always ensuring API_VERSION
is set to the package version, regardless of the existence of
girder-version.json.