### PR TITLE
Ingest item_task Docker images as part of Vagrant VM construction

### DIFF
--- a/plugins/item_tasks/devops/README.md
+++ b/plugins/item_tasks/devops/README.md
@@ -15,8 +15,23 @@ The Girder admin user is girder/girder.
 Logs for Girder go to /var/log/upstart/girder.log.
 Logs for girder-worker go to /var/log/upstart/girder_worker.log.
 
-To ingest dockerhub docker images, set the variable `item_tasks_images` with
+To ingest dockerhub docker images, set the variable `item_tasks_dockerhub_images` with
 a list of dockerhub image paths.
+
+To ingest locally built docker images, set the variable `item_tasks_local_images` with
+a list of local image paths.
+
+As an example of a local docker image, build the Dockerfile in the Vagrant VM
+that is included with the item_tasks plugin.
+
+```
+ssh vagrant
+cd /home/vagrant/girder/plugins/item_tasks/demo
+sudo su worker
+docker build . -t item-tasks-demo:latest
+exit
+exit
+```
  
 # Basic operations
 

--- a/plugins/item_tasks/devops/README.md
+++ b/plugins/item_tasks/devops/README.md
@@ -14,6 +14,9 @@ The Girder admin user is girder/girder.
 
 Logs for Girder go to /var/log/upstart/girder.log.
 Logs for girder-worker go to /var/log/upstart/girder_worker.log.
+
+To ingest dockerhub docker images, set the variable `item_tasks_images` with
+a list of dockerhub image paths.
  
 # Basic operations
 

--- a/plugins/item_tasks/devops/README.md
+++ b/plugins/item_tasks/devops/README.md
@@ -18,21 +18,7 @@ Logs for girder-worker go to /var/log/upstart/girder_worker.log.
 To ingest dockerhub docker images, set the variable `item_tasks_dockerhub_images` with
 a list of dockerhub image paths.
 
-To ingest locally built docker images, set the variable `item_tasks_local_images` with
-a list of local image paths.
 
-As an example of a local docker image, build the Dockerfile in the Vagrant VM
-that is included with the item_tasks plugin.
-
-```
-ssh vagrant
-cd /home/vagrant/girder/plugins/item_tasks/demo
-sudo su worker
-docker build . -t item-tasks-demo:latest
-exit
-exit
-```
- 
 # Basic operations
 
 These commands should be run from the same directory as this README file,

--- a/plugins/item_tasks/devops/playbooks/post-tasks/girder.yml
+++ b/plugins/item_tasks/devops/playbooks/post-tasks/girder.yml
@@ -89,18 +89,42 @@
 - set_fact:
     public_folder_id: "{{ public_folder_ret['gc_return'][0]['_id'] }}"
 
-- name: Load Docker images from DockerHub into item_tasks
+- name: Load DockerHub images into item_tasks
   girder:
     username: "girder"
     password: "girder"
     post:
       path: "item_task/{{public_folder_id}}/json_description"
       parameters:
-        image: "{{item}}"
-  with_items: "{{item_tasks_images}}"
+        image: "{{ item }}"
+  with_items: "{{item_tasks_dockerhub_images}}"
   register: job_return
 
 - name: Wait for Docker images to be ingested successfully as item_tasks
+  girder:
+    username: 'girder'
+    password: 'girder'
+    get:
+      path: "job/{{ item['gc_return']['_id'] }}"
+  register: job_result
+  until: job_result['gc_return']['status'] == 3
+  retries: 5
+  delay: 10
+  with_items: "{{ job_return['results'] }}"
+
+- name: Load local images into item_tasks
+  girder:
+    username: "girder"
+    password: "girder"
+    post:
+      path: "item_task/{{public_folder_id}}/json_description"
+      parameters:
+        image: "{{ item }}"
+        pullImage: "false"
+  with_items: "{{item_tasks_local_images}}"
+  register: job_return
+
+- name: Wait for local images to be ingested successfully as item_tasks
   girder:
     username: 'girder'
     password: 'girder'

--- a/plugins/item_tasks/devops/playbooks/post-tasks/girder.yml
+++ b/plugins/item_tasks/devops/playbooks/post-tasks/girder.yml
@@ -94,10 +94,10 @@
     username: "girder"
     password: "girder"
     post:
-      path: "item_task/{{public_folder_id}}/json_description"
+      path: "item_task/{{ public_folder_id }}/json_description"
       parameters:
         image: "{{ item }}"
