### PR TITLE
Compute all missing file hashes when files are uploaded

### DIFF
--- a/clients/web/src/views/widgets/FileInfoWidget.js
+++ b/clients/web/src/views/widgets/FileInfoWidget.js
@@ -9,6 +9,10 @@ import 'girder/utilities/jquery/girderModal';
  * This widget shows information about a single file in a modal dialog.
  */
 var FileInfoWidget = View.extend({
+    initialize: function (settings) {
+        this.parentItem = settings.parentItem;
+    },
+
     render: function () {
         this.$el.html(FileInfoDialogTemplate({
             file: this.model,

--- a/clients/web/src/views/widgets/FileListWidget.js
+++ b/clients/web/src/views/widgets/FileListWidget.js
@@ -29,6 +29,7 @@ var FileListWidget = View.extend({
             new FileInfoWidget({
                 el: $('#g-dialog-container'),
                 model: this.collection.get(cid),
+                parentItem: this.parentItem,
                 parentView: this
             }).render();
         },

--- a/plugins/hashsum_download/plugin_tests/hashsumSpec.js
+++ b/plugins/hashsum_download/plugin_tests/hashsumSpec.js
@@ -11,44 +11,65 @@ var app = new girder.views.App({
 });
 girder.events.trigger('g:appload.after');
 
-$(function () {
-    describe('Unit test the file view augmentation', function () {
-        var file;
-        var sha512 = 'd9f804f8f7caceec12a1207c16c6b70cb1dbfd8ea8f48a36168c98898c' +
-            '1f138a11e9d1b40769d3c112afb099c6be5d57fc1ee8cf353df91ca0d3cf5524ddb047';
+describe('Unit test the file view augmentation', function () {
+    var file;
+    var sha512 = 'd9f804f8f7caceec12a1207c16c6b70cb1dbfd8ea8f48a36168c98898c' +
+        '1f138a11e9d1b40769d3c112afb099c6be5d57fc1ee8cf353df91ca0d3cf5524ddb047';
 
-        it('Create a file and its info dialog', function () {
-            waitsFor('app to render', function () {
-                return $('#g-app-body-container').length > 0;
-            });
-
-            runs(function () {
-                file = new girder.models.FileModel({
-                    _id: 'fake_id',
-                    size: 12345,
-                    name: 'my_file.txt',
-                    sha512: sha512,
-                    mimeType: 'text/plain',
-                    created: '2016-06-28T14:58:59.235000+00:00'
-                });
-
-                new girder.views.widgets.FileInfoWidget({
-                    model: file,
-                    el: $('#g-dialog-container'),
-                    parentView: app
-                }).render();
-            });
-
-            girderTest.waitForDialog();
-
-            runs(function () {
-                var container = $('.g-file-info-line[property="sha512"]');
-                expect(container.length).toBe(1);
-                expect($('input.g-hash-textbox', container).val()).toBe(sha512);
-                expect($('a.g-keyfile-download', container).attr('href')).toBe(
-                    girder.rest.apiRoot + '/file/fake_id/hashsum_file/sha512'
-                );
-            });
+    it('Create a file and its info dialog', function () {
+        waitsFor('app to render', function () {
+            return $('#g-app-body-container').length > 0;
         });
+
+        runs(function () {
+            file = new girder.models.FileModel({
+                _id: 'fake_id',
+                size: 12345,
+                name: 'my_file.txt',
+                sha512: sha512,
+                mimeType: 'text/plain',
+                created: '2016-06-28T14:58:59.235000+00:00'
+            });
+
+            new girder.views.widgets.FileInfoWidget({
+                model: file,
+                el: $('#g-dialog-container'),
+                parentView: app
+            }).render();
+        });
+
+        girderTest.waitForDialog();
+
+        runs(function () {
+            var container = $('.g-file-info-line[property="sha512"]');
+            expect(container.length).toBe(1);
+            expect($('input.g-hash-textbox', container).val()).toBe(sha512);
+            expect($('a.g-keyfile-download', container).attr('href')).toBe(
+                girder.rest.apiRoot + '/file/fake_id/hashsum_file/sha512'
+            );
+        });
+    });
+});
+
+describe('Test configuration page', function () {
+    it('register admin', girderTest.createUser(
+        'admin', 'admin@email.com', 'John', 'Doe', 'password!'));
+
+    it('navigate to config page', function () {
+        window.location.assign('#plugins/hashsum_download/config');
+
+        waitsFor(function () {
+            return $('#hashsum_download_auto_compute').length > 0;
+        }, 'config page to load');
+    });
+
+    it('update auto compute setting', function () {
+        expect($('#hashsum_download_auto_compute').is(':checked')).toBe(false);
+        $('#hashsum_download_auto_compute').click();
+        $('.btn[value="Save"]').click();
+
+        waitsFor(function () {
+            return $('#g-alerts-container .alert-success').length > 0;
+        }, 'saved alert to appear', 3000);
     });
 });

--- a/plugins/hashsum_download/plugin_tests/hashsumSpec.js
+++ b/plugins/hashsum_download/plugin_tests/hashsumSpec.js
@@ -59,13 +59,13 @@ describe('Test configuration page', function () {
         window.location.assign('#plugins/hashsum_download/config');
 
         waitsFor(function () {
-            return $('#hashsum_download_auto_compute').length > 0;
+            return $('#hashsum-download-auto-compute').length > 0;
         }, 'config page to load');
     });
 
     it('update auto compute setting', function () {
-        expect($('#hashsum_download_auto_compute').is(':checked')).toBe(false);
-        $('#hashsum_download_auto_compute').click();
+        expect($('#hashsum-download-auto-compute').is(':checked')).toBe(false);
+        $('#hashsum-download-auto-compute').click();
         $('.btn[value="Save"]').click();
 
         waitsFor(function () {

--- a/plugins/hashsum_download/plugin_tests/hashsum_download_test.py
+++ b/plugins/hashsum_download/plugin_tests/hashsum_download_test.py
@@ -288,6 +288,11 @@ class HashsumDownloadTest(base.TestCase):
         self.assertIn('sha256', file)
         self.assertEqual(file['sha256'], expected.hexdigest())
 
+        expected = hashlib.sha512()
+        expected.update(self.userData)
+        self.assertIn('sha512', file)
+        self.assertEqual(file['sha512'], expected.hexdigest())
+
         hashsum_download.SUPPORTED_ALGORITHMS = old
 
     def testManualComputeHashes(self):

--- a/plugins/hashsum_download/plugin_tests/hashsum_download_test.py
+++ b/plugins/hashsum_download/plugin_tests/hashsum_download_test.py
@@ -17,9 +17,11 @@
 #  limitations under the License.
 ###############################################################################
 
-import six
 import hashlib
+import six
+import time
 
+from girder.models.model_base import ValidationException
 from tests import base
 
 
@@ -260,3 +262,60 @@ class HashsumDownloadTest(base.TestCase):
         resp = self.request(template % (self.privateFile['_id'], 'sha512'))
         self.assertStatus(resp, 401)
         six.assertRegex(self, resp.json['message'], '^Read access denied')
+
+    def testAutoComputeHashes(self):
+        from girder.plugins import hashsum_download
+        with self.assertRaises(ValidationException):
+            self.model('setting').set(hashsum_download.PluginSettings.AUTO_COMPUTE, 'bad')
+
+        old = hashsum_download.SUPPORTED_ALGORITHMS
+        hashsum_download.SUPPORTED_ALGORITHMS = {'sha512', 'sha256'}
+        self.model('setting').set(hashsum_download.PluginSettings.AUTO_COMPUTE, True)
+
+        file = self.model('upload').uploadFromFile(
+            obj=six.BytesIO(self.userData), size=len(self.userData), name='Another file',
+            parentType='folder', parent=self.privateFolder, user=self.user)
+
+        start = time.time()
+        while time.time() < start + 15:
+            file = self.model('file').load(file['_id'], force=True)
+            if 'sha256' in file:
+                break
+            time.sleep(0.2)
+
+        expected = hashlib.sha256()
+        expected.update(self.userData)
+        self.assertIn('sha256', file)
+        self.assertEqual(file['sha256'], expected.hexdigest())
+
+        hashsum_download.SUPPORTED_ALGORITHMS = old
+
+    def testManualComputeHashes(self):
+        from girder.plugins import hashsum_download
+        self.model('setting').set(hashsum_download.PluginSettings.AUTO_COMPUTE, False)
+        old = hashsum_download.SUPPORTED_ALGORITHMS
+        hashsum_download.SUPPORTED_ALGORITHMS = {'sha512', 'sha256'}
+
+        self.assertNotIn('sha256', self.privateFile)
+
+        expected = hashlib.sha256()
+        expected.update(self.userData)
+
+        # Running the compute endpoint should only compute the missing ones
+        resp = self.request(
+            '/file/%s/hashsum' % self.privateFile['_id'], method='POST', user=self.user)
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, {
+            'sha256': expected.hexdigest()
+        })
+
+        # Running again should be a no-op
+        resp = self.request(
+            '/file/%s/hashsum' % self.privateFile['_id'], method='POST', user=self.user)
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, None)
+
+        file = self.model('file').load(self.privateFile['_id'], force=True)
+        self.assertEqual(file['sha256'], expected.hexdigest())
+
+        hashsum_download.SUPPORTED_ALGORITHMS = old

--- a/plugins/hashsum_download/server/__init__.py
+++ b/plugins/hashsum_download/server/__init__.py
@@ -19,6 +19,7 @@
 
 import hashlib
 import six
+import warnings
 
 from girder import events
 from girder.api import access
@@ -39,9 +40,12 @@ class PluginSettings(object):
 
 
 class HashedFile(File):
-
-    # deprecated, use module-level constant instead
-    supportedAlgorithms = SUPPORTED_ALGORITHMS
+    @property
+    def supportedAlgorithms(self):  # pragma: no cover
+        warnings.warn(
+            'HashedFile.supportedAlgorithms is deprecated, use the module-level '
+            'SUPPORTED_ALGORITHMS instead.', DeprecationWarning)
+        return SUPPORTED_ALGORITHMS
 
     def __init__(self, node):
         super(File, self).__init__()

--- a/plugins/hashsum_download/server/__init__.py
+++ b/plugins/hashsum_download/server/__init__.py
@@ -100,11 +100,11 @@ class HashedFile(File):
     @access.user(scope=TokenScope.DATA_WRITE)
     @autoDescribeRoute(
         Description('Manually compute the checksum values for a given file.')
-            .modelParam('id', 'The ID of the file.', model='file', level=AccessType.WRITE)
-            .param('progress', 'Whether to track progress of the operation', dataType='boolean',
-                   default=False, required=False)
-            .errorResponse()
-            .errorResponse('Write access was denied on the file.', 403)
+        .modelParam('id', 'The ID of the file.', model='file', level=AccessType.WRITE)
+        .param('progress', 'Whether to track progress of the operation', dataType='boolean',
+               default=False, required=False)
+        .errorResponse()
+        .errorResponse('Write access was denied on the file.', 403)
     )
     def computeHashes(self, file, progress, params):
         with ProgressContext(

--- a/plugins/hashsum_download/web_client/main.js
+++ b/plugins/hashsum_download/web_client/main.js
@@ -1,2 +1,13 @@
 // Extends and overrides API
 import './views/FileInfoWidget';
+
+import router from 'girder/router';
+import events from 'girder/events';
+import { exposePluginConfig } from 'girder/utilities/PluginUtils';
+
+exposePluginConfig('hashsum_download', 'plugins/hashsum_download/config');
+
+import ConfigView from './views/ConfigView';
+router.route('plugins/hashsum_download/config', 'celeryJobsConfig', function () {
+    events.trigger('g:navigateTo', ConfigView);
+});

--- a/plugins/hashsum_download/web_client/main.js
+++ b/plugins/hashsum_download/web_client/main.js
@@ -8,6 +8,6 @@ import { exposePluginConfig } from 'girder/utilities/PluginUtils';
 exposePluginConfig('hashsum_download', 'plugins/hashsum_download/config');
 
 import ConfigView from './views/ConfigView';
-router.route('plugins/hashsum_download/config', 'celeryJobsConfig', function () {
+router.route('plugins/hashsum_download/config', 'hashsumDownloadConfig', function () {
     events.trigger('g:navigateTo', ConfigView);
 });

--- a/plugins/hashsum_download/web_client/templates/config.pug
+++ b/plugins/hashsum_download/web_client/templates/config.pug
@@ -1,0 +1,10 @@
+.g-config-breadcrumb-container
+form#g-hashsum-download-config-form(role="form")
+  .checkbox
+    label.control-label(for="hashsum_download_auto_compute")
+      input#hashsum_download_auto_compute(type="checkbox",
+          checked=(settings['hashsum_download.auto_compute'] ? 'checked' : null))
+      span Automatically compute file checksums on upload
+
+  p#g-hashsum-download-error-message.g-validation-failed-message
+  input.btn.btn-sm.btn-primary(type="submit", value="Save")

--- a/plugins/hashsum_download/web_client/templates/config.pug
+++ b/plugins/hashsum_download/web_client/templates/config.pug
@@ -1,8 +1,8 @@
 .g-config-breadcrumb-container
 form#g-hashsum-download-config-form(role="form")
   .checkbox
-    label.control-label(for="hashsum_download_auto_compute")
-      input#hashsum_download_auto_compute(type="checkbox",
+    label.control-label(for="hashsum-download-auto-compute")
+      input#hashsum-download-auto-compute(type="checkbox",
           checked=(settings['hashsum_download.auto_compute'] ? 'checked' : null))
       span Automatically compute file checksums on upload
 

--- a/plugins/hashsum_download/web_client/templates/hashsumDownloadFileInfoWidget.pug
+++ b/plugins/hashsum_download/web_client/templates/hashsumDownloadFileInfoWidget.pug
@@ -5,3 +5,8 @@ if file.has('sha512')
     input.g-hash-textbox(readonly, type="text", value=file.get('sha512'))
     a.g-keyfile-download(title="Download key file", href=keyfileUrl(file.id, 'sha512'))
       i.icon-key-inv
+else if parentItem.getAccessLevel() >= AccessType.WRITE
+  .g-file-info-line(property="hash-compute")
+    i.icon-barcode
+    span Hash unknown &mdash;
+    a.g-hashsum-compute  click to compute

--- a/plugins/hashsum_download/web_client/views/ConfigView.js
+++ b/plugins/hashsum_download/web_client/views/ConfigView.js
@@ -1,0 +1,71 @@
+import PluginConfigBreadcrumbWidget from 'girder/views/widgets/PluginConfigBreadcrumbWidget';
+import View from 'girder/views/View';
+import events from 'girder/events';
+import { restRequest } from 'girder/rest';
+
+import template from '../templates/config.pug';
+
+var ConfigView = View.extend({
+    events: {
+        'submit #g-hashsum-download-config-form': function (event) {
+            event.preventDefault();
+            this.$('#g-hashsum-download-error-message').empty();
+
+            this._saveSettings([{
+                key: 'hashsum_download.auto_compute',
+                value: this.$('#hashsum_download_auto_compute').is(':checked')
+            }]);
+        }
+    },
+
+    initialize: function () {
+        this.breadcrumb = new PluginConfigBreadcrumbWidget({
+            pluginName: 'Hashsum download',
+            parentView: this
+        });
+
+        restRequest({
+            type: 'GET',
+            path: 'system/setting',
+            data: {
+                list: JSON.stringify([
+                    'hashsum_download.auto_compute'
+                ])
+            }
+        }).done(resp => {
+            this.settings = resp;
+            this.render();
+        });
+    },
+
+    render: function () {
+        this.$el.html(template({
+            settings: this.settings
+        }));
+        this.breadcrumb.setElement(this.$('.g-config-breadcrumb-container')).render();
+        return this;
+    },
+
+    _saveSettings: function (settings) {
+        restRequest({
+            type: 'PUT',
+            path: 'system/setting',
+            data: {
+                list: JSON.stringify(settings)
+            },
+            error: null
+        }).done(() => {
+            events.trigger('g:alert', {
+                icon: 'ok',
+                text: 'Settings saved.',
+                type: 'success',
+                timeout: 4000
+            });
+        }).error(resp => {
+            this.$('#g-hashsum-download-error-message').text(
+                resp.responseJSON.message);
+        });
+    }
+});
+
+export default ConfigView;

--- a/plugins/hashsum_download/web_client/views/ConfigView.js
+++ b/plugins/hashsum_download/web_client/views/ConfigView.js
@@ -13,7 +13,7 @@ var ConfigView = View.extend({
 
             this._saveSettings([{
                 key: 'hashsum_download.auto_compute',
-                value: this.$('#hashsum_download_auto_compute').is(':checked')
+                value: this.$('#hashsum-download-auto-compute').is(':checked')
             }]);
         }
     },

--- a/plugins/hashsum_download/web_client/views/FileInfoWidget.js
+++ b/plugins/hashsum_download/web_client/views/FileInfoWidget.js
@@ -1,24 +1,43 @@
 import FileInfoWidget from 'girder/views/widgets/FileInfoWidget';
-import { apiRoot } from 'girder/rest';
+import { apiRoot, restRequest } from 'girder/rest';
+import { AccessType } from 'girder/constants';
 import { wrap } from 'girder/utilities/PluginUtils';
 
-import HashsumDownloadFileInfoWidgetTemplate from '../templates/hashsumDownloadFileInfoWidget.pug';
+import template from '../templates/hashsumDownloadFileInfoWidget.pug';
 
 import '../stylesheets/hashsumDownloadFileInfoWidget.styl';
 
 var keyfileUrl = function (id, algo) {
-    return apiRoot + '/file/' + id + '/hashsum_file/' + algo;
+    return `${apiRoot}/file/${id}/hashsum_file/${algo}`;
 };
 
 wrap(FileInfoWidget, 'render', function (render) {
     render.call(this);
 
-    this.$('.g-file-info-line[property="id"]').before(HashsumDownloadFileInfoWidgetTemplate({
+    this.$('.g-file-info-line[property="id"]').before(template({
         file: this.model,
-        keyfileUrl: keyfileUrl
+        parentItem: this.parentItem,
+        keyfileUrl,
+        AccessType
     }));
 
     this.$('.g-keyfile-download').tooltip();
 
     return this;
 });
+
+if (!FileInfoWidget.prototype.events) {
+    FileInfoWidget.prototype.events = {};
+}
+FileInfoWidget.prototype.events['click .g-hashsum-compute'] = function () {
+    restRequest({
+        path: `file/${this.model.id}/hashsum`,
+        type: 'POST',
+        data: {
+            'progress': true
+        }
+    }).done(resp => {
+        this.model.set(resp);
+        this.render();
+    });
+};


### PR DESCRIPTION
@jamiesnape @jcfr @mgrauer the first commit here demonstrates the basic functionality of async computing hashes on files at upload time. TODO:

- [x] Admin endpoint to compute missing hashes on existing files
- [x] Setting to control this behavior (off by default)
- [x] Tests