### PR TITLE
Deprecate restRequest.error

### DIFF
--- a/clients/web/src/models/AccessControlledModel.js
+++ b/clients/web/src/models/AccessControlledModel.js
@@ -33,7 +33,7 @@ var AccessControlledModel = Model.extend({
             }, params || {})
         }).done(_.bind(function () {
             this.trigger('g:accessListSaved');
-        }, this)).error(_.bind(function (err) {
+        }, this)).fail(_.bind(function (err) {
             this.trigger('g:error', err);
         }, this));
     },
@@ -62,7 +62,7 @@ var AccessControlledModel = Model.extend({
                 }
                 this.trigger('g:accessFetched');
                 return resp;
-            }, this)).error(_.bind(function (err) {
+            }, this)).fail(_.bind(function (err) {
                 this.trigger('g:error', err);
             }, this));
         } else {

--- a/clients/web/src/models/AssetstoreModel.js
+++ b/clients/web/src/models/AssetstoreModel.js
@@ -26,7 +26,7 @@ var AssetstoreModel = Model.extend({
             error: null
         }).done(_.bind(function (resp) {
             this.trigger('g:imported', resp);
-        }, this)).error(_.bind(function (resp) {
+        }, this)).fail(_.bind(function (resp) {
             this.trigger('g:error', resp);
         }, this));
     },

--- a/clients/web/src/models/CollectionCreationPolicyModel.js
+++ b/clients/web/src/models/CollectionCreationPolicyModel.js
@@ -11,7 +11,7 @@ var CollectionCreationPolicyModel = AccessControlledModel.extend({
             this.set('access', resp);
             this.trigger('g:accessFetched');
             return resp;
-        }).error(err => {
+        }).fail(err => {
             this.trigger('g:error', err);
         });
     }

--- a/clients/web/src/models/FileModel.js
+++ b/clients/web/src/models/FileModel.js
@@ -155,7 +155,7 @@ var FileModel = Model.extend({
                 this.set(upload);
                 this.trigger('g:upload.complete');
             }
-        }, this)).error(_.bind(function (resp) {
+        }, this)).fail(_.bind(function (resp) {
             var text = 'Error: ', identifier;
 
             if (resp.status === 0) {
@@ -192,7 +192,7 @@ var FileModel = Model.extend({
         }).done(_.bind(function (resp) {
             this.startByte = resp.offset;
             this._uploadChunk(this.resumeInfo.file, this.resumeInfo.uploadId);
-        }, this)).error(_.bind(function (resp) {
+        }, this)).fail(_.bind(function (resp) {
             var msg;
 
             if (resp.status === 0) {

--- a/clients/web/src/models/GroupModel.js
+++ b/clients/web/src/models/GroupModel.js
@@ -37,7 +37,7 @@ var GroupModel = AccessControlledModel.extend({
                 }
             }
             this.trigger('g:invited');
-        }, this)).error(_.bind(function (err) {
+        }, this)).fail(_.bind(function (err) {
             this.trigger('g:error', err);
         }, this));
     },
@@ -57,7 +57,7 @@ var GroupModel = AccessControlledModel.extend({
             this.set(resp);
 
             this.trigger('g:joined');
-        }, this)).error(_.bind(function (err) {
+        }, this)).fail(_.bind(function (err) {
             this.trigger('g:error', err);
         }, this));
     },
@@ -75,7 +75,7 @@ var GroupModel = AccessControlledModel.extend({
             this.set(resp);
 
             this.trigger('g:inviteRequested');
-        }, this)).error(_.bind(function (err) {
+        }, this)).fail(_.bind(function (err) {
             this.trigger('g:error', err);
         }, this));
     },
@@ -103,7 +103,7 @@ var GroupModel = AccessControlledModel.extend({
             this.set(resp);
 
             this.trigger('g:promoted');
-        }, this)).error(_.bind(function (err) {
+        }, this)).fail(_.bind(function (err) {
             this.trigger('g:error', err);
         }, this));
     },
