### PR TITLE
Revert "Update Girder systemd service to load after mongod.service"

### DIFF
--- a/devops/ansible/roles/girder/templates/daemon/girder.service.j2
+++ b/devops/ansible/roles/girder/templates/daemon/girder.service.j2
@@ -1,6 +1,6 @@
 [Unit]
 Description=Girder
-After=network.target {% if girder_use_systemd %}mongod.service{% endif %}
+After=network.target
 
 [Service]
 User={{ ansible_user_id }}


### PR DESCRIPTION
This reverts commit f6048cb27f875c5928c29929263a55a4b791c721.

This commit created an unintentional coupling between Girder and Mongo
units which is unnecessary. While this might be convenient for single
machine deployments, putting this into our default role requires
Girder and Mongo be run on the same machine.

If someone *does* want this behavior on a provisioned instance, they should use systemd drop in units.