### PR TITLE
Install necessary libraries for ldap.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -qy software-properties-common python-soft
     git \
     libffi-dev \
     libsasl2-dev \
+    libldap2-dev \
     libpython-dev && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/devops/ansible/roles/girder/tasks/girder.yml
+++ b/devops/ansible/roles/girder/tasks/girder.yml
@@ -14,6 +14,9 @@
     - libjpeg-dev
     - libssl-dev
     - zlib1g-dev
+    # Needed for LDAP plugin
+    - libsasl2-dev
+    - libldap2-dev
   when: ansible_os_family == "Debian"
 
 - name: Install Girder system dependencies
@@ -32,6 +35,7 @@
     - zlib-devel
     - python2-pip
     - python-devel
+    - openldap-devel
   when: ansible_os_family == "RedHat"
 
 - name: Download Girder


### PR DESCRIPTION
Since adding the LDAP plugin, the ansible task fails on standard Ubuntu installations because it is missing appropriate libraries.  This adds them back in.  I've tested it via Vagrant with Ubuntu 14.04 and CentOS 7, and as an ansible role used in another project in Ubuntu 16.04.