@@ -129,7 +129,7 @@ var GroupModel = AccessControlledModel.extend({
             this.set(resp);
 
             this.trigger('g:demoted');
-        }, this)).error(_.bind(function (err) {
+        }, this)).fail(_.bind(function (err) {
             this.trigger('g:error', err);
         }, this));
     },
@@ -153,7 +153,7 @@ var GroupModel = AccessControlledModel.extend({
             this.set(resp);
 
             this.trigger('g:removed');
-        }, this)).error(_.bind(function (err) {
+        }, this)).fail(_.bind(function (err) {
             this.trigger('g:error', err);
         }, this));
     },

--- a/clients/web/src/models/ItemModel.js
+++ b/clients/web/src/models/ItemModel.js
@@ -45,7 +45,7 @@ var ItemModel = Model.extend({
             path: this.resourceName + '/' + this.get('_id') + '/rootpath'
         }).done(_.bind(function (resp) {
             callback(resp);
-        }, this)).error(_.bind(function (err) {
+        }, this)).fail(_.bind(function (err) {
             this.trigger('g:error', err);
         }, this));
     }

--- a/clients/web/src/models/MetadataMixin.js
+++ b/clients/web/src/models/MetadataMixin.js
@@ -17,7 +17,7 @@ var MetadataMixin = {
             if (_.isFunction(successCallback)) {
                 successCallback();
             }
-        }, this)).error(_.bind(function (err) {
+        }, this)).fail(_.bind(function (err) {
             err.message = err.responseJSON.message;
             if (_.isFunction(errorCallback)) {
                 errorCallback(err);
@@ -55,7 +55,7 @@ var MetadataMixin = {
             if (_.isFunction(successCallback)) {
                 successCallback();
             }
-        }).error(err => {
+        }).fail(err => {
             err.message = err.responseJSON.message;
             if (_.isFunction(errorCallback)) {
                 errorCallback(err);

--- a/clients/web/src/models/Model.js
+++ b/clients/web/src/models/Model.js
@@ -71,7 +71,7 @@ var Model = Backbone.Model.extend({
         }).done(_.bind(function (resp) {
             this.set(resp);
             this.trigger('g:saved');
-        }, this)).error(_.bind(function (err) {
+        }, this)).fail(_.bind(function (err) {
             this.trigger('g:error', err);
         }, this));
     },
@@ -110,7 +110,7 @@ var Model = Backbone.Model.extend({
             } else {
                 this.trigger('g:fetched');
             }
-        }).error((err) => {
+        }).fail((err) => {
             this.trigger('g:error', err);
         });
     },
@@ -170,7 +170,7 @@ var Model = Backbone.Model.extend({
                 this.collection.remove(this);
             }
             this.trigger('g:deleted');
-        }, this)).error(_.bind(function (err) {
+        }, this)).fail(_.bind(function (err) {
             this.trigger('g:error', err);
         }, this));
     },

--- a/clients/web/src/models/UserModel.js
+++ b/clients/web/src/models/UserModel.js
@@ -97,7 +97,7 @@ var UserModel = Model.extend({
             error: null
         }).done(_.bind(function () {
             this.trigger('g:passwordChanged');
-        }, this)).error(_.bind(function (err) {
+        }, this)).fail(_.bind(function (err) {
             this.trigger('g:error', err);
         }, this));
     },
@@ -115,7 +115,7 @@ var UserModel = Model.extend({
             error: null
         }).done(_.bind(function () {
             this.trigger('g:passwordChanged');
-        }, this)).error(_.bind(function (err) {
+        }, this)).fail(_.bind(function (err) {
             this.trigger('g:error', err);
         }, this));
     }

