### PR TITLE
Ensure galaxy_deploy.sh fetches all git objects

### DIFF
--- a/scripts/galaxy_deploy.sh
+++ b/scripts/galaxy_deploy.sh
@@ -9,6 +9,10 @@ readonly SUBTREE_PREFIX="devops/ansible/roles/girder"
 readonly SUBTREE_DEST_REPO="git@github.com:$ANSIBLE_ROLE_GITHUB_ORG/$ANSIBLE_ROLE_GITHUB_REPO.git"
 readonly SUBTREE_DEST_BRANCH="master"
 
+# Make sure all git objects are accessible
+# This is useful in CI contexts where shallow clones are common
+git fetch --unshallow
+
 # Push any changes that have occurred
 git subtree push --prefix="$SUBTREE_PREFIX" "$SUBTREE_DEST_REPO" "$SUBTREE_DEST_BRANCH"
 


### PR DESCRIPTION
This is necessary because CircleCI does a shallow fetch by default,
which won't always work when subtree pushing elsewhere.

@manthey Take 2