### PR TITLE
Update setuptools on circleci to resolve errors

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,7 +22,7 @@ dependencies:
     - ./scripts/install_cmake.sh
     - npm config set progress false
     - npm update; npm prune
-    - set -o pipefail; pyenv exec pip install -U pip | cat
+    - set -o pipefail; pyenv exec pip install -U pip setuptools | cat
     - set -o pipefail; pyenv exec pip install -r requirements-dev.txt -e .[plugins,sftp] -e clients/python | cat
     - pyenv rehash
     - set -o pipefail; pyenv exec girder-install web --all-plugins --dev | cat


### PR DESCRIPTION
Some dependent python package must have been updated today that is incompatible with the version of setuptools installed in the circleci environment.  This results in an error message saying:
```python
Traceback (most recent call last):
  File "/opt/circleci/.pyenv/versions/2.7.11/bin/girder-install", line 5, in <module>
    from pkg_resources import load_entry_point
  File "/opt/circleci/python/2.7.11/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3084, in <module>
    @_call_aside
  File "/opt/circleci/python/2.7.11/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3070, in _call_aside
    f(*args, **kwargs)
  File "/opt/circleci/python/2.7.11/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3097, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/opt/circleci/python/2.7.11/lib/python2.7/site-packages/pkg_resources/__init__.py", line 651, in _build_master
    ws.require(__requires__)
  File "/opt/circleci/python/2.7.11/lib/python2.7/site-packages/pkg_resources/__init__.py", line 952, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/opt/circleci/python/2.7.11/lib/python2.7/site-packages/pkg_resources/__init__.py", line 847, in resolve
    new_requirements = dist.requires(req.extras)[::-1]
  File "/opt/circleci/python/2.7.11/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2602, in requires
    dm = self._dep_map
  File "/opt/circleci/python/2.7.11/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2803, in _dep_map
    self.__dep_map = self._compute_dependencies()
  File "/opt/circleci/python/2.7.11/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2836, in _compute_dependencies
    common = frozenset(reqs_for_extra(None))
  File "/opt/circleci/python/2.7.11/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2833, in reqs_for_extra
    if req.marker_fn(override={'extra':extra}):
  File "/opt/circleci/python/2.7.11/lib/python2.7/site-packages/_markerlib/markers.py", line 113, in marker_fn
    return eval(compiled_marker, environment)
  File "<environment marker>", line 1, in <module>
NameError: name 'platform_system' is not defined
```