### PR TITLE
Simplify WidgetModel creation and add docstrings

### DIFF
--- a/plugins/item_tasks/plugin_tests/widget.js
+++ b/plugins/item_tasks/plugin_tests/widget.js
@@ -106,7 +106,8 @@ girderTest.promise.then(function () {
         it('boolean', function () {
             var w = new itemTasks.models.WidgetModel({
                 type: 'boolean',
-                title: 'Boolean widget'
+                title: 'Boolean widget',
+                value: false
             });
             expect(w.isNumeric()).toBe(false);
             expect(w.isBoolean()).toBe(true);

--- a/plugins/item_tasks/web_client/models/WidgetModel.js
+++ b/plugins/item_tasks/web_client/models/WidgetModel.js
@@ -4,31 +4,99 @@ import tinycolor from 'tinycolor2';
 
 /**
  * A backbone model controlling the behavior and rendering of widgets.
+ * This model and the corresponding views provide UI elements to
+ * prompt the user for input.  Several different kinds of widgets
+ * are available:
+ *
+ * Primitive types:
+ *   * color:
+ *      a color picker
+ *   * range:
+ *      a slider for choosing a numeric value within some range
+ *   * number:
+ *      an input box that accepts arbitrary numbers
+ *   * boolean:
+ *      a checkbox
+ *   * string:
+ *      an input element that accepts arbitrary strings
+ *   * integer:
+ *      an input box that accepts integers
+ *   * number-vector:
+ *      an input box that accepts a comma seperated list of numbers
+ *   * string-vector:
+ *      an input box that accepts a comma seperated list of strings
+ *   * number-enumeration:
+ *      a select box containing numbers
+ *   * number-enumeration-multiple:
+ *      a multiselect box containing numbers
+ *   * string-enumeration:
+ *      a select box containing strings
+ *   * string-enumeration-multiple:
+ *      a multiselect box containing strings
+ *
+ * Girder models:
+ *   * file:
+ *      an input file (evaluates to an item id)
+ *   * directory:
+ *      an input folder (evaluates to a folder id)
+ *   * new-file:
+ *      an output file (contains an existing folder id and a
+ *      name that will be used for the new item.
+ *   * image:
+ *      an alias for the "file" type that expects the file
+ *      contents is an image (this is not validated)
+ *
+ * @param {object} [attrs]
+ * @param {string} [attrs.type]
+ *   The widget type.  See the list of supported types.
+ *
+ * @param {string} [attrs.title]
+ *   The label of the widget displayed to the user.  Falls back
+ *   to `attrs.name` or `attrs.id` if not provided.
+ *
+ * @param {string} [attrs.description]
+ *   A brief description of the parameter provided to the user.
+ *
+ * @param {object} [attrs.default]
+ *   The fallback value if attrs.value is not set.  Primitive
+ *   types expect this object to contain a "data" key whose
+ *   value is the default.
+ *
+ * @param {*} [attrs.value]
+ *   The current value of the widget.  Watch changes to this
+ *   attribute to respond to user selections.
+ *
+ * @param {array} [attrs.values]
+ *   The set of possible values for an enumerated type.  This
+ *   is used to fill in the options presented in a dropdown box.
+ *
+ * @param {number} [attrs.min]
+ *   The minimum value allowed for a numeric value.
+ *
+ * @param {number} [attrs.max]
+ *   The maximum value allowed for a numeric value.
+ *
+ * @param {number} [attrs.step]
+ *   The resolution of allowed numeric values.  This
+ *   value determines the "ticks" in the number slider.
  */
 var WidgetModel = Backbone.Model.extend({
     /**
      * Sets initial model attributes with normalization.
      */
-    initialize: function (model) {
-        this.set(_.defaults(model || {}, this.defaults));
-    },
+    initialize: function (attrs, options) {
+        attrs = attrs || {};
+        options = options || {};
 
-    defaults: {
-        type: '',          // The specific widget type
-        title: '',         // The label to display with the widget
-        description: '',   // The description to display with the widget
-        value: '',         // The current value of the widget
+        _.defaults(attrs, {
+            title: attrs.name || attrs.id,
+            id: attrs.name,
+            description: '',
+            value: options && options.value,
+            fileName: options && options.fileName
+        });
 
-        values: []         // A list of possible values for enum types
-
-        // optional attributes only used for certain widget types
-        /*
-        parent: {},        // A parent girder model
-        path: [],          // The path of a girder model in a folder hierarchy
-        min: undefined,    // A minimum value
-        max: undefined,    // A maximum value
-        step: 1            // Discrete value intervals
-        */
+        this.set(attrs);
     },
 
     /**

--- a/plugins/item_tasks/web_client/models/WidgetModel.js
+++ b/plugins/item_tasks/web_client/models/WidgetModel.js
@@ -79,22 +79,27 @@ import tinycolor from 'tinycolor2';
  * @param {number} [attrs.step]
  *   The resolution of allowed numeric values.  This
  *   value determines the "ticks" in the number slider.
+ *
+ * @param {string} [attrs.fileName]
+ *   For output files, this is the name used for the new file.
  */
 var WidgetModel = Backbone.Model.extend({
     /**
      * Sets initial model attributes with normalization.
      */
-    initialize: function (attrs, options) {
+    initialize: function (attrs) {
         attrs = attrs || {};
-        options = options || {};
 
         _.defaults(attrs, {
             title: attrs.name || attrs.id,
             id: attrs.name,
-            description: '',
-            value: options && options.value,
-            fileName: options && options.fileName
+            description: ''
         });
+
+        if (!_.has(attrs, 'value') &&
+            _.has(attrs.default || {}, 'data')) {
+            attrs.value = attrs.default.data;
+        }
 
         this.set(attrs);
     },

--- a/plugins/item_tasks/web_client/views/TaskRunView.js
+++ b/plugins/item_tasks/web_client/views/TaskRunView.js
@@ -30,27 +30,12 @@ const TaskRunView = View.extend({
         // Build all the widget models from the task IO spec
         this._inputWidgets.add(this._inputs.map((input) => {
             const info = this._getInputInfo(input, inputs);
-            return new WidgetModel({
-                type: input.type,
-                title: input.name || input.id,
-                id: input.id || input.name,
-                description: input.description || '',
-                values: input.values,
-                value: info.value,
-                fileName: info.fileName
-            });
+            return new WidgetModel(input, info);
         }));
 
         this._outputWidgets.add(this._outputs.map((output) => {
             const info = this._getOutputInfo(output, outputs);
-            return new WidgetModel({
-                type: output.type,
-                title: output.name || output.id,
-                id: output.id || output.name,
-                description: output.description || '',
-                value: info && info.value,
-                fileName: info && info.fileName
-            });
+            return new WidgetModel(output, info);
         }));
 
         this._inputsPanel = new ControlsPanel({


### PR DESCRIPTION
This replaces the logic of setting task inputs and outputs from a previous job with a single function that is more compact and easier to understand.  It also moves the logic for setting default attributes into the widget model.