### PR TITLE
Allow usage of a complete URL for static root

### DIFF
--- a/girder/utility/server.py
+++ b/girder/utility/server.py
@@ -22,6 +22,7 @@ import functools
 import mako
 import mimetypes
 import os
+import posixpath
 import six
 
 import girder.events
@@ -65,11 +66,12 @@ def _configureStaticRoutes(webroot, plugins, event=None):
         # relpath to behave as expected.  We always expect the api_root to
         # contain at least two components, but the reference from static needs to
         # be from only the first component.
-        apiRootBase = os.path.split(os.path.join('/', config.getConfig()['server']['api_root']))[0]
-        apiStaticRoot = os.path.relpath(routeTable[constants.GIRDER_STATIC_ROUTE_ID],
-                                        apiRootBase)
-        staticRoot = os.path.relpath(routeTable[constants.GIRDER_STATIC_ROUTE_ID],
-                                     routeTable[constants.GIRDER_ROUTE_ID])
+        apiRootBase = posixpath.split(posixpath.join('/',
+                                                     config.getConfig()['server']['api_root']))[0]
+        apiStaticRoot = posixpath.relpath(routeTable[constants.GIRDER_STATIC_ROUTE_ID],
+                                          apiRootBase)
+        staticRoot = posixpath.relpath(routeTable[constants.GIRDER_STATIC_ROUTE_ID],
+                                       routeTable[constants.GIRDER_ROUTE_ID])
 
     webroot.updateHtmlVars({
         'apiRoot': config.getConfig()['server']['api_root'],

--- a/tests/cases/webroot_test.py
+++ b/tests/cases/webroot_test.py
@@ -18,6 +18,7 @@
 ###############################################################################
 
 from .. import base
+from girder.constants import GIRDER_ROUTE_ID, GIRDER_STATIC_ROUTE_ID, SettingKey
 
 
 def setUpModule():
@@ -40,3 +41,22 @@ class WebRootTestCase(base.TestCase):
         body = self.getBody(resp)
         self.assertTrue('girder_app.min.js' in body)
         self.assertTrue('girder_lib.min.js' in body)
+
+    def testWebRootProperlyHandlesStaticRouteUrls(self):
+        self.model('setting').set(SettingKey.ROUTE_TABLE, {
+            GIRDER_ROUTE_ID: '/',
+            GIRDER_STATIC_ROUTE_ID: 'http://my-cdn-url.com/static'
+        })
+
+        resp = self.request(path='/', method='GET', isJson=False, prefix='')
+        self.assertStatus(resp, 200)
+        body = self.getBody(resp)
+
+        self.assertTrue('href="http://my-cdn-url.com/static/img/Girder_Favicon.png"' in body)
+
+        # Same assertion should hold true for Swagger
+        resp = self.request(path='/', method='GET', isJson=False)
+        self.assertStatus(resp, 200)
+        body = self.getBody(resp)
+
+        self.assertTrue('href="http://my-cdn-url.com/static/img/Girder_Favicon.png"' in body)


### PR DESCRIPTION
Prior to this, the static route accepted URLs (e180d73) but would still pass
them to os.path.relpath leading to a malformed static url. Here, we
leave the static route alone if it's a URL.

This PR allows us to use a CDN when deploying on Beanstalk (or anywhere).