### PR TITLE
Fix arguments to Backbone.Collection.reset() during collection fetch

### DIFF
--- a/clients/web/src/collections/Collection.js
+++ b/clients/web/src/collections/Collection.js
@@ -249,7 +249,7 @@ var Collection = Backbone.Collection.extend({
                         if (this.append && !reset) {
                             this.add(finalList);
                         } else {
-                            this.reset(finalList, this.offset);
+                            this.reset(finalList);
                         }
                     }
 

--- a/clients/web/test/spec/collectionBaseClassSpec.js
+++ b/clients/web/test/spec/collectionBaseClassSpec.js
@@ -66,6 +66,30 @@ describe('Test normal collection operation', function () {
         waitsFor(done.check, 'to be done');
     });
 
+    it('ensure collection fetch fires backbone "reset" event with expected options', function () {
+        var done = canary();
+        var collection = new girder.collections.ApiKeyCollection();
+        var previousModels = null;
+
+        // Within a "reset" event, Backbone provides the list of previous models
+        // as options.previousModels.
+        collection.once('reset', function (collection, options) {
+            previousModels = options.previousModels;
+        });
+
+        collection.fetch()
+            .fail(failIfError)
+            .always(done);
+
+        waitsFor(done.check, 'to be done');
+
+        runs(function () {
+            expect(collection.length).toBe(10);
+            expect(Array.isArray(previousModels)).toBe(true);
+            expect(previousModels.length).toBe(0);
+        });
+    });
+
     it('ensure collections can go backwards and forwards', function () {
         var done = canary();
         var collection = new girder.collections.ApiKeyCollection();


### PR DESCRIPTION
The second argument to Backbone.Collection.reset() should be an options object.

Although no explicit errors occurred when using a vanilla collection, passing
the offset instead of an object causes errors when using a collection that has
Backbone.Select [1] mixed in.

[1] https://github.com/hashchange/backbone.select