### PR TITLE
Fix log errors from item_tasks plugin

### DIFF
--- a/plugins/item_tasks/server/__init__.py
+++ b/plugins/item_tasks/server/__init__.py
@@ -36,7 +36,7 @@ def _onUpload(event):
     """
     try:
         ref = json.loads(event.info.get('reference'))
-    except ValueError:
+    except (ValueError, TypeError):
         return
 
     if isinstance(ref, dict) and ref.get('type') == 'item_tasks.output':


### PR DESCRIPTION
Any time a file was uploaded that did not contain a reference
field, the item_tasks plugin was throwing an exception. This
was not visible to end users since it's an async task, but was
appearing in the admin logs.