--- a/clients/web/src/rest.js
+++ b/clients/web/src/rest.js
@@ -30,7 +30,7 @@ function setStaticRoot(root) {
 /**
  * Make a request to the REST API. Bind a "done" handler to the return
  * value that will be called when the response is successful. To bind a
- * custom error handler, bind an "error" handler to the return promise,
+ * custom error handler, bind a "fail" handler to the return promise,
  * which will be executed in addition to the normal behavior of logging
  * the error to the console. To override the default error handling
  * behavior, pass an "error" key in your opts object; this should be done
@@ -113,7 +113,13 @@ function __restRequest(opts) {
         opts.headers = opts.headers || {};
         opts.headers['Girder-Token'] = token;
     }
-    return Backbone.ajax(opts);
+
+    let jqXHR = Backbone.ajax(opts);
+    jqXHR.error = function () {
+        console.warn('Use of restRequest.error is deprecated, use restRequest.fail instead.');
+        return jqXHR.fail.apply(jqXHR, arguments);
+    };
+    return jqXHR;
 }
 
 /**

--- a/clients/web/src/routes.js
+++ b/clients/web/src/routes.js
@@ -131,7 +131,7 @@ router.route('plugins', 'plugins', function () {
         type: 'GET'
     }).done(_.bind(function (resp) {
         events.trigger('g:navigateTo', PluginsView, resp);
-    }, this)).error(_.bind(function () {
+    }, this)).fail(_.bind(function () {
         events.trigger('g:navigateTo', UsersView);
     }, this));
 });
@@ -169,7 +169,7 @@ router.route('useraccount/:id/token/:token', 'accountToken', function (id, token
             tab: 'password',
             temporary: token
         });
-    }, this)).error(_.bind(function () {
+    }, this)).fail(_.bind(function () {
         router.navigate('users', {trigger: true});
     }, this));
 });
@@ -195,7 +195,7 @@ router.route('useraccount/:id/verification/:token', 'accountVerify', function (i
             type: 'success',
             timeout: 4000
         });
-    }, this)).error(_.bind(function () {
+    }, this)).fail(_.bind(function () {
         events.trigger('g:navigateTo', FrontPageView);
         events.trigger('g:alert', {
             icon: 'cancel',

--- a/clients/web/src/server.js
+++ b/clients/web/src/server.js
@@ -21,7 +21,7 @@ function restartServer() {
                     } else {
                         window.setTimeout(wait, 1000);
                     }
-                }).error(() => {
+                }).fail(() => {
                     window.setTimeout(wait, 1000);
                 });
             }

--- a/clients/web/src/utilities/S3UploadHandler.js
+++ b/clients/web/src/utilities/S3UploadHandler.js
@@ -73,7 +73,7 @@ prototype.execute = function () {
                     error: null
                 }).done(_.bind(function (resp) {
                     this.trigger('g:upload.complete', resp);
-                }, handler)).error(_.bind(function (resp) {
+                }, handler)).fail(_.bind(function (resp) {
                     var msg;
 
                     if (resp.status === 0) {
@@ -125,7 +125,7 @@ prototype.resume = function () {
     }).done(_.bind(function (resp) {
         this.params.upload.s3.request = resp;
         this.execute();
-    }, this)).error(_.bind(function (resp) {
+    }, this)).fail(_.bind(function (resp) {
         var msg;
 
         if (resp.status === 0) {
@@ -239,7 +239,7 @@ prototype._sendNextChunk = function () {
         });
 
         xhr.send(data);
-    }, this)).error(_.bind(function () {
+    }, this)).fail(_.bind(function () {
         this.trigger('g:upload.error', {
             message: 'Error getting signed chunk request from Girder.'
         });
@@ -298,7 +298,7 @@ prototype._finalizeMultiChunkUpload = function () {
         };
 
         xhr.send(new window.XMLSerializer().serializeToString(root));
-    }, this)).error(_.bind(function (resp) {
+    }, this)).fail(_.bind(function (resp) {
         var msg;
 
         if (resp.status === 0) {

--- a/clients/web/src/views/body/SystemConfigurationView.js
+++ b/clients/web/src/views/body/SystemConfigurationView.js
@@ -59,7 +59,7 @@ var SystemConfigurationView = View.extend({
                     type: 'success',
                     timeout: 4000
                 });
-            }, this)).error(_.bind(function (resp) {
+            }, this)).fail(_.bind(function (resp) {
                 this.$('.g-submit-settings').girderEnable(true);
                 this.$('#g-settings-error-message').text(resp.responseJSON.message);
             }, this));

--- a/clients/web/src/views/body/UserAccountView.js
+++ b/clients/web/src/views/body/UserAccountView.js
@@ -183,7 +183,7 @@ var UserAccountView = View.extend({
                 tab: 'password',
                 temporary: token
             });
-        }, this)).error(_.bind(function () {
+        }, this)).fail(_.bind(function () {
             router.navigate('users', {trigger: true});
         }, this));
     }

--- a/clients/web/src/views/layout/LoginView.js
+++ b/clients/web/src/views/layout/LoginView.js
@@ -47,7 +47,7 @@ var LoginView = View.extend({
                 error: null
             }).done(_.bind(function (resp) {
                 this.$('.g-validation-failed-message').html(resp.message);
-            }, this)).error(_.bind(function (err) {
+            }, this)).fail(_.bind(function (err) {
                 this.$('.g-validation-failed-message').html(err.responseJSON.message);
             }, this));
         },

--- a/clients/web/src/views/layout/ResetPasswordView.js
+++ b/clients/web/src/views/layout/ResetPasswordView.js
@@ -31,7 +31,7 @@ var ResetPasswordView = View.extend({
                     text: 'Password reset email sent.',
                     type: 'success'
                 });
-            }, this)).error(_.bind(function (err) {
+            }, this)).fail(_.bind(function (err) {
                 this.$('.g-validation-failed-message').text(err.responseJSON.message);
                 this.$('#g-reset-password-button').girderEnable(true);
             }, this));

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -757,7 +757,7 @@ girderTest.binaryUpload = function (path) {
             }
         }).done(function (resp) {
             file = resp;
-        }).error(function (resp) {
+        }).fail(function (resp) {
             console.log('Could not complete simulated upload of ' + path + ' to ' + folderId);
             console.log(resp.responseJSON.message);
         });

--- a/plugins/autojoin/web_client/views/ConfigView.js
+++ b/plugins/autojoin/web_client/views/ConfigView.js
@@ -121,7 +121,7 @@ var ConfigView = View.extend({
                 type: 'success',
                 timeout: 4000
             });
-        }, this)).error(_.bind(function (resp) {
+        }, this)).fail(_.bind(function (resp) {
             this.$('#g-autojoin-error-message').text(
                 resp.responseJSON.message
             );

--- a/plugins/celery_jobs/web_client/views/ConfigView.js
+++ b/plugins/celery_jobs/web_client/views/ConfigView.js
@@ -87,7 +87,7 @@ var ConfigView = View.extend({
                 type: 'success',
                 timeout: 4000
             });
-        }, this)).error(_.bind(function (resp) {
+        }, this)).fail(_.bind(function (resp) {
             this.$('#g-celery-jobs-error-message').text(
                 resp.responseJSON.message);
         }, this));

--- a/plugins/curation/web_client/views/CurationDialog.js
+++ b/plugins/curation/web_client/views/CurationDialog.js
@@ -118,7 +118,7 @@ var CurationDialog = View.extend({
                 type: 'success',
                 timeout: 4000
             });
-        }, this)).error(_.bind(function (resp) {
+        }, this)).fail(_.bind(function (resp) {
             this.$('#g-curation-error-message').text(
                 resp.responseJSON.message
             );

--- a/plugins/geospatial/web_client/models/ItemModel.js
+++ b/plugins/geospatial/web_client/models/ItemModel.js
@@ -11,7 +11,7 @@ wrap(ItemModel, 'fetch', function (fetch) {
         error: null
     }).done(_.bind(function (resp) {
         this.set(resp);
-    }, this)).error(_.bind(function (err) {
+    }, this)).fail(_.bind(function (err) {
         this.trigger('g:error', err);
     }, this));
     return this;

--- a/plugins/google_analytics/web_client/views/ConfigView.js
+++ b/plugins/google_analytics/web_client/views/ConfigView.js
@@ -64,7 +64,7 @@ var ConfigView = View.extend({
                 type: 'success',
                 timeout: 4000
             });
-        }, this)).error(_.bind(function (resp) {
+        }, this)).fail(_.bind(function (resp) {
             this.$('#g-google_analytics-error-message').text(
                 resp.responseJSON.message
             );

--- a/plugins/gravatar/web_client/views/ConfigView.js
+++ b/plugins/gravatar/web_client/views/ConfigView.js
@@ -64,7 +64,7 @@ var ConfigView = View.extend({
                 type: 'success',
                 timeout: 4000
             });
-        }, this)).error(_.bind(function (resp) {
+        }, this)).fail(_.bind(function (resp) {
             this.$('#g-gravatar-error-message').text(
                 resp.responseJSON.message
             );

--- a/plugins/hashsum_download/web_client/views/ConfigView.js
+++ b/plugins/hashsum_download/web_client/views/ConfigView.js
@@ -61,7 +61,7 @@ var ConfigView = View.extend({
                 type: 'success',
                 timeout: 4000
             });
-        }).error(resp => {
+        }).fail(resp => {
             this.$('#g-hashsum-download-error-message').text(
                 resp.responseJSON.message);
         });

--- a/plugins/hdfs_assetstore/web_client/models/AssetstoreModel.js
+++ b/plugins/hdfs_assetstore/web_client/models/AssetstoreModel.js
@@ -14,7 +14,7 @@ AssetstoreModel.hdfsImport = function (params) {
         error: null
     }).done(_.bind(function () {
         this.trigger('g:imported');
-    }, this)).error(_.bind(function (err) {
+    }, this)).fail(_.bind(function (err) {
         this.trigger('g:error', err);
     }, this));
 

--- a/plugins/homepage/web_client/views/ConfigView.js
+++ b/plugins/homepage/web_client/views/ConfigView.js
@@ -73,7 +73,7 @@ var ConfigView = View.extend({
                 type: 'success',
                 timeout: 4000
             });
-        }, this)).error(_.bind(function (resp) {
+        }, this)).fail(_.bind(function (resp) {
             this.$('#g-homepage-error-message').text(
                 resp.responseJSON.message
             );

--- a/plugins/item_licenses/web_client/views/ConfigView.js
+++ b/plugins/item_licenses/web_client/views/ConfigView.js
@@ -78,7 +78,7 @@ var ConfigView = View.extend({
                 type: 'success',
                 timeout: 3000
             });
-        }, this)).error(_.bind(function (resp) {
+        }, this)).fail(_.bind(function (resp) {
             this.$('#g-item-licenses-error-message').text(
                 resp.responseJSON.message
             );

--- a/plugins/item_previews/web_client/views/ItemPreviewWidget.js
+++ b/plugins/item_previews/web_client/views/ItemPreviewWidget.js
@@ -83,7 +83,7 @@ var ItemPreviewWidget = View.extend({
                 error: null // don't do default error behavior (validation may fail)
             }).done(function (resp) {
                 view.$('.json[data-id="' + id + '"]').text(JSON.stringify(resp, null, '\t'));
-            }).error(function (err) {
+            }).fail(function (err) {
                 console.error('Could not preview item', err);
             });
         });

--- a/plugins/item_tasks/web_client/views/ConfigureTaskDialog.js
+++ b/plugins/item_tasks/web_client/views/ConfigureTaskDialog.js
@@ -33,7 +33,7 @@ var ConfigureTaskDialog = View.extend({
                 error: null
             }).done((job) => {
                 router.navigate(`job/${job._id}`, {trigger: true});
-            }).error((resp) => {
+            }).fail((resp) => {
                 this.$('.g-validation-failed-message').text(resp.responseJSON.message);
             });
         }

--- a/plugins/item_tasks/web_client/views/ConfigureTasksDialog.js
+++ b/plugins/item_tasks/web_client/views/ConfigureTasksDialog.js
@@ -25,7 +25,7 @@ var ConfigureTasksDialog = View.extend({
                 error: null
             }).done((job) => {
                 router.navigate(`job/${job._id}`, {trigger: true});
-            }).error((resp) => {
+            }).fail((resp) => {
                 this.$('.g-validation-failed-message').text(resp.responseJSON.message);
             });
         }

--- a/plugins/item_tasks/web_client/views/TaskRunView.js
+++ b/plugins/item_tasks/web_client/views/TaskRunView.js
@@ -186,7 +186,7 @@ const TaskRunView = View.extend({
             error: null
         }).done((resp) => {
             router.navigate(`job/${resp._id}`, {trigger: true});
-        }).error((resp) => {
+        }).fail((resp) => {
             $(e.currentTarget).girderEnable(true);
             this.$('.g-validation-failed-message').text('Error: ' + resp.responseJSON.message);
         });

--- a/plugins/ldap/web_client/views/ConfigView.js
+++ b/plugins/ldap/web_client/views/ConfigView.js
@@ -121,7 +121,7 @@ var ConfigView = View.extend({
                 type: 'success',
                 timeout: 3000
             });
-        }).error(resp => {
+        }).fail(resp => {
             this.$('.g-validation-failed-message').text(resp.responseJSON.message);
         });
     }

--- a/plugins/oauth/web_client/views/ConfigView.js
+++ b/plugins/oauth/web_client/views/ConfigView.js
@@ -174,7 +174,7 @@ var ConfigView = View.extend({
                 type: 'success',
                 timeout: 3000
             });
-        }, this)).error(_.bind(function (resp) {
+        }, this)).fail(_.bind(function (resp) {
             this.$('#g-oauth-provider-' + providerId + '-error-message').text(
                 resp.responseJSON.message);
         }, this));

--- a/plugins/provenance/web_client/views/ConfigView.js
+++ b/plugins/provenance/web_client/views/ConfigView.js
@@ -63,7 +63,7 @@ var ConfigView = View.extend({
                 type: 'success',
                 timeout: 4000
             });
-        }, this)).error(_.bind(function (resp) {
+        }, this)).fail(_.bind(function (resp) {
             this.$('#g-provenance-error-message').text(
                 resp.responseJSON.message
             );

--- a/plugins/user_quota/web_client/models/extendModel.js
+++ b/plugins/user_quota/web_client/models/extendModel.js
@@ -20,7 +20,7 @@ function extendModel(Model, modelType) {
             }
         }).done(_.bind(function () {
             this.trigger('g:quotaPolicySaved');
-        }, this)).error(_.bind(function (err) {
+        }, this)).fail(_.bind(function (err) {
             this.trigger('g:error', err);
         }, this));
 
@@ -44,7 +44,7 @@ function extendModel(Model, modelType) {
             }).done(_.bind(function (resp) {
                 this.set('quotaPolicy', resp.quota);
                 this.fetch();
-            }, this)).error(_.bind(function (err) {
+            }, this)).fail(_.bind(function (err) {
                 this.trigger('g:error', err);
             }, this));
         } else {

--- a/plugins/user_quota/web_client/views/ConfigView.js
+++ b/plugins/user_quota/web_client/views/ConfigView.js
@@ -87,7 +87,7 @@ var ConfigView = View.extend({
                 type: 'success',
                 timeout: 4000
             });
-        }, this)).error(_.bind(function (resp) {
+        }, this)).fail(_.bind(function (resp) {
             this.$('#g-user-quota-error-message').text(
                 resp.responseJSON.message
             );

--- a/plugins/worker/web_client/views/ConfigView.js
+++ b/plugins/worker/web_client/views/ConfigView.js
@@ -76,7 +76,7 @@ var ConfigView = View.extend({
                 type: 'success',
                 timeout: 4000
             });
-        }, this)).error(_.bind(function (resp) {
+        }, this)).fail(_.bind(function (resp) {
             this.$('#g-worker-settings-error-message').text(
                 resp.responseJSON.message);
         }, this));


### PR DESCRIPTION
* Deprecate restRequest.error
  * This method has been deprecated since jQuery 1.8. Since it's still used frequently in Girder, patch it to issue a warning.
* Remove use of deprecated restRequest.error method