### PR TITLE
WIP: Item tasks search and tags

### DIFF
--- a/plugins/item_tasks/server/__init__.py
+++ b/plugins/item_tasks/server/__init__.py
@@ -71,7 +71,10 @@ def load(info):
         constants.TOKEN_SCOPE_AUTO_CREATE_CLI, 'Item task auto-creation',
         'Create new CLIs via automatic introspection.', admin=True)
 
-    ModelImporter.model('item').ensureIndex(['meta.isItemTask', {'sparse': True}])
+    ModelImporter.model('item').ensureIndices([
+        ['meta.isItemTask', {'sparse': True}],
+        ['meta.itemTaskSpec.tags', {'sparse': True}]
+    ])
     ModelImporter.model('item').exposeFields(level=AccessType.READ, fields='createdByJob')
     ModelImporter.model('job', 'jobs').exposeFields(level=AccessType.READ, fields={
         'itemTaskId', 'itemTaskBindings'})

--- a/plugins/item_tasks/server/rest.py
+++ b/plugins/item_tasks/server/rest.py
@@ -19,6 +19,7 @@ class ItemTask(Resource):
         self.resourceName = 'item_task'
 
         self.route('GET', (), self.listTasks)
+        self.route('GET', ('search',), self.search)
         self.route('POST', (':id', 'execution'), self.executeTask)
         self.route('POST', (':id', 'slicer_cli_description'), self.runSlicerCliDescription)
         self.route('PUT', (':id', 'slicer_cli_xml'), self.setSpecFromXml)
@@ -38,6 +39,28 @@ class ItemTask(Resource):
 
         return list(self.model('item').filterResultsByPermission(
             cursor, self.getCurrentUser(), level=AccessType.READ, limit=limit, offset=offset,
+            flags=constants.ACCESS_FLAG_EXECUTE_TASK))
+
+    @access.public
+    @autoDescribeRoute(
+        Description('Search for tasks that can be executed in the system.')
+        .param('q', 'The search query.')
+        .pagingParams(defaultSort=None, defaultLimit=20)
+    )
+    def search(self, q, limit, offset, params):
+        user = self.getCurrentUser()
+        itemModel = self.model('item')
+
+        filters = {
+            'meta.isItemTask': {'$exists': True}
+        }
+
+        cursor = itemModel.textSearch(query=q, filters=filters, user=user)
+
+        # AccessControlledModel.textSearch() already runs filterResultsByPermission(),
+        # but doesn't accept flags. Filter the results again to apply the flags.
+        return list(itemModel.filterResultsByPermission(
+            cursor, user, level=AccessType.READ, limit=limit, offset=offset,
             flags=constants.ACCESS_FLAG_EXECUTE_TASK))
 
     def _validateTask(self, item):

--- a/plugins/item_tasks/web_client/routes.js
+++ b/plugins/item_tasks/web_client/routes.js
@@ -3,12 +3,17 @@ import events from 'girder/events';
 
 import TaskListView from './views/TaskListView';
 import TaskRunView from './views/TaskRunView';
