### PR TITLE
Browser widget usability improvements

### DIFF
--- a/clients/web/src/templates/widgets/browserWidget.pug
+++ b/clients/web/src/templates/widgets/browserWidget.pug
@@ -20,7 +20,7 @@
 
       if preview
         .g-selected-model.g-wait-for-root.form-group.hidden
-          label.control-label(for='g-selected-model') Selected id
+          label.control-label(for='g-selected-model') Selected #{selectItem ? 'item' : 'folder'}
           input#g-selected-model.form-control(type='text', readonly)
 
       .g-validation-failed-message.hidden

--- a/clients/web/src/views/widgets/BrowserWidget.js
+++ b/clients/web/src/views/widgets/BrowserWidget.js
@@ -29,6 +29,7 @@ var BrowserWidget = View.extend({
      * @param {boolean} [showPreview=true] Show a preview of the current object id
      * @param {function} [validate] A validation function returning a string that is displayed on error
      * @param {object} [rootSelectorSettings] Settings passed to the root selector widget
+     * @param {boolean} [showMetadata=false] Show the metadata editor inside the hierarchy widget
      * @param {Model} [root] The default root model to pass to the hierarchy widget
      * @param {boolean} [selectItem=false] Adjust behavior to enable selecting items rather
      *   than folders. This will add a handler to the hierarchy widget responding to
@@ -56,6 +57,7 @@ var BrowserWidget = View.extend({
         this.root = settings.root;
         this.input = settings.input;
         this.selectItem = !!settings.selectItem;
+        this.showMetadata = !!settings.showMetadata;
         this._selected = null;
 
         // generate the root selection view and listen to it's events
@@ -75,7 +77,8 @@ var BrowserWidget = View.extend({
                 help: this.helpText,
                 preview: this.showPreview,
                 submit: this.submitText,
-                input: this.input
+                input: this.input,
+                selectItem: this.selectItem
             })
         ).girderModal(this);
         this._renderRootSelection();
@@ -111,7 +114,8 @@ var BrowserWidget = View.extend({
             routing: false,
             showActions: false,
             showItems: this.showItems,
-            onItemClick: _.bind(this._selectItem, this)
+            onItemClick: _.bind(this._selectItem, this),
+            showMetadata: this.showMetadata
         });
         this.listenTo(this._hierarchyView, 'g:setCurrentModel', this._selectModel);
         this._hierarchyView.setElement(this.$('.g-hierarchy-widget-container')).render();
@@ -125,7 +129,7 @@ var BrowserWidget = View.extend({
         this.$('.g-input-element').removeClass('has-error');
         this.$('#g-selected-model').val('');
         if (this._selected) {
-            this.$('#g-selected-model').val(this._selected.id);
+            this.$('#g-selected-model').val(this._selected.get('name'));
         }
     },
 

--- a/clients/web/test/spec/browserSpec.js
+++ b/clients/web/test/spec/browserSpec.js
@@ -342,6 +342,11 @@ describe('Test the hierarchy browser modal', function () {
                 lastName: 'Doe'
             }));
 
+            var folderModel = new girder.models.FolderModel({
+                _id: '1',
+                name: 'my folder'
+            });
+
             returnVal = [];
             view = new girder.views.widgets.BrowserWidget({
                 parentView: null,
@@ -359,12 +364,16 @@ describe('Test the hierarchy browser modal', function () {
 
             expect(hwSettings.parentModel).toBe(girder.auth.getCurrentUser());
             expect(view.$('g-hierarchy-widget-container').hasClass('hidden')).toBe(false);
-            expect(view.$('#g-selected-model').val()).toBe(girder.auth.getCurrentUser().id);
+            expect(view.$('#g-selected-model').val()).toBe('');
+
+            view._hierarchyView.parentModel = folderModel;
+            view._hierarchyView.trigger('g:setCurrentModel');
+            expect(view.$('#g-selected-model').val()).toBe(folderModel.get('name'));
 
             var ncalls = 0;
             view.on('g:saved', function (model) {
                 ncalls += 1;
-                expect(model.id).toBe(girder.auth.getCurrentUser().id);
+                expect(model.id).toBe(folderModel.id);
             });
 
             waitsFor(function () {
@@ -402,13 +411,18 @@ describe('Test the hierarchy browser modal', function () {
                 }
             }).render();
 
+            var itemModel = new girder.models.ItemModel({
+                _id: '1',
+                name: 'my item'
+            });
+
             waitsFor(function () {
                 return $(view.$el).is(':visible');
             });
             runs(function () {
                 expect(view.selectedModel()).toBe(null);
                 view.$('#g-root-selector').val('0').trigger('change').trigger('select');
-                hwSettings.onItemClick({id: '1'});
+                hwSettings.onItemClick(itemModel);
                 expect(view.selectedModel().id).toBe('1');
             });
         });


### PR DESCRIPTION
This implements a couple of small changes to the browser widget suggested by @mgrauer.

1. It longer shows the metadata editor by default.
2. The "selected id" box now shows the name of the selected document.
