### PR TITLE
Upgrade dicom_viewer dependency to vtk.js 2.24.1

### DIFF
--- a/plugins/dicom_viewer/plugin.json
+++ b/plugins/dicom_viewer/plugin.json
@@ -6,8 +6,8 @@
     "npm": {
         "dependencies": {
             "daikon": "^1.2.15",
-            "kw-web-suite": "^2.0.1",
-            "vtk.js": "2.18.5"
+            "shader-loader": "1.3.0",
+            "vtk.js": "2.24.1"
         }
     }
 }

--- a/plugins/dicom_viewer/webpack.helper.js
+++ b/plugins/dicom_viewer/webpack.helper.js
@@ -10,14 +10,7 @@ module.exports = function (config) {
         loaders: [{
             loader: 'babel-loader',
             query: {
-                presets: ['es2015', 'react']
-            }
-        }, {
-            loader: 'string-replace-loader',
-            query: {
-                multiple: [
-                    {search: /test\.onlyIfWebGL/g, replace: 'test'}
-                ]
+                presets: ['es2015']
             }
         }]
     });


### PR DESCRIPTION
This simplifies our build process and reduces the size of
the plugin, as well as reducing npm install time by removing
the dependency on kw-web-suite.