### PR TITLE
Allow girder-client to accept multiple files for upload.

### DIFF
--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -192,7 +192,8 @@ def _lookup_parent_type(client, object_id):
 
 
 def _CommonParameters(path_exists=False, path_writable=True,
-                      additional_parent_types=('collection', 'user'), path_default=None):
+                      additional_parent_types=('collection', 'user'),
+                      path_default=None, multiple_local=False):
     parent_types = ['folder'] + list(additional_parent_types)
     parent_type_cls = _HiddenOption
     parent_type_default = 'folder'
@@ -211,7 +212,9 @@ def _CommonParameters(path_exists=False, path_writable=True,
                 'local_folder',
                 type=click.Path(exists=path_exists, dir_okay=True,
                                 writable=path_writable, readable=True),
-                default=path_default
+                default=path_default,
+                nargs=1 if not multiple_local else -1,
+                required=multiple_local
             ),
         ]
         for decorator in reversed(decorators):
@@ -257,8 +260,11 @@ def _localsync(gc, parent_type, parent_id, local_folder):
 _short_help = 'Upload files to Girder'
 
 
-@main.command('upload', short_help=_short_help, help='%s\n\n%s' % (_short_help, _common_help))
-@_CommonParameters(path_exists=True, path_writable=False)
+@main.command('upload', short_help=_short_help, help='%s\n\n%s' % (
+    _short_help,
+    'PARENT_ID is the id of the Girder parent target and '
+    'LOCAL_FOLDER is one or more paths to local folders or files.'))
+@_CommonParameters(path_exists=True, path_writable=False, multiple_local=True)
 @click.option('--leaf-folders-as-items', is_flag=True,
               help='upload all files in leaf folders to a single Item named after the folder')
 @click.option('--reuse', is_flag=True,
@@ -272,10 +278,11 @@ def _upload(gc, parent_type, parent_id, local_folder,
             leaf_folders_as_items, reuse, blacklist, dry_run):
     if parent_type == 'auto':
         parent_type = _lookup_parent_type(gc, parent_id)
-    gc.upload(
-        local_folder, parent_id, parent_type,
-        leafFoldersAsItems=leaf_folders_as_items, reuseExisting=reuse,
-        blacklist=blacklist.split(','), dryRun=dry_run)
+    for local in local_folder:
+        gc.upload(
+            local, parent_id, parent_type,
+            leafFoldersAsItems=leaf_folders_as_items, reuseExisting=reuse,
+            blacklist=blacklist.split(','), dryRun=dry_run)
 
 
 if __name__ == '__main__':

--- a/tests/cases/py_client/cli_test.py
+++ b/tests/cases/py_client/cli_test.py
@@ -221,6 +221,17 @@ class PythonCliTestCase(base.TestCase):
         self.assertEqual(ret['exitVal'], 0)
         self.assertIn('Ignoring file hello.txt as it is blacklisted', ret['stdout'])
 
+        # Test with multiple files in a dry-run
+        ret = invokeCli([
+            'upload', str(self.publicFolder['_id']), '--parent-type=folder',
+            os.path.join(localDir, 'hello.txt'),
+            os.path.join(localDir, 'world.txt'), '--dry-run'],
+            username='mylogin', password='password')
+        self.assertEqual(ret['exitVal'], 0)
+        self.assertIn('Uploading Item from hello.txt', ret['stdout'])
+        self.assertIn('Uploading Item from world.txt', ret['stdout'])
+
+        # Actually upload the test data
         ret = invokeCli(args, username='mylogin', password='password', useApiUrl=True)
         self.assertEqual(ret['exitVal'], 0)
         six.assertRegex(


### PR DESCRIPTION
This allows uploading files using shell wildcards, such as:
```
girder-cli upload /collection/mycollection/myfolder *.png
```