### PR TITLE
Downgrade dicom_viewer plugin to vtk.js v2.2.0

### DIFF
--- a/plugins/dicom_viewer/plugin.json
+++ b/plugins/dicom_viewer/plugin.json
@@ -7,7 +7,7 @@
         "dependencies": {
             "daikon": "^1.2.15",
             "kw-web-suite": "^2.0.1",
-            "vtk.js": "2.18.0"
+            "vtk.js": "2.2.0"
         }
     }
 }

--- a/plugins/dicom_viewer/webpack.helper.js
+++ b/plugins/dicom_viewer/webpack.helper.js
@@ -16,6 +16,9 @@ module.exports = function (config) {
             loader: 'string-replace-loader',
             query: {
                 multiple: [
+                    {search: /vtkDebugMacro/g, replace: 'console.debug'},
+                    {search: /vtkErrorMacro/g, replace: 'console.error'},
+                    {search: /vtkWarningMacro/g, replace: 'console.warn'},
                     {search: /test\.onlyIfWebGL/g, replace: 'test'}
                 ]
             }


### PR DESCRIPTION
As discussed in the MR https://github.com/girder/girder/pull/1951 , vtk-js
faces a regression issue: https://github.com/Kitware/vtk-js/issues/214

This downgrade would be revert at the time the issue will be fixed