### PR TITLE
Dynamic linking between dependent plugins

### DIFF
--- a/girder/utility/install.py
+++ b/girder/utility/install.py
@@ -69,7 +69,8 @@ def fix_path(path):
 
 def _getPluginBuildArgs(buildAll, plugins):
     if buildAll:
-        return ['--all-plugins']
+        sortedPlugins = plugin_utilities.getToposortedPlugins()
+        return ['--plugins=%s' % ','.join(sortedPlugins)]
     elif not plugins:  # build only the enabled plugins
         settings = model_importer.ModelImporter().model('setting')
         plugins = settings.get(constants.SettingKey.PLUGINS_ENABLED, default=())

--- a/girder/utility/plugin_utilities.py
+++ b/girder/utility/plugin_utilities.py
@@ -109,11 +109,14 @@ def loadPlugins(plugins, root, appconf, apiRoot=None, buildDag=True):
     return root, appconf, apiRoot
 
 
-def getToposortedPlugins(plugins, ignoreMissing=False, keys=('dependencies',)):
+def getToposortedPlugins(plugins=None, ignoreMissing=False, keys=('dependencies',)):
     """
     Given a set of plugins to load, construct the full DAG of required plugins
     to load and yields them in toposorted order.
 
+    :param plugins: A set of plugins that must be in the output list. If you want
+        to toposort all available plugins, omit this parameter.
+    :type plugins: iterable of str
     :param ignoreMissing: Normally if one of the plugins specified does not exist,
         this raises a ValidationError. Set this to False to suppress that and instead
         print an error message and continue.
@@ -121,11 +124,14 @@ def getToposortedPlugins(plugins, ignoreMissing=False, keys=('dependencies',)):
     :param keys: Keys that should be used to determine dependencies.
     :type keys: list of str
     """
-    plugins = set(plugins)
-
     allPlugins = findAllPlugins()
     dag = {}
     visited = set()
+
+    if plugins is None:
+        plugins = set(allPlugins.keys())
+    else:
+        plugins = set(plugins)
 
     def addDeps(plugin):
         if plugin not in allPlugins:

