### PR TITLE
Indicate presence of permission flags visually

### DIFF
--- a/clients/web/src/stylesheets/widgets/accessWidget.styl
+++ b/clients/web/src/stylesheets/widgets/accessWidget.styl
@@ -34,7 +34,7 @@ i.g-flag-icon
 .g-flag-count-indicator
   display inline-block
   border-radius 3px
-  background-color rgba(200, 0, 0, 0.75)
+  background-color #c80000
   color white
   position absolute
   font-size 9px

--- a/clients/web/src/stylesheets/widgets/accessWidget.styl
+++ b/clients/web/src/stylesheets/widgets/accessWidget.styl
@@ -28,6 +28,21 @@
   font-weight bold
   padding 3px 10px
 
+i.g-flag-icon
+  position relative
+
+.g-flag-count-indicator
+  display inline-block
+  border-radius 3px
+  background-color rgba(200, 0, 0, 0.75)
+  color white
+  position absolute
+  font-size 9px
+  bottom -4px
+  right -1px
+  padding 0 0.3em
+  font-style normal
+
 .g-ac-list
   border 1px solid #d7d7d7
   border-top none

--- a/clients/web/src/templates/widgets/accessEditorMixins.pug
+++ b/clients/web/src/templates/widgets/accessEditorMixins.pug
@@ -16,8 +16,8 @@ mixin privacyEditor(typeName)
     if _.keys(flagList).length
       a.g-action-manage-public-flags.hide(title="Public access flags")
         i.g-flag-icon.icon-flag
-          if publicFlags
-            .g-flag-count-indicator(class=(publicFlags.length ? null : "hide"))= publicFlags.length
+          - var flagLen = (publicFlags && publicFlags.length) || 0
+          .g-flag-count-indicator(class=(flagLen ? null : "hide"))= flagLen
         |  Manage public access flags...
       .g-public-flags-popover-container.hide
         each flag, key in flagList

--- a/clients/web/src/templates/widgets/accessEditorMixins.pug
+++ b/clients/web/src/templates/widgets/accessEditorMixins.pug
@@ -15,7 +15,9 @@ mixin privacyEditor(typeName)
 
     if _.keys(flagList).length
       a.g-action-manage-public-flags.hide(title="Public access flags")
-        i.icon-flag
+        i.g-flag-icon.icon-flag
+          if publicFlags
+            .g-flag-count-indicator(class=(publicFlags.length ? null : "hide"))= publicFlags.length
         |  Manage public access flags...
       .g-public-flags-popover-container.hide
         each flag, key in flagList

--- a/clients/web/src/templates/widgets/accessEntry.pug
+++ b/clients/web/src/templates/widgets/accessEntry.pug
@@ -15,7 +15,8 @@ div(class=`g-${type}-access-entry`, resourceid=entry.id)
     .g-access-action-container
       if !noAccessFlag && _.keys(flagList).length
         a.g-action-manage-flags(title="Access flags")
-          i.icon-flag
+          i.g-flag-icon.icon-flag
+            .g-flag-count-indicator(class=(entry.flags && entry.flags.length ? null : "hide"))= entry.flags.length
         .g-flags-popover-container.hide(resourcetype=type, resourceid=entry.id, title="Access flags")
           each flag, key in flagList
             - var checked = _.contains(entry.flags, key) ? 'checked' : null;

