### PR TITLE
Update dicom_viewer plugin to vtk.js v2.10.4

### DIFF
--- a/plugins/dicom_viewer/plugin.json
+++ b/plugins/dicom_viewer/plugin.json
@@ -7,7 +7,7 @@
         "dependencies": {
             "daikon": "^1.2.15",
             "kw-web-suite": "^2.0.1",
-            "vtk.js": "2.2.0"
+            "vtk.js": "2.10.4"
         }
     }
 }


### PR DESCRIPTION
Going above v2.10.4 leads to the following error:
```
500 Internal Server Error {"message": "Exception:
Exception(u'Web client install failed:
`npm run build -- --no-progress=false --env=prod --plugins=item_previews,
hashsum_download,dicom_viewer --configure-plugins=` returned 1.',)",
"trace": [["/home/mayeul/MyProjects/girder/girder/api/rest.py", 567,
"endpointDecorator", "val = fun(self, args, kwargs)"],
["/home/mayeul/MyProjects/girder/girder/api/rest.py", 1129, "POST",
"return self.handleRoute(method, path, params)"],
["/home/mayeul/MyProjects/girder/girder/api/rest.py", 890, "handleRoute",
"val = handler(**kwargs)"], ["/home/mayeul/MyProjects/girder/girder/api/access.py",
39, "wrapped", "return args[0](*iargs, **ikwargs)"],
["/home/mayeul/MyProjects/girder/girder/api/describe.py", 601, "wrapped",
"return fun(*args, **kwargs)"], ["/home/mayeul/MyProjects/girder/girder/api/v1/system.py",
440, "buildWebCode", "install.runWebBuild(dev=dev, progress=progress)"],
["/home/mayeul/MyProjects/girder/girder/utility/install.py", 174,
"runWebBuild", "(' '.join(cmd), proc.returncode))"]], "type": "internal"}
```