### PR TITLE
Stop using pinned requirements.txt in Ansible role

### DIFF
--- a/devops/ansible/roles/girder/meta/main.yml
+++ b/devops/ansible/roles/girder/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
     versions:
       - trusty
       - xenial
-  - name: RedHat
+  - name: EL
     versions:
       - 7
 

--- a/devops/ansible/roles/girder/meta/main.yml
+++ b/devops/ansible/roles/girder/meta/main.yml
@@ -2,6 +2,7 @@ galaxy_info:
   author: Kitware, Inc.
   description: Install the Girder data management platform.
   company: Kitware, Inc.
+  issue_tracker_url: https://github.com/girder/girder/issues
 
   license: Apache
   min_ansible_version: 2.0

--- a/devops/ansible/roles/girder/tasks/pip.yml
+++ b/devops/ansible/roles/girder/tasks/pip.yml
@@ -4,11 +4,6 @@
     state: latest
     virtualenv: "{{ girder_virtualenv | default(omit) }}"
 
-- name: Install Girder Python requirements
-  pip:
-    requirements: "{{ girder_path }}/requirements.txt"
-    virtualenv: "{{ girder_virtualenv | default(omit) }}"
-
 - name: Install Girder and plugin requirements
   pip:
     name: ".[plugins]"


### PR DESCRIPTION
Thanks for pointing out this bug @kotfic.

This PR also adds a couple of fixes/additions to the `meta/main.yml` that Ansible Galaxy was complaining about.