+import TaskListSearchResultsView from './views/TaskListSearchResultsView';
 import ItemModel from 'girder/models/ItemModel';
 import JobModel from 'girder_plugins/jobs/models/JobModel';
 
 router.route('item_tasks', 'itemTaskList', () => {
     events.trigger('g:navigateTo', TaskListView);
     events.trigger('g:highlightItem', 'TasksView');
+});
+
+router.route('item_tasks/search', 'itemTaskSearchResults', (params) => {
+    events.trigger('g:navigateTo', TaskListSearchResultsView, params || {});
 });
 
 router.route('item_task/:id/run', (id, params) => {

--- a/plugins/item_tasks/web_client/routes.js
+++ b/plugins/item_tasks/web_client/routes.js
@@ -4,6 +4,7 @@ import events from 'girder/events';
 import TaskListView from './views/TaskListView';
 import TaskRunView from './views/TaskRunView';
 import TaskListSearchResultsView from './views/TaskListSearchResultsView';
+import TaskListTaggedView from './views/TaskListTaggedView';
 import ItemModel from 'girder/models/ItemModel';
 import JobModel from 'girder_plugins/jobs/models/JobModel';
 
@@ -14,6 +15,10 @@ router.route('item_tasks', 'itemTaskList', () => {
 
 router.route('item_tasks/search', 'itemTaskSearchResults', (params) => {
     events.trigger('g:navigateTo', TaskListSearchResultsView, params || {});
+});
+
+router.route('item_tasks/tagged', 'itemTaskTagged', (params) => {
+    events.trigger('g:navigateTo', TaskListTaggedView, params || {});
 });
 
 router.route('item_task/:id/run', (id, params) => {

--- a/plugins/item_tasks/web_client/stylesheets/taskList.styl
+++ b/plugins/item_tasks/web_client/stylesheets/taskList.styl
@@ -1,6 +1,12 @@
 .g-task-list-header
+  display flex
   margin-bottom 10px
 
   .g-task-pagination
+    user-select none
     ul
       margin 0px
+
+  .g-task-search-form
+    display inline-block
+    margin-left 15px

--- a/plugins/item_tasks/web_client/stylesheets/taskListSearchResults.styl
+++ b/plugins/item_tasks/web_client/stylesheets/taskListSearchResults.styl
@@ -1,0 +1,10 @@
+.g-task-list-search-results-header
+  margin-bottom 10px
+
+  .g-task-pagination
+    user-select none
+    ul
+      margin 0px
+
+.g-task-list-search-results-status
+  margin-bottom 10px

--- a/plugins/item_tasks/web_client/stylesheets/taskListTag.styl
+++ b/plugins/item_tasks/web_client/stylesheets/taskListTag.styl
@@ -1,0 +1,12 @@
+//- Override Bootstrap label styles
+.g-task-list-tag-container
+  .g-task-list-tag
+    font-size 100%
+    font-weight normal
+    color #808080
+    background-color #f4f4f4
+
+    &:focus
+    &:hover
+      color #555
+      background-color #eee

--- a/plugins/item_tasks/web_client/stylesheets/taskListTagged.styl
+++ b/plugins/item_tasks/web_client/stylesheets/taskListTagged.styl
@@ -1,0 +1,10 @@
+.g-task-list-tagged-header
+  margin-bottom 10px
+
+  .g-task-pagination
+    user-select none
+    ul
+      margin 0px
+
+.g-task-list-tagged-status
+  margin-bottom 10px

--- a/plugins/item_tasks/web_client/stylesheets/taskListWidget.styl
+++ b/plugins/item_tasks/web_client/stylesheets/taskListWidget.styl
@@ -1,0 +1,10 @@
+.g-task-list-task-items
+  .g-task-list-tag-container
+    margin-top 5px
+
+  .g-task-list-task-items-footer
+    padding 5px 15px
+    font-size 12px
+    color #aaa
+    background-color #fff
+    user-select none

--- a/plugins/item_tasks/web_client/templates/taskList.pug
+++ b/plugins/item_tasks/web_client/templates/taskList.pug
@@ -1,8 +1,11 @@
 .g-task-list-header
   .g-task-pagination
+  form.form-inline.g-task-search-form(role="form")
+    .form-group.g-task-search-container
+      input.form-control.input-sm.g-task-search-field(type="text", placeholder="Search tasks...")
 
-.list-group.g-task-list-container
-  each task in tasks
-    a.list-group-item.g-execute-task-link(href=`#item_task/${task.id}/run`)
-      h4.list-group-item-heading.g-execute-task-link-header= task.name()
-      .list-group-item-text.g-execute-task-link-body= task.get('description')
+.g-task-list-widget-container
+
+if collection.isEmpty()
+  i.icon-attention
+  |  No tasks are available.

--- a/plugins/item_tasks/web_client/templates/taskListSearchResults.pug
+++ b/plugins/item_tasks/web_client/templates/taskListSearchResults.pug
@@ -1,0 +1,12 @@
+.g-task-list-search-results-header
+  .g-task-pagination
+
+.g-task-list-search-results-status
+  if !collection.isEmpty()
+    i.icon-search
+    |  Search results for tasks containing "#{query}"
+  else
+    i.icon-attention
+    |  No tasks matching your search term were found.
+
+.g-task-list-widget-container

--- a/plugins/item_tasks/web_client/templates/taskListTagged.pug
+++ b/plugins/item_tasks/web_client/templates/taskListTagged.pug
@@ -1,0 +1,16 @@
+.g-task-list-tagged-header
+  .g-task-pagination
+
+.g-task-list-tagged-status
+  if !collection.isEmpty()
+    i.icon-tags
+    |  Tasks tagged with&nbsp;
+    span.g-task-list-tag-container
+      each tag in tags
+        a.label.label-default.g-task-list-tag(href=`#item_tasks/tagged?tags=${tag}`)= tag
+        | &#x20;
+  else
+    i.icon-attention
+    |  No tasks with all of the specified tags were found.
+
+.g-task-list-widget-container

--- a/plugins/item_tasks/web_client/templates/taskListWidget.pug
+++ b/plugins/item_tasks/web_client/templates/taskListWidget.pug
@@ -1,0 +1,15 @@
+if !collection.isEmpty()
+  .panel.panel-default.g-task-list-task-items
+    ul.list-group
+      each task in collection.models
+        li.list-group-item.g-execute-task-link
+          h4.list-group-item-heading.g-execute-task-link-header
+            a(href=`#item_task/${task.id}/run`)= task.name()
+          .list-group-item-text.g-execute-task-link-body= task.get('description')
+    if collection.hasNextPage()
+      .panel-footer.g-task-list-task-items-footer
+        a.g-task-list-task-items-next-page
+          | See next page &raquo;
+    else
+      .panel-footer.g-task-list-task-items-footer
+        | End of list

--- a/plugins/item_tasks/web_client/templates/taskListWidget.pug
+++ b/plugins/item_tasks/web_client/templates/taskListWidget.pug
@@ -2,10 +2,16 @@ if !collection.isEmpty()
   .panel.panel-default.g-task-list-task-items
     ul.list-group
       each task in collection.models
+        - var tags = task.get('meta').itemTaskSpec.tags
         li.list-group-item.g-execute-task-link
           h4.list-group-item-heading.g-execute-task-link-header
             a(href=`#item_task/${task.id}/run`)= task.name()
           .list-group-item-text.g-execute-task-link-body= task.get('description')
+          if tags
+            .g-task-list-tag-container
+              each tag in tags
+                a.label.label-default.g-task-list-tag(href=`#item_tasks/tagged?tags=${tag}`)= tag
+                | &#x20;
     if collection.hasNextPage()
       .panel-footer.g-task-list-task-items-footer
         a.g-task-list-task-items-next-page

--- a/plugins/item_tasks/web_client/views/TaskListSearchResultsView.js
+++ b/plugins/item_tasks/web_client/views/TaskListSearchResultsView.js
@@ -1,30 +1,31 @@
-import router from 'girder/router';
 import View from 'girder/views/View';
 import PaginateWidget from 'girder/views/widgets/PaginateWidget';
 import TaskListWidget from './TaskListWidget';
 import ItemTaskCollection from '../collections/ItemTaskCollection';
 
-import template from '../templates/taskList.pug';
-import '../stylesheets/taskList.styl';
+import template from '../templates/taskListSearchResults.pug';
+import '../stylesheets/taskListSearchResults.styl';
 
 /**
- * View for a list of tasks. The list can be paged through. The user can search
- * for tasks using a search box. Clicking a task's tag shows a list of tasks which
- * have that tag.
+ * View for a list of tasks resulting from a text search. The search results are
+ * ordered by search score and can be paged through.
  */
-var TaskListView = View.extend({
-    events: {
-        'submit .g-task-search-form': function (e) {
-            e.preventDefault();
-            const query = this.$('.g-task-search-field').val().trim();
-            if (query) {
-                router.navigate(`item_tasks/search?q=${query}`, {trigger: true});
-            }
-        }
-    },
+var TaskListSearchResultsView = View.extend({
+    /*
+     * @param {string} settings.q
+     *   The search query.
+     */
+    initialize: function (settings) {
+        this.query = settings.q || null;
 
-    initialize: function () {
         this.collection = new ItemTaskCollection();
+
+        // Set the fetch URL to the search endpoint
+        this.collection.altUrl = 'item_task/search';
+
+        // Clear the comparator to retain the sort order returned by the
+        // search endpoint
+        this.collection.comparator = null;
 
         this.paginateWidget = new PaginateWidget({
             collection: this.collection,
@@ -36,7 +37,11 @@ var TaskListView = View.extend({
             parentView: this
         });
 
-        this.collection.fetch()
+        const params = {
+            q: this.query
+        };
+
+        this.collection.fetch(params)
             .then(() => {
                 this.render();
 
@@ -49,7 +54,8 @@ var TaskListView = View.extend({
 
     render: function () {
         this.$el.html(template({
-            collection: this.collection
+            collection: this.collection,
+            query: this.query
         }));
 
         this.paginateWidget.setElement(this.$('.g-task-pagination')).render();
@@ -59,4 +65,4 @@ var TaskListView = View.extend({
     }
 });
 
-export default TaskListView;
+export default TaskListSearchResultsView;

--- a/plugins/item_tasks/web_client/views/TaskListTaggedView.js
+++ b/plugins/item_tasks/web_client/views/TaskListTaggedView.js
@@ -1,0 +1,62 @@
+import View from 'girder/views/View';
+import PaginateWidget from 'girder/views/widgets/PaginateWidget';
+import TaskListWidget from './TaskListWidget';
+import ItemTaskCollection from '../collections/ItemTaskCollection';
+
+import template from '../templates/taskListTagged.pug';
+import '../stylesheets/taskListTag.styl';
+import '../stylesheets/taskListTagged.styl';
+
+/**
+ * View for a list of tasks which have all of a list of specified tags. The
+ * search results can be paged through.
+ */
+var TaskListTaggedView = View.extend({
+    /*
+     * @param {string} settings.tags
+     *   A semicolon-delimited list of tags.
+     */
+    initialize: function (settings) {
+        this.tags = settings.tags ? settings.tags.split(';') : null;
+
+        this.collection = new ItemTaskCollection();
+
+        this.paginateWidget = new PaginateWidget({
+            collection: this.collection,
+            parentView: this
+        });
+
+        this.taskListWidget = new TaskListWidget({
+            collection: this.collection,
+            parentView: this
+        });
+
+        const params = {
+            tags: JSON.stringify(this.tags)
+        };
+
+        this.collection.fetch(params)
+            .then(() => {
+                this.render();
+
+                // Render PaginateWidget when collection changes
+                this.listenTo(this.collection, 'reset', () => {
+                    this.paginateWidget.render();
+                });
+            });
+    },
+
+    render: function () {
+        this.$el.html(template({
+            collection: this.collection,
+            tags: this.tags
+        }));
+
+        this.paginateWidget.setElement(this.$('.g-task-pagination')).render();
+        this.taskListWidget.setElement(this.$('.g-task-list-widget-container')).render();
+
+        return this;
+    }
+});
+
+export default TaskListTaggedView;

--- a/plugins/item_tasks/web_client/views/TaskListWidget.js
+++ b/plugins/item_tasks/web_client/views/TaskListWidget.js
@@ -1,6 +1,7 @@
 import View from 'girder/views/View';
 
 import template from '../templates/taskListWidget.pug';
+import '../stylesheets/taskListTag.styl';
 import '../stylesheets/taskListWidget.styl';
 
 /**

--- a/plugins/item_tasks/web_client/views/TaskListWidget.js
+++ b/plugins/item_tasks/web_client/views/TaskListWidget.js
@@ -1,0 +1,34 @@
+import View from 'girder/views/View';
+
+import template from '../templates/taskListWidget.pug';
+import '../stylesheets/taskListWidget.styl';
+
+/**
+ * View that displays a list of item tasks.
+ */
+var TaskListWidget = View.extend({
+    events: {
+        'click .g-task-list-task-items-next-page': function (e) {
+            e.preventDefault();
+            this.collection.fetchNextPage();
+        }
+    },
+
+    /**
+     * @param {ItemTaskCollection} settings.collection
+     *   The collection of item tasks.
+     */
+    initialize: function (settings) {
+        this.listenTo(this.collection, 'reset', this.render);
+    },
+
+    render: function () {
+        this.$el.html(template({
+            collection: this.collection
+        }));
+
+        return this;
+    }
+});
+
+export default TaskListWidget;


### PR DESCRIPTION
Supersedes #2000.

Enhancements to item_tasks task list:
- Add search box to search for tasks
  - Search results are displayed in a separate view
- Item tasks support a string array of tags in the `meta.itemTaskSpec.tags` field
  - The task list page shows the tags
  - Clicking a tag navigates to a view that lists all tasks with that tag
  - That view supports filtering by multiple tags, but currently there is no user interface to select multiple tags
  - Future enhancements could include a view listing all tags for tasks executable by the current user

@mgrauer @zachmullen @jeffbaumes Before I continue, please let me know what parts of this look useful.