### PR TITLE
Improve promise usage conventions

### DIFF
--- a/clients/web/src/auth.js
+++ b/clients/web/src/auth.js
@@ -108,9 +108,8 @@ function login(username, password, cors) {
         events.trigger('g:login', response);
 
         return response.user;
-    }, function (jqxhr) {
+    }).fail(function (jqxhr) {
         events.trigger('g:login.error', jqxhr.status, jqxhr);
-        return jqxhr;
     });
 }
 
@@ -118,13 +117,13 @@ function logout() {
     return restRequest({
         method: 'DELETE',
         path: '/user/authentication'
-    }).then(function () {
+    }).done(function () {
         setCurrentUser(null);
         setCurrentToken(null);
 
         events.trigger('g:login', null);
         events.trigger('g:logout.success');
-    }, function (jqxhr) {
+    }).fail(function (jqxhr) {
         events.trigger('g:logout.error', jqxhr.status, jqxhr);
     });
 }

--- a/clients/web/src/collections/Collection.js
+++ b/clients/web/src/collections/Collection.js
@@ -254,6 +254,7 @@ var Collection = Backbone.Collection.extend({
 
                     this.trigger('g:changed');
                 }
+                return undefined;
             });
             xhr.girder = {fetch: true};
             return result;

--- a/clients/web/src/models/AccessControlledModel.js
+++ b/clients/web/src/models/AccessControlledModel.js
@@ -68,7 +68,7 @@ var AccessControlledModel = Model.extend({
             }, this));
         } else {
             this.trigger('g:accessFetched');
-            return $.when(this.get('access'));
+            return $.Deferred().resolve(this.get('access')).promise();
         }
     }
 });