--- a/clients/web/src/views/widgets/AccessWidget.js
+++ b/clients/web/src/views/widgets/AccessWidget.js
@@ -399,24 +399,37 @@ var AccessWidget = View.extend({
         var el = $(e.currentTarget),
             type = el.attr('resourcetype'),
             id = el.attr('resourceid'),
-            flag = el.attr('flag');
+            flag = el.attr('flag'),
+            container = this.$(`.g-flags-popover-container[resourcetype='${type}'][resourceid='${id}']`);
 
         // Since we clicked in a cloned popover element, we must apply this
         // change within the original element as well.
-        this.$(`.g-flags-popover-container[resourcetype='${type}'][resourceid='${id}']`)
-            .find(`.g-flag-checkbox[flag="${flag}"]`)
+        container.find(`.g-flag-checkbox[flag="${flag}"]`)
             .attr('checked', el.is(':checked') ? 'checked' : null);
+        this._updateFlagCount(container, '.g-flag-checkbox');
     },
 
     _togglePublicAccessFlag: function (e) {
         var el = $(e.currentTarget),
-            flag = el.attr('flag');
+            flag = el.attr('flag'),
+            container = this.$('.g-public-flags-popover-container');
 
         // Since we clicked in a cloned popover element, we must apply this
         // change within the original element as well.
-        this.$('.g-public-flags-popover-container')
-            .find(`.g-public-flag-checkbox[flag="${flag}"]`)
+        container.find(`.g-public-flag-checkbox[flag="${flag}"]`)
             .attr('checked', el.is(':checked') ? 'checked' : null);
+        this._updateFlagCount(container, '.g-public-flag-checkbox');
+    },
+
+    _updateFlagCount: function (container, sel) {
+        const nChecked = container.find(`${sel}[checked="checked"]`).length;
+        const countEl = container.parent().find('.g-flag-count-indicator');
+        countEl.text(nChecked);
+        if (nChecked) {
+            countEl.removeClass('hide');
+        } else {
+            countEl.addClass('hide');
+        }
     }
 });
 

--- a/clients/web/test/spec/customWidgetsSpec.js
+++ b/clients/web/test/spec/customWidgetsSpec.js
@@ -487,8 +487,11 @@
             }, 'public flag popover to display');
 
             runs(function () {
+                var countSel = '.g-action-manage-public-flags .g-flag-count-indicator';
                 // Make sure the public flags popover rendered properly
                 expect($('.popover input.g-public-flag-checkbox').length).toBe(2);
+                expect($(countSel).text()).toBe('0');
+                expect($(countSel).is(':visible')).toBe(false);
 
                 var adminCheckbox = $('.popover input.g-public-flag-checkbox[flag="adminFlag"]');
                 var openCheckbox = $('.popover .g-public-flag-checkbox[flag="openFlag"]');
@@ -501,6 +504,9 @@
 
                 // Enable the open flag and close the popover
                 openCheckbox.click();
+                expect($(countSel).text()).toBe('1');
+                expect($(countSel).is(':visible')).toBe(true);
+
                 $('.popover .g-close-public-flags-popover').click();
             });
 
@@ -517,8 +523,11 @@
             }, 'individual user flag popover to display');
 
             runs(function () {
+                var countSel = '.g-action-manage-flags .g-flag-count-indicator';
                 // Make sure the per-user flag checkbox rendered properly
                 expect($('.popover input.g-flag-checkbox').length).toBe(2);
+                expect($(countSel).text()).toBe('0');
+                expect($(countSel).is(':visible')).toBe(false);
 
                 var adminCheckbox = $('.popover input.g-flag-checkbox[flag="adminFlag"]');
                 var openCheckbox = $('.popover .g-flag-checkbox[flag="openFlag"]');
@@ -530,6 +539,9 @@
                 expect(openCheckbox.is(':disabled')).toBe(false);
 
                 openCheckbox.click();
+
+                expect($(countSel).text()).toBe('1');
+                expect($(countSel).is(':visible')).toBe(true);
                 $('.popover .g-close-flags-popover').click();
             });
 


### PR DESCRIPTION
In the Access editor UI, users would previously have to
open the flags popover to see whether any flags were granted
to a user, group, or the public. Now, the presence of permission
flags is visible right away.

In the below screenshot, there is one public flag enabled, and one enabled for the user zachmullen.

![screen shot 2017-05-04 at 3 39 49 pm](https://cloud.githubusercontent.com/assets/555959/25721883/05fd8ec4-30e0-11e7-8efa-c4b0762eafcf.png)

