### PR TITLE
Add more arguments to girder's add_test ctest wrappers

### DIFF
--- a/tests/JavascriptTests.cmake
+++ b/tests/JavascriptTests.cmake
@@ -107,7 +107,7 @@ function(add_web_client_test case specFile)
 
   set(_options NOCOVERAGE)
   set(_args PLUGIN ASSETSTORE WEBSECURITY BASEURL PLUGIN_DIR TIMEOUT TEST_MODULE REQUIRED_FILES
-            SETUP_MODULES ENVIRONMENT)
+            SETUP_MODULES ENVIRONMENT EXTERNAL_DATA)
   set(_multival_args RESOURCE_LOCKS ENABLEDPLUGINS)
   cmake_parse_arguments(fn "${_options}" "${_args}" "${_multival_args}" ${ARGN})
 

--- a/tests/JavascriptTests.cmake
+++ b/tests/JavascriptTests.cmake
@@ -146,6 +146,15 @@ function(add_web_client_test case specFile)
     set(test_module "tests.web_client_test")
   endif()
 
+  if(fn_EXTERNAL_DATA)
+    set(_data_files "")
+    foreach(_data_file ${fn_EXTERNAL_DATA})
+      list(APPEND _data_files "DATA{${GIRDER_EXTERNAL_DATA_BUILD_PATH}/${_data_file}}")
+    endforeach()
+    girder_ExternalData_expand_arguments("${testname}_data" _tmp ${_data_files})
+    girder_ExternalData_add_target("${testname}_data")
+  endif()
+
   add_test(
       NAME ${testname}
       WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
@@ -171,6 +180,7 @@ function(add_web_client_test case specFile)
     "GIRDER_TEST_ASSETSTORE=${testname}"
     "GIRDER_PORT=${web_client_port}"
     "MONGOD_EXECUTABLE=${MONGOD_EXECUTABLE}"
+    "GIRDER_TEST_DATA_PREFIX=${GIRDER_EXTERNAL_DATA_ROOT}"
     "${fn_ENVIRONMENT}"
   )
   math(EXPR next_web_client_port "${web_client_port} + 1")

--- a/tests/JavascriptTests.cmake
+++ b/tests/JavascriptTests.cmake
@@ -98,6 +98,7 @@ function(add_web_client_test case specFile)
   # SETUP_MODULES: colon-separated list of python scripts to import at test setup time
   #     for side effects such as mocking, adding API routes, etc.
   # REQUIRED_FILES: A list of files required to run the test.
+  # ENVIRONMENT: A list of key=value pairs to add to the test's runtime environment
   if (NOT BUILD_JAVASCRIPT_TESTS)
     return()
   endif()
@@ -106,7 +107,7 @@ function(add_web_client_test case specFile)
 
   set(_options NOCOVERAGE)
   set(_args PLUGIN ASSETSTORE WEBSECURITY BASEURL PLUGIN_DIR TIMEOUT TEST_MODULE REQUIRED_FILES
-            SETUP_MODULES)
+            SETUP_MODULES ENVIRONMENT)
   set(_multival_args RESOURCE_LOCKS ENABLEDPLUGINS)
   cmake_parse_arguments(fn "${_options}" "${_args}" "${_multival_args}" ${ARGN})
 
@@ -170,6 +171,7 @@ function(add_web_client_test case specFile)
     "GIRDER_TEST_ASSETSTORE=${testname}"
     "GIRDER_PORT=${web_client_port}"
     "MONGOD_EXECUTABLE=${MONGOD_EXECUTABLE}"
+    "${fn_ENVIRONMENT}"
   )
   math(EXPR next_web_client_port "${web_client_port} + 1")
   set(web_client_port ${next_web_client_port} PARENT_SCOPE)

--- a/tests/PythonTests.cmake
+++ b/tests/PythonTests.cmake
@@ -84,7 +84,8 @@ function(add_python_test case)
 
   set(_options BIND_SERVER PY2_ONLY RUN_SERIAL)
   set(_args DBNAME PLUGIN SUBMODULE)
-  set(_multival_args RESOURCE_LOCKS TIMEOUT EXTERNAL_DATA REQUIRED_FILES COVERAGE_PATHS)
+  set(_multival_args RESOURCE_LOCKS TIMEOUT EXTERNAL_DATA REQUIRED_FILES COVERAGE_PATHS
+                     ENVIRONMENT)
   cmake_parse_arguments(fn "${_options}" "${_args}" "${_multival_args}" ${ARGN})
 
   if(fn_PY2_ONLY AND PYTHON_VERSION MATCHES "^3")
@@ -142,6 +143,7 @@ function(add_python_test case)
     "GIRDER_TEST_PORT=${server_port}"
     "GIRDER_TEST_DATA_PREFIX=${GIRDER_EXTERNAL_DATA_ROOT}"
     "MONGOD_EXECUTABLE=${MONGOD_EXECUTABLE}"
+    "${fn_ENVIRONMENT}"
   )
   set_property(TEST ${name} PROPERTY COST 50)
   set_property(TEST ${name} PROPERTY REQUIRED_FILES ${fn_REQUIRED_FILES})


### PR DESCRIPTION
Adds `ENVIRONMENT` to both javascript and python tests and `EXTERNAL_DATA` to javascript tests.