--- a/clients/web/src/models/UserModel.js
+++ b/clients/web/src/models/UserModel.js
@@ -21,7 +21,7 @@ var UserModel = Model.extend({
      */
     current: function () {
         fetchCurrentUser()
-            .then(_.bind(function (user) {
+            .done(_.bind(function (user) {
                 if (user) {
                     this.set(user);
                 } else {

--- a/clients/web/src/views/widgets/AccessWidget.js
+++ b/clients/web/src/views/widgets/AccessWidget.js
@@ -86,7 +86,7 @@ var AccessWidget = View.extend({
         $.when(
             flagListPromise,
             this.model.fetchAccess()
-        ).then(() => {
+        ).done(() => {
             this.render();
         });
     },

--- a/clients/web/test/spec/browserSpec.js
+++ b/clients/web/test/spec/browserSpec.js
@@ -18,7 +18,7 @@ describe('Test the hierarchy browser modal', function () {
             if (onRestRequest) {
                 return onRestRequest.apply(this, arguments);
             }
-            return $.when(returnVal);
+            return $.Deferred().resolve(returnVal).promise();
         });
         transition = $.support.transition;
         $.support.transition = false;
@@ -99,12 +99,12 @@ describe('Test the hierarchy browser modal', function () {
             onRestRequest = function (params) {
                 if (params.path === '/user/authentication') {
                     // The return value for the initial login call
-                    return $.when(user);
+                    return $.Deferred().resolve(user).promise();
                 }
 
                 // After login return an empty array for collection fetches
                 // on the RootSelector
-                return $.when([]);
+                return $.Deferred().resolve([]).promise();
             };
 
             girder.auth.login('johndoe', 'password');

--- a/clients/web/test/spec/collectionBaseClassSpec.js
+++ b/clients/web/test/spec/collectionBaseClassSpec.js
@@ -59,7 +59,7 @@ describe('Test normal collection operation', function () {
             return collection.fetch();
         });
 
-        $.when(createPromise, fetchPromise).then(function () {
+        $.when(createPromise, fetchPromise).done(function () {
             expect(collection.length).toBe(10);
         }).fail(failIfError).always(done);
 
@@ -177,7 +177,7 @@ describe('Test normal collection operation', function () {
             expect(collection.pageNum()).toBe(1);
 
             return collection.fetchPreviousPage();
-        }).then(function () {
+        }).done(function () {
             expect(collection.length).toBe(2);
             expect(collection.at(0).get('name')).toBe('test0');
             expect(collection.at(1).get('name')).toBe('test1');
@@ -222,7 +222,7 @@ describe('Test collection filtering', function () {
             return filteredCollection.fetch();
         });
 
-        $.when(createPromise, fetchPromise).then(function () {
+        $.when(createPromise, fetchPromise).done(function () {
             expect(filteredCollection.length).toBe(10);
         }).fail(failIfError).always(done);
 
@@ -240,7 +240,7 @@ describe('Test collection filtering', function () {
             return match;
         };
 
-        collection.fetch().then(function () {
+        collection.fetch().done(function () {
             expect(collection.length).toBe(5);
         }).fail(failIfError).always(done);
 
@@ -272,7 +272,7 @@ describe('Test collection filtering', function () {
          *     had not yet been included
          */
         collection.pageLimit = 5;
-        collection.fetch().then(function () {
+        collection.fetch().done(function () {
             expect(collection.length).toBe(5);
             expect(collection.at(0).get('name')).toBe('filterTest0');
             expect(collection.at(1).get('name')).toBe('filterTest1');
@@ -343,7 +343,7 @@ describe('Test collection filtering', function () {
             expect(collection.pageNum()).toBe(1);
 
             return collection.fetchPreviousPage();
-        }).then(function () {
+        }).done(function () {
             expect(collection.length).toBe(2);
             expect(collection.at(0).get('name')).toBe('filterTest0');
             expect(collection.at(1).get('name')).toBe('filterTest1');

--- a/clients/web/test/specRunner.js
+++ b/clients/web/test/specRunner.js
@@ -173,7 +173,7 @@ page.onLoadFinished = function (status) {
         }
         page.evaluate(function () {
             if (window.girderTest) {
-                girderTest.promise.then(function () {
+                girderTest.promise.done(function () {
                     jasmine.getEnv().execute();
                 }).fail(function (err) {
                     window.callPhantom({

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -633,7 +633,7 @@ girderTest.promise = $.Deferred().resolve().promise();
  */
 girderTest.addScript = function (url) {
     var defer = new $.Deferred();
-    girderTest.promise.then(function () {
+    girderTest.promise.done(function () {
         $.getScript(url).done(function () {
             defer.resolve();
         }).fail(function () {
@@ -1214,7 +1214,7 @@ $(function () {
     });
     if (specs.length) {
         $.when.apply($, specs)
-            .then(function () {
+            .done(function () {
                 window.jasmine.getEnv().execute();
             });
     }
@@ -1228,7 +1228,7 @@ $(function () {
  */
 girderTest.startApp = function () {
     var defer = new $.Deferred();
-    girderTest.promise.then(function () {
+    girderTest.promise.done(function () {
         /* Track bootstrap transitions.  This is largely a duplicate of the
          * Bootstrap emulateTransitionEnd function, with the only change being
          * our tracking of the transition.  This still relies on the browser
@@ -1255,7 +1255,7 @@ girderTest.startApp = function () {
             parentView: null,
             start: false
         });
-        app.start().then(function () {
+        app.start().done(function () {
             girder.events.trigger('g:appload.after');
             defer.resolve(app);
         });

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -626,7 +626,7 @@ girderTest.waitForDialog = function (desc) {
 /**
  * Contains a promise that is resolved when all requested sources are loaded.
  */
-girderTest.promise = $.when();
+girderTest.promise = $.Deferred().resolve().promise();
 
 /**
  * Import a javascript file and.

--- a/docs/external-web-clients.rst
+++ b/docs/external-web-clients.rst
@@ -73,7 +73,7 @@ application bootstrapping
              fetch: false,  // disable automatic fetching of the user model
              history: false,// disable initialization of Backbone's router
              render: false  // disable automatic rendering on start
-         }).then(_.bind(function () {
+         }).done(() => {
 
             // set the current user somehow
             girder.currentUser = new girder.models.UserModel({...});
@@ -87,7 +87,7 @@ application bootstrapping
 
             // start up the router with the `pushState` option enabled
             Backbone.history.start({pushState: true});
-         }, this));
+         });
       }
    });
 

--- a/plugins/item_tasks/plugin_tests/widgetsSpec.js
+++ b/plugins/item_tasks/plugin_tests/widgetsSpec.js
@@ -6,7 +6,7 @@ girderTest.addCoveredScripts([
     '/clients/web/static/built/plugins/item_tasks/plugin.min.js'
 ]);
 
-girderTest.promise.then(function () {
+girderTest.promise.done(function () {
     var itemTasks = girder.plugins.item_tasks;
 
     describe('widget model', function () {


### PR DESCRIPTION
* Don't use `$.when` to create resolved promises
  * Given that the multi-argument version of `$.then` has different behavior, `$.when` should not be used with zero or one arguments. Instead, use the more explicit construction to create resolved promises.
* Use `.done` instead of `.then` for handlers without a return value
  * `.then` creates a new promise, with the fulfillment value of the handler's return value. Using `.then` without returning a new value causes the new fulfillment value to become `undefined`; if this is desired, then an explicit `return undefined` should be used instead.
  *  In cases where the promise is not returned or chained past the last `.then`, `.done` should still be used for consistency.
* Ensure that Collection.fetch explicitly has a resolution value