### PR TITLE
Replace deprecated jQuery functions

### DIFF
--- a/clients/web-external/main.js
+++ b/clients/web-external/main.js
@@ -1,4 +1,4 @@
-$(document).ready(function () {
+$(function () {
     girder.apiRoot = '/girder/api/v1';
     girder.router.enabled(false);
 

--- a/clients/web/src/dialog.js
+++ b/clients/web/src/dialog.js
@@ -85,7 +85,7 @@ function confirm(params) {
         el.text(params.text);
     }
 
-    $('#g-confirm-button').unbind('click').click(function () {
+    $('#g-confirm-button').off('click').click(function () {
         $('#g-dialog-container').modal('hide');
         params.confirmCallback();
     });

--- a/clients/web/src/utilities/jquery/girderModal.js
+++ b/clients/web/src/utilities/jquery/girderModal.js
@@ -37,7 +37,7 @@ $.fn.girderModal = function (view) {
         // register the event in .on('shown.bs.modal', cb). Let's show
         // the modal in the next animation frame to fix this behavior for now.
         setTimeout(function () {
-            that.modal().find('[data-dismiss="modal"]').unbind('click').click(function () {
+            that.modal().find('[data-dismiss="modal"]').off('click').click(function () {
                 that.modal('hide');
             });
         }, 0);

--- a/clients/web/test/spec/adminSpec.js
+++ b/clients/web/test/spec/adminSpec.js
@@ -80,7 +80,7 @@ describe('Test the settings page', function () {
         expect($('#g-core-email-from-address').val()).toBe('');
         expect($('#g-core-registration-policy').val()).toBe('open');
         expect($('#g-core-upload-minimum-chunk-size').val()).toBe('');
-        expect($.parseJSON($('#g-core-collection-create-policy').val())).toEqual({
+        expect(JSON.parse($('#g-core-collection-create-policy').val())).toEqual({
             open: false,
             users: [],
             groups: []

--- a/docs/external-web-clients.rst
+++ b/docs/external-web-clients.rst
@@ -95,7 +95,7 @@ application bootstrapping
    var app = new App({start: false});
 
    // start your application after the page loads
-   $(document).ready(function () {
+   $(function () {
       app.start();
    });
 


### PR DESCRIPTION
* Use $(fn) as a document-ready handlers
  * The other forms are deprecated in jQuery 3.
* Replace jQuery .unbind with .off
  * The .unbind method is deprecated in jQuery 3.
* Use JSON.parse instead of $.parseJSON
  * The jQuery method is deprecated in jQuery 3.