### PR TITLE
Pull image option on slicer CLI task config

### DIFF
--- a/plugins/item_tasks/web_client/templates/configureTask.pug
+++ b/plugins/item_tasks/web_client/templates/configureTask.pug
@@ -31,6 +31,10 @@
           label
             input.g-slicer-cli-use-description(type="checkbox", checked=true)
             | Update the description of this item from the CLI description
+        .checkbox
+          label
+            input.g-slicer-cli-pull-image(type="checkbox", checked=true)
+            | Pull image from Docker Hub prior to running
         .g-validation-failed-message
       .modal-footer
         a.btn.btn-default(data-dismiss="modal") Close

--- a/plugins/item_tasks/web_client/views/ConfigureTaskDialog.js
+++ b/plugins/item_tasks/web_client/views/ConfigureTaskDialog.js
@@ -15,7 +15,8 @@ var ConfigureTaskDialog = View.extend({
 
             var data = {
                 setName: this.$('.g-slicer-cli-use-name').is(':checked'),
-                setDescription: this.$('.g-slicer-cli-use-description').is(':checked')
+                setDescription: this.$('.g-slicer-cli-use-description').is(':checked'),
+                pullImage: this.$('.g-slicer-cli-pull-image').is(':checked')
             };
 
             if (image) {


### PR DESCRIPTION
@cdeepakroy PTAL, this allows pulling the image to be optional when configuring a slicer CLI XML item task.

![screen shot 2017-05-16 at 1 29 48 pm](https://cloud.githubusercontent.com/assets/555959/26119645/f604f42a-3a3b-11e7-99c2-e1fa983cdbaf.png)
