### PR TITLE
Upgrade to jQuery 3

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,8 @@
 {
     "extends": "girder",
     "rules": {
-        "no-throw-literal": "off"
+        "no-throw-literal": "off",
+        "promise/always-return": "error",
+        "promise/no-nesting": "error"
     }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
     "extends": "girder",
+    "rules": {
+        "no-throw-literal": "off"
+    }
 }

--- a/clients/web/src/server.js
+++ b/clients/web/src/server.js
@@ -73,13 +73,11 @@ restartServer._checkServer = function (lastStartDate) {
         error: null
     })
     .then((resp) => {
-        const checkResolution = $.Deferred();
         if (resp.serverStartDate !== lastStartDate) {
-            checkResolution.resolve();
+            return undefined;
         } else {
-            checkResolution.reject();
+            throw undefined;
         }
-        return checkResolution.promise();
     });
 };
 

--- a/clients/web/src/views/body/SystemConfigurationView.js
+++ b/clients/web/src/views/body/SystemConfigurationView.js
@@ -34,7 +34,7 @@ var SystemConfigurationView = View.extend({
                     return {
                         key: key,
                         value: _.object(_.map($('.g-core-route-table'), function (el) {
-                            return [$(el).data('webroot-name'), $(el).val()];
+                            return [$(el).data('webrootName'), $(el).val()];
                         }))
                     };
                 }

--- a/clients/web/test/spec/browserSpec.js
+++ b/clients/web/test/spec/browserSpec.js
@@ -33,28 +33,61 @@ describe('Test the hierarchy browser modal', function () {
     describe('root selection', function () {
         it('defaults', function () {
             returnVal = [];
-            var view = new girder.views.widgets.RootSelectorWidget({el: testEl, parentView: null});
-            view.render();
-            var select = view.$('select#g-root-selector');
-            expect(select.length).toBe(1);
-            expect(select.find('option:eq(0)').text()).toBe('Select a root...');
-            expect(select.find('optgroup[label="Collections"]').length).toBe(1);
-            expect(select.find('optgroup[label="Users"]').length).toBe(1);
+
+            var view;
+            runs(function () {
+                view = new girder.views.widgets.RootSelectorWidget({
+                    el: testEl,
+                    parentView: null
+                });
+                // RootSelectorWidget will self-render, as soon as its initial 'fetch()' completes
+
+                // We should be able to attach a spy to 'view.render' without a race condition, as
+                // long as we do it before returning to the main event loop (where async results
+                // from 'fetch()' might already be pending)
+                spyOn(view, 'render').andCallThrough();
+            });
+
+            waitsFor(function () {
+                // 'view.render' will be called once for each of 'view.groups', and 'view.groups'
+                // has 2 collections here, so rendering should only be considered finished once all
+                // complete
+                return view.render.callCount >= 2;
+            });
+
+            runs(function () {
+                var select = view.$('select#g-root-selector');
+                expect(select.length).toBe(1);
+                expect(select.find('option:eq(0)').text()).toBe('Select a root...');
+                expect(select.find('optgroup[label="Collections"]').length).toBe(1);
+                expect(select.find('optgroup[label="Users"]').length).toBe(1);
+            });
         });
 
         it('display order', function () {
             returnVal = [];
-            var view = new girder.views.widgets.RootSelectorWidget({
-                el: testEl,
-                parentView: null,
-                display: ['Users']
+
+            var view;
+            runs(function () {
+                view = new girder.views.widgets.RootSelectorWidget({
+                    el: testEl,
+                    parentView: null,
+                    display: ['Users']
+                });
+                spyOn(view, 'render').andCallThrough();
             });
-            view.render();
-            var select = view.$('select#g-root-selector');
-            expect(select.length).toBe(1);
-            expect(select.find('option:eq(0)').text()).toBe('Select a root...');
-            expect(select.find('optgroup[label="Collections"]').length).toBe(0);
-            expect(select.find('optgroup[label="Users"]').length).toBe(1);
+
+            waitsFor(function () {
+                return view.render.callCount >= 2;
+            });
+
+            runs(function () {
+                var select = view.$('select#g-root-selector');
+                expect(select.length).toBe(1);
+                expect(select.find('option:eq(0)').text()).toBe('Select a root...');
+                expect(select.find('optgroup[label="Collections"]').length).toBe(0);
+                expect(select.find('optgroup[label="Users"]').length).toBe(1);
+            });
         });
 
         it('user logged in', function () {
@@ -64,17 +97,27 @@ describe('Test the hierarchy browser modal', function () {
                 firstName: 'John',
                 lastName: 'Doe'
             }));
-
             returnVal = [];
-            var view = new girder.views.widgets.RootSelectorWidget({
-                el: testEl,
-                parentView: null
+
+            var view;
+            runs(function () {
+                view = new girder.views.widgets.RootSelectorWidget({
+                    el: testEl,
+                    parentView: null
+                });
+                spyOn(view, 'render').andCallThrough();
             });
-            view.render();
-            var select = view.$('select#g-root-selector');
-            expect(select.length).toBe(1);
-            expect(select.find('option:eq(0)').text()).toBe('Select a root...');
-            expect(select.find('option[value="0"]').text()).toBe('Home');
+
+            waitsFor(function () {
+                return view.render.callCount >= 2;
+            });
+
+            runs(function () {
+                var select = view.$('select#g-root-selector');
+                expect(select.length).toBe(1);
+                expect(select.find('option:eq(0)').text()).toBe('Select a root...');
+                expect(select.find('option[value="0"]').text()).toBe('Home');
+            });
         });
 
         it('rerender on login', function () {
@@ -90,12 +133,6 @@ describe('Test the hierarchy browser modal', function () {
                     token: ''
                 }
             };
-            var view = new girder.views.widgets.RootSelectorWidget({
-                el: testEl,
-                parentView: null
-            });
-            view.render();
-
             onRestRequest = function (params) {
                 if (params.path === '/user/authentication') {
                     // The return value for the initial login call
@@ -107,150 +144,249 @@ describe('Test the hierarchy browser modal', function () {
                 return $.Deferred().resolve([]).promise();
             };
 
-            girder.auth.login('johndoe', 'password');
+            var view;
+            runs(function () {
+                view = new girder.views.widgets.RootSelectorWidget({
+                    el: testEl,
+                    parentView: null
+                });
+                spyOn(view, 'render').andCallThrough();
+            });
 
-            var select = view.$('select#g-root-selector');
-            expect(select.length).toBe(1);
-            expect(select.find('option:eq(0)').text()).toBe('Select a root...');
-            expect(select.find('option[value="0"]').text()).toBe('Home');
+            waitsFor(function () {
+                return view.render.callCount >= 2;
+            });
+
+            runs(function () {
+                view.render.reset();
+                girder.auth.login('johndoe', 'password');
+            });
+
+            waitsFor(function () {
+                return view.render.callCount >= 2;
+            });
+
+            runs(function () {
+                var select = view.$('select#g-root-selector');
+                expect(select.length).toBe(1);
+                expect(select.find('option:eq(0)').text()).toBe('Select a root...');
+                expect(select.find('option[value="0"]').text()).toBe('Home');
+            });
         });
 
         it('custom optgroup', function () {
-            var col = new girder.collections.CollectionCollection();
+            var col;
+            var view;
 
-            returnVal = [];
-            var view = new girder.views.widgets.RootSelectorWidget({
-                el: testEl,
-                parentView: null,
-                groups: {
-                    Custom: col
-                },
-                display: ['Collections', 'Custom']
+            runs(function () {
+                returnVal = [];
+                col = new girder.collections.CollectionCollection();
+
+                view = new girder.views.widgets.RootSelectorWidget({
+                    el: testEl,
+                    parentView: null,
+                    groups: {
+                        Custom: col
+                    },
+                    display: ['Collections', 'Custom']
+                });
+                spyOn(view, 'render').andCallThrough();
             });
-            view.render();
-            var select = view.$('select#g-root-selector');
-            expect(select.length).toBe(1);
-            expect(select.find('option:eq(0)').text()).toBe('Select a root...');
-            expect(select.find('optgroup:eq(0)').prop('label')).toBe('Collections');
-            expect(select.find('optgroup:eq(1)').prop('label')).toBe('Custom');
 
-            returnVal = [
-                {_id: 'abc', name: 'custom 1', _modelType: 'collection'},
-                {_id: 'def', name: 'custom 2', _modelType: 'user', login: 'thelogin'},
-                {_id: '123', name: 'custom 3', _modelType: 'folder'}
-            ];
-            col.fetch();
+            waitsFor(function () {
+                return view.render.callCount >= 3;
+            });
 
-            select = view.$('select#g-root-selector');
-            var opt = select.find('optgroup[label="Custom"] > option[value="abc"]');
-            expect(opt.data('group')).toBe('Custom');
-            expect(opt.text()).toBe('custom 1');
+            runs(function () {
+                var select = view.$('select#g-root-selector');
+                expect(select.length).toBe(1);
+                expect(select.find('option:eq(0)').text()).toBe('Select a root...');
+                expect(select.find('optgroup:eq(0)').prop('label')).toBe('Collections');
+                expect(select.find('optgroup:eq(1)').prop('label')).toBe('Custom');
 
-            opt = select.find('optgroup[label="Custom"] > option[value="def"]');
-            expect(opt.data('group')).toBe('Custom');
-            expect(opt.text()).toBe('thelogin');
+                returnVal = [
+                    {_id: 'abc', name: 'custom 1', _modelType: 'collection'},
+                    {_id: 'def', name: 'custom 2', _modelType: 'user', login: 'thelogin'},
+                    {_id: '123', name: 'custom 3', _modelType: 'folder'}
+                ];
+                view.render.reset();
+                col.fetch();
+            });
 
-            opt = select.find('optgroup[label="Custom"] > option[value="123"]');
-            expect(opt.data('group')).toBe('Custom');
-            expect(opt.text()).toBe('custom 3');
+            waitsFor(function () {
+                return view.render.callCount >= 1;
+            });
+
+            runs(function () {
+                var select = view.$('select#g-root-selector');
+                var opt = select.find('optgroup[label="Custom"] > option[value="abc"]');
+                expect(opt.data('group')).toBe('Custom');
+                expect(opt.text()).toBe('custom 1');
+
+                opt = select.find('optgroup[label="Custom"] > option[value="def"]');
+                expect(opt.data('group')).toBe('Custom');
+                expect(opt.text()).toBe('thelogin');
+
+                opt = select.find('optgroup[label="Custom"] > option[value="123"]');
+                expect(opt.data('group')).toBe('Custom');
+                expect(opt.text()).toBe('custom 3');
+            });
         });
 
         it('respond to user selection', function () {
-            returnVal = [
-                {_id: 'abc', name: 'custom 1', _modelType: 'collection'},
-                {_id: 'def', name: 'custom 2', _modelType: 'user', login: 'thelogin'},
-                {_id: '123', name: 'custom 3', _modelType: 'folder'}
-            ];
-            var col = new girder.collections.CollectionCollection();
-            col.fetch();
+            var col;
+            var view;
 
-            returnVal = [];
-            var view = new girder.views.widgets.RootSelectorWidget({
-                el: testEl,
-                parentView: null,
-                groups: {
-                    Custom: col
-                },
-                display: ['Collections', 'Custom']
+            runs(function () {
+                returnVal = [
+                    {_id: 'abc', name: 'custom 1', _modelType: 'collection'},
+                    {_id: 'def', name: 'custom 2', _modelType: 'user', login: 'thelogin'},
+                    {_id: '123', name: 'custom 3', _modelType: 'folder'}
+                ];
+                col = new girder.collections.CollectionCollection();
+                col.fetch();
             });
-            view.render();
-            var called = 0;
-            view.on('g:selected', function (evt) {
-                expect(evt.root.attributes).toEqual({
-                    _id: '123',
-                    name: 'custom 3',
-                    _modelType: 'folder'
+
+            waitsFor(function () {
+                return col.size() === 3;
+            });
+
+            runs(function () {
+                returnVal = [];
+
+                view = new girder.views.widgets.RootSelectorWidget({
+                    el: testEl,
+                    parentView: null,
+                    groups: {
+                        Custom: col
+                    },
+                    display: ['Collections', 'Custom']
                 });
-                called += 1;
+                spyOn(view, 'render').andCallThrough();
             });
 
-            view.$('select').val('123').trigger('change');
-            expect(called).toBe(1);
+            waitsFor(function () {
+                return view.render.callCount >= 3;
+            });
+
+            runs(function () {
+                var called = 0;
+                view.on('g:selected', function (evt) {
+                    expect(evt.root.attributes).toEqual({
+                        _id: '123',
+                        name: 'custom 3',
+                        _modelType: 'folder'
+                    });
+                    called += 1;
+                });
+
+                view.$('select').val('123').trigger('change');
+                // Assume that the 'change' event propagates synchronously
+                expect(called).toBe(1);
+            });
         });
 
         it('respond to Home selection', function () {
+            var col;
+            var view;
             girder.auth.setCurrentUser(new girder.models.UserModel({
                 _id: '0',
                 login: 'johndoe',
                 firstName: 'John',
                 lastName: 'Doe'
             }));
-            returnVal = [
-                {_id: 'abc', name: 'custom 1', _modelType: 'collection'},
-                {_id: 'def', name: 'custom 2', _modelType: 'user', login: 'thelogin'},
-                {_id: '123', name: 'custom 3', _modelType: 'folder'}
-            ];
-            var col = new girder.collections.CollectionCollection();
-            col.fetch();
 
-            returnVal = [];
-            var view = new girder.views.widgets.RootSelectorWidget({
-                el: testEl,
-                parentView: null,
-                groups: {
-                    Custom: col
-                },
-                display: ['Home', 'Collections', 'Custom']
+            runs(function () {
+                returnVal = [
+                    {_id: 'abc', name: 'custom 1', _modelType: 'collection'},
+                    {_id: 'def', name: 'custom 2', _modelType: 'user', login: 'thelogin'},
+                    {_id: '123', name: 'custom 3', _modelType: 'folder'}
+                ];
+                col = new girder.collections.CollectionCollection();
+                col.fetch();
             });
-            view.render();
-            var called = 0;
-            view.on('g:selected', function (evt) {
-                expect(evt.root.attributes).toEqual({
-                    _id: '0',
-                    login: 'johndoe',
-                    firstName: 'John',
-                    lastName: 'Doe'
+
+            waitsFor(function () {
+                return col.size() === 3;
+            });
+
+            runs(function () {
+                returnVal = [];
+
+                view = new girder.views.widgets.RootSelectorWidget({
+                    el: testEl,
+                    parentView: null,
+                    groups: {
+                        Custom: col
+                    },
+                    display: ['Home', 'Collections', 'Custom']
                 });
-                called += 1;
+                spyOn(view, 'render').andCallThrough();
             });
 
-            view.$('select').val('0').trigger('change');
-            expect(called).toBe(1);
+            waitsFor(function () {
+                return view.render.callCount >= 3;
+            });
+
+            runs(function () {
+                var called = 0;
+                view.on('g:selected', function (evt) {
+                    expect(evt.root.attributes).toEqual({
+                        _id: '0',
+                        login: 'johndoe',
+                        firstName: 'John',
+                        lastName: 'Doe'
+                    });
+                    called += 1;
+                });
+
+                view.$('select').val('0').trigger('change');
+                // Assume that the 'change' event propagates synchronously
+                expect(called).toBe(1);
+            });
         });
 
         it('preselected option', function () {
+            var col;
+            var view;
             returnVal = [
                 {_id: 'abc', name: 'custom 1', _modelType: 'collection'},
                 {_id: 'def', name: 'custom 2', _modelType: 'user', login: 'thelogin'},
                 {_id: '123', name: 'custom 3', _modelType: 'folder'}
             ];
-            var col = new girder.collections.CollectionCollection();
-            col.fetch();
 
-            returnVal = [];
-            var view = new girder.views.widgets.RootSelectorWidget({
-                el: testEl,
-                parentView: null,
-                groups: {
-                    Custom: col
-                },
-                display: ['Collections', 'Custom'],
-                selected: col.models[2]
+            runs(function () {
+                col = new girder.collections.CollectionCollection();
+                col.fetch();
             });
-            view.render();
-            var select = view.$('select#g-root-selector');
-            expect(select.length).toBe(1);
-            expect(select.val()).toBe('123');
+
+            waitsFor(function () {
+                return col.size() === 3;
+            });
+
+            runs(function () {
+                returnVal = [];
+                view = new girder.views.widgets.RootSelectorWidget({
+                    el: testEl,
+                    parentView: null,
+                    groups: {
+                        Custom: col
+                    },
+                    display: ['Collections', 'Custom'],
+                    selected: col.models[2]
+                });
+                spyOn(view, 'render').andCallThrough();
+            });
+
+            waitsFor(function () {
+                return view.render.callCount >= 3;
+            });
+
+            runs(function () {
+                var select = view.$('select#g-root-selector');
+                expect(select.length).toBe(1);
+                expect(select.val()).toBe('123');
+            });
         });
     });
 

--- a/clients/web/test/spec/emptyLayoutSpec.js
+++ b/clients/web/test/spec/emptyLayoutSpec.js
@@ -51,8 +51,9 @@ describe('Test empty and default layouts', function () {
         }, 'wait for app header container to appear so we can know it will disappear');
 
         girderTest.testRoute('collections/emptylayout', false, function () {
-            // go to emptylayout, be sure that app header is gone
-            return $('#g-app-header-container').is(':visible') === false;
+            // go to emptylayout, be sure that app header is gone, and collection list has finished loading
+            return $('#g-app-header-container').is(':visible') === false &&
+                $('.g-collection-list-header').is(':visible') === true;
         });
 
         runs(expectEmptyLayout);
@@ -62,8 +63,9 @@ describe('Test empty and default layouts', function () {
         girderTest.testRoute('collections', false, function () {
             // route back to the standard collections view, this should
             // revert to the default layout
-            // be sure that app header is back
-            return $('#g-app-header-container').is(':visible') === true;
+            // be sure that app header is back, and collection list has finished loading
+            return $('#g-app-header-container').is(':visible') === true &&
+                $('.g-collection-list-header').is(':visible') === true;
         });
 
         runs(expectDefaultLayout);
@@ -81,16 +83,18 @@ describe('Test empty and default layouts', function () {
         }, 'wait for app header container to appear so we can know it will disappear');
 
         girderTest.testRoute('collections/emptylayout', false, function () {
-            // go to emptylayout, be sure that app header is gone
-            return $('#g-app-header-container').is(':visible') === false;
+            // go to emptylayout, be sure that app header is gone, and collection list has finished loading
+            return $('#g-app-header-container').is(':visible') === false &&
+                $('.g-collection-list-header').is(':visible') === true;
         });
 
         runs(expectEmptyLayout);
 
         girderTest.testRoute('collections/defaultlayout', false, function () {
             // this should revert to the default layout
-            // be sure that app header is back
-            return $('#g-app-header-container').is(':visible') === true;
+            // be sure that app header is back, and collection list has finished loading
+            return $('#g-app-header-container').is(':visible') === true &&
+                $('.g-collection-list-header').is(':visible') === true;
         });
 
         runs(expectDefaultLayout);

--- a/clients/web/test/spec/modelSpec.js
+++ b/clients/web/test/spec/modelSpec.js
@@ -28,7 +28,7 @@ describe('Test the model class', function () {
             }
             // The jqXHR response of a rest request needs an error function
             resp.error = resp.fail;
-            return resp;
+            return resp.promise();
         });
     });
 

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -632,17 +632,11 @@ girderTest.promise = $.Deferred().resolve().promise();
  * Import a javascript file and.
  */
 girderTest.addScript = function (url) {
-    var defer = new $.Deferred();
-    girderTest.promise.done(function () {
-        $.getScript(url).done(function () {
-            defer.resolve();
-        }).fail(function () {
-            defer.reject('Failed to load script: ' + url);
+    girderTest.promise = girderTest.promise
+        .then(_.partial($.getScript, url))
+        .catch(function () {
+            throw 'Failed to load script: ' + url;
         });
-    }).fail(function () {
-        defer.reject.apply(defer, arguments);
-    });
-    girderTest.promise = defer.promise();
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "grunt-webpack": "2.0.0",
     "pug": "^2.0.0-rc.1",
     "pug-loader": "^2.3.0",
-    "jquery": "2.2.4",
+    "jquery": "~3.2.1",
     "jsoneditor": "4.1.2",
     "nib": "^1.1.0",
     "remarkable": "1.7.1",

--- a/plugins/item_licenses/plugin_tests/itemLicensesSpec.js
+++ b/plugins/item_licenses/plugin_tests/itemLicensesSpec.js
@@ -244,9 +244,7 @@ $(function () {
             girderTest.waitForLoad();
             runs(function () {
                 expect($('.g-item-name').text()).toBe('testFile.txt');
-                // TODO: to investigate; only one license will be shown when girder is live.
-                // It will be duplicated while testing -- g:rendered seems to be received twice.
-                expect($('.g-item-license').length).not.toBe(0); // was .toBe(1)
+                expect($('.g-item-license').length).toBe(1);
                 expect($('.g-item-license').text()).toContain('Apache License 2');
             });
 

--- a/plugins/item_licenses/plugin_tests/itemLicensesSpec.js
+++ b/plugins/item_licenses/plugin_tests/itemLicensesSpec.js
@@ -88,15 +88,13 @@ $(function () {
             girderTest.waitForLoad();
 
             waitsFor(function () {
-                return $('.g-item-name').length === 1;
-            }, 'the item page to load');
+                return $('.g-item-name').length === 1 && $('.g-item-license').length === 1;
+            }, 'the item page and license field to load');
             girderTest.waitForLoad();
 
             runs(function () {
                 // Item info should show license
-                // TODO: to investigate; only one license will be shown when girder is live.
-                // It will be duplicated while testing -- g:rendered seems to be received twice.
-                expect($('.g-item-license').length).not.toBe(0); // was .toBe(1)
+                expect($('.g-item-license').length).toBe(1);
                 expect($('.g-item-license').text()).toContain('The MIT License (MIT)');
             });
         });
@@ -140,8 +138,8 @@ $(function () {
             girderTest.waitForLoad();
 
             waitsFor(function () {
-                return $('.g-item-name').length === 1;
-            }, 'the item page to load');
+                return $('.g-item-name').length === 1 && $('.g-item-license').length === 1;
+            }, 'the item page and license field to load');
             girderTest.waitForLoad();
             runs(function () {
                 // Item info should show license
@@ -239,8 +237,8 @@ $(function () {
             });
             girderTest.waitForLoad();
             waitsFor(function () {
-                return $('.g-item-name').length === 1;
-            }, 'the item page to load');
+                return $('.g-item-name').length === 1 && $('.g-item-license').length === 1;
+            }, 'the item page and license field to load');
             girderTest.waitForLoad();
             runs(function () {
                 expect($('.g-item-name').text()).toBe('testFile.txt');
@@ -302,15 +300,13 @@ $(function () {
             girderTest.waitForLoad();
 
             waitsFor(function () {
-                return $('.g-item-name').length === 1;
-            }, 'the item page to load');
+                return $('.g-item-name').length === 1 && $('.g-item-license').length === 1;
+            }, 'the item page and license field to load');
             girderTest.waitForLoad();
 
             runs(function () {
                 // Item info should show that license is unspecified
-                // TODO: to investigate; only one license will be shown when girder is live.
-                // It will be duplicated while testing -- g:rendered seems to be received twice.
-                expect($('.g-item-license').length).not.toBe(0); // was .toBe(1)
+                expect($('.g-item-license').length).toBe(1);
                 expect($('.g-item-license').text()).toContain('Unspecified');
             });
         });
@@ -356,8 +352,8 @@ $(function () {
             girderTest.waitForLoad();
 
             waitsFor(function () {
-                return $('.g-item-name').length === 1;
-            }, 'the item page to load');
+                return $('.g-item-name').length === 1 && $('.g-item-license').length === 1;
+            }, 'the item page and license field to load');
             girderTest.waitForLoad();
             runs(function () {
                 // Item info should show license
@@ -407,8 +403,8 @@ $(function () {
             girderTest.waitForLoad();
 
             waitsFor(function () {
-                return $('.g-item-name').length === 1;
-            }, 'the item page to load');
+                return $('.g-item-name').length === 1 && $('.g-item-license').length === 1;
+            }, 'the item page and license field to load');
             girderTest.waitForLoad();
             runs(function () {
                 // Item info should show that license is unspecified

--- a/plugins/jobs/plugin_tests/jobsSpec.js
+++ b/plugins/jobs/plugin_tests/jobsSpec.js
@@ -133,11 +133,11 @@ $(function () {
                     showFilters: true,
                     showPageSizeSelector: true
                 }).render();
-
+            });
+            girderTest.waitForLoad();
+            runs(function () {
                 expect($('.g-jobs-list-table>tbody>tr').length).toBe(0);
             });
-
-            girderTest.waitForLoad();
 
             runs(function () {
                 jobs = _.map([1, 2, 3], function (i) {

--- a/plugins/jobs/plugin_tests/jobsSpec.js
+++ b/plugins/jobs/plugin_tests/jobsSpec.js
@@ -22,35 +22,42 @@ $(function () {
                 return $('#g-app-body-container').length > 0;
             });
 
+            var oldFetch;
+            var jobInfo = {
+                _id: 'foo',
+                title: 'My batch job',
+                status: girder.plugins.jobs.JobStatus.INACTIVE,
+                log: ['Hello world\n', 'goodbye world'],
+                updated: '2015-01-12T12:00:12Z',
+                created: '2015-01-12T12:00:00Z',
+                when: '2015-01-12T12:00:00Z',
+                timestamps: [{
+                    status: girder.plugins.jobs.JobStatus.QUEUED,
+                    time: '2015-01-12T12:00:02Z'
+                }, {
+                    status: girder.plugins.jobs.JobStatus.RUNNING,
+                    time: '2015-01-12T12:00:03Z'
+                }, {
+                    status: girder.plugins.jobs.JobStatus.SUCCESS,
+                    time: '2015-01-12T12:00:12Z'
+                }]
+            };
             runs(function () {
-                var jobInfo = {
-                    _id: 'foo',
-                    title: 'My batch job',
-                    status: girder.plugins.jobs.JobStatus.INACTIVE,
-                    log: ['Hello world\n', 'goodbye world'],
-                    updated: '2015-01-12T12:00:12Z',
-                    created: '2015-01-12T12:00:00Z',
-                    when: '2015-01-12T12:00:00Z',
-                    timestamps: [{
-                        status: girder.plugins.jobs.JobStatus.QUEUED,
-                        time: '2015-01-12T12:00:02Z'
-                    }, {
-                        status: girder.plugins.jobs.JobStatus.RUNNING,
-                        time: '2015-01-12T12:00:03Z'
-                    }, {
-                        status: girder.plugins.jobs.JobStatus.SUCCESS,
-                        time: '2015-01-12T12:00:12Z'
-                    }]
-                };
-
                 // mock fetch to simulate fetching a job
-                var oldFetch = girder.plugins.jobs.models.JobModel.prototype.fetch;
+                oldFetch = girder.plugins.jobs.models.JobModel.prototype.fetch;
                 girder.plugins.jobs.models.JobModel.prototype.fetch = function () {
                     this.set(jobInfo);
                     this.trigger('g:fetched');
                 };
 
-                girder.router.navigate('job/foo', { trigger: true });
+                girder.router.navigate('job/foo', {trigger: true});
+            });
+
+            waitsFor(function () {
+                return $('.g-job-info-key').length > 0;
+            }, 'the JobDetailsWidget to finish rendering');
+
+            runs(function () {
                 girder.plugins.jobs.models.JobModel.prototype.fetch = oldFetch;
 
                 expect($('.g-monospace-viewer[property="kwargs"]').length).toBe(0);

--- a/plugins/thumbnails/plugin_tests/thumbnailsSpec.js
+++ b/plugins/thumbnails/plugin_tests/thumbnailsSpec.js
@@ -61,9 +61,7 @@ $(function () {
             girderTest.waitForLoad();
 
             waitsFor(function () {
-                // TODO: to investigate; only one thumbnail will be shown when girder is live.
-                // It will be duplicated while testing -- g:rendered seems to be received twice.
-                return $('.g-thumbnail-container').length > 0; // was .length === 1
+                return $('.g-thumbnail-container').length === 1;
             }, 'thumbnail to appear on the item');
         });
     });

--- a/plugins/thumbnails/plugin_tests/thumbnailsSpec.js
+++ b/plugins/thumbnails/plugin_tests/thumbnailsSpec.js
@@ -24,6 +24,10 @@ $(function () {
                 $('a.g-my-folders').click();
             });
             girderTest.waitForLoad();
+            waitsFor(function () {
+                // The page may be loaded, but the folder list still populates asynchronously
+                return $('.g-folder-list>.g-folder-list-entry').length === 2;
+            });
 
             runs(function () {
                 $('a.g-folder-list-link:last').click();


### PR DESCRIPTION
Fixes #1892

* Retrieve HTML data attributes with camel case
  * Per the HTML spec, data attributes should be set on elements as kebab-case attributes, but stored and accessed in Javascript via transformed camel-case variables.
  * https://www.w3.org/TR/html5/dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes
* Upgrade to jQuery 3
* Utilize Promise/A+ compliant behavior of `.then`
  * Since thrown values in .then or .catch are converted into Promise rejection values (which may legitimately contain any value), the eslint `no-throw-literal` rule must be disabled now.
* Refactor `RootSelectorWidget` test to respect async events
  * As documented in new code comments, most of the lifecycle of the `RootSelectorWidget` occurs asynchronously. Although the `browserSpec` tests explicitly disables Bootstrap transitions, tests should still not assume that events will occur instantly and synchronously. In jQuery3, Ajax callbacks happen truly asynchronously, in the main event loop queue, so these tests would not pass.
* Fix broken tests, now that events may be truly asynchronous
* Add new static analysis rules for promises
* Fix the thumbnails test to wait for some asynchronous events to complete
* Attempt to fix possible race conditions in the `jobsSpec` test
* Fix race condition in `web_client_empty_layout` test
  * Just because a new layout is loaded, doesn't mean the `CollectionsView` has finished rendering itself, as that depends on the collection list to fetch.