### PR TITLE
Fix Bootstrap collapse transitions

### DIFF
--- a/clients/web/src/views/body/SystemConfigurationView.js
+++ b/clients/web/src/views/body/SystemConfigurationView.js
@@ -13,6 +13,7 @@ import 'girder/stylesheets/body/systemConfig.styl';
 
 import 'bootstrap/js/collapse';
 import 'bootstrap/js/tooltip';
+import 'bootstrap/js/transition';
 import 'bootstrap-switch'; // /dist/js/bootstrap-switch.js',
 import 'bootstrap-switch/dist/css/bootstrap3/bootstrap-switch.css';
 

--- a/clients/web/src/views/widgets/GroupMembersWidget.js
+++ b/clients/web/src/views/widgets/GroupMembersWidget.js
@@ -15,6 +15,7 @@ import GroupMemberListTemplate from 'girder/templates/widgets/groupMemberList.pu
 import 'bootstrap/js/collapse';
 import 'bootstrap/js/dropdown';
 import 'bootstrap/js/tooltip';
+import 'bootstrap/js/transition';
 
 import 'girder/utilities/jquery/girderModal';
 

--- a/clients/web/src/views/widgets/NewAssetstoreWidget.js
+++ b/clients/web/src/views/widgets/NewAssetstoreWidget.js
@@ -5,6 +5,7 @@ import { AssetstoreType } from 'girder/constants';
 import NewAssetstoreTemplate from 'girder/templates/widgets/newAssetstore.pug';
 
 import 'bootstrap/js/collapse';
+import 'bootstrap/js/transition';
 
 import 'girder/utilities/jquery/girderEnable';
 


### PR DESCRIPTION
Fix CSS transitions for collapsing panels. Bootstrap Collapse requires the
transitions plugin; see http://getbootstrap.com/javascript/#collapse.