### PR TITLE
Fix conditional so it works in python 3

### DIFF
--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -791,12 +791,11 @@ class AccessControlledModel(Model):
             if '_id' not in doc:
                 doc = self.save(doc)
             else:
-                updateType = update.keys()[0]
                 # copy all other (potentially updated) fields to the update list
-                if updateType == '$set':
+                if '$set' in update:
                     for propKey in doc:
                         if propKey != 'access':
-                            update[updateType][propKey] = doc[propKey]
+                            update['$set'][propKey] = doc[propKey]
                 else:
                     update['$set'] = {k: v for k, v in six.viewitems(doc)
                                       if k != 'access'}


### PR DESCRIPTION
@TristanWright this fixes a bug on python 3, resulting from the fact that dict_keys are not iterable.

I changed the condition to simply check whether '$set' was in the dict, which is really what we want to know anyway.