### PR TITLE
Job Cancellation UI

### DIFF
--- a/plugins/jobs/plugin_tests/jobsSpec.js
+++ b/plugins/jobs/plugin_tests/jobsSpec.js
@@ -59,6 +59,7 @@ $(function () {
                 expect($('.g-job-info-value[property="title"]').text()).toBe(jobInfo.title);
                 expect($('.g-job-info-value[property="when"]').text()).toContain('January 12, 2015');
                 expect($('.g-job-status-badge').text()).toContain('Inactive');
+                expect($('button.g-job-cancel').length).toBe(1);
 
                 expect($('.g-timeline-segment').length).toBe(3);
                 expect($('.g-timeline-point').length).toBe(4);
@@ -90,6 +91,7 @@ $(function () {
                 });
 
                 expect($('.g-job-status-badge').text()).toContain('Success');
+                expect($('button.g-job-cancel').length).toBe(0);
 
                 // Make sure view change only happens for the currently viewed job
                 girder.utilities.eventStream.trigger('g:event.job_status', {
@@ -353,6 +355,63 @@ $(function () {
             waitsFor(function () {
                 return widget.$('.g-jobs-list-table tr').length === 0;
             }, 'no record show be shown');
+        });
+
+        it('job list cancellation', function () {
+            var jobs, widget;
+
+            runs(function () {
+                widget = new girder.plugins.jobs.views.JobListWidget({
+                    el: $('#g-app-body-container'),
+                    parentView: app,
+                    filter: {},
+                    triggerJobClick: true,
+                    showGraphs: true,
+                    showFilters: true,
+                    showPageSizeSelector: true
+                }).render();
+            });
+
+            girderTest.waitForLoad();
+
+            runs(function () {
+                jobs = _.map([1, 2, 3], function (i) {
+                    return new girder.plugins.jobs.models.JobModel({
+                        _id: 'foo' + i,
+                        title: 'My batch job ' + i,
+                        status: i,
+                        updated: '2015-01-12T12:00:0' + i,
+                        created: '2015-01-12T12:00:0' + i,
+                        when: '2015-01-12T12:00:0' + i
+                    });
+                });
+
+                widget.collection.add(jobs);
+            });
+
+            waitsFor(function () {
+                return $('.g-jobs-list-table>tbody>tr').length === 3;
+            }, 'job list to auto-reload when collection is updated');
+
+            runs(function () {
+                // button is disabled when no job is checked
+                expect(widget.$('.g-job-check-menu-button').is(':disabled')).toBe(true);
+
+                widget.$('input:checkbox:not(:checked).g-job-checkbox').click();
+                widget.$('input:checkbox:not(:checked).g-job-checkbox').click();
+                widget.$('input:checkbox:not(:checked).g-job-checkbox').click();
+
+                expect(widget.$('.g-job-check-menu-button').is(':disabled')).toBe(false);
+                expect(widget.$('.g-job-checkbox-all').is(':checked')).toBe(true);
+                widget.$('.g-job-checkbox-all').click();
+
+                expect(widget.$('input:checkbox:not(:checked).g-job-checkbox').length).toBe(3);
+
+                widget.$('.g-job-checkbox-all').click();
+                expect(widget.$('input:checkbox:not(:checked).g-job-checkbox').length).toBe(0);
+
+                widget.$('.g-jobs-list-cancel').click();
+            });
         });
 
         it('timing history and time chart', function () {

--- a/plugins/jobs/web_client/stylesheets/jobDetailsWidget.styl
+++ b/plugins/jobs/web_client/stylesheets/jobDetailsWidget.styl
@@ -17,5 +17,9 @@
   text-transform uppercase
   font-size 13px
 
+.g-job-cancel
+  margin-left 10px
+  padding 2px 8px
+
 .g-job-timeline-container
   margin-top 5px

--- a/plugins/jobs/web_client/stylesheets/jobListWidget.styl
+++ b/plugins/jobs/web_client/stylesheets/jobListWidget.styl
@@ -1,5 +1,9 @@
 @import '~nib/index.styl'
 
+.check-menu-dropdown
+  .g-job-check-menu-button
+    padding 2px 1px 0 2px
+
 .g-jobs-list-table
   width 100%
 

--- a/plugins/jobs/web_client/stylesheets/jobListWidget.styl
+++ b/plugins/jobs/web_client/stylesheets/jobListWidget.styl
@@ -2,6 +2,7 @@
 
 .check-menu-dropdown
   position relative
+  width 20px
   left -2px
   
   .g-job-check-menu-button

--- a/plugins/jobs/web_client/stylesheets/jobListWidget.styl
+++ b/plugins/jobs/web_client/stylesheets/jobListWidget.styl
@@ -1,8 +1,15 @@
 @import '~nib/index.styl'
 
 .check-menu-dropdown
+  position relative
+  left -2px
+  
   .g-job-check-menu-button
     padding 2px 1px 0 2px
+
+    i
+      position relative
+      top -3px
 
 .g-jobs-list-table
   width 100%

--- a/plugins/jobs/web_client/templates/jobDetailsWidget.pug
+++ b/plugins/jobs/web_client/templates/jobDetailsWidget.pug
@@ -1,3 +1,7 @@
+ol.breadcrumb
+  li.breadcrumb-item
+    a(href="#/jobs") Jobs
+  li.breadcrumb-item.active Job detail
 .g-field-container
   .g-job-info-key.inline(property="title") Title:
   .g-job-info-value.inline(property="title")= job.get('title')
@@ -12,6 +16,10 @@
   .g-job-status-badge(status=statusText.toLowerCase(), style=`color: ${textColor}; background-color: ${color};`)
     i(class=JobStatus.icon(job.get('status')))
     |  #{statusText}
+  if [JobStatus.CANCELED, JobStatus.SUCCESS, JobStatus.ERROR].indexOf(job.get('status')) === -1
+    button.g-job-cancel.btn.btn-default.btn-sm(type="button")
+      i.icon-cancel 
+      | Cancel
 if job.get('timestamps') && job.get('timestamps').length
   .g-field-container
     .g-job-info-key Timeline:
@@ -39,7 +47,3 @@ if job.get('args') && job.get('args').length
 if job.get('kwargs')
   .g-job-info-key(property="kwargs") Keyword arguments:
   .g-monospace-viewer(property="kwargs")= JSON.stringify(job.get('kwargs'), null, '  ')
-if job.get('status') === JobStatus.RUNNING
-  button.job-cancel.btn.btn-default.btn-sm(type="submit")
-    i.icon-cancel
-    | Cancel

--- a/plugins/jobs/web_client/templates/jobList.pug
+++ b/plugins/jobs/web_client/templates/jobList.pug
@@ -2,8 +2,21 @@ table.g-jobs-list-table
   if showHeader
     thead
       tr
+        if columns & columnEnum.COLUMN_ACTION_CHECKBOX
+          th
+            input.g-job-checkbox-all(type="checkbox", checked=allJobChecked)
         if columns & columnEnum.COLUMN_STATUS_ICON
           th
+            if columns & columnEnum.COLUMN_ACTION_CHECKBOX
+              .dropdown.check-menu-dropdown
+                button.btn.btn-sm.btn-default.dropdown-toggle.g-job-check-menu-button(data-toggle="dropdown", disabled=!anyJobChecked)
+                  i.icon-check
+                  i.icon-down-dir
+                ul.dropdown-menu
+                  li
+                    a.g-job-cancel
+                      i.icon-cancel
+                      | Cancel
         if columns & columnEnum.COLUMN_TITLE
           th Title
         if columns & columnEnum.COLUMN_UPDATED
@@ -15,7 +28,10 @@ table.g-jobs-list-table
 
   tbody
     each job in jobs
-      tr(g-job-id=job.id)
+      tr(g-job-id=job.id,class=jobHighlightStates[job.id]?"g-highlight":"")
+        if columns & columnEnum.COLUMN_ACTION_CHECKBOX
+          td
+            input.g-job-checkbox(type="checkbox", checked=jobCheckedStates[job.id])
         if columns & columnEnum.COLUMN_STATUS_ICON
           td(style='color: ' + JobStatus.color(job.get('status')))
             i(class=JobStatus.icon(job.get('status')))

--- a/plugins/jobs/web_client/templates/jobList.pug
+++ b/plugins/jobs/web_client/templates/jobList.pug
@@ -4,19 +4,17 @@ table.g-jobs-list-table
       tr
         if columns & columnEnum.COLUMN_ACTION_CHECKBOX
           th
-            input.g-job-checkbox-all(type="checkbox", checked=allJobChecked)
-        if columns & columnEnum.COLUMN_STATUS_ICON
-          th
-            if columns & columnEnum.COLUMN_ACTION_CHECKBOX
-              .dropdown.check-menu-dropdown
+            .dropdown.check-menu-dropdown
                 button.btn.btn-sm.btn-default.dropdown-toggle.g-job-check-menu-button(data-toggle="dropdown", disabled=!anyJobChecked)
-                  i.icon-check
+                  input.g-job-checkbox-all(type="checkbox", checked=allJobChecked)
                   i.icon-down-dir
                 ul.dropdown-menu
                   li
-                    a.g-job-cancel
+                    a.g-jobs-list-cancel
                       i.icon-cancel
                       | Cancel
+        if columns & columnEnum.COLUMN_STATUS_ICON
+          th
         if columns & columnEnum.COLUMN_TITLE
           th Title
         if columns & columnEnum.COLUMN_UPDATED
@@ -28,7 +26,7 @@ table.g-jobs-list-table
 
   tbody
     each job in jobs
-      tr(g-job-id=job.id,class=jobHighlightStates[job.id]?"g-highlight":"")
+      tr(g-job-id=job.id, class=jobHighlightStates[job.id]?"g-highlight":"")
         if columns & columnEnum.COLUMN_ACTION_CHECKBOX
           td
             input.g-job-checkbox(type="checkbox", checked=jobCheckedStates[job.id])

--- a/plugins/jobs/web_client/views/JobDetailsWidget.js
+++ b/plugins/jobs/web_client/views/JobDetailsWidget.js
@@ -13,8 +13,7 @@ import '../stylesheets/jobDetailsWidget.styl';
 
 var JobDetailsWidget = View.extend({
     events: {
-        'click .job-cancel': function (event) {
-            event.preventDefault();
+        'click .g-job-cancel': function (event) {
             this._cancelJob();
         }
     },

--- a/plugins/jobs/web_client/views/JobListWidget.js
+++ b/plugins/jobs/web_client/views/JobListWidget.js
@@ -334,7 +334,7 @@ var JobListWidget = View.extend({
             }
             events.trigger('g:alert', {
                 icon: 'ok',
-                text: `Cancel requests sent for ${results.length} ${results.length === 1 ? 'job' : 'jobs'}`,
+                text: `Cancel ${results.length === 1 ? 'request' : 'requests'} sent for ${results.length} ${results.length === 1 ? 'job' : 'jobs'}`,
                 type: 'info',
                 timeout: 4000
             });

--- a/plugins/jobs/web_client/views/JobListWidget.js
+++ b/plugins/jobs/web_client/views/JobListWidget.js
@@ -3,6 +3,7 @@ import _ from 'underscore';
 import PaginateWidget from 'girder/views/widgets/PaginateWidget';
 import View from 'girder/views/View';
 import router from 'girder/router';
+import events from 'girder/events';
 import { restRequest } from 'girder/rest';
 import { defineFlags, formatDate, DATE_SECOND } from 'girder/misc';
 import eventStream from 'girder/utilities/EventStream';
@@ -27,6 +28,27 @@ var JobListWidget = View.extend({
         'change select.g-page-size': function (e) {
             this.collection.pageLimit = parseInt($(e.target).val());
             this.collection.fetch({}, true);
+        },
+        'change input.g-job-checkbox': function (e) {
+            var jobId = $(e.target).closest('tr').attr('g-job-id');
+            if ($(e.target).is(':checked')) {
+
+                this.jobCheckedStates[jobId] = true;
+            } else {
+                delete this.jobCheckedStates[jobId];
+            }
+            this._renderData();
+        },
+        'change input.g-job-checkbox-all': function (e) {
+            if ($(e.target).is(':checked')) {
+                this.jobs.forEach(job => this.jobCheckedStates[job.id] = true);
+            } else {
+                this.jobCheckedStates = {};
+            }
+            this._renderData();
+        },
+        'click .check-menu-dropdown a.g-job-cancel': function (e) {
+            this._cancelJobs();
         }
     },
 
@@ -44,6 +66,17 @@ var JobListWidget = View.extend({
             obj[status.text] = true;
             return obj;
         }, {});
+        this.jobCheckedStates = {};
+        this.jobHighlightStates = {};
+        Object.defineProperty(this, 'jobs', {
+            get: () => this.collection.toArray()
+        });
+        Object.defineProperty(this, 'anyJobChecked', {
+            get: () => Object.keys(this.jobCheckedStates).find(key => this.jobCheckedStates[key])
+        });
+        Object.defineProperty(this, 'allJobChecked', {
+            get: () => !this.jobs.find(job => !this.jobCheckedStates[job.id])
+        });
 
         this.jobGraphWidget = null;
 
@@ -58,8 +91,8 @@ var JobListWidget = View.extend({
         this.collection.pageLimit = settings.pageLimit || this.collection.pageLimit;
 
         this.collection
-            .on('g:changed', this._renderData, this)
-            .on('add', this._renderData, this);
+            .on('g:changed', this._onDataChange, this)
+            .on('add', this._onDataChange, this);
 
         this._fetchWithFilter();
 
@@ -142,6 +175,7 @@ var JobListWidget = View.extend({
     },
 
     columnEnum: defineFlags([
+        'COLUMN_ACTION_CHECKBOX',
         'COLUMN_STATUS_ICON',
         'COLUMN_TITLE',
         'COLUMN_UPDATED',
@@ -188,10 +222,13 @@ var JobListWidget = View.extend({
         return this;
     },
 
-    _renderData: function () {
-        var jobs = this.collection.toArray();
+    _onDataChange: function () {
+        this.jobCheckedStates = {};
+        this._renderData();
+    },
 
-        if (!jobs.length) {
+    _renderData: function () {
+        if (!this.jobs.length) {
             this.$('.g-main-content,.g-job-pagination').hide();
             this.$('.g-no-job-record').show();
             return;
@@ -202,7 +239,7 @@ var JobListWidget = View.extend({
 
         if (this.currentView === 'list') {
             this.$('.g-main-content').html(JobListTemplate({
-                jobs: jobs,
+                jobs: this.jobs,
                 showHeader: this.showHeader,
                 columns: this.columns,
                 columnEnum: this.columnEnum,
@@ -210,12 +247,16 @@ var JobListWidget = View.extend({
                 triggerJobClick: this.triggerJobClick,
                 JobStatus: JobStatus,
                 formatDate: formatDate,
-                DATE_SECOND: DATE_SECOND
+                DATE_SECOND: DATE_SECOND,
+                jobCheckedStates: this.jobCheckedStates,
+                jobHighlightStates: this.jobHighlightStates,
+                allJobChecked: this.allJobChecked,
+                anyJobChecked: this.anyJobChecked
             }));
         }
 
         if (this.currentView === 'timing-history' || this.currentView === 'time') {
-            this.jobGraphWidget.update(jobs);
+            this.jobGraphWidget.update(this.jobs);
         }
 
         if (this.showPaging) {
@@ -224,26 +265,30 @@ var JobListWidget = View.extend({
     },
 
     _statusChange: function (event) {
-        let job = _.find(this.collection.toArray(), job => job.get('_id') === event.data._id);
+        let job = _.find(this.jobs, job => job.get('_id') === event.data._id);
         if (!job) {
             return;
         }
         job.set(event.data);
         this._renderData();
-        this._highlightRecordIfOnList(event.data._id);
+        this.trySetHighlightRecord(event.data._id);
     },
 
     _jobCreated: function (event) {
         this._fetchWithFilter()
             .then(() => {
-                this._highlightRecordIfOnList(event.data._id);
+                this.trySetHighlightRecord(event.data._id);
             });
     },
 
-    _highlightRecordIfOnList: function (jobId) {
-        if (this.currentView === 'list') {
-            var tr = this.$('tr[g-job-id=' + jobId + ']').addClass('g-highlight');
-            setTimeout(() => tr.removeClass('g-highlight'), 1000);
+    trySetHighlightRecord: function (jobId) {
+        if (this.jobs.find(job => job.id === jobId)) {
+            this.jobHighlightStates[jobId] = true;
+            this._renderData();
+            setTimeout(() => {
+                delete this.jobHighlightStates[jobId];
+                this._renderData();
+            }, 1000);
         }
     },
 
@@ -266,6 +311,31 @@ var JobListWidget = View.extend({
                 resolve();
             };
             this.collection.on('g:changed', callback);
+        });
+    },
+
+    _cancelJobs: function () {
+        Promise.all(
+            Object.keys(this.jobCheckedStates)
+                .filter(jobId => {
+                    var status = this.jobs.find(job => job.id === jobId).get('status');
+                    return [JobStatus.CANCELED, JobStatus.SUCCESS, JobStatus.ERROR].indexOf(status) === -1;
+                })
+                .map(jobId => Promise.resolve(restRequest({
+                    path: `job/${jobId}/cancel`,
+                    type: 'PUT',
+                    error: null
+                })))
+        ).then(results => {
+            if (!results.length) {
+                return;
+            }
+            events.trigger('g:alert', {
+                icon: 'ok',
+                text: `Cancel requests sent for ${results.length} ${results.length == 1 ? 'job' : 'jobs'}`,
+                type: 'info',
+                timeout: 4000
+            })
         });
     }
 });

--- a/plugins/jobs/web_client/views/JobListWidget.js
+++ b/plugins/jobs/web_client/views/JobListWidget.js
@@ -32,22 +32,24 @@ var JobListWidget = View.extend({
         'change input.g-job-checkbox': function (e) {
             var jobId = $(e.target).closest('tr').attr('g-job-id');
             if ($(e.target).is(':checked')) {
-
                 this.jobCheckedStates[jobId] = true;
             } else {
                 delete this.jobCheckedStates[jobId];
             }
             this._renderData();
         },
+        'click input.g-job-checkbox-all': function (e) {
+            e.stopPropagation();
+        },
         'change input.g-job-checkbox-all': function (e) {
             if ($(e.target).is(':checked')) {
-                this.jobs.forEach(job => this.jobCheckedStates[job.id] = true);
+                this.jobs.forEach(job => { this.jobCheckedStates[job.id] = true; });
             } else {
                 this.jobCheckedStates = {};
             }
             this._renderData();
         },
-        'click .check-menu-dropdown a.g-job-cancel': function (e) {
+        'click .check-menu-dropdown a.g-jobs-list-cancel': function (e) {
             this._cancelJobs();
         }
     },
@@ -332,10 +334,10 @@ var JobListWidget = View.extend({
             }
             events.trigger('g:alert', {
                 icon: 'ok',
-                text: `Cancel requests sent for ${results.length} ${results.length == 1 ? 'job' : 'jobs'}`,
+                text: `Cancel requests sent for ${results.length} ${results.length === 1 ? 'job' : 'jobs'}`,
                 type: 'info',
                 timeout: 4000
-            })
+            });
         });
     }
 });


### PR DESCRIPTION
Based on a small group meeting, the following feature has been implemented
- Checkboxes for job list page
- Menu to apply action to checked item, currently only cancel
- Breadcrumb on job detail page, reposition of cancel button on the detail page

The placement of the menu button is what I found after couple of tries that maximizes space usage and preserve compatibility (the checkbox column is optional)
![2017-06-02_15-25-09](https://cloud.githubusercontent.com/assets/3123478/26741529/b65845f6-47a7-11e7-8e23-d579aaaae570.gif)
