### PR TITLE
Throw an error when some Model / Collection methods are called incorrectly

### DIFF
--- a/clients/web/src/collections/Collection.js
+++ b/clients/web/src/collections/Collection.js
@@ -129,8 +129,7 @@ var Collection = Backbone.Collection.extend({
      */
     fetch: function (params, reset) {
         if (this.altUrl === null && this.resourceName === null) {
-            console.error('Error: You must set an altUrl or resourceName on your collection.');
-            return;
+            throw new Error('An altUrl or resourceName must be set on the Collection.');
         }
 
         if (this.filterFunc && !this.append) {

--- a/clients/web/src/models/AccessControlledModel.js
+++ b/clients/web/src/models/AccessControlledModel.js
@@ -20,8 +20,7 @@ var AccessControlledModel = Model.extend({
      */
     updateAccess: function (params) {
         if (this.altUrl === null && this.resourceName === null) {
-            console.error('Error: You must set an altUrl or a resourceName on your model.');
-            return;
+            throw new Error('An altUrl or resourceName must be set on the Model.');
         }
 
         return restRequest({
@@ -48,8 +47,7 @@ var AccessControlledModel = Model.extend({
      */
     fetchAccess: function (force) {
         if (this.altUrl === null && this.resourceName === null) {
-            console.error('Error: You must set an altUrl or a resourceName on your model.');
-            return;
+            throw new Error('An altUrl or resourceName must be set on the Model.');
         }
 
         if (!this.get('access') || force) {

--- a/clients/web/src/models/Model.js
+++ b/clients/web/src/models/Model.js
@@ -41,8 +41,7 @@ var Model = Backbone.Model.extend({
      */
     save: function () {
         if (this.altUrl === null && this.resourceName === null) {
-            console.error('Error: You must set an altUrl or resourceName on your model.');
-            return;
+            throw new Error('An altUrl or resourceName must be set on the Model.');
         }
 
         var path, type;
@@ -88,8 +87,7 @@ var Model = Backbone.Model.extend({
      */
     fetch: function (opts) {
         if (this.altUrl === null && this.resourceName === null) {
-            console.error('Error: You must set an altUrl or a resourceName on your model.');
-            return;
+            throw new Error('An altUrl or resourceName must be set on the Model.');
         }
 
         opts = opts || {};
@@ -150,8 +148,7 @@ var Model = Backbone.Model.extend({
      */
     destroy: function (opts) {
         if (this.altUrl === null && this.resourceName === null) {
-            console.error('Error: You must set an altUrl or a resourceName on your model.');
-            return;
+            throw new Error('An altUrl or resourceName must be set on the Model.');
         }
 
         var args = {

--- a/clients/web/test/spec/modelSpec.js
+++ b/clients/web/test/spec/modelSpec.js
@@ -59,9 +59,9 @@ describe('Test the model class', function () {
         expect(model.get('count')).toBe(12);
         // test save
         model.resourceName = null;
-        model.save();
-        model.resourceName = 'sampleResource';
+        expect(model.save).toThrow();
         expect(requestCount).toBe(0);
+        model.resourceName = 'sampleResource';
         model.save();
         expect(requestCount).toBe(1);
         expect(lastRequest.type).toBe('POST');
@@ -79,9 +79,9 @@ describe('Test the model class', function () {
         // test fetch
         requestCount = 0;
         model.resourceName = null;
-        model.fetch();
-        model.resourceName = 'sampleResource';
+        expect(model.fetch).toThrow();
         expect(requestCount).toBe(0);
+        model.resourceName = 'sampleResource';
         model.fetch();
         expect(requestCount).toBe(1);
         expect(lastRequest.type).toBe(undefined);
@@ -122,9 +122,9 @@ describe('Test the model class', function () {
         // destroy
         requestCount = 0;
         model.resourceName = null;
-        model.destroy();
-        model.resourceName = 'sampleResource';
+        expect(model.destroy).toThrow();
         expect(requestCount).toBe(0);
+        model.resourceName = 'sampleResource';
         model.destroy();
         expect(requestCount).toBe(1);
         expect(lastRequest.type).toBe('DELETE');


### PR DESCRIPTION
This now ensures that these functions will always return a Promise (when they do return).