### PR TITLE
GridFS assetstore speed improvements.

### DIFF
--- a/clients/web/test/spec/adminSpec.js
+++ b/clients/web/test/spec/adminSpec.js
@@ -554,7 +554,7 @@ describe('Test the assetstore page', function () {
         'g-new-gridfs-replicaset': 'replicaset'
     }, null, function () {
         return $('.g-validation-failed-message:contains(' +
-                      '"Could not connect to the database: ")').length === 1;
+                 '"Could not connect to the database: ")').length === 1;
     }, 'validation failure to display', true);
 
     _testAssetstore('s3', 'g-create-s3-tab', {

--- a/girder/utility/gridfs_assetstore_adapter.py
+++ b/girder/utility/gridfs_assetstore_adapter.py
@@ -22,6 +22,7 @@ from hashlib import sha512
 import pymongo
 import six
 from six import BytesIO
+import time
 import uuid
 
 from girder import logger
@@ -35,6 +36,10 @@ from .abstract_assetstore_adapter import AbstractAssetstoreAdapter
 # 2MB chunks. Clients must not send any chunks that are smaller than this
 # unless they are sending the final chunk.
 CHUNK_SIZE = 2097152
+
+# Cache recent connections so we can skip some start up actions
+RECENT_CONNECTION_CACHE_TIME = 600  # seconds
+_recentConnections = {}
 
 
 def _ensureChunkIndices(collection):
@@ -79,31 +84,45 @@ class GridFsAssetstoreAdapter(AbstractAssetstoreAdapter):
 
     @staticmethod
     def fileIndexFields():
-        return ['sha512']
+        return ['sha512', 'chunkUuid']
 
     def __init__(self, assetstore):
         """
         :param assetstore: The assetstore to act on.
         """
         super(GridFsAssetstoreAdapter, self).__init__(assetstore)
+        recent = False
+        connectionArgs = (self.assetstore.get('mongohost', None),
+                          self.assetstore.get('replicaset', None))
         try:
-            self.chunkColl = getDbConnection(
-                self.assetstore.get('mongohost', None),
-                self.assetstore.get('replicaset', None)
-            )[self.assetstore['db']].chunk
-            _ensureChunkIndices(self.chunkColl)
+            # Guard in case the connectionArgs is unhashable
+            key = connectionArgs
+            if key in _recentConnections:
+                recent = (time.time() - _recentConnections[key]['created'] <
+                          RECENT_CONNECTION_CACHE_TIME)
+        except Exception:
+            key = None
+        try:
+            # MongoClient automatically reuses connections from a pool, however
+            # getting the connection takes time, so use our own cache.  We also
+            # avoid redoing ensureChunkIndices, which is also takes time.
+            self.chunkColl = getDbConnection(*connectionArgs)[self.assetstore['db']].chunk
+            if not recent:
+                _ensureChunkIndices(self.chunkColl)
+                if key is not None:
+                    _recentConnections[key] = {
+                        'created': time.time()
+                    }
         except pymongo.errors.ConnectionFailure:
             logger.error('Failed to connect to GridFS assetstore %s',
                          self.assetstore['db'])
             self.chunkColl = 'Failed to connect'
             self.unavailable = True
-            return
         except pymongo.errors.ConfigurationError:
             logger.exception('Failed to configure GridFS assetstore %s',
                              self.assetstore['db'])
             self.chunkColl = 'Failed to configure'
             self.unavailable = True
-            return
 
     def initUpload(self, upload):
         """

--- a/girder/utility/gridfs_assetstore_adapter.py
+++ b/girder/utility/gridfs_assetstore_adapter.py
@@ -39,6 +39,7 @@ CHUNK_SIZE = 2097152
 
 # Cache recent connections so we can skip some start up actions
 RECENT_CONNECTION_CACHE_TIME = 600  # seconds
+RECENT_CONNECTION_CACHE_MAX_SIZE = 100
 _recentConnections = {}
 
 
@@ -110,6 +111,8 @@ class GridFsAssetstoreAdapter(AbstractAssetstoreAdapter):
             if not recent:
                 _ensureChunkIndices(self.chunkColl)
                 if key is not None:
+                    if len(_recentConnections) >= RECENT_CONNECTION_CACHE_MAX_SIZE:
+                        _recentConnections.clear()
                     _recentConnections[key] = {
                         'created': time.time()
                     }

--- a/girder/utility/gridfs_assetstore_adapter.py
+++ b/girder/utility/gridfs_assetstore_adapter.py
@@ -101,12 +101,12 @@ class GridFsAssetstoreAdapter(AbstractAssetstoreAdapter):
             if key in _recentConnections:
                 recent = (time.time() - _recentConnections[key]['created'] <
                           RECENT_CONNECTION_CACHE_TIME)
-        except Exception:
+        except TypeError:
             key = None
         try:
             # MongoClient automatically reuses connections from a pool, however
             # getting the connection takes time, so use our own cache.  We also
-            # avoid redoing ensureChunkIndices, which is also takes time.
+            # avoid redoing ensureChunkIndices, which also takes time.
             self.chunkColl = getDbConnection(*connectionArgs)[self.assetstore['db']].chunk
             if not recent:
                 _ensureChunkIndices(self.chunkColl)

--- a/girder/utility/gridfs_assetstore_adapter.py
+++ b/girder/utility/gridfs_assetstore_adapter.py
@@ -104,9 +104,9 @@ class GridFsAssetstoreAdapter(AbstractAssetstoreAdapter):
         except TypeError:
             key = None
         try:
-            # MongoClient automatically reuses connections from a pool, however
-            # getting the connection takes time, so use our own cache.  We also
-            # avoid redoing ensureChunkIndices, which also takes time.
+            # MongoClient automatically reuses connections from a pool, but we
+            # want to avoid redoing ensureChunkIndices each time we get such a
+            # connection.
             self.chunkColl = getDbConnection(*connectionArgs)[self.assetstore['db']].chunk
             if not recent:
                 _ensureChunkIndices(self.chunkColl)


### PR DESCRIPTION
Speed up GridFS deletes by adding the right index.  We check if a gridfs chunk is used by querying for the chunkUuid.  There was no index on this, so deletes were very slow with even a modest number of GridFS files.

Record if we have used a Mongo connection recently.  If so, don't ensure indices on it.  On my local system using a remote mongo GridFS server, ensuring indices that already exist consumes an average of around 6 ms.