### PR TITLE
FIX automatically rebuild for --watch

### DIFF
--- a/grunt_tasks/build.js
+++ b/grunt_tasks/build.js
@@ -84,6 +84,7 @@ module.exports = function (grunt) {
         failOnError: !isWatch, // report error to grunt if webpack find errors; set to false if
         watch: isWatch,        // use webpack's watcher (you need to keep the grunt process alive)
         keepalive: isWatch,    // don't finish the grunt task (in combination with the watch option)
+        watchOptions: {poll: true},
         inline: false          // embed the webpack-dev-server runtime into the bundle (default false)
     };
 


### PR DESCRIPTION
Working on a plugin, I noticed that doing:
```
girder-install web --watch-plugin your_plugin_name
```
wasn't working on my side.

I had to add this commit to make it work.

Note: Now weirdly, I do not need this line anymore to make it work... But anyway, I still open a PR in case it may help people.