### PR TITLE
Client download fail check

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -1093,7 +1093,7 @@ class GirderClient(object):
 
         url = '%sfile/%s/download' % (self.urlBase, fileId)
         req = self._requestFunc('get')(url, stream=True, headers={'Girder-Token': self.token})
-        if req.status_code != requests.codes.ok:
+        if not req.ok:
             raise HttpError(req.status_code, req.text, url, 'GET')
         with tempfile.NamedTemporaryFile(delete=False) as tmp:
             with self.progressReporterCls(

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -1090,7 +1090,7 @@ class GirderClient(object):
         progressFileName = fileId
         if isinstance(path, six.string_types):
             progressFileName = os.path.basename(path)
-            
+
         url = '%sfile/%s/download' % (self.urlBase, fileId)
         req = self._requestFunc('get')(url, stream=True, headers={'Girder-Token': self.token})
         if req.status_code != requests.codes.ok:

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -1090,9 +1090,12 @@ class GirderClient(object):
         progressFileName = fileId
         if isinstance(path, six.string_types):
             progressFileName = os.path.basename(path)
-        req = self._requestFunc('get')(
-            '%sfile/%s/download' % (self.urlBase, fileId),
-            stream=True, headers={'Girder-Token': self.token})
+        # import rpdb
+        # rpdb.set_trace()
+        url = '%sfile/%s/download' % (self.urlBase, fileId)
+        req = self._requestFunc('get')(url, stream=True, headers={'Girder-Token': self.token})
+        if req.status_code != requests.codes.ok:
+            raise HttpError(req.status_code, req.text, url, 'GET')
         with tempfile.NamedTemporaryFile(delete=False) as tmp:
             with self.progressReporterCls(
                     label=progressFileName,

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -1090,8 +1090,7 @@ class GirderClient(object):
         progressFileName = fileId
         if isinstance(path, six.string_types):
             progressFileName = os.path.basename(path)
-        # import rpdb
-        # rpdb.set_trace()
+            
         url = '%sfile/%s/download' % (self.urlBase, fileId)
         req = self._requestFunc('get')(url, stream=True, headers={'Girder-Token': self.token})
         if req.status_code != requests.codes.ok:

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -567,7 +567,7 @@ class PythonClientTestCase(base.TestCase):
 
         @httmock.urlmatch(path=r'.*/file/.+/download$')
         def mock(url, request):
-            return httmock.response(500,'error', request=request)
+            return httmock.response(500, 'error', request=request)
 
         # Attempt to download file to object stream, should raise HttpError
         with httmock.HTTMock(mock):

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -565,15 +565,14 @@ class PythonClientTestCase(base.TestCase):
 
         obj = six.BytesIO()
 
-        @httmock.urlmatch(path=r'.*.*/file/.+/download$')
+        @httmock.urlmatch(path=r'.*/file/.+/download$')
         def mock(url, request):
-            resp = request.models.Response()
-            resp.status_code = 500
-            resp.text = "error"
-            return resp
+            return httmock.response(500,'error', request=request)
 
         # Attempt to download file to object stream, should raise HttpError
-        self.assertRaises(girder_client.HttpError, self.client.downloadFile(file['_id'], obj))
+        with httmock.HTTMock(mock):
+            with self.assertRaises(girder_client.HttpError):
+                self.client.downloadFile(file['_id'], obj)
 
     def testAddMetadataToItem(self):
         item = self.client.createItem(self.publicFolder['_id'],


### PR DESCRIPTION
Solves issue: #1860
 
If the download api request returns an error, downloadFile raises an HttpError