### PR TITLE
Circleci display test summary

### DIFF
--- a/cmake/run_circleci.sh
+++ b/cmake/run_circleci.sh
@@ -21,6 +21,11 @@ esac
 mkdir $HOME/build
 touch $HOME/build/test_failed
 ctest -VV -S $HOME/girder/cmake/circle_continuous.cmake
+
+# Convert CTest output to Junit and ensure CircleCI will include it in its summary
+pip install scikit-ci-addons==0.15.0
+mkdir ${CIRCLE_TEST_REPORTS}/CTest
+ci_addons ctest_junit_formatter $HOME/build > ${CIRCLE_TEST_REPORTS}/CTest/JUnit-${CIRCLE_NODE_INDEX}.xml || exit 1
 if [ -f $HOME/build/test_failed ] ; then
 	exit 1
 fi


### PR DESCRIPTION
This PR updates `run_circleci.sh` so that it convert CTest results into a format usable by the CircleCI test summary.

It makes use of [ctest-junit-formatter](http://scikit-ci-addons.readthedocs.io/en/latest/addons.html#ctest-junit-formatter) provided by `scikit-ci-addons`.

Here is an example of test summary:

![ctest-within-circleci](https://cloud.githubusercontent.com/assets/219043/25487338/e99df39e-2b31-11e7-96ea-b4857d07a628.png)
