### PR TITLE
Fix an incorrect CSS property in jobs plugin

### DIFF
--- a/girder/api/api_docs.mako
+++ b/girder/api/api_docs.mako
@@ -3,7 +3,7 @@
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>${title}</title>
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Droid+Sans:400,700">
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Droid+Sans:normal,bold">
     <link rel="stylesheet" href="${staticRoot}/built/fontello/css/fontello.css">
     <link rel="stylesheet" href="${staticRoot}/built/swagger/css/reset.css">
     <link rel="stylesheet" href="${staticRoot}/built/swagger/css/screen.css">

--- a/girder/utility/webroot.mako
+++ b/girder/utility/webroot.mako
@@ -3,7 +3,7 @@
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>${title}</title>
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Droid+Sans:400,700">
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Droid+Sans:normal,bold">
     <link rel="stylesheet" href="${staticRoot}/built/fontello/css/fontello.css">
     <link rel="stylesheet" href="${staticRoot}/built/fontello/css/animation.css">
     <link rel="stylesheet" href="${staticRoot}/built/girder_lib.min.css">

--- a/plugins/jobs/web_client/stylesheets/jobDetailsWidget.styl
+++ b/plugins/jobs/web_client/stylesheets/jobDetailsWidget.styl
@@ -1,7 +1,7 @@
 .g-job-info-key
   font-weight bold
   margin 12px 8px 0 0
-  font-weight 16px
+  font-size 16px
 
   &.inline
     display inline-block


### PR DESCRIPTION
* Fix an incorrect CSS property in jobs plugin
* Use more readable font weights to fetch fonts
  * This returns the same result from the Google font API, but is more
readable.