### PR TITLE
Allow non-JSON responses via the python client methods

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -414,7 +414,7 @@ class GirderClient(object):
             return getattr(requests, method.lower())
 
     def sendRestRequest(self, method, path, parameters=None,
-                        data=None, files=None, json=None, headers=None):
+                        data=None, files=None, json=None, headers=None, jsonResp=True):
         """
         This method looks up the appropriate method, constructs a request URL
         from the base URL, path, and parameters, and then sends the request. If
@@ -440,6 +440,9 @@ class GirderClient(object):
         :type json: dict
         :param headers: If present, a dictionary of headers to encode in the request.
         :type headers: dict
+        :param jsonResp: Whether the response should be parsed as JSON. If False, the raw
+            response is returned.
+        :type jsonResp: bool
         """
         if not parameters:
             parameters = {}
@@ -456,50 +459,53 @@ class GirderClient(object):
             _headers.update(headers)
 
         result = f(
-            url, params=parameters, data=data, files=files, json=json,
-            headers=_headers)
+            url, params=parameters, data=data, files=files, json=json, headers=_headers)
 
         # If success, return the json object. Otherwise throw an exception.
         if result.status_code in (200, 201):
-            return result.json()
+            if jsonResp:
+                return result.json()
+            else:
+                return result.content
         # TODO handle 300-level status (follow redirect?)
         else:
             raise HttpError(
                 status=result.status_code, url=result.url, method=method, text=result.text)
 
-    def get(self, path, parameters=None):
+    def get(self, path, parameters=None, jsonResp=True):
         """
         Convenience method to call :py:func:`sendRestRequest` with the 'GET' HTTP method.
         """
-        return self.sendRestRequest('GET', path, parameters)
+        return self.sendRestRequest('GET', path, parameters, jsonResp=jsonResp)
 
-    def post(self, path, parameters=None, files=None, data=None, json=None, headers=None):
+    def post(self, path, parameters=None, files=None, data=None, json=None, headers=None,
+             jsonResp=True):
         """
         Convenience method to call :py:func:`sendRestRequest` with the 'POST' HTTP method.
         """
         return self.sendRestRequest('POST', path, parameters, files=files,
-                                    data=data, json=json, headers=headers)
+                                    data=data, json=json, headers=headers, jsonResp=jsonResp)
 
-    def put(self, path, parameters=None, data=None, json=None):
+    def put(self, path, parameters=None, data=None, json=None, jsonResp=True):
         """
         Convenience method to call :py:func:`sendRestRequest` with the 'PUT'
         HTTP method.
         """
         return self.sendRestRequest('PUT', path, parameters, data=data,
-                                    json=json)
+                                    json=json, jsonResp=jsonResp)
 
-    def delete(self, path, parameters=None):
+    def delete(self, path, parameters=None, jsonResp=True):
         """
         Convenience method to call :py:func:`sendRestRequest` with the 'DELETE' HTTP method.
         """
-        return self.sendRestRequest('DELETE', path, parameters)
+        return self.sendRestRequest('DELETE', path, parameters, jsonResp=jsonResp)
 
-    def patch(self, path, parameters=None, data=None, json=None):
+    def patch(self, path, parameters=None, data=None, json=None, jsonResp=True):
         """
         Convenience method to call :py:func:`sendRestRequest` with the 'PATCH' HTTP method.
         """
         return self.sendRestRequest('PATCH', path, parameters, data=data,
-                                    json=json)
+                                    json=json, jsonResp=jsonResp)
 
     def createResource(self, path, params):
         """

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -441,7 +441,7 @@ class GirderClient(object):
         :param headers: If present, a dictionary of headers to encode in the request.
         :type headers: dict
         :param jsonResp: Whether the response should be parsed as JSON. If False, the raw
-            response is returned.
+            response object is returned.
         :type jsonResp: bool
         """
         if not parameters:
@@ -466,7 +466,7 @@ class GirderClient(object):
             if jsonResp:
                 return result.json()
             else:
-                return result.content
+                return result
         # TODO handle 300-level status (follow redirect?)
         else:
             raise HttpError(

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -441,7 +441,15 @@ class GirderClient(object):
         :param headers: If present, a dictionary of headers to encode in the request.
         :type headers: dict
         :param jsonResp: Whether the response should be parsed as JSON. If False, the raw
-            response object is returned.
+            response object is returned. To get the raw binary content of the response,
+            use the ``content`` attribute of the return value, e.g.
+
+            .. code-block:: python
+
+                resp = client.get('my/endpoint', jsonResp=False)
+                print(resp.content)  # Raw binary content
+                print(resp.headers)  # Dict of headers
+
         :type jsonResp: bool
         """
         if not parameters:

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -763,3 +763,7 @@ class PythonClientTestCase(base.TestCase):
 
             checkDescription(self.client.getServerAPIDescription(useCached=False))
             self.assertEqual(len(hits), 2)
+
+    def testNonJsonResponse(self):
+        resp = self.client.get('user', jsonResp=False)
+        self.assertIsInstance(resp, six.binary_type)

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -766,4 +766,4 @@ class PythonClientTestCase(base.TestCase):
 
     def testNonJsonResponse(self):
         resp = self.client.get('user', jsonResp=False)
-        self.assertIsInstance(resp, six.binary_type)
+        self.assertIsInstance(resp.content, six.binary_type)


### PR DESCRIPTION
This fixes an issue @dgutman ran into with the python client. There was no way to use its core methods to receive a non-JSON response from any endpoints besides the core download ones.