### PR TITLE
Reduce rest calls when uploading new files.

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -877,7 +877,7 @@ class GirderClient(object):
     def uploadFileToFolder(self, folderId, filepath, reference=None, mimeType=None, filename=None,
                            progressCallback=None):
         """
-        Uploads a file to an folder, creating a new item in the process.  If
+        Uploads a file to a folder, creating a new item in the process.  If
         the file has 0 bytes, no uploading will be performed, and no item will
         be created.
 
@@ -1084,7 +1084,7 @@ class GirderClient(object):
 
     def addMetadataToFolder(self, folderId, metadata):
         """
-        Takes an folder ID and a dictionary containing the metadata
+        Takes a folder ID and a dictionary containing the metadata
 
         :param folderId: ID of the folder to set metadata on.
         :param metadata: dictionary of metadata to set on folder.

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -876,8 +876,8 @@ class GirderClient(object):
                            progressCallback=None):
         """
         Uploads a file to an folder, creating a new item in the process.  If
-        the has 0 bytes, no uploading will be performed, and no item will be
-        created.
+        the file has 0 bytes, no uploading will be performed, and no item will
+        be created.
 
         :param folderId: ID of parent folder for file.
         :param filepath: path to file on disk.
@@ -1455,9 +1455,10 @@ class GirderClient(object):
             print('Uploading Item from %s' % localFile)
         if not dryRun:
             # If we are reusing existing items or have upload callbacks, then
-            # we need to know the item as part of the process.  Otherwise, we
-            # can just upload to the parent folder and never learn about the
-            # created item.
+            # we need to know the item as part of the process.  If this is a
+            # zero-length file, we create an item.  Otherwise, we can just
+            # upload to the parent folder and never learn about the created
+            # item.
             if reuseExisting or len(self._itemUploadCallbacks) or os.path.getsize(filePath) == 0:
                 currentItem = self.loadOrCreateItem(
                     os.path.basename(localFile), parentFolderId, reuseExisting)

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -24,7 +24,6 @@ import mock
 import os
 import shutil
 import six
-import time
 from six import StringIO
 import hashlib
 import httmock
@@ -382,7 +381,7 @@ class PythonClientTestCase(base.TestCase):
         def processEvent(event):
             eventList.append(event.info)
 
-        events.bind('data.process', 'lib_test', processEvent)
+        events.bind('model.file.finalizeUpload.after', 'lib_test', processEvent)
 
         path = os.path.join(self.libTestDir, 'sub0', 'f')
         size = os.path.getsize(path)
@@ -390,21 +389,13 @@ class PythonClientTestCase(base.TestCase):
             self.client.uploadFile(
                 self.publicFolder['_id'], fh, name='test1', size=size, parentType='folder',
                 reference='test1_reference')
-
-        starttime = time.time()
-        while (not events.daemon.eventQueue.empty() and
-                time.time() - starttime < 5):
-            time.sleep(0.05)
         self.assertEqual(len(eventList), 1)
-        self.assertEqual(eventList[0]['reference'], 'test1_reference')
+        self.assertEqual(eventList[0]['upload']['reference'], 'test1_reference')
 
         self.client.uploadFileToItem(str(eventList[0]['file']['itemId']), path,
                                      reference='test2_reference')
-        while (not events.daemon.eventQueue.empty() and
-                time.time() - starttime < 5):
-            time.sleep(0.05)
         self.assertEqual(len(eventList), 2)
-        self.assertEqual(eventList[1]['reference'], 'test2_reference')
+        self.assertEqual(eventList[1]['upload']['reference'], 'test2_reference')
         self.assertNotEqual(eventList[0]['file']['_id'],
                             eventList[1]['file']['_id'])
 
@@ -414,11 +405,8 @@ class PythonClientTestCase(base.TestCase):
         size = os.path.getsize(path)
         self.client.uploadFileToItem(str(eventList[0]['file']['itemId']), path,
                                      reference='test3_reference')
-        while (not events.daemon.eventQueue.empty() and
-                time.time() - starttime < 5):
-            time.sleep(0.05)
         self.assertEqual(len(eventList), 3)
-        self.assertEqual(eventList[2]['reference'], 'test3_reference')
+        self.assertEqual(eventList[2]['upload']['reference'], 'test3_reference')
         self.assertNotEqual(eventList[0]['file']['_id'],
                             eventList[2]['file']['_id'])
         self.assertEqual(eventList[1]['file']['_id'],
@@ -441,11 +429,8 @@ class PythonClientTestCase(base.TestCase):
         # Test uploading to a folder
         self.client.uploadFileToFolder(
             str(self.publicFolder['_id']), path, reference='test4_reference')
-        while (not events.daemon.eventQueue.empty() and
-                time.time() - starttime < 5):
-            time.sleep(0.05)
         self.assertEqual(len(eventList), 6)
-        self.assertEqual(eventList[-1]['reference'], 'test4_reference')
+        self.assertEqual(eventList[-1]['upload']['reference'], 'test4_reference')
         self.assertNotEqual(eventList[2]['file']['_id'],
                             eventList[-1]['file']['_id'])
 

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -438,6 +438,17 @@ class PythonClientTestCase(base.TestCase):
         file = self.client.uploadFileToItem(item['_id'], testPath)
         self.assertEqual(file['mimeType'], 'text/plain')
 
+        # Test uploading to a folder
+        self.client.uploadFileToFolder(
+            str(self.publicFolder['_id']), path, reference='test4_reference')
+        while (not events.daemon.eventQueue.empty() and
+                time.time() - starttime < 5):
+            time.sleep(0.05)
+        self.assertEqual(len(eventList), 6)
+        self.assertEqual(eventList[-1]['reference'], 'test4_reference')
+        self.assertNotEqual(eventList[2]['file']['_id'],
+                            eventList[-1]['file']['_id'])
+
     def testUploadContentWithMultipart(self):
         with mock.patch.object(self.client, 'getServerVersion', return_value=['2', '1', '0']):
             self._testUploadContent()
@@ -713,6 +724,12 @@ class PythonClientTestCase(base.TestCase):
         uploadedFile = self.client.uploadFileToItem(item['_id'], path, filename='g1')
 
         self.assertEqual(uploadedFile['name'], 'g1')
+
+    def _testUploadFileToFolder(self):
+        path = os.path.join(self.libTestDir, 'sub1', 'f1')
+        uploadedFile = self.client.uploadFileToFolder(
+            self.publicFolder['_id'], path, filename='g2')
+        self.assertEqual(uploadedFile['name'], 'g2')
 
     def testGetServerVersion(self):
 


### PR DESCRIPTION
When uploading files as new items, don't bother creating items beforehand and then checking if the file already exists in the item.  This skips two rest calls per file upload in the case where items are not being reused and there are no upload callbacks, substantially reducing overhead when uploading a large number of files.

In one test, this saves 14 minutes when uploading 100,000 files (around 9ms per file transfer), which was roughly 18% of the total upload time (files averaging around 1 Mb and being stored to an external GridFS assetstore).