### PR TITLE
Do fewer resource path lookups.

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -1522,8 +1522,8 @@ class GirderClient(object):
         create a hierarchy on the server under the parentId.
 
         :param filePattern: a glob pattern for files that will be uploaded,
-            recursively copying any file folder structures.  If this is a list,
-            each item in the list will be used in turn.
+            recursively copying any file folder structures.  If this is a list
+            or tuple each item in it will be used in turn.
         :type filePattern: str
         :param parentId: Id of the parent in Girder or resource path.
         :type parentId: ObjectId or Unix-style path to the resource in Girder.
@@ -1539,7 +1539,7 @@ class GirderClient(object):
             do not actually communicate with the server.
         :type dryRun: bool
         """
-        filePatternList = filePattern if isinstance(filePattern, list) else [filePattern]
+        filePatternList = filePattern if isinstance(filePattern, (list, tuple)) else [filePattern]
         blacklist = blacklist or []
         empty = True
         parentId = self._checkResourcePath(parentId)

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -278,11 +278,10 @@ def _upload(gc, parent_type, parent_id, local_folder,
             leaf_folders_as_items, reuse, blacklist, dry_run):
     if parent_type == 'auto':
         parent_type = _lookup_parent_type(gc, parent_id)
-    for local in local_folder:
-        gc.upload(
-            local, parent_id, parent_type,
-            leafFoldersAsItems=leaf_folders_as_items, reuseExisting=reuse,
-            blacklist=blacklist.split(','), dryRun=dry_run)
+    gc.upload(
+        local_folder, parent_id, parent_type,
+        leafFoldersAsItems=leaf_folders_as_items, reuseExisting=reuse,
+        blacklist=blacklist.split(','), dryRun=dry_run)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When uploading multiple items from the CLI to a resource path, pass the tuple of items to upload to the upload function.  This allows the upload patent to only be converted from a resource path to an ID once, thus saving multiple queries.