### PR TITLE
Add the Fontello "animation.css" file to the test environment

### DIFF
--- a/grunt_tasks/dev.js
+++ b/grunt_tasks/dev.js
@@ -65,6 +65,7 @@ module.exports = function (grunt) {
         fs.writeFileSync('clients/web/static/built/testing/testEnv.html', fn({
             cssFiles: [
                 '/static/built/fontello/css/fontello.css',
+                '/static/built/fontello/css/animation.css',
                 '/static/built/girder_lib.min.css',
                 '/static/built/girder_app.min.css',
                 '/static/built/testing.min.css'


### PR DESCRIPTION
This is mostly a safety mechanism, but should prevent any future issues if advanced language features are used to define Girder classes.