### PR TITLE
Automate the deployment of Ansible role to Galaxy

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -38,3 +38,9 @@ deployment:
     owner: girder
     commands:
       - curl 'https://doc.esdoc.org/api/create' -X POST --data-urlencode "gitUrl=git@github.com:girder/girder.git"
+
+  ansible_galaxy:
+    branch: master
+    owner: girder
+    commands:
+      - ./scripts/galaxy_deploy.sh

--- a/scripts/galaxy_deploy.sh
+++ b/scripts/galaxy_deploy.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+# Ansible role repo to deploy to
+readonly ANSIBLE_ROLE_GITHUB_ORG="girder"
+readonly ANSIBLE_ROLE_GITHUB_REPO="ansible-role-girder"
+
+readonly SUBTREE_PREFIX="devops/ansible/roles/girder"
+readonly SUBTREE_DEST_REPO="git@github.com:$ANSIBLE_ROLE_GITHUB_ORG/$ANSIBLE_ROLE_GITHUB_REPO.git"
+readonly SUBTREE_DEST_BRANCH="master"
+
+# Push any changes that have occurred
+git subtree push --prefix="$SUBTREE_PREFIX" "$SUBTREE_DEST_REPO" "$SUBTREE_DEST_BRANCH"
+
+# Install ansible for ansible-galaxy
+pip install ansible
+
+# Import the changes into Ansible Galaxy
+ansible-galaxy login --github-token="$ANSIBLE_GALAXY_GITHUB_TOKEN"
+ansible-galaxy import girder ansible-role-girder


### PR DESCRIPTION
Since there's a lot going on here and this involves storing secrets in our CI environment, the more eyes the better.

In order to deploy to Ansible Galaxy we need to do a subtree push of our role to [girder/ansible-role-girder](https://github.com/girder/ansible-role-girder). This requires that a read-write deploy key is made for that repo and CircleCI stores the private key while github stores the public key.

Following that, we need to import the role into Galaxy which requires identifying to Galaxy as a user with permissions on the `ansible-role-girder` repo. This is done by giving CircleCI a personal access token (from my GitHub account) that only has the "read user data" permission, since all that is needed is identification (for more details read [here](http://docs.ansible.com/ansible/galaxy.html#authenticate-with-galaxy)).

The biggest downside I see to this is that if something happens with one of our tests and it spits out the contents of environment variables, our Galaxy token is exposed.

Note that Circle doesn't pass these secrets on to fork builds, and the galaxy script is only called on merges to master.