### PR TITLE
Make NodeJS 6 the minimum supported version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ machine:
     JASMINE_TIMEOUT: 15000
     DEBIAN_FRONTEND: noninteractive
   node:
-    version: 5.12
+    version: 6
   post:
     - pyenv global 2.7.11
     - if [ "$CIRCLE_NODE_INDEX" -eq 1 ] ; then pyenv global 3.4.4 ; fi

--- a/devops/ansible/roles/girder/tasks/npm-Debian.yml
+++ b/devops/ansible/roles/girder/tasks/npm-Debian.yml
@@ -1,13 +1,15 @@
 ---
 
 - name: NodeJS | Add PPA key
-  command: "apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 68576280"
+  apt_key:
+    keyserver: "keyserver.ubuntu.com"
+    id: "68576280"
   become: yes
   become_user: root
 
 - name: NodeJS | Add PPA
   apt_repository:
-    repo: "deb https://deb.nodesource.com/node_4.x {{ ansible_distribution_release }} main"
+    repo: "deb https://deb.nodesource.com/node_6.x {{ ansible_distribution_release }} main"
   become: yes
   become_user: root
 
@@ -18,6 +20,6 @@
   become_user: root
 
 - name: NodeJS | Update npm
-  command: "npm install -g npm@3"
+  command: "npm install -g npm"
   become: yes
   become_user: root

--- a/devops/ansible/roles/girder/tasks/npm-RedHat.yml
+++ b/devops/ansible/roles/girder/tasks/npm-RedHat.yml
@@ -1,23 +1,19 @@
 ---
 
-- name: NodeJS | Download repo setup script
-  # Due to issues with this potentially running on python < 2.7.9, validating
-  # certs via Python (ansible) can be an issue.
-  # We could use curl and bypass this, but instead we'll just disable cert validation
-  # and require the output match the known good checksum.
-  get_url:
-    url: https://rpm.nodesource.com/setup_4.x
-    dest: "/tmp/setup_4.x"
-    validate_certs: no
-    checksum: sha256:3359378636868f9fd9f0565a28191ed7e831e91b703b581ab9ff737a4574e5f4
-
 - name: NodeJS | Install repo
-  shell: "bash /tmp/setup_4.x"
+  yum_repository:
+    name: nodesource
+    description: Node.js Packages for Enterprise Linux 7 - $basearch
+    baseurl: https://rpm.nodesource.com/pub_6.x/el/7/$basearch
+    gpgcheck: yes
+    gpgkey: https://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL
+    enabled: yes
   become: yes
   become_user: root
 
 - name: NodeJS | Install package
   yum:
     name: nodejs
+    update_cache: yes
   become: yes
   become_user: root

--- a/docs/prerequisites.rst
+++ b/docs/prerequisites.rst
@@ -6,7 +6,7 @@ The following software packages are required to be installed on your system:
 * `Python 2.7 or 3.4 <https://www.python.org>`_
 * `pip <https://pypi.python.org/pypi/pi>`_
 * `MongoDB 2.6+ <http://www.mongodb.org/>`_
-* `Node.js <http://nodejs.org/>`_
+* `Node.js 6.5+ <http://nodejs.org/>`_
 * `curl <http://curl.haxx.se/>`_
 * `zlib <http://www.zlib.net/>`_
 * `libjpeg <http://libjpeg.sourceforge.net/>`_
@@ -26,6 +26,17 @@ See the specific instructions for your platform below.
 .. warning:: Some Girder plugins do not support Python 3 at this time due to
    third party library dependencies. Namely, the HDFS Assetstore plugin and the
    Metadata Extractor plugin will only be available in a Python 2.7 environment.
+
+.. note:: It's recommended to get the latest version of the npm package manager, and Girder currently
+   requires at least version 3.10 of npm. To upgrade to the latest npm, after installing Node.js,
+   run:
+
+   .. code-block:: bash
+
+      npm install -g npm
+
+   This may need to be run as root using ``sudo``.
+
 
 * :ref:`debian-ubuntu`
 * :ref:`centos-fedora-rhel`
@@ -91,12 +102,6 @@ Install Node.js and NPM using APT: ::
 
     sudo apt-get install nodejs
 
-.. note:: It's recommended to get the latest version of the npm package manager, and Girder currently
-   requires at least version 3 of npm. To upgrade to the latest npm, run: ::
-
-      npm install -g npm
-
-   This may need to be run as root using ``sudo``.
 
 .. _centos-fedora-rhel:
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "type": "git",
     "url": "https://github.com/girder/girder.git"
   },
+  "engines": {
+    "node": ">=6.5",
+    "npm": ">=3.10"
+  },
   "dependencies": {
     "as-jqplot": "1.0.8",
     "babel-core": "^6.24.1",


### PR DESCRIPTION
Per https://github.com/nodejs/LTS :
* NodeJS 4 went out of active support on April 1, 2017, so only critical bugs, critical security fixes, and documentation updates will be made to it in the future.
* NodeJS 5 is not an LTS release, and currently has no support.
* NodeJS 6 is the supported LTS release, at present, until April 2018.

Per http://node.green/ , NodeJS 6.5 is the first release that generally supports the full ES6 feature set.

Accordingly, Girder should now consider NodeJS 6.5 to be the minimum supported version. Girder has adequate documentation (updated by this commit) on how to install NodeJS 6.x, and Ansible scripts to do the same. For systems without root access, the "nvm" tool can be used to install any newer version of NodeJS.

Since NodeJS 6.5 is released with npm 3.10, per https://nodejs.org/en/download/releases/ , Girder should consider that to be the minimum supported version of npm.

Fixes #1848