### PR TITLE
When installing via Vagrant, bind mount node_modules directory.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,9 +29,26 @@ Vagrant.configure("2") do |config|
     provisioner_type = "ansible"
   end
 
+  client_testing = ENV["ANSIBLE_CLIENT_TESTING"] || false
+  bind_node_modules = (ENV.fetch("BIND_NODE_MODULES", "true") != "false" && !client_testing)
+
+  if bind_node_modules 
+    $script = <<SCRIPT
+mkdir -p /home/vagrant/girder/node_modules
+chown vagrant:vagrant /home/vagrant/girder/node_modules
+mkdir -p /home/vagrant/girder_node_modules
+chown vagrant:vagrant /home/vagrant/girder_node_modules
+if [[ ! $(grep -q "girder_node_modules" /etc/fstab) ]]; then
+  echo "# bind mount girder node_modules" >> /etc/fstab
+  echo "/home/vagrant/girder_node_modules /home/vagrant/girder/node_modules none defaults,bind 0 0" >> /etc/fstab
+fi
+mount /home/vagrant/girder_node_modules
+SCRIPT
+    config.vm.provision "shell", inline: $script
+  end
+
   config.vm.provision provisioner_type do |ansible|
 
-    client_testing = ENV["ANSIBLE_CLIENT_TESTING"] || false
     if client_testing then
       ansible.groups = {
         "girder" => ["default"]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,7 +30,7 @@ Vagrant.configure("2") do |config|
   end
 
   client_testing = ENV["ANSIBLE_CLIENT_TESTING"] || false
-  bind_node_modules = (ENV.fetch("BIND_NODE_MODULES", "true") != "false" && !client_testing)
+  bind_node_modules = (ENV.fetch("BIND_NODE_MODULES", "true") != "false" && !client_testing && !ENV["ANSIBLE_TESTING"])
 
   if bind_node_modules 
     $script = <<SCRIPT

--- a/devops/ansible/roles/girder/tasks/main.yml
+++ b/devops/ansible/roles/girder/tasks/main.yml
@@ -16,6 +16,34 @@
   become: yes
   become_user: root
 
+- name: Check if vagrant path exists
+  stat: path=/home/vagrant/girder
+  register: check_vagrant_path
+
+- name: Create actual directory for node_modules
+  file:
+    path: "{{ ansible_user_dir }}/girder_node_modules"
+    state: directory
+  when: check_vagrant_path.stat.exists
+
+- name: Create virtual directory for node_modules
+  file:
+    path: "{{ girder_path }}/node_modules"
+    state: directory
+  when: check_vagrant_path.stat.exists
+
+- name: Bind mount node_modules
+  mount:
+    src: "{{ ansible_user_dir }}/girder_node_modules"
+    path: "{{ girder_path }}/node_modules"
+    opts: bind
+    fstype: none
+    state: mounted
+  register: fstab
+  become: yes
+  become_user: root
+  when: check_vagrant_path.stat.exists
+
 - include: npm-RedHat.yml
   when:
     - girder_web

--- a/devops/ansible/roles/girder/tasks/main.yml
+++ b/devops/ansible/roles/girder/tasks/main.yml
@@ -16,34 +16,6 @@
   become: yes
   become_user: root
 
-- name: Check if vagrant path exists
-  stat: path=/home/vagrant/girder
-  register: check_vagrant_path
-
-- name: Create actual directory for node_modules
-  file:
-    path: "{{ ansible_user_dir }}/girder_node_modules"
-    state: directory
-  when: check_vagrant_path.stat.exists
-
-- name: Create virtual directory for node_modules
-  file:
-    path: "{{ girder_path }}/node_modules"
-    state: directory
-  when: check_vagrant_path.stat.exists
-
-- name: Bind mount node_modules
-  mount:
-    src: "{{ ansible_user_dir }}/girder_node_modules"
-    path: "{{ girder_path }}/node_modules"
-    opts: bind
-    fstype: none
-    state: mounted
-  register: fstab
-  become: yes
-  become_user: root
-  when: check_vagrant_path.stat.exists
-
 - include: npm-RedHat.yml
   when:
     - girder_web


### PR DESCRIPTION
This works around the issue that npm symlinks files in the node_modules directory, and that VirtualBox's vboxfs doesn't expose symlinks on Windows.

Fixes issue #2027.