### PR TITLE
Don't use $.when to re-wrap promises

### DIFF
--- a/clients/web/src/collections/Collection.js
+++ b/clients/web/src/collections/Collection.js
@@ -164,7 +164,7 @@ var Collection = Backbone.Collection.extend({
                 }, this.params)
             });
 
-            var result = $.when(xhr).then((list) => {
+            var result = xhr.then((list) => {
                 if (this.pageLimit > 0 && list.length > this.pageLimit) {
                     // This means we have more pages to display still. Pop off
                     // the extra that we fetched.

--- a/clients/web/test/spec/collectionBaseClassSpec.js
+++ b/clients/web/test/spec/collectionBaseClassSpec.js
@@ -97,7 +97,7 @@ describe('Test normal collection operation', function () {
         collection.pageLimit = 2;
         collection.append = false;
 
-        $.when(collection.fetchNextPage()).then(function () {
+        collection.fetchNextPage().then(function () {
             expect(collection.length).toBe(2);
             expect(collection.at(0).get('name')).toBe('test0');
             expect(collection.at(1).get('name')).toBe('test1');
@@ -240,7 +240,7 @@ describe('Test collection filtering', function () {
             return match;
         };
 
-        $.when(collection.fetch()).then(function () {
+        collection.fetch().then(function () {
             expect(collection.length).toBe(5);
         }).fail(failIfError).always(done);
 
@@ -272,7 +272,7 @@ describe('Test collection filtering', function () {
          *     had not yet been included
          */
         collection.pageLimit = 5;
-        $.when(collection.fetch()).then(function () {
+        collection.fetch().then(function () {
             expect(collection.length).toBe(5);
             expect(collection.at(0).get('name')).toBe('filterTest0');
             expect(collection.at(1).get('name')).toBe('filterTest1');
@@ -302,7 +302,7 @@ describe('Test collection filtering', function () {
         collection.pageLimit = 2;
         collection.append = false;
 
-        $.when(collection.fetchNextPage()).then(function () {
+        collection.fetchNextPage().then(function () {
             expect(collection.length).toBe(2);
             expect(collection.at(0).get('name')).toBe('filterTest0');
             expect(collection.at(1).get('name')).toBe('filterTest1');


### PR DESCRIPTION
This is redundant.

Given that the multi-argument version of `$.then` has different behavior, `$.when` should not be used with a single argument.