### PR TITLE
Use jQuery Deferred and Promise, instead of ES6 Promise

### DIFF
--- a/clients/web/src/server.js
+++ b/clients/web/src/server.js
@@ -1,49 +1,87 @@
+import $ from 'jquery';
+
 import { confirm } from 'girder/dialog';
 import events from 'girder/events';
 import { restRequest } from 'girder/rest';
 
 /**
- * Restart the server, wait until it has restarted, then reload the current
- * page.
+ * Periodically re-run a promise-returning function, until it is fulfilled.
+ * @param func A promise-returning function, taking no arguments.
+ * @param delay A delay, in milliseconds, to wait before re-running a rejected "func".
+ * @returns {$.Promise} A promise, which fulfills with the same values as the fulfilled "func".
+ */
+function _retryUntilFulfilled(func, delay) {
+    const resolution = $.Deferred();
+    const loop = () => {
+        // Run the function
+        func()
+            .done(function () {
+                // If it's fulfilled, then fulfill the resolution with the same values
+                resolution.resolve.apply(resolution, arguments);
+            })
+            .fail(() => {
+                // If it's rejected, check again
+                window.setTimeout(loop, delay);
+            });
+    };
+    loop();
+    return resolution.promise();
+}
+
+/**
+ * Restart the server, wait until it has restarted, then reload the current page.
+ * @returns {$.Promise} A promise which resolves when the server is restarted.
  */
 function restartServer() {
-    function waitForServer() {
-        return new Promise((resolve, reject) => {
-            function wait() {
-                restRequest({
-                    type: 'GET',
-                    path: 'system/version',
-                    error: null
-                }).done(resp => {
-                    if (resp.serverStartDate !== restartServer._lastStartDate) {
-                        resolve();
-                        restartServer._reloadWindow();
-                    } else {
-                        window.setTimeout(wait, 1000);
-                    }
-                }).fail(() => {
-                    window.setTimeout(wait, 1000);
-                });
-            }
-            wait();
-        });
-    }
-
-    return Promise.resolve(restRequest({
+    // Query the server first
+    return restRequest({
         type: 'GET',
         path: 'system/version'
-    }).done(resp => {
-        restartServer._lastStartDate = resp.serverStartDate;
-        restartServer._callSystemRestart();
-        events.trigger('g:alert', {
-            icon: 'cw',
-            text: 'Restarting server',
-            type: 'warning',
-            timeout: 60000
+    })
+        // Restart the server
+        .then((resp) => {
+            // Store the last start date in an attribute, so testing code can mutate it
+            restartServer._lastStartDate = resp.serverStartDate;
+            events.trigger('g:alert', {
+                icon: 'cw',
+                text: 'Restarting server',
+                type: 'warning',
+                timeout: 60000
+            });
+            return restartServer._callSystemRestart();
+        })
+        // Check until the server is restarted
+        .then(() => _retryUntilFulfilled(
+            () => restartServer._checkServer(restartServer._lastStartDate),
+            1000
+        ))
+        // Reload the window after everything completes
+        .done(() => {
+            restartServer._reloadWindow();
         });
-        return waitForServer();
-    }));
 }
+
+/**
+ * Check once whether the server is restarted, returning a promise which reflects the status.
+ * @param {string} lastStartDate A timestamp string with the original start date.
+ * @returns {$.Promise} A promise which resolves or rejects, depending on the restarted state.
+ */
+restartServer._checkServer = function (lastStartDate) {
+    return restRequest({
+        type: 'GET',
+        path: 'system/version',
+        error: null
+    })
+    .then((resp) => {
+        const checkResolution = $.Deferred();
+        if (resp.serverStartDate !== lastStartDate) {
+            checkResolution.resolve();
+        } else {
+            checkResolution.reject();
+        }
+        return checkResolution.promise();
+    });
+};
 
 function restartServerPrompt() {
     confirm({
@@ -60,7 +98,7 @@ function rebuildWebClient() {
 
 /* Having these as object properties facilitates testing */
 restartServer._callSystemRestart = function () {
-    restRequest({type: 'PUT', path: 'system/restart'});
+    return restRequest({type: 'PUT', path: 'system/restart'});
 };
 
 restartServer._reloadWindow = function () {
@@ -68,7 +106,11 @@ restartServer._reloadWindow = function () {
 };
 
 restartServer._rebuildWebClient = function () {
-    return Promise.resolve(restRequest({ path: 'system/web_build', type: 'POST', data: { progress: true } }));
+    return restRequest({
+        path: 'system/web_build',
+        type: 'POST',
+        data: { progress: true }
+    });
 };
 
 export {

--- a/clients/web/src/server.js
+++ b/clients/web/src/server.js
@@ -83,6 +83,18 @@ restartServer._checkServer = function (lastStartDate) {
     });
 };
 
+/* Having these as object properties facilitates testing */
+restartServer._callSystemRestart = function () {
+    return restRequest({
+        type: 'PUT',
+        path: 'system/restart'
+    });
+};
+
+restartServer._reloadWindow = function () {
+    window.location.reload();
+};
+
 function restartServerPrompt() {
     confirm({
         text: 'Are you sure you want to restart the server?  This ' +
@@ -93,19 +105,10 @@ function restartServerPrompt() {
 }
 
 function rebuildWebClient() {
-    return restartServer._rebuildWebClient();
+    return rebuildWebClient._rebuildWebClient();
 }
 
-/* Having these as object properties facilitates testing */
-restartServer._callSystemRestart = function () {
-    return restRequest({type: 'PUT', path: 'system/restart'});
-};
-
-restartServer._reloadWindow = function () {
-    window.location.reload();
-};
-
-restartServer._rebuildWebClient = function () {
+rebuildWebClient._rebuildWebClient = function () {
     return restRequest({
         path: 'system/web_build',
         type: 'POST',

--- a/clients/web/src/views/body/PluginsView.js
+++ b/clients/web/src/views/body/PluginsView.js
@@ -36,18 +36,20 @@ var PluginsView = View.extend({
                 confirmCallback: function () {
                     $(e.currentTarget).girderEnable(false);
                     rebuildWebClient()
-                    .done(() => {
-                        events.trigger('g:alert', {
-                            text: 'Web client code built successfully',
-                            type: 'success',
-                            duration: 3000
-                        });
+                        .then(() => {
+                            events.trigger('g:alert', {
+                                text: 'Web client code built successfully',
+                                type: 'success',
+                                duration: 3000
+                            });
 
-                        restartServer()
-                        .done(() => {
+                            return restartServer();
+                        })
+                        .always(() => {
+                            // Re-enable the button whether the chain succeeds or fails, though if
+                            // it succeeds, the page will probably be refreshed
                             $(e.currentTarget).girderEnable(true);
                         });
-                    });
                 }
             });
         }

--- a/clients/web/src/views/body/PluginsView.js
+++ b/clients/web/src/views/body/PluginsView.js
@@ -35,15 +35,18 @@ var PluginsView = View.extend({
                 yesText: 'Restart',
                 confirmCallback: function () {
                     $(e.currentTarget).girderEnable(false);
-                    rebuildWebClient().then(() => {
+                    rebuildWebClient()
+                    .done(() => {
                         events.trigger('g:alert', {
                             text: 'Web client code built successfully',
                             type: 'success',
                             duration: 3000
                         });
-                        return restartServer();
-                    }).then(() => {
-                        $(e.currentTarget).girderEnable(true);
+
+                        restartServer()
+                        .done(() => {
+                            $(e.currentTarget).girderEnable(true);
+                        });
                     });
                 }
             });

--- a/clients/web/test/spec/adminSpec.js
+++ b/clients/web/test/spec/adminSpec.js
@@ -576,13 +576,16 @@ describe('Test the assetstore page', function () {
 describe('Test the plugins page', function () {
     beforeEach(function () {
         spyOn(girder.server.restartServer, '_callSystemRestart').andCallFake(function () {
+            var restartResolution = $.Deferred();
             window.setTimeout(function () {
                 girder.server.restartServer._lastStartDate = 0;
+                restartResolution.resolve();
             }, 100);
+            return restartResolution.promise();
         });
         // We don't want to really rebuild the web code, so replace the original one with a resolved Promise
         spyOn(girder.server.restartServer, '_rebuildWebClient').andCallFake(function () {
-            return Promise.resolve();
+            return $.Deferred().resolve().promise();
         });
         spyOn(girder.server.restartServer, '_reloadWindow');
     });

--- a/clients/web/test/spec/adminSpec.js
+++ b/clients/web/test/spec/adminSpec.js
@@ -583,11 +583,11 @@ describe('Test the plugins page', function () {
             }, 100);
             return restartResolution.promise();
         });
+        spyOn(girder.server.restartServer, '_reloadWindow');
         // We don't want to really rebuild the web code, so replace the original one with a resolved Promise
-        spyOn(girder.server.restartServer, '_rebuildWebClient').andCallFake(function () {
+        spyOn(girder.server.rebuildWebClient, '_rebuildWebClient').andCallFake(function () {
             return $.Deferred().resolve().promise();
         });
-        spyOn(girder.server.restartServer, '_reloadWindow');
     });
 
     it('Test that anonymous loading plugins page prompts login', function () {

--- a/plugins/jobs/web_client/views/JobListWidget.js
+++ b/plugins/jobs/web_client/views/JobListWidget.js
@@ -236,7 +236,7 @@ var JobListWidget = View.extend({
 
     _jobCreated: function (event) {
         this._fetchWithFilter()
-            .then(() => {
+            .done(() => {
                 this._highlightRecordIfOnList(event.data._id);
             });
     },
@@ -249,25 +249,27 @@ var JobListWidget = View.extend({
     },
 
     _fetchWithFilter() {
-        return new Promise((resolve, reject) => {
-            var filter = {};
-            if (this.userId) {
-                filter.userId = this.userId;
-            }
-            if (this.typeFilter) {
-                filter.types = JSON.stringify(this.typeFilter);
-            }
-            if (this.statusFilter) {
-                filter.statuses = JSON.stringify(this.statusFilter);
-            }
-            this.collection.params = filter;
-            this.collection.fetch({}, true);
-            var callback = () => {
-                this.collection.off('g:changed', callback);
-                resolve();
-            };
-            this.collection.on('g:changed', callback);
-        });
+        const fetchResolution = $.Deferred();
+
+        var filter = {};
+        if (this.userId) {
+            filter.userId = this.userId;
+        }
+        if (this.typeFilter) {
+            filter.types = JSON.stringify(this.typeFilter);
+        }
+        if (this.statusFilter) {
+            filter.statuses = JSON.stringify(this.statusFilter);
+        }
+        this.collection.params = filter;
+        this.collection.fetch({}, true);
+        var callback = () => {
+            this.collection.off('g:changed', callback);
+            fetchResolution.resolve();
+        };
+        this.collection.on('g:changed', callback);
+
+        return fetchResolution.promise();
     }
 });
 

--- a/plugins/jobs/web_client/views/JobListWidget.js
+++ b/plugins/jobs/web_client/views/JobListWidget.js
@@ -249,8 +249,6 @@ var JobListWidget = View.extend({
     },
 
     _fetchWithFilter() {
-        const fetchResolution = $.Deferred();
-
         var filter = {};
         if (this.userId) {
             filter.userId = this.userId;
@@ -262,14 +260,7 @@ var JobListWidget = View.extend({
             filter.statuses = JSON.stringify(this.statusFilter);
         }
         this.collection.params = filter;
-        this.collection.fetch({}, true);
-        var callback = () => {
-            this.collection.off('g:changed', callback);
-            fetchResolution.resolve();
-        };
-        this.collection.on('g:changed', callback);
-
-        return fetchResolution.promise();
+        return this.collection.fetch({}, true);
     }
 });
 


### PR DESCRIPTION
* Use jQuery Deferred and Promise, instead of ES6 Promise, in core
  * The ES6 promises cannot be transpiled by Babel, and requires a polyfill for some browsers (mostly IE) and the test environment. All other web code in Girder uses jQuery promises, which are not interoperable with ES6 promises (particularly in jQuery < v3).
* Reorder and move some private functions to a more logical grouping
* Use jQuery Deferred and Promise, instead of ES6 Promise, in plugins

Updates code written in https://github.com/girder/girder/pull/1844.