### PR TITLE
Drop test databases at the end of the test.

### DIFF
--- a/plugins/user_quota/plugin_tests/user_quota_test.py
+++ b/plugins/user_quota/plugin_tests/user_quota_test.py
@@ -34,6 +34,7 @@ def setUpModule():
 
 def tearDownModule():
     base.stopServer()
+    base.dropAllTestDatabases()
 
 
 class QuotaTestCase(base.TestCase):

--- a/tests/base.py
+++ b/tests/base.py
@@ -117,7 +117,7 @@ def dropTestDatabase(dropModels=True):
     if 'girder_test_' not in dbName:
         raise Exception('Expected a testing database name, but got %s' % dbName)
     if dbName in db_connection.database_names():
-        if (dbName not in usedDBs and 'newdb' in os.environ.get('EXTRADEBUG', '').split()):
+        if dbName not in usedDBs and 'newdb' in os.environ.get('EXTRADEBUG', '').split():
             raise Exception('Warning: database %s already exists' % dbName)
         db_connection.drop_database(dbName)
     usedDBs[dbName] = True
@@ -132,7 +132,7 @@ def dropGridFSDatabase(dbName):
     """
     db_connection = getDbConnection()
     if dbName in db_connection.database_names():
-        if (dbName not in usedDBs and 'newdb' in os.environ.get('EXTRADEBUG', '').split()):
+        if dbName not in usedDBs and 'newdb' in os.environ.get('EXTRADEBUG', '').split():
             raise Exception('Warning: database %s already exists' % dbName)
         db_connection.drop_database(dbName)
     usedDBs[dbName] = True

--- a/tests/base.py
+++ b/tests/base.py
@@ -47,6 +47,7 @@ remote = cherrypy.lib.httputil.Host('127.0.0.1', 30001)
 mockSmtp = mock_smtp.MockSmtpReceiver()
 mockS3Server = None
 enabledPlugins = []
+usedDBs = {}
 
 
 def startServer(mock=True, mockS3=False):
@@ -54,6 +55,10 @@ def startServer(mock=True, mockS3=False):
     Test cases that communicate with the server should call this
     function in their setUpModule() function.
     """
+    # If the server starts, a database will exist and we can remove it later
+    dbName = cherrypy.config['database']['uri'].split('/')[-1]
+    usedDBs[dbName] = True
+
     server = setupServer(test=True, plugins=enabledPlugins)
 
     if mock:
@@ -86,6 +91,18 @@ def stopServer():
     """
     cherrypy.engine.exit()
     mockSmtp.stop()
+    dropAllTestDatabases()
+
+
+def dropAllTestDatabases():
+    """
+    Unless otherwise requested, drop all test databases.
+    """
+    if 'keepdb' not in os.environ.get('EXTRADEBUG', '').split():
+        db_connection = getDbConnection()
+        for dbName in usedDBs:
+            db_connection.drop_database(dbName)
+        usedDBs.clear()
 
 
 def dropTestDatabase(dropModels=True):
@@ -99,8 +116,11 @@ def dropTestDatabase(dropModels=True):
 
     if 'girder_test_' not in dbName:
         raise Exception('Expected a testing database name, but got %s' % dbName)
-    db_connection.drop_database(dbName)
-
+    if dbName in db_connection.database_names():
+        if (dbName not in usedDBs and 'newdb' in os.environ.get('EXTRADEBUG', '').split()):
+            raise Exception('Warning: database %s already exists' % dbName)
+        db_connection.drop_database(dbName)
+    usedDBs[dbName] = True
     if dropModels:
         model_importer.reinitializeAll()
 
@@ -111,7 +131,11 @@ def dropGridFSDatabase(dbName):
     :param dbName: the name of the database to drop.
     """
     db_connection = getDbConnection()
-    db_connection.drop_database(dbName)
+    if dbName in db_connection.database_names():
+        if (dbName not in usedDBs and 'newdb' in os.environ.get('EXTRADEBUG', '').split()):
+            raise Exception('Warning: database %s already exists' % dbName)
+        db_connection.drop_database(dbName)
+    usedDBs[dbName] = True
 
 
 def dropFsAssetstore(path):
@@ -635,3 +659,7 @@ def _sigintHandler(*args):
 
 
 signal.signal(signal.SIGINT, _sigintHandler)
+# If we insist on test databases not existing when we start, make sure we
+# check right away.
+if 'newdb' in os.environ.get('EXTRADEBUG', '').split():
+    dropTestDatabase(False)

--- a/tests/cases/custom_root_test.py
+++ b/tests/cases/custom_root_test.py
@@ -39,6 +39,7 @@ class CustomRootTestCase(base.TestCase):
     def tearDown(self):
         base.stopServer()
         self.unmockPluginDir()
+        base.dropAllTestDatabases()
 
     def testCustomWebRoot(self):
         """

--- a/tests/cases/sftp_test.py
+++ b/tests/cases/sftp_test.py
@@ -71,6 +71,7 @@ def tearDownModule():
     if server:
         server.shutdown()
         server.server_close()
+    base.dropAllTestDatabases()
 
 
 class SftpTestCase(base.TestCase):


### PR DESCRIPTION
Currently, we reference a mongo database, usually one per test.  Some tests that use gridfs reference additional databases.  With mongo, storing values in a database that doesn't yet exist creates it.  We try to drop the databases as we start tests, but there are conditions where we read the database before we drop it (such as determining the static root).  By removing the databases at the end of the tests, this eliminates behavioral changes on different test runs depending on where the database persisted or not.  Also, it avoids cluttering mongo with databases when one isn't running tests.

This can be overridden with EXTRADEBUG=keepdb.

If EXTRADEBUG includes 'newdb', a failure will be triggered if the database already exists (so running tests using EXTRADEBUG='keepdb newdb' twice should always result in a failure).