### PR TITLE
Fail gracefully if script is missing in phantom env

### DIFF
--- a/clients/web/test/specRunner.js
+++ b/clients/web/test/specRunner.js
@@ -126,6 +126,9 @@ page.onCallback = function (data) {
             break;
         case 'exit':
             // The "Testing Finished" string is magical and causes web_client_test.py not to retry
+            if (data.errorMessage) {
+                console.error(data.errorMessage);
+            }
             console.log('Testing Finished with status=' + data.code);
             phantom.exit(data.code);
     }
@@ -172,6 +175,18 @@ page.onLoadFinished = function (status) {
             if (window.girderTest) {
                 girderTest.promise.then(function () {
                     jasmine.getEnv().execute();
+                }).fail(function (err) {
+                    window.callPhantom({
+                        action: 'exit',
+                        code: 1,
+                        errorMessage: err
+                    });
+                });
+            } else {
+                window.callPhantom({
+                    action: 'exit',
+                    code: 1,
+                    errorMessage: 'Girder test utils not loaded into phantom env.'
                 });
             }
         });

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -630,7 +630,11 @@ girderTest.addScript = function (url) {
     girderTest.promise.then(function () {
         $.getScript(url).done(function () {
             defer.resolve();
+        }).fail(function () {
+            defer.reject('Failed to load script: ' + url);
         });
+    }).fail(function () {
+        defer.reject.apply(defer, arguments);
     });
     girderTest.promise = defer.promise();
 };
@@ -1226,6 +1230,8 @@ girderTest.startApp = function () {
         });
         girder.events.trigger('g:appload.after');
         defer.resolve(app);
+    }).fail(function () {
+        defer.reject.apply(defer, arguments);
     });
     girderTest.promise = defer.promise();
     return girderTest.promise;

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -1226,10 +1226,13 @@ girderTest.startApp = function () {
         girder.events.trigger('g:appload.before');
         var app = new girder.views.App({
             el: 'body',
-            parentView: null
+            parentView: null,
+            start: false
         });
-        girder.events.trigger('g:appload.after');
-        defer.resolve(app);
+        app.start().then(function () {
+            girder.events.trigger('g:appload.after');
+            defer.resolve(app);
+        });
     }).fail(function () {
         defer.reject.apply(defer, arguments);
     });

--- a/tests/web_client_test.py
+++ b/tests/web_client_test.py
@@ -187,7 +187,6 @@ class WebClientTestCase(base.TestCase):
             retry = False
             task = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                     stderr=subprocess.STDOUT)
-            hasJasmine = False
             jasmineFinished = False
             for line in iter(task.stdout.readline, b''):
                 if isinstance(line, six.binary_type):
@@ -202,8 +201,6 @@ class WebClientTestCase(base.TestCase):
                     open('phantom_temp_%s.tmp' % os.environ['GIRDER_PORT'],
                          'wb').write(msg.get_payload(decode=True))
                     continue  # we don't want to print this
-                if 'Jasmine' in line:
-                    hasJasmine = True
                 if 'Testing Finished' in line:
                     jasmineFinished = True
                 try:
@@ -212,10 +209,8 @@ class WebClientTestCase(base.TestCase):
                     sys.stdout.write(repr(line))
                 sys.stdout.flush()
             returncode = task.wait()
-            if not retry and hasJasmine and jasmineFinished:
+            if not retry and jasmineFinished:
                 break
-            if not hasJasmine:
-                time.sleep(1)
             sys.stderr.write('Retrying test\n')
             # If we are retrying, we need to reset the whole test, as the
             # databases and other resources are in an unknown state


### PR DESCRIPTION
Prior to this change, a missing plugin.min.js would cause the
test environment to hang indefinitely. Now, we fail gracefully
with an error message indicating a missing script.

ping @jeffbaumes @zackgalbreath since you both encountered this issue separately.