### PR TITLE
Prevent deleting a file that is being uploaded.

### DIFF
--- a/girder/models/upload.py
+++ b/girder/models/upload.py
@@ -37,6 +37,7 @@ class Upload(Model):
     """
     def initialize(self):
         self.name = 'upload'
+        self.ensureIndices(['sha512'])
 
     def _getChunkSize(self, minSize=32 * 1024**2):
         """

--- a/girder/models/upload.py
+++ b/girder/models/upload.py
@@ -37,7 +37,7 @@ class Upload(Model):
     """
     def initialize(self):
         self.name = 'upload'
-        self.ensureIndices(['sha512'])
+        self.ensureIndex('sha512')
 
     def _getChunkSize(self, minSize=32 * 1024**2):
         """

--- a/girder/utility/filesystem_assetstore_adapter.py
+++ b/girder/utility/filesystem_assetstore_adapter.py
@@ -109,7 +109,6 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
         self.tempDir = os.path.join(self.assetstore['root'], 'temp')
         # Use a filelock at the root level of the assetstore; this should work
         # between multiple servers.
-        self.deleteLock = filelock.FileLock(os.path.join(self.assetstore['root'], '_deleteLock'))
         try:
             mkdir(self.tempDir)
         except OSError:
@@ -230,7 +229,7 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
         # Only maintain the lock which checking if the file exists.  The only
         # other place the lock is used is checking if an upload task has
         # reserved the file, so this is sufficient.
-        with self.deleteLock:
+        with filelock.FileLock(abspath + '.deleteLock'):
             pathExists = os.path.exists(abspath)
         if pathExists:
             # Already have this file stored, just delete temp file.
@@ -317,7 +316,7 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
         if matching.count(True) == 1:
             path = os.path.join(self.assetstore['root'], file['path'])
             if os.path.isfile(path):
-                with self.deleteLock:
+                with filelock.FileLock(path + '.deleteLock'):
                     if self.model('upload').findOne(q) is None:
                         try:
                             os.unlink(path)

--- a/girder/utility/filesystem_assetstore_adapter.py
+++ b/girder/utility/filesystem_assetstore_adapter.py
@@ -303,7 +303,7 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
         Deletes the file from disk if it is the only File in this assetstore
         with the given sha512. Imported files are not actually deleted.
         """
-        if file.get('imported'):
+        if file.get('imported') or 'path' not in file:
             return
 
         q = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ bcrypt==2.0.0
 boto==2.40.0
 cffi==1.8.3
 CherryPy==6.0.1
+filelock==2.0.8
 functools32==3.2.3.post2; python_version <= '2.7'
 jsonschema==2.6.0
 Mako==1.0.4

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ install_reqs = [
     'bcrypt',
     'boto',
     'CherryPy',
+    'filelock',
     'jsonschema',
     'Mako',
     'pymongo>=3',


### PR DESCRIPTION
If an upload occurs where the file has the same hash as an existing file, we don't duplicate the file.  There was a window of time where if a delete occurred during the upload, we would detect that the file already existed, but then allow the delete to occur.  This fixes this by checking to see if there are any pending uploads with the file and using a lock to ensure that the check and deletes cannot conflict with one another.

This fixes issue #1999.