### PR TITLE
WIP: Improve S3 assetstore error message

### DIFF
--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -152,7 +152,8 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
         else:
             try:
                 bucket = conn.get_bucket(bucket_name=doc['bucket'],
-                                         validate=True)
+                                         validate=False)
+                bucket.get_all_keys(maxkeys=0)
                 testKey = boto.s3.key.Key(
                     bucket=bucket, name='/'.join(
                         filter(None, (doc['prefix'], 'test'))))

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -158,6 +158,7 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
                     bucket=bucket, name='/'.join(
                         filter(None, (doc['prefix'], 'test'))))
                 testKey.set_contents_from_string('')
+                testKey.delete()
             except Exception:
                 logger.exception('S3 assetstore validation exception')
                 raise ValidationException('Unable to write into bucket "%s".' %


### PR DESCRIPTION
This also fixes an issue where we were leaving around a file created by our S3 assetstore initialization code.

To quote the boto docs:
```
If the default ``validate=True`` is passed, a request is made to the
service to ensure the bucket exists. Prior to Boto v2.25.0, this fetched
a list of keys (but with a max limit set to ``0``, always returning an empty
list) in the bucket (& included better error messages), at an
increased expense. As of Boto v2.25.0, this now performs a HEAD request
(less expensive but worse error messages).

If you were relying on parsing the error message before, you should call
something like::

bucket = conn.get_bucket('<bucket_name>', validate=False)
bucket.get_all_keys(maxkeys=0)
```