### PR TITLE
Use npm install --no-save for npm v5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-package-lock.json
+/package-lock.json
 *.py[cod]
 node_modules
 docs/_build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+package-lock.json
 *.py[cod]
 node_modules
 docs/_build

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -339,7 +339,10 @@ module.exports = function (grunt) {
             // Get the list of the packages to install and append them to the
             // args object.
             var modules = Array.prototype.slice.call(arguments, 2);
-            args = args.concat(['install'], modules);
+
+            // npm@5 saves dependencies to package.json by default, add
+            // the --no-save flag to disable this behavior
+            args = args.concat(['install', '--no-save'], modules);
 
             // Launch the child process.
             child = child_process.spawnSync('npm', args, {


### PR DESCRIPTION
I didn't version guard the flag because it doesn't seem to break any old versions of npm, and it is difficult to detect in the script which version of npm is being used (you can't `require('npm')`).  I tested it on versions 3, 4, and 5.

Fixes #2043 
