### PR TITLE
Add ansible tests for item_tasks plugin

### DIFF
--- a/plugins/item_tasks/devops/README.md
+++ b/plugins/item_tasks/devops/README.md
@@ -17,7 +17,7 @@ Logs for girder-worker go to /var/log/upstart/girder_worker.log.
  
 # Basic operations
 
-These commands should be run from the same director as this README file,
+These commands should be run from the same directory as this README file,
 where the item_tasks Vagrantfile is located.  If these commands are run
 from a different directory, the wrong Vagrantfile may be used.
 

--- a/plugins/item_tasks/devops/README.md
+++ b/plugins/item_tasks/devops/README.md
@@ -17,6 +17,10 @@ Logs for girder-worker go to /var/log/upstart/girder_worker.log.
  
 # Basic operations
 
+These commands should be run from the same director as this README file,
+where the item_tasks Vagrantfile is located.  If these commands are run
+from a different directory, the wrong Vagrantfile may be used.
+
 ## Create the box for the first time and provision it
 
 `vagrant up`

--- a/plugins/item_tasks/devops/Vagrantfile
+++ b/plugins/item_tasks/devops/Vagrantfile
@@ -8,6 +8,7 @@ Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/trusty64"
   config.vm.network "forwarded_port", guest: 8080, host: 9080
   config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
     vb.name = "it_fullstack_dev"
     vb.customize ["modifyvm", :id, "--memory", 2048]
     vb.customize ["modifyvm", :id, "--cpus", 2]

--- a/plugins/item_tasks/plugin.cmake
+++ b/plugins/item_tasks/plugin.cmake
@@ -15,3 +15,34 @@ add_web_client_test(
 
 add_eslint_test(${PLUGIN} "${PROJECT_SOURCE_DIR}/plugins/${PLUGIN}/web_client")
 add_puglint_test(${PLUGIN} "${PROJECT_SOURCE_DIR}/plugins/${PLUGIN}/web_client/templates")
+
+
+if(ANSIBLE_TESTS)
+  find_program(VAGRANT_EXECUTABLE vagrant)
+
+  add_test(NAME "${PLUGIN}.vagrant_up"
+    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/plugins/${PLUGIN}/devops"
+    COMMAND "${VAGRANT_EXECUTABLE}" "up" "--no-provision")
+  set_tests_properties("${PLUGIN}.vagrant_up" PROPERTIES
+    RUN_SERIAL ON
+    LABELS girder_ansible)
+
+  add_test(NAME "${PLUGIN}.vagrant_provision"
+    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/plugins/${PLUGIN}/devops"
+    COMMAND ${VAGRANT_EXECUTABLE} "provision")
+  set_tests_properties("${PLUGIN}.vagrant_provision"
+    PROPERTIES
+    FAIL_REGULAR_EXPRESSION "VM not created."
+    RUN_SERIAL ON
+    DEPENDS "${PLUGIN}.vagrant_up"
+    LABELS girder_ansible)
+
+  add_test(NAME "${PLUGIN}.vagrant_destroy"
+    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/plugins/${PLUGIN}/devops"
+    COMMAND "${VAGRANT_EXECUTABLE}" "destroy" "-f")
+  set_tests_properties("${PLUGIN}.vagrant_destroy" PROPERTIES
+    DEPENDS "${PLUGIN}.vagrant_up;${PLUGIN}.vagrant_provision"
+    RUN_SERIAL ON
+    FAIL_REGULAR_EXPRESSION "Host file not found;no hosts matched"
+    LABELS girder_ansible)
+endif()


### PR DESCRIPTION
@mgrauer 
This should exercise the ability of vagrant up/provision/destroy the
included Vagrantfile for the item tasks plugin. These tests are only
added if CMake is configured with ANSIBLE_TESTS=ON as they are long running
and shouldn't be run during CI.