-  with_items: "{{item_tasks_dockerhub_images}}"
+  with_items: "{{ item_tasks_dockerhub_images }}"
   register: job_return
 
 - name: Wait for Dockerhub images to be ingested successfully as item_tasks
@@ -107,6 +107,7 @@
     get:
       path: "job/{{ item['gc_return']['_id'] }}"
   register: job_result
+  when: job_return
   until: job_result['gc_return']['status'] == 3
   retries: 5
   delay: 10

--- a/plugins/item_tasks/devops/playbooks/post-tasks/girder.yml
+++ b/plugins/item_tasks/devops/playbooks/post-tasks/girder.yml
@@ -100,31 +100,7 @@
   with_items: "{{item_tasks_dockerhub_images}}"
   register: job_return
 
-- name: Wait for Docker images to be ingested successfully as item_tasks
-  girder:
-    username: 'girder'
-    password: 'girder'
-    get:
-      path: "job/{{ item['gc_return']['_id'] }}"
-  register: job_result
-  until: job_result['gc_return']['status'] == 3
-  retries: 5
-  delay: 10
-  with_items: "{{ job_return['results'] }}"
-
-- name: Load local images into item_tasks
-  girder:
-    username: "girder"
-    password: "girder"
-    post:
-      path: "item_task/{{public_folder_id}}/json_description"
-      parameters:
-        image: "{{ item }}"
-        pullImage: "false"
-  with_items: "{{item_tasks_local_images}}"
-  register: job_return
-
-- name: Wait for local images to be ingested successfully as item_tasks
+- name: Wait for Dockerhub images to be ingested successfully as item_tasks
   girder:
     username: 'girder'
     password: 'girder'

--- a/plugins/item_tasks/devops/playbooks/post-tasks/girder.yml
+++ b/plugins/item_tasks/devops/playbooks/post-tasks/girder.yml
@@ -65,3 +65,49 @@
       root: "{{ ansible_user_dir }}/assetstore"
       current: true
     state: present
+
+- name: Get Me
+  girder:
+    username: "girder"
+    password: "girder"
+    get:
+      path: "user/me"
+  register: token_ret
+
+- name: Get my public folder
+  girder:
+    username: "girder"
+    password: "girder"
+    get:
+      path: "folder"
+      parameters:
+        parentType: "user"
+        parentId: "{{ token_ret['gc_return']['_id'] }}"
+        text: "Public"
+  register: public_folder_ret
+
+- set_fact:
+    public_folder_id: "{{ public_folder_ret['gc_return'][0]['_id'] }}"
+
+- name: Load Docker images from DockerHub into item_tasks
+  girder:
+    username: "girder"
+    password: "girder"
+    post:
+      path: "item_task/{{public_folder_id}}/json_description"
+      parameters:
+        image: "{{item}}"
+  with_items: "{{item_tasks_images}}"
+  register: job_return
+
+- name: Wait for Docker images to be ingested successfully as item_tasks
+  girder:
+    username: 'girder'
+    password: 'girder'
+    get:
+      path: "job/{{ item['gc_return']['_id'] }}"
+  register: job_result
+  until: job_result['gc_return']['status'] == 3
+  retries: 5
+  delay: 10
+  with_items: "{{ job_return['results'] }}"

--- a/plugins/item_tasks/devops/playbooks/site.yml
+++ b/plugins/item_tasks/devops/playbooks/site.yml
@@ -15,6 +15,9 @@
       - docker
       - girder_io
 
+    # Images to pull/import into item_tasks (from Dockerhub)
+    item_tasks_dockerhub_images: []
+
   pre_tasks:
 
     - name: Update package cache

--- a/plugins/item_tasks/devops/playbooks/site.yml
+++ b/plugins/item_tasks/devops/playbooks/site.yml
@@ -1,7 +1,7 @@
 - hosts: all
 
   vars:
-    girder_update: no
+    girder_update: yes
     girder_force: no
     girder_virtualenv: "{{ ansible_user_dir }}/.virtualenvs/girder"
     girder_enabled_plugins:


### PR DESCRIPTION
This adds to the item_tasks Vagrant/Ansible to ingest Docker images as part of the construction of the VM, then waits for those Docker images to be fully ingested.  At the current time it is not working for local Docker images, but does work for images on DockerHub.

To test this, after following the instructions in the README on this branch to build the local demo Docker image on the VM, you can add the following variables to the site.yml near the top where other girder and girder_worker vars are set.

```
    item_tasks_local_images:
      - item-tasks-demo
    item_tasks_dockerhub_images:
      - kitware/pysciencedock
```