### PR TITLE
Ignore W503 - line break occurred before a binary operator

### DIFF
--- a/tests/flake8.cfg
+++ b/tests/flake8.cfg
@@ -21,6 +21,7 @@ exclude: girder/external/*
 #            line
 #     E226 - missing whitespace around arithmetic operator
 #     E241 - multiple spaces after ","
+#     W503 - line break occurred before a binary operator
 #
 #   Docstring errors
 #   ~~~~~~~~~~~~~~~~
@@ -53,4 +54,4 @@ exclude: girder/external/*
 #     N803 - Argument name should be lowercase.
 #     N806 - Variable in function should be lowercase.
 #     N812 - Lowercase imported as non lowercase.
-ignore: D100,D101,D102,D103,D104,D105,D200,D201,D202,D203,D204,D205,D400,D401,D402,E123,E226,E241,N802,N803,N806,N812
+ignore: D100,D101,D102,D103,D104,D105,D200,D201,D202,D203,D204,D205,D400,D401,D402,E123,E226,E241,N802,N803,N806,N812,W503


### PR DESCRIPTION
(Follows discussion at https://github.com/DigitalSlideArchive/HistomicsTK/pull/325#issuecomment-298703918)

Add `W503` to the `ignore` list in Girder's `flake8.cfg`. Given changes to PEP8, it ought to be ignored -- cf. https://github.com/PyCQA/pycodestyle/issues/498.