### PR TITLE
Don't use developer names in source code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:6
-MAINTAINER Patrick Reynolds <patrick.reynolds@kitware.com>
+MAINTAINER Kitware, Inc. <kitware@kitware.com>
 
 EXPOSE 8080
 

--- a/devops/ansible/roles/girder/library/README.md
+++ b/devops/ansible/roles/girder/library/README.md
@@ -22,11 +22,11 @@ The girder ansible module relies on the girder-client to do most of the heavy li
 - name: Create 'admin' User
   girder:
     user:
-      firstName: "Chris"
-      lastName: "Kotfila"
+      firstName: "John"
+      lastName: "Doe"
       login: "admin"
       password: "letmein"
-      email: "chris.kotfila@kitware.com"
+      email: "john.doe@test.com"
       admin: yes
     state: present
 ```
@@ -42,7 +42,7 @@ The girder ansible module relies on the girder-client to do most of the heavy li
       lastName: "Bar"
       login: "foobar"
       password: "foobarbaz"
-      email: "foo.bar@kitware.com"
+      email: "foo.bar@test.com"
       admin: yes
     state: present
 ```
@@ -90,7 +90,7 @@ To enable or disable all plugins you may pass the "*" argument.  This does not (
       - gravatar
     state: present
 ```
-**Note:** that the list of enabled plugins is now ```thumbnails```, ```jobs```, ```gravatar```. The 'plugins' task ensures that plugins are enabled or disabled, it does *not* define the complete list of enabled or disabled plugins. Additionally,  while the plugins are enabled they will not be active until the server is restarted. This should be achieved through another task (either through setting up girder as a system level task,  or through posting to system/restart). 
+**Note:** that the list of enabled plugins is now ```thumbnails```, ```jobs```, ```gravatar```. The 'plugins' task ensures that plugins are enabled or disabled, it does *not* define the complete list of enabled or disabled plugins. Additionally,  while the plugins are enabled they will not be active until the server is restarted. This should be achieved through another task (either through setting up girder as a system level task,  or through posting to system/restart).
 
 
 ### Filesystem Assetstore Tests

--- a/devops/ansible/roles/girder/library/girder.py
+++ b/devops/ansible/roles/girder/library/girder.py
@@ -39,7 +39,7 @@ __version__ = "0.3.0"
 DOCUMENTATION = '''
 ---
 module: girder
-author: "Chris Kotfila (chris.kotfila@kitware.com)
+author: "Kitware, Inc. <kitware@kitware.com>
 version_added: "0.1"
 short_description: A module that wraps girder_client
 requirements: [ girder_client==1.1.0 ]

--- a/devops/ansible/roles/girder/library/girder.py
+++ b/devops/ansible/roles/girder/library/girder.py
@@ -456,11 +456,11 @@ EXAMPLES = '''
 - name: Create 'admin' User
   girder:
     user:
-      firstName: "Chris"
-      lastName: "Kotfila"
+      firstName: "John"
+      lastName: "Doe"
       login: "admin"
       password: "letmein"
-      email: "chris.kotfila@kitware.com"
+      email: "john.due@test.com"
       admin: yes
     state: present
 
@@ -474,7 +474,7 @@ EXAMPLES = '''
       lastName: "Bar"
       login: "foobar"
       password: "foobarbaz"
-      email: "foo.bar@kitware.com"
+      email: "foo.bar@test.com"
       admin: yes
     state: present
 
@@ -500,10 +500,10 @@ EXAMPLES = '''
     password: "letmein"
     user:
       firstName: "Alice"
-      lastName: "Test"
+      lastName: "Doe"
       login: "alice"
       password: "letmein"
-      email: "alice.test@kitware.com"
+      email: "alice.doe@test.com"
     state: present
 
 # Create a 'bill' user
@@ -514,10 +514,10 @@ EXAMPLES = '''
     password: "letmein"
     user:
       firstName: "Bill"
-      lastName: "Test"
+      lastName: "Doe"
       login: "bill"
       password: "letmein"
-      email: "bill.test@kitware.com"
+      email: "bill.doe@test.com"
     state: present
 
 # Create a 'chris' user
@@ -528,10 +528,10 @@ EXAMPLES = '''
     password: "letmein"
     user:
       firstName: "Chris"
-      lastName: "Test"
+      lastName: "Doe"
       login: "chris"
       password: "letmein"
-      email: "chris.test@kitware.com"
+      email: "chris.doe@test.com"
     state: present
 
 - name: Create a test group with users

--- a/devops/ansible/roles/girder/library/test/test_access.yml
+++ b/devops/ansible/roles/girder/library/test/test_access.yml
@@ -6,11 +6,11 @@
       girder:
         port: 8080
         user:
-          firstName: "Chris"
-          lastName: "Kotfila"
+          firstName: "John"
+          lastName: "Doe"
           login: "admin"
           password: "letmein"
-          email: "chris.kotfila@kitware.com"
+          email: "john.doe@test.com"
           admin: yes
         state: present
 
@@ -22,10 +22,10 @@
         password: "letmein"
         user:
           firstName: "Alice"
-          lastName: "Test"
+          lastName: "Doe"
           login: "alice"
           password: "letmein"
-          email: "alice.test@kitware.com"
+          email: "alice.doe@test.com"
         state: present
 
     # Create an 'bill' user
@@ -36,10 +36,10 @@
         password: "letmein"
         user:
           firstName: "Bill"
-          lastName: "Test"
+          lastName: "Doe"
           login: "bill"
           password: "letmein"
-          email: "bill.test@kitware.com"
+          email: "bill.doe@test.com"
         state: present
 
     # Create an 'chris' user
@@ -50,10 +50,10 @@
         password: "letmein"
         user:
           firstName: "Chris"
-          lastName: "Test"
+          lastName: "Doe"
           login: "chris"
           password: "letmein"
-          email: "chris.test@kitware.com"
+          email: "chris.doe@test.com"
         state: present
 
     - girder:
@@ -958,10 +958,10 @@
         password: "letmein"
         user:
           firstName: "Alice"
-          lastName: "Test"
+          lastName: "Doe"
           login: "alice"
           password: "letmein"
-          email: "alice.test@kitware.com"
+          email: "alice.doe@test.com"
         state: absent
 
     - name: Remove 'bill' User
@@ -971,10 +971,10 @@
         password: "letmein"
         user:
           firstName: "Bill"
-          lastName: "Test"
+          lastName: "Doe"
           login: "bill"
           password: "letmein"
-          email: "bill.test@kitware.com"
+          email: "bill.doe@test.com"
         state: absent
 
     - name: Remove 'chris' User
@@ -984,8 +984,8 @@
         password: "letmein"
         user:
           firstName: "Chris"
-          lastName: "Test"
+          lastName: "Doe"
           login: "chris"
           password: "letmein"
-          email: "chris.test@kitware.com"
+          email: "chris.doe@test.com"
         state: absent

--- a/devops/ansible/roles/girder/library/test/test_apikey.yml
+++ b/devops/ansible/roles/girder/library/test/test_apikey.yml
@@ -6,11 +6,11 @@
       girder:
         port: 8080
         user:
-          firstName: "Chris"
-          lastName: "Kotfila"
+          firstName: "John"
+          lastName: "Doe"
           login: "admin"
           password: "letmein"
-          email: "chris.kotfila@kitware.com"
+          email: "john.doe@test.com"
           admin: yes
         state: present
 

--- a/devops/ansible/roles/girder/library/test/test_assetstore.yml
+++ b/devops/ansible/roles/girder/library/test/test_assetstore.yml
@@ -10,11 +10,11 @@
       girder:
         port: 8080
         user:
-          firstName: "Chris"
-          lastName: "Kotfila"
+          firstName: "John"
+          lastName: "Doe"
           login: "admin"
           password: "letmein"
-          email: "chris.kotfila@kitware.com"
+          email: "john.doe@test.com"
           admin: yes
         state: present
 
@@ -86,7 +86,7 @@
         state: present
       register: ret
 
-    # Updating an assetstore with idential information should
+    # Updating an assetstore with identical information should
     # show no change.
     - assert:
         that:

--- a/devops/ansible/roles/girder/library/test/test_files.yml
+++ b/devops/ansible/roles/girder/library/test/test_files.yml
@@ -5,11 +5,11 @@
       girder:
         port: 8080
         user:
-          firstName: "Chris"
-          lastName: "Kotfila"
+          firstName: "John"
+          lastName: "Doe"
           login: "admin"
           password: "letmein"
-          email: "chris.kotfila@kitware.com"
+          email: "john.doe@test.com"
           admin: yes
         state: present
 

--- a/devops/ansible/roles/girder/library/test/test_hierarchy.yml
+++ b/devops/ansible/roles/girder/library/test/test_hierarchy.yml
@@ -6,11 +6,11 @@
       girder:
         port: 8080
         user:
-          firstName: "Chris"
-          lastName: "Kotfila"
+          firstName: "John"
+          lastName: "Doe"
           login: "admin"
           password: "letmein"
-          email: "chris.kotfila@kitware.com"
+          email: "john.doe@test.com"
           admin: yes
         state: present
 
@@ -30,10 +30,10 @@
         password: "letmein"
         user:
           firstName: "Alice"
-          lastName: "Test"
+          lastName: "Doe"
           login: "alice"
           password: "letmein"
-          email: "alice.test@kitware.com"
+          email: "alice.doe@test.com"
           folders:
             - name: "Public"
             - name: "Private"
@@ -99,10 +99,10 @@
         password: "letmein"
         user:
           firstName: "Bill"
-          lastName: "Test"
+          lastName: "Doe"
           login: "bill"
           password: "letmein"
-          email: "bill.test@kitware.com"
+          email: "bill.doe@test.com"
         state: present
 
     # Create an 'chris' user
@@ -113,10 +113,10 @@
         password: "letmein"
         user:
           firstName: "Chris"
-          lastName: "Test"
+          lastName: "Doe"
           login: "chris"
           password: "letmein"
-          email: "chris.test@kitware.com"
+          email: "chris.doe@test.com"
         state: present
 
     - name: Create a test group with users
@@ -390,10 +390,10 @@
         password: "letmein"
         user:
           firstName: "Alice"
-          lastName: "Test"
+          lastName: "Doe"
           login: "alice"
           password: "letmein"
-          email: "alice.test@kitware.com"
+          email: "alice.doe@test.com"
         state: absent
 
     - name: Remove 'bill' User
@@ -403,10 +403,10 @@
         password: "letmein"
         user:
           firstName: "Bill"
-          lastName: "Test"
+          lastName: "Doe"
           login: "bill"
           password: "letmein"
-          email: "bill.test@kitware.com"
+          email: "bill.doe@test.com"
         state: absent
 
     - name: Remove 'chris' User
@@ -416,8 +416,8 @@
         password: "letmein"
         user:
           firstName: "Chris"
-          lastName: "Test"
+          lastName: "Doe"
           login: "chris"
           password: "letmein"
-          email: "chris.test@kitware.com"
+          email: "chris.doe@test.com"
         state: absent

--- a/devops/ansible/roles/girder/library/test/test_plugin.yml
+++ b/devops/ansible/roles/girder/library/test/test_plugin.yml
@@ -5,11 +5,11 @@
       girder:
         port: 8080
         user:
-          firstName: "Chris"
-          lastName: "Kotfila"
+          firstName: "John"
+          lastName: "Doe"
           login: "admin"
           password: "letmein"
-          email: "chris.kotfila@kitware.com"
+          email: "john.doe@test.com"
           admin: yes
         state: present
 

--- a/devops/ansible/roles/girder/library/test/test_resources.yml
+++ b/devops/ansible/roles/girder/library/test/test_resources.yml
@@ -6,11 +6,11 @@
       girder:
         port: 8080
         user:
-          firstName: "Chris"
-          lastName: "Kotfila"
+          firstName: "John"
+          lastName: "Doe"
           login: "admin"
           password: "letmein"
-          email: "chris.kotfila@kitware.com"
+          email: "john.doe@test.com"
           admin: yes
         state: present
 

--- a/devops/ansible/roles/girder/library/test/test_setting.yml
+++ b/devops/ansible/roles/girder/library/test/test_setting.yml
@@ -5,11 +5,11 @@
       girder:
         port: 8080
         user:
-          firstName: "Chris"
-          lastName: "Kotfila"
+          firstName: "John"
+          lastName: "Doe"
           login: "admin"
           password: "letmein"
-          email: "chris.kotfila@kitware.com"
+          email: "john.doe@test.com"
           admin: yes
         state: present
 

--- a/devops/ansible/roles/girder/library/test/test_user.yml
+++ b/devops/ansible/roles/girder/library/test/test_user.yml
@@ -6,11 +6,11 @@
       girder:
         port: 8080
         user:
-          firstName: "Chris"
-          lastName: "Kotfila"
+          firstName: "John"
+          lastName: "Doe"
           login: "admin"
           password: "letmein"
-          email: "chris.kotfila@kitware.com"
+          email: "john.doe@test.com"
           admin: yes
         state: present
       register: gc_return
@@ -40,11 +40,11 @@
       girder:
         port: 8080
         user:
-          firstName: "Chris"
-          lastName: "Kotfila"
+          firstName: "John"
+          lastName: "Doe"
           login: "admin"
           password: "letmein"
-          email: "chris.kotfila@kitware.com"
+          email: "john.doe@test.com"
           admin: yes
         state: present
       register: ret
@@ -57,15 +57,15 @@
 
     # Should show 'changed'  because we update the name
     # Note that 'login' and 'password' cannot but updated
-    - name: Update 'admin' User (Chris => Christopher)
+    - name: Update 'admin' User (John => Jack)
       girder:
         port: 8080
         user:
-          firstName: "Christopher"
-          lastName: "Kotfila"
+          firstName: "Jack"
+          lastName: "Doe"
           login: "admin"
           password: "letmein"
-          email: "chris.kotfila@kitware.com"
+          email: "john.doe@test.com"
           admin: yes
         state: present
       register: ret
@@ -99,7 +99,7 @@
           lastName: "Bar"
           login: "foobar"
           password: "foobarbaz"
-          email: "foo.bar@kitware.com"
+          email: "foo.bar@test.com"
           admin: yes
         state: present
 

--- a/plugins/autojoin/plugin_tests/autojoinSpec.js
+++ b/plugins/autojoin/plugin_tests/autojoinSpec.js
@@ -75,7 +75,7 @@ $(function () {
 
         it('create auto join rules', function () {
             runs(function () {
-                $('#g-autojoin-pattern').val('@kitware.com');
+                $('#g-autojoin-pattern').val('@test.com');
                 $('#g-autojoin-group').val(group1);
                 $('#g-autojoin-level').val(2);
                 $('#g-autojoin-add').click();
@@ -125,7 +125,7 @@ $(function () {
 
         it('logout', girderTest.logout());
         it('register a user', girderTest.createUser(
-            'user2', 'user2@kitware.com', 'Joe', 'User', 'password'
+            'user2', 'user2@test.com', 'Joe', 'User', 'password'
         ));
         it('go to groups page', girderTest.goToGroupsPage());
         it('verify correct groups', function () {

--- a/plugins/autojoin/plugin_tests/autojoin_test.py
+++ b/plugins/autojoin/plugin_tests/autojoin_test.py
@@ -32,7 +32,7 @@ class AutoJoinTest(base.TestCase):
         # set auto join rules
         rules = [
             {
-                'pattern': '@kitware.com',
+                'pattern': '@test.com',
                 'groupId': str(g1['_id']),
                 'level': AccessType.ADMIN
             },
@@ -58,9 +58,9 @@ class AutoJoinTest(base.TestCase):
         user1 = self.model('user').createUser(
             'user1', 'password', 'John', 'Doe', 'user1@example.com')
         user2 = self.model('user').createUser(
-            'user2', 'password', 'John', 'Doe', 'user2@kitware.com')
+            'user2', 'password', 'John', 'Doe', 'user2@test.com')
         user3 = self.model('user').createUser(
-            'user3', 'password', 'John', 'Doe', 'user3@kitware.co')
+            'user3', 'password', 'John', 'Doe', 'user3@test.co')
 
         # check correct groups were joined
         self.assertEqual(user1['groups'], [g2['_id'], g3['_id']])


### PR DESCRIPTION
All package metadata should point to Kitware, Inc.'s support link.

Developer names and real email domains should not be used in source code or for testing. This creates additional risks for spam, phishing, etc. with no corresponding benefit. Unique fake names are easy to generate.