### PR TITLE
Honor mongo URI options.

### DIFF
--- a/clients/web/test/spec/adminSpec.js
+++ b/clients/web/test/spec/adminSpec.js
@@ -539,21 +539,23 @@ describe('Test the assetstore page', function () {
         'g-new-fs-root': '/tmp/assetstore'
     }, _testFilesystemImport);
 
-    _testAssetstore('gridfs', 'g-create-gridfs-tab',
-        {'g-new-gridfs-name': 'name',
-            'g-new-gridfs-db': 'girder_webclient_gridfs'});
+    _testAssetstore('gridfs', 'g-create-gridfs-tab', {
+        'g-new-gridfs-name': 'name',
+        'g-new-gridfs-db': 'girder_webclient_gridfs'
+    });
 
     /* The specified assetstore should NOT exist, and the specified mongohost
      * should NOT be present (nothing should respond on those ports). */
-    _testAssetstore('gridfs-rs', 'g-create-gridfs-tab',
-        {'g-new-gridfs-name': 'name',
-            'g-new-gridfs-db': 'girder_webclient_gridfsrs',
-            'g-new-gridfs-mongohost': 'mongodb://127.0.0.2:27080,' +
-                        '127.0.0.2:27081,127.0.0.2:27082',
-            'g-new-gridfs-replicaset': 'replicaset'}, null, function () {
-                return $('.g-validation-failed-message:contains(' +
-                              '"Could not connect to the database: ")').length === 1;
-            }, 'validation failure to display', true);
+    _testAssetstore('gridfs-rs', 'g-create-gridfs-tab', {
+        'g-new-gridfs-name': 'name',
+        'g-new-gridfs-db': 'girder_webclient_gridfsrs',
+        'g-new-gridfs-mongohost': 'mongodb://127.0.0.2:27080,127.0.0.2:27081,' +
+                                  '127.0.0.2:27082/?serverSelectionTimeoutMS=250',
+        'g-new-gridfs-replicaset': 'replicaset'
+    }, null, function () {
+        return $('.g-validation-failed-message:contains(' +
+                      '"Could not connect to the database: ")').length === 1;
+    }, 'validation failure to display', true);
 
     _testAssetstore('s3', 'g-create-s3-tab', {
         'g-new-s3-name': 'name',

--- a/girder/models/__init__.py
+++ b/girder/models/__init__.py
@@ -18,6 +18,7 @@
 ###############################################################################
 
 import pymongo
+from six.moves import urllib
 
 from pymongo.read_preferences import ReadPreference
 from girder import logger, logprint
@@ -80,6 +81,12 @@ def getDbConnection(uri=None, replicaSet=None, autoRetry=True, **kwargs):
         'replicaSet': replicaSet
     }
     clientOptions.update(kwargs)
+    # if the connection URI overrides any option, honor it above our own
+    # settings.
+    uriParams = urllib.parse.parse_qs(urllib.parse.urlparse(uri).query)
+    for key in uriParams:
+        if key in clientOptions:
+            del clientOptions[key]
 
     if uri is None:
         dbUriRedacted = 'mongodb://localhost:27017/girder'


### PR DESCRIPTION
If we specified a Mongo option, our value would supersede a value explicitly added to a Mongo URI.  This prevented overriding values such as serverConnectionTimeoutMS.

Allowing values from the URI provides an easy mechanism to speed up the gridfs-replica set test.