### PR TITLE
Item tasks demo and tests

### DIFF
--- a/plugins/item_tasks/demo/Dockerfile
+++ b/plugins/item_tasks/demo/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.3
+
+ADD run.sh /run.sh
+ADD demo.json /demo.json
+ENTRYPOINT ["/run.sh"]

--- a/plugins/item_tasks/demo/demo.json
+++ b/plugins/item_tasks/demo/demo.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "item_tasks widget types demo",
-    "description": "A basic demonstration showing how to work with item_tasks control widgets",
+    "description": "A simple demonstration showing how to work with item_tasks control widgets",
     "mode": "docker",
     "pull_image": false,
     "container_args": [

--- a/plugins/item_tasks/demo/demo.json
+++ b/plugins/item_tasks/demo/demo.json
@@ -130,8 +130,8 @@
         }
       }, {
         "id": "file_input",
-        "name": "File input",
-        "description": "Choose an existing file that will be used by the task",
+        "name": "Item input",
+        "description": "Choose an existing item that will be used by the task",
         "type": "file",
         "target": "filepath"
       }
@@ -139,8 +139,8 @@
     "outputs": [
       {
         "id": "file_output",
-        "name": "File output",
-        "description": "Choose a directory and name for a new file",
+        "name": "Item output",
+        "description": "Choose a directory and name for an output item",
         "type": "new-file",
         "target": "filepath"
       }

--- a/plugins/item_tasks/demo/demo.json
+++ b/plugins/item_tasks/demo/demo.json
@@ -1,0 +1,149 @@
+[
+  {
+    "name": "item_tasks widget types demo",
+    "description": "A basic demonstration showing how to work with item_tasks control widgets",
+    "mode": "docker",
+    "pull_image": false,
+    "container_args": [
+      "demo",
+      "$input{color_input}",
+      "$input{range_input}",
+      "$input{number_input}",
+      "$input{boolean_input}",
+      "$input{string_input}",
+      "$input{integer_input}",
+      "$input{number_vector_input}",
+      "$input{string_vector_input}",
+      "$input{number_choice_input}",
+      "$input{string_choice_input}",
+      "$input{number_multi_choice_input}",
+      "$input{string_multi_choice_input}",
+      "$input{file_input}",
+      "/mnt/girder_worker/data/file_output"
+    ],
+    "inputs": [
+      {
+        "id": "color_input",
+        "name": "Color input",
+        "description": "Provide a color value",
+        "type": "color",
+        "default": {
+          "data": "#1234EF"
+        }
+      }, {
+        "id": "range_input",
+        "name": "Slider input",
+        "description": "Provide a number within a range",
+        "type": "range",
+        "default": {
+          "data": 5
+        },
+        "min": 0,
+        "max": 15,
+        "step": 0.1
+      }, {
+        "id": "number_input",
+        "name": "Number input",
+        "description": "Provide a number between 0 and 1",
+        "type": "number",
+        "default": {
+          "data": 0.5
+        },
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }, {
+        "id": "boolean_input",
+        "name": "Boolean input",
+        "description": "Enable or disable a flag",
+        "type": "boolean",
+        "default": {
+          "data": true
+        }
+      }, {
+        "id": "string_input",
+        "name": "String input",
+        "description": "Provide a string value",
+        "type": "string",
+        "default": {
+          "data": "default value"
+        }
+      }, {
+        "id": "integer_input",
+        "name": "Integer input",
+        "description": "Provide an integer",
+        "type": "integer",
+        "default": {
+          "data": 3
+        }
+      }, {
+        "id": "number_vector_input",
+        "name": "Number list input",
+        "description": "Provide a comma-seperated list of numbers",
+        "type": "number-vector",
+        "default": {
+          "data": [1, 2, 3]
+        }
+      }, {
+        "id": "string_vector_input",
+        "name": "String list input",
+        "description": "Provide a comma-seperated list of strings",
+        "type": "string-vector",
+        "default": {
+          "data": ["one", "two", "three"]
+        }
+      }, {
+        "id": "number_choice_input",
+        "name": "Number choice input",
+        "description": "Choose a number",
+        "type": "number-enumeration",
+        "values": [0, 1, 3.14, 2.72, 1.62, 1.41],
+        "default": {
+          "data": 3.14
+        }
+      }, {
+        "id": "string_choice_input",
+        "name": "String choice input",
+        "description": "Choose a string",
+        "type": "string-enumeration",
+        "values": ["red", "green", "blue", "cyan", "yellow", "magenta"],
+        "default": {
+          "data": "green"
+        }
+      }, {
+        "id": "number_multi_choice_input",
+        "name": "Multiple number choice input",
+        "description": "Choose some numbers",
+        "type": "number-enumeration-multiple",
+        "values": [0, 1, 3.14, 2.72, 1.62, 1.41],
+        "default": {
+          "data": [3.14, 1.62]
+        }
+      }, {
+        "id": "string_multi_choice_input",
+        "name": "Multiple string choice input",
+        "description": "Choose some strings",
+        "type": "string-enumeration-multiple",
+        "values": ["red", "green", "blue", "cyan", "yellow", "magenta"],
+        "default": {
+          "data": ["green", "yellow"]
+        }
+      }, {
+        "id": "file_input",
+        "name": "File input",
+        "description": "Choose an existing file that will be used by the task",
+        "type": "file",
+        "target": "filepath"
+      }
+    ],
+    "outputs": [
+      {
+        "id": "file_output",
+        "name": "File output",
+        "description": "Choose a directory and name for a new file",
+        "type": "new-file",
+        "target": "filepath"
+      }
+    ]
+  }
+]

--- a/plugins/item_tasks/demo/run.sh
+++ b/plugins/item_tasks/demo/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if test "$1" = 'demo' ; then
+    eval file=\${$#}
+    for a in "$@" ; do
+	echo "$a"
+	echo "$a" >> "$file"
+    done
+else
+    cat ./demo.json
+fi
+

--- a/plugins/item_tasks/plugin.cmake
+++ b/plugins/item_tasks/plugin.cmake
@@ -14,4 +14,5 @@ add_web_client_test(
     SETUP_MODULES "${CMAKE_CURRENT_LIST_DIR}/plugin_tests/mock_worker.py")
 
 add_eslint_test(${PLUGIN} "${PROJECT_SOURCE_DIR}/plugins/${PLUGIN}/web_client")
+add_eslint_test(${PLUGIN}-tests "${PROJECT_SOURCE_DIR}/plugins/${PLUGIN}/plugin_tests")
 add_puglint_test(${PLUGIN} "${PROJECT_SOURCE_DIR}/plugins/${PLUGIN}/web_client/templates")

--- a/plugins/item_tasks/plugin_tests/tasks.js
+++ b/plugins/item_tasks/plugin_tests/tasks.js
@@ -1,3 +1,5 @@
+/* global girderTest describe it runs waitsFor expect */
+
 girderTest.addCoveredScripts([
     '/clients/web/static/built/plugins/jobs/plugin.min.js',
     '/clients/web/static/built/plugins/worker/plugin.min.js',
@@ -83,7 +85,7 @@ describe('Run the item task', function () {
     it('navigate to task', function () {
         $('.g-nav-link[g-target="item_tasks"]').click();
 
-        waitsFor(function (){
+        waitsFor(function () {
             return $('.g-execute-task-link').length > 0;
         }, 'task list to be rendered');
 
@@ -258,12 +260,11 @@ describe('Auto-configure the JSON item task folder', function () {
     });
 });
 
-
 describe('Navigate to the new JSON task', function () {
     it('navigate to task', function () {
         $('.g-nav-link[g-target="item_tasks"]').click();
 
-        waitsFor(function (){
+        waitsFor(function () {
             return $('.g-execute-task-link').length > 0;
         }, 'task list to be rendered');
 

--- a/plugins/item_tasks/plugin_tests/tasks.js
+++ b/plugins/item_tasks/plugin_tests/tasks.js
@@ -286,3 +286,176 @@ describe('Navigate to the new JSON task', function () {
         });
     });
 });
+
+describe('Auto-configure the demo JSON task', function () {
+    it('go to collection page', function () {
+        $('ul.g-global-nav .g-nav-link[g-target="collections"]').click();
+    });
+
+    it('create collection and folder', girderTest.createCollection('demo task test', '', 'tasks'));
+
+    it('navigate to the folder', function () {
+        runs(function () {
+            $('.g-folder-list-link').click();
+        });
+
+        waitsFor(function () {
+            return $('.g-empty-parent-message:visible').length > 0;
+        }, 'folder empty list to appear');
+    });
+
+    it('run configuration job', function () {
+        $('.g-folder-actions-button').click();
+        $('.g-folder-actions-menu .g-create-docker-tasks').click();
+
+        girderTest.waitForDialog();
+
+        runs(function () {
+            $('.modal-dialog .g-configure-docker-image').val('item-tasks-demo');
+            $('.modal-dialog button.btn.btn-success[type="submit"]').click();
+        });
+
+        waitsFor(function () {
+            return $('.g-job-info-key').length > 0;
+        }, 'navigation to the configuration job');
+
+        waitsFor(function () {
+            return $('.g-job-status-badge').attr('status') === 'success';
+        }, 'job success status', 10000);
+    });
+});
+
+describe('Navigate to the demo task', function () {
+    it('navigate to task', function () {
+        $('.g-nav-link[g-target="item_tasks"]').click();
+
+        waitsFor(function () {
+            return $('.g-execute-task-link').length > 0;
+        }, 'task list to be rendered');
+
+        runs(function () {
+            expect($('.g-execute-task-link').length).toBe(4);
+            expect($('.g-execute-task-link').eq(0).text()).toBe('item_tasks widget types demo');
+            window.location.assign($('a.g-execute-task-link').eq(0).attr('href'));
+        });
+
+        waitsFor(function () {
+            return $('.g-task-description-container').length > 0;
+        }, 'task run view to display');
+
+        runs(function () {
+            expect($('.g-task-description-container').text()).toContain(
+                'A simple demonstration showing how to work with item_tasks control widgets');
+            expect($('.g-inputs-container').length).toBe(1);
+            expect($('.g-outputs-container').length).toBe(1);
+        });
+    });
+
+    it('task defaults', function () {
+        expect($('#color_input').val()).toBe('#1234ef');
+        expect($('#range_input').val()).toBe('5');
+        expect($('#number_input').val()).toBe('0.5');
+        expect($('#boolean_input').prop('checked')).toBe(true);
+        expect($('#string_input').val()).toBe('default value');
+        expect($('#integer_input').val()).toBe('3');
+        expect($('#number_vector_input').val()).toBe('1,2,3');
+        expect($('#string_vector_input').val()).toBe('one,two,three');
+        expect($('#number_choice_input').val()).toBe('3.14');
+        expect($('#string_choice_input').val()).toBe('green');
+        expect($('#number_multi_choice_input').val()).toEqual(['3.14', '1.62']);
+        expect($('#string_multi_choice_input').val()).toEqual(['green', 'yellow']);
+        expect($('#file_input').val()).toBe('');
+        expect($('#file_output').val()).toBe('');
+    });
+
+    it('set inputs and outputs', function () {
+        runs(function () {
+            $('#color_input').val('#b22222').trigger('change');
+            $('#range_input').val('6').trigger('change');
+            $('#number_input').val('1').trigger('change');
+            $('#boolean_input').click();
+            $('#string_input').val('another value').trigger('change');
+            $('#integer_input').val('-4').trigger('change');
+            $('#number_vector_input').val('-1,-2,-3').trigger('change');
+            $('#string_vector_input').val('red,blue,green').trigger('change');
+            $('#number_choice_input').val('1').trigger('change');
+            $('#string_choice_input').val('cyan').trigger('change');
+            $('#number_multi_choice_input').val(['3.14', '1.62']).trigger('change');
+            $('#string_multi_choice_input').val(['green', 'blue']).trigger('change');
+            $('#file_input').parent().find('button').click();
+        });
+
+        girderTest.waitForDialog();
+        runs(function () {
+            // Select our collection for the input item
+            var id = $('.modal-dialog #g-root-selector option[data-group="Collections"]').attr('value');
+            $('.modal-dialog #g-root-selector').val(id).trigger('change');
+        });
+
+        waitsFor(function () {
+            return $('.modal-dialog .g-folder-list-link').text().indexOf('tasks') !== -1;
+        }, 'hierarchy widget to update for input root');
+
+        runs(function () {
+            $('.modal-dialog .g-folder-list-link:first').click();
+        });
+
+        waitsFor(function () {
+            return $('.modal-dialog .g-item-list-link').length > 0;
+        }, 'folder nav in input selection widget');
+
+        runs(function () {
+            expect($('.modal-dialog #g-selected-model').val()).toBe('');
+            $('.modal-dialog .g-item-list-link').click();
+            expect($('.modal-dialog #g-selected-model').val()).not.toBe('');
+            $('.modal-dialog .g-submit-button').click();
+        });
+
+        waitsFor(function () {
+            return $('#g-dialog-container').css('display') === 'none';
+        }, 'modal dialog to disappear');
+
+        runs(function () {
+            // set the output
+            $('#file_output').parent().find('button').click();
+        });
+
+        girderTest.waitForDialog();
+
+        runs(function () {
+            $('#g-input-element').val('output.txt');
+            $('.modal-dialog .g-submit-button').click();
+        });
+
+        waitsFor(function () {
+            return $('#g-dialog-container').css('display') === 'none';
+        }, 'modal dialog to disappear');
+    });
+
+    it('run the task', function () {
+        runs(function () {
+            $('.g-run-task').click();
+        });
+
+        waitsFor(function () {
+            return $('.g-job-status-badge').attr('status') === 'success';
+        }, 'job success status', 10000);
+
+        runs(function () {
+            var args = JSON.parse($('.g-job-log-container').text());
+            expect(args.color_input.data).toBe('#b22222');
+            expect(args.range_input.data).toBe(6);
+            expect(args.number_input.data).toBe(1);
+            expect(args.boolean_input.data).toBe(false);
+            expect(args.integer_input.data).toBe(-4);
+            expect(args.number_vector_input.data).toBe('-1,-2,-3');
+            expect(args.string_vector_input.data).toBe('red,blue,green');
+            expect(args.number_choice_input.data).toBe(1);
+            expect(args.string_choice_input.data).toBe('cyan');
+            expect(args.number_multi_choice_input.data).toBe('3.14,1.62');
+            expect(args.string_multi_choice_input.data).toBe('green,blue');
+            expect(args.file_input.fileName).toBe('item_tasks widget types demo');
+            expect(args.file_input.resource_type).toBe('item');
+        });
+    });
+});

--- a/plugins/item_tasks/plugin_tests/widget.js
+++ b/plugins/item_tasks/plugin_tests/widget.js
@@ -84,8 +84,8 @@ girderTest.promise.then(function () {
             expect(w.isValid()).toBe(false);
 
             w.set('value', '3.5');
-            expect(w.value()).toBe(3);
-            expect(w.isValid()).toBe(true);
+            expect(w.value()).toBe(3.5);
+            expect(w.isValid()).toBe(false);
 
             w.set('value', '-11');
             expect(w.value()).toBe(-11);

--- a/plugins/item_tasks/plugin_tests/widget.js
+++ b/plugins/item_tasks/plugin_tests/widget.js
@@ -95,6 +95,15 @@ girderTest.promise.then(function () {
 
             w.set('value', '8');
             expect(w.isValid()).toBe(true);
+
+            // ensure that minimum values are coerced into integers
+            w = new itemTasks.models.WidgetModel({
+                type: 'integer',
+                title: 'Integer widget',
+                min: 2.5,
+                max: 10
+            });
+            expect(w.get('min')).toBe(3);
         });
         it('float number', function () {
             var w = new itemTasks.models.WidgetModel({

--- a/plugins/item_tasks/plugin_tests/widget.js
+++ b/plugins/item_tasks/plugin_tests/widget.js
@@ -1,3 +1,5 @@
+/* global girder girderTest describe it expect Backbone beforeEach afterEach */
+
 girderTest.addCoveredScripts([
     '/clients/web/static/built/plugins/jobs/plugin.min.js',
     '/clients/web/static/built/plugins/worker/plugin.min.js',

--- a/plugins/item_tasks/web_client/models/WidgetModel.js
+++ b/plugins/item_tasks/web_client/models/WidgetModel.js
@@ -102,7 +102,7 @@ var WidgetModel = Backbone.Model.extend({
         }
 
         /*
-         * Integers are special numeric types where adjecent values differ
+         * Integers are special numeric types where adjacent values differ
          * by exactly 1.  Setting the "step" field to one, ensures that
          * clicking the input element arrows increment or decrement the
          * value by one.

--- a/plugins/item_tasks/web_client/models/WidgetModel.js
+++ b/plugins/item_tasks/web_client/models/WidgetModel.js
@@ -101,6 +101,9 @@ var WidgetModel = Backbone.Model.extend({
             attrs.value = attrs.default.data;
         }
 
+        if (attrs.type === 'integer') {
+            attrs.step = 1;
+        }
         this.set(attrs);
     },
 
@@ -208,8 +211,6 @@ var WidgetModel = Backbone.Model.extend({
         var out;
         if (this.isNumeric()) {
             out = this._validateNumeric(value);
-        } else if (this.isInteger()) {
-            out = this._validateInteger(value);
         }
         if (this.isEnumeration() && !_.contains(this.get('values'), this._normalizeValue(value))) {
             out = 'Invalid value choice';
@@ -270,34 +271,6 @@ var WidgetModel = Backbone.Model.extend({
     },
 
     /**
-     * Validate an integral value.
-     * @param {*} value The value to validate
-     * @returns {undefined|string} An error message or undefined
-     */
-    _validateInteger: function (value) {
-        var min = parseInt(this.get('min'));
-        var max = parseInt(this.get('max'));
-        var step = parseInt(this.get('step'));
-
-        // make sure it is a valid number
-        if (!isFinite(value)) {
-            return `Invalid integer "${value}"`;
-        }
-
-        // make sure it is in valid range
-        if (value < min || value > max) {
-            return `Value out of range [${min}, ${max}]]`;
-        }
-
-        // make sure value is approximately an integer number
-        // of "steps" larger than "min"
-        min = min || 0;
-        if ((value - min) % step) {
-            return `Value does not satisfy step "${step}"`;
-        }
-    },
-
-    /**
      * Validate a widget that selects a girder model.
      * @note This method is synchronous, so it cannot validate
      * the model on the server.
@@ -325,6 +298,7 @@ var WidgetModel = Backbone.Model.extend({
     isNumeric: function () {
         return _.contains([
             'range',
+            'integer',
             'number',
             'number-vector',
             'number-enumeration',

--- a/plugins/item_tasks/web_client/models/WidgetModel.js
+++ b/plugins/item_tasks/web_client/models/WidgetModel.js
@@ -101,8 +101,22 @@ var WidgetModel = Backbone.Model.extend({
             attrs.value = attrs.default.data;
         }
 
+        /*
+         * Integers are special numeric types where adjecent values differ
+         * by exactly 1.  Setting the "step" field to one, ensures that
+         * clicking the input element arrows increment or decrement the
+         * value by one.
+         */
         if (attrs.type === 'integer') {
             attrs.step = 1;
+
+            if (_.has(attrs, 'min')) {
+                /*
+                 * Ensure the minimum value is an integer for correct
+                 * validation and input element behavior.
+                 */
+                attrs.min = Math.ceil(attrs.min);
+            }
         }
         this.set(attrs);
     },

--- a/plugins/item_tasks/web_client/stylesheets/controlWidget.styl
+++ b/plugins/item_tasks/web_client/stylesheets/controlWidget.styl
@@ -1,3 +1,5 @@
+@import '~nib/index.styl'
+
 .g-control-widget-label
   margin-bottom 2px
 
@@ -9,3 +11,6 @@
 .g-control-item
     input.form-control
       height auto
+
+    select
+      appearance none

--- a/plugins/item_tasks/web_client/templates/enumerationMultiWidget.pug
+++ b/plugins/item_tasks/web_client/templates/enumerationMultiWidget.pug
@@ -1,6 +1,6 @@
 extends ./widget.pug
 
 block input
-  select.form-control(id=id, name=title, multiple='multiple', size=10)
+  select.form-control(id=id, name=title, multiple='multiple', size=Math.min(values.length, 10))
     each v in values
       option(selected=value.includes(v))= v

--- a/plugins/item_tasks/web_client/templates/widget.pug
+++ b/plugins/item_tasks/web_client/templates/widget.pug
@@ -1,6 +1,6 @@
 mixin input(title, type, id, value)
   - var inputType = 'text'
-  if type === 'number'
+  if type === 'number' || type === 'integer'
     - inputType = 'number'
   if type.match(/-vector$/)
     - value = value.join(',')

--- a/plugins/item_tasks/web_client/views/ControlWidget.js
+++ b/plugins/item_tasks/web_client/views/ControlWidget.js
@@ -46,6 +46,12 @@ var ControlWidget = View.extend({
         this.$el.html(this.template()(this.model.attributes));
         this.$('.g-control-item[data-type="range"] input').slider();
         this.$('.g-control-item[data-type="color"] .input-group').colorpicker({});
+
+        // work around a problem with the initial position of the tooltip
+        window.setTimeout(
+            () => this.$('.g-control-item[data-type="range"] input').slider('relayout'),
+            0
+        );
         return this;
     },
 

--- a/plugins/item_tasks/web_client/views/TaskRunView.js
+++ b/plugins/item_tasks/web_client/views/TaskRunView.js
@@ -134,7 +134,7 @@ const TaskRunView = View.extend({
         const inputs = {}, outputs = {};
 
         const translate = (model) => {
-            const val = model.value();
+            let val = model.value();
 
             switch (model.get('type')) {
                 case 'image': // This is an input
@@ -159,9 +159,12 @@ const TaskRunView = View.extend({
                         name: model.get('fileName')
                     };
                 default:
+                    if (model.isVector()) {
+                        val = val.join(',');
+                    }
                     return {
                         mode: 'inline',
-                        data: model.value()
+                        data: val
                     };
             }
         };


### PR DESCRIPTION
This adds a new `item_tasks` container that serves to demonstrate the different widgets available.  It is also used to generate an integration test case.  While working on this, I fixed a number of bugs and inconsistencies in the UI:

1. Integer types now display as a numeric input
2. Fixed the height on select boxes so that descending elements in the text is no longer cut off
3. Limiting the size of a multiselect box to the number of values
4. Added linting tests to the item task testing specs
5. Fixed a small offset in the range slider tooltip