### PR TITLE
Change a style of the user text links.

### DIFF
--- a/clients/web/src/stylesheets/layout/headerUser.styl
+++ b/clients/web/src/stylesheets/layout/headerUser.styl
@@ -5,6 +5,7 @@
 
   a
     color white
+    display inline-block
 
     &:hover
       color #e0e0e0


### PR DESCRIPTION
On the header bar, when you are logged in, the entire height around the user name acts as the click target for the link.  When you are logged out, the Register and Log In links' click targets are just the height of the text.  This makes the logged out click targets the full height.