--- a/grunt_tasks/build.js
+++ b/grunt_tasks/build.js
@@ -96,7 +96,6 @@ module.exports = function (grunt) {
                 },
                 output: {
                     library: '[name]'
-
                 },
                 plugins: [
                     // Remove this if it turns out we don't want to use it for every bundle target.

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -32,8 +32,8 @@ module.exports = function (grunt) {
     var plugins = grunt.option('plugins');
 
     if (grunt.option('all-plugins')) {
-        throw new Error(
-            'The --all-plugins option no longer works, use `girder-install web --all-plugins` instead.')
+        grunt.fail.warn(
+            'The --all-plugins option no longer works, use `girder-install web --all-plugins` instead.');
     }
 
     if (_.isString(plugins) && plugins) {

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -28,7 +28,6 @@ module.exports = function (grunt) {
     var paths = require('./webpack.paths.js');
     var webpackPlugins = require('./webpack.plugins.js');
 
-    var buildAll = grunt.option('all-plugins');
     var configurePlugins = grunt.option('configure-plugins');
     var plugins = grunt.option('plugins');
 
@@ -44,7 +43,7 @@ module.exports = function (grunt) {
         configurePlugins = [];
     }
 
-    if (!buildAll && !plugins.length && !configurePlugins.length) {
+    if (!plugins.length && !configurePlugins.length) {
         return;
     }
 
@@ -442,22 +441,14 @@ module.exports = function (grunt) {
         }
     };
 
-    // Glob for plugins and configure each one to be built
-    if (buildAll) {
-        // Glob for plugins and configure each one to be built
-        grunt.file.expand(grunt.config.get('pluginDir') + '/*').forEach(function (dir) {
-            configurePluginForBuilding(path.resolve(dir), true);
-        });
-    } else {
-        // Configure only the plugins that were requested via --configure-plugins
-        configurePlugins.forEach(function (name) {
-            configurePluginForBuilding(path.resolve(grunt.config.get('pluginDir'), name), false);
-        });
-        // Build only the plugins that were requested via --plugins
-        plugins.forEach(function (name) {
-            configurePluginForBuilding(path.resolve(grunt.config.get('pluginDir'), name), true);
-        });
-    }
+    // Configure the plugins that were requested via --configure-plugins in order
+    configurePlugins.forEach(function (name) {
+        configurePluginForBuilding(path.resolve(grunt.config.get('pluginDir'), name), false);
+    });
+    // Build the plugins that were requested via --plugins in order
+    plugins.forEach(function (name) {
+        configurePluginForBuilding(path.resolve(grunt.config.get('pluginDir'), name), true);
+    });
 
     /**
      * Register a "meta" task that will configure and run other tasks

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -31,6 +31,11 @@ module.exports = function (grunt) {
     var configurePlugins = grunt.option('configure-plugins');
     var plugins = grunt.option('plugins');
 
+    if (grunt.option('all-plugins')) {
+        throw new Error(
+            'The --all-plugins option no longer works, use `girder-install web --all-plugins` instead.')
+    }
+
     if (_.isString(plugins) && plugins) {
         plugins = plugins.split(',');
     } else {

--- a/grunt_tasks/webpack.plugins.js
+++ b/grunt_tasks/webpack.plugins.js
@@ -1,6 +1,7 @@
 /**
  * This file contains custom webpack plugins.
  */
+'use strict';
 
 // This plugin modifies the generated webpack code to execute a module within the DLL bundle
 // in addition to preserving the default behavior of exporting the webpack require function
@@ -12,10 +13,9 @@ class DllBootstrapPlugin {
     apply(compiler) {
         compiler.plugin('compilation', (compilation) => {
             compilation.mainTemplate.plugin('startup', (source, chunk) => {
-                let module;
                 const bootstrapEntry = this.options[chunk.name];
                 if (bootstrapEntry) {
-                    module = chunk.modules.find((m) => m.rawRequest === bootstrapEntry);
+                    const module = chunk.modules.find((m) => m.rawRequest === bootstrapEntry);
                     source = `__webpack_require__(${module.id});\n${source}`;
                 }
                 return source;

--- a/grunt_tasks/webpack.plugins.js
+++ b/grunt_tasks/webpack.plugins.js
@@ -1,0 +1,29 @@
+/**
+ * This file contains custom webpack plugins.
+ */
+
+// This plugin modifies the generated webpack code to execute a module within the DLL bundle
+// in addition to preserving the default behavior of exporting the webpack require function
+class DllBootstrapPlugin {
+    constructor(options) {
+        this.options = options || {};
+    }
+
+    apply(compiler) {
+        compiler.plugin('compilation', (compilation) => {
+            compilation.mainTemplate.plugin('startup', (source, chunk) => {
+                let module;
+                const bootstrapEntry = this.options[chunk.name];
+                if (bootstrapEntry) {
+                    module = chunk.modules.find((m) => m.rawRequest === bootstrapEntry);
+                    source = `__webpack_require__(${module.id});\n${source}`;
+                }
+                return source;
+            });
+        });
+    }
+}
+
+module.exports = {
+    DllBootstrapPlugin
+};

--- a/plugins/item_tasks/plugin.yml
+++ b/plugins/item_tasks/plugin.yml
@@ -2,6 +2,7 @@ name: Item tasks
 description: Allows items in Girder to be used as specifications for tasks to be run on the worker.
 url: http://girder.readthedocs.io/en/latest/plugins.html#item-tasks
 dependencies:
+  - jobs
   - worker
 npm:
   dependencies:

--- a/plugins/item_tasks/web_client/main.js
+++ b/plugins/item_tasks/web_client/main.js
@@ -81,9 +81,9 @@ HierarchyWidget.prototype.events['click .g-create-docker-tasks'] = function () {
 };
 
 // Show task inputs and outputs on job details view
+import JobDetailsWidget from 'girder_plugins/jobs/views/JobDetailsWidget';
 import JobDetailsInfoView from './views/JobDetailsInfoView';
-/* global girder */
-wrap(girder.plugins.jobs.views.JobDetailsWidget, 'render', function (render) {
+wrap(JobDetailsWidget, 'render', function (render) {
     render.call(this);
 
     if (this.job.has('itemTaskBindings')) {

--- a/plugins/worker/web_client/JobStatus.js
+++ b/plugins/worker/web_client/JobStatus.js
@@ -1,9 +1,6 @@
-// Since plugins are not dynamically linked against other plugin libraries,
-// we have to modify the runtime global JobStatus, rather than importing it
-// here statically, which would only modify a local copy.
+import JobStatus from 'girder_plugins/jobs/JobStatus';
 
-/*global girder*/
-girder.plugins.jobs.JobStatus.registerStatus({
+JobStatus.registerStatus({
     WORKER_FETCHING_INPUT: {
         value: 820,
         text: 'Fetching input',


### PR DESCRIPTION
At long last, we have it! If plugin A explicitly lists plugin B in its runtime dependencies, any code imported from plugin B into plugin A will no longer be copied, but shared at runtime. This means you can augment symbols from one plugin inside a downstream plugin, as shown here in the example of modifying the JobStatus object.