### PR TITLE
Wait for bootstrap transitions.

### DIFF
--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -1225,23 +1225,24 @@ $(function () {
 girderTest.startApp = function () {
     var defer = new $.Deferred();
     girderTest.promise.then(function () {
-        /* Track bootstrap transitions using our own test event. */
-        $.support.transition = {end: 'girdertest_transitionend'};
+        /* Track bootstrap transitions.  This is largely a duplicate of the
+         * Bootstrap emulateTransitionEnd function, with the only change being
+         * our tracking of the transition.  This still relies on the browser
+         * possibly firing css transition end events, with this function as a
+         * fail-safe. */
         $.fn.emulateTransitionEnd = function (duration) {
             girder._inTransition = true;
+            var called = false;
             var $el = this;
-            window.setTimeout(function () {
+            $(this).one('bsTransitionEnd', function () { called = true; });
+            var callback = function () {
+                if (!called) {
+                    $($el).trigger($.support.transition.end);
+                }
                 girder._inTransition = false;
-                $($el).trigger($.support.transition.end);
-            }, duration);
+            };
+            setTimeout(callback, duration);
             return this;
-        };
-        $.event.special.bsTransitionEnd = {
-            bindType: $.support.transition.end,
-            delegateType: $.support.transition.end,
-            handle: function (e) {
-                if ($(e.target).is(this)) return e.handleObj.handler.apply(this, arguments);
-            }
         };
 
         girder.events.trigger('g:appload.before');


### PR DESCRIPTION
We use bootstrap transitions on dialogs.  These are meant to trigger the appropriate browser event, which, if it doesn't fire in the expected amount of time, also uses a window timeout as a fallback to trigger the event.

Unfortunately, there isn't currently any official way in Bootstrap 3 to know if you are in a transition state, and some of our tests rely on the previous activities being completed before starting the next activities.   Bootstrap 4 is adding an internal flag to determine if it is in a transition, but it has not been released yet.

This adds our own testing event for transition end, ignoring the browser's css transitionend event.  It allows a flag to specify that we are in a transition, and therefore allows waitForDialog and waitForLoad to detect if we are still in a transition.