### PR TITLE
Allow coverage paths to be overridden by add_python_test

### DIFF
--- a/docs/developer-cookbook.rst
+++ b/docs/developer-cookbook.rst
@@ -457,7 +457,8 @@ core tests, the following paths are used:
 For tests created within a plugin, the plugin's ``server`` directory is
 added to this list.  If you wish to report coverage on files residing outside
 of one of these directories, you can add a ``COVERAGE_PATHS`` argument
-to the ``add_python_test`` call.  For example, to add coverage reporting only
+to the ``add_python_test`` call.  This argument accepts one or more
+comma-separated paths.  For example, to add coverage reporting to
 to python files in a plugin's ``utils`` directory for a given test:
 
 .. code-block:: cmake
@@ -466,6 +467,7 @@ to python files in a plugin's ``utils`` directory for a given test:
         PLUGIN cats
         COVERAGE_PATHS "${PROJECT_SOURCE_DIRECTORY}/plugins/cats/utils"
     )
+
 
 Mounting a custom application
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/developer-cookbook.rst
+++ b/docs/developer-cookbook.rst
@@ -442,6 +442,31 @@ by the environment variable ``GIRDER_TEST_DATA_PREFIX`` as follows
     with open(test_file, 'r') as f:
         content = f.read() # The content of the downloaded test file
 
+.. _python-coverage-paths:
+
+Setting python code coverage paths
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, python tests added via the ``add_python_test`` cmake function
+will only report coverage for python files within certain paths.  For
+core tests, the following paths are used:
+
+- ``girder``
+- ``clients/python/girder_client``
+
+For tests created within a plugin, the plugin's ``server`` directory is
+added to this list.  If you wish to report coverage on files residing outside
+of one of these directories, you can add a ``COVERAGE_PATHS`` argument
+to the ``add_python_test`` call.  For example, to add coverage reporting only
+to python files in a plugin's ``utils`` directory for a given test:
+
+.. code-block:: cmake
+
+    add_python_test(cat
+        PLUGIN cats
+        COVERAGE_PATHS "${PROJECT_SOURCE_DIRECTORY}/plugins/cats/utils"
+    )
+
 Mounting a custom application
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -531,6 +531,9 @@ files, they must be prefixed by your plugin name as follows
 Then inside your unittest, the file will be available under the main data path
 as ``os.environ['GIRDER_TEST_DATA_PREFIX'] + '/plugins/cats/test_file.txt'``.
 
+.. note:: When enabling coverage in a plugin, only files residing under the plugin's
+          ``server`` directory will be included.  See :ref:`python-coverage-paths`
+          to change the paths used to generate python coverage reports.
 
 .. _client-side-plugins:
 

--- a/tests/PythonTests.cmake
+++ b/tests/PythonTests.cmake
@@ -84,7 +84,7 @@ function(add_python_test case)
 
   set(_options BIND_SERVER PY2_ONLY RUN_SERIAL)
   set(_args DBNAME PLUGIN SUBMODULE)
-  set(_multival_args RESOURCE_LOCKS TIMEOUT EXTERNAL_DATA REQUIRED_FILES)
+  set(_multival_args RESOURCE_LOCKS TIMEOUT EXTERNAL_DATA REQUIRED_FILES COVERAGE_PATHS)
   cmake_parse_arguments(fn "${_options}" "${_args}" "${_multival_args}" ${ARGN})
 
   if(fn_PY2_ONLY AND PYTHON_VERSION MATCHES "^3")
@@ -103,6 +103,12 @@ function(add_python_test case)
     set(other_covg "")
   endif()
 
+  if(fn_COVERAGE_PATHS)
+    set(coverage_source_paths "${fn_COVERAGE_PATHS}")
+  else()
+    set(coverage_source_paths "girder,${PROJECT_SOURCE_DIR}/clients/python/girder_client${other_covg}")
+  endif()
+
   if(fn_SUBMODULE)
     set(module ${module}.${fn_SUBMODULE})
     set(name ${name}.${fn_SUBMODULE})
@@ -113,7 +119,7 @@ function(add_python_test case)
       NAME ${name}
       WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
       COMMAND "${PYTHON_COVERAGE_EXECUTABLE}" run --parallel-mode "--rcfile=${PYTHON_COVERAGE_CONFIG}"
-              "--source=girder,${PROJECT_SOURCE_DIR}/clients/python/girder_client${other_covg}"
+              "--source=${coverage_source_paths}"
               -m unittest -v ${module}
     )
   else()

--- a/tests/PythonTests.cmake
+++ b/tests/PythonTests.cmake
@@ -104,9 +104,7 @@ function(add_python_test case)
   endif()
 
   if(fn_COVERAGE_PATHS)
-    set(coverage_source_paths "${fn_COVERAGE_PATHS}")
-  else()
-    set(coverage_source_paths "girder,${PROJECT_SOURCE_DIR}/clients/python/girder_client${other_covg}")
+    set(other_covg "${other_covg},${fn_COVERAGE_PATHS}")
   endif()
 
   if(fn_SUBMODULE)
@@ -119,7 +117,7 @@ function(add_python_test case)
       NAME ${name}
       WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
       COMMAND "${PYTHON_COVERAGE_EXECUTABLE}" run --parallel-mode "--rcfile=${PYTHON_COVERAGE_CONFIG}"
-              "--source=${coverage_source_paths}"
+              "--source=girder,${PROJECT_SOURCE_DIR}/clients/python/girder_client${other_covg}"
               -m unittest -v ${module}
     )
   else()


### PR DESCRIPTION
See the discussion in https://github.com/DigitalSlideArchive/HistomicsTK/pull/291 for background.