### PR TITLE
Build Girder web core without Mongo access

### DIFF
--- a/girder/utility/install.py
+++ b/girder/utility/install.py
@@ -123,7 +123,7 @@ def _pipeOutputToProgress(proc, progress):
 
 
 def runWebBuild(wd=None, dev=False, npm='npm', allPlugins=False, plugins=None, progress=None,
-                coreOnly=False):
+                noPlugins=False):
     """
     Use this to run `npm install` inside the package. Also builds the web code
     using `npm run build`.
@@ -139,10 +139,10 @@ def runWebBuild(wd=None, dev=False, npm='npm', allPlugins=False, plugins=None, p
     :type plugins: str, list or None
     :param progress: A progress context for reporting output of the tasks.
     :type progress: ``girder.utility.progress.ProgressContext`` or None
-    :param coreOnly: Enable this to build the girder web with no additional plugins.
-    :type coreOnly: bool
+    :param noPlugins: Enable this to build the girder web with no additional plugins.
+    :type noPlugins: bool
     """
-    if coreOnly:
+    if noPlugins:
         plugins = []
     elif isinstance(plugins, six.string_types):
         plugins = plugins.split(',')
@@ -211,7 +211,7 @@ def install_web(opts=None):
     else:
         runWebBuild(
             dev=opts.development, npm=opts.npm, allPlugins=opts.all_plugins,
-            plugins=opts.plugins, coreOnly=opts.core_only)
+            plugins=opts.plugins, noPlugins=opts.no_plugins)
 
 
 def install_plugin(opts):
@@ -338,7 +338,7 @@ def main():
     pluginGroup.add_argument('--plugin-prefix', default='plugin',
                              help='prefix of the generated plugin bundle')
 
-    pluginGroup.add_argument('--core-only', action='store_true',
+    pluginGroup.add_argument('--no-plugins', action='store_true',
                              help='build only the girder web with no additional plugins')
 
     web.set_defaults(func=install_web)

--- a/girder/utility/install.py
+++ b/girder/utility/install.py
@@ -327,6 +327,9 @@ def main():
     web.add_argument('--watch-plugin', default='',
                      help='watch for changes and rebuild a specific plugin in dev mode')
 
+    web.add_argument('--plugin-prefix', default='plugin',
+                     help='prefix of the generated plugin bundle')
+
     pluginGroup = web.add_mutually_exclusive_group()
 
     pluginGroup.add_argument('--all-plugins', action='store_true',
@@ -334,9 +337,6 @@ def main():
 
     pluginGroup.add_argument('--plugins', default=None,
                              help='comma-separated list of plugins to build')
-
-    pluginGroup.add_argument('--plugin-prefix', default='plugin',
-                             help='prefix of the generated plugin bundle')
 
     pluginGroup.add_argument('--no-plugins', action='store_true',
                              help='build only the girder web with no additional plugins')

--- a/girder/utility/install.py
+++ b/girder/utility/install.py
@@ -71,7 +71,7 @@ def _getPluginBuildArgs(buildAll, plugins):
     if buildAll:
         sortedPlugins = plugin_utilities.getToposortedPlugins()
         return ['--plugins=%s' % ','.join(sortedPlugins)]
-    elif not plugins:  # build only the enabled plugins
+    elif plugins is None:  # build only the enabled plugins
         settings = model_importer.ModelImporter().model('setting')
         plugins = settings.get(constants.SettingKey.PLUGINS_ENABLED, default=())
 
@@ -143,7 +143,7 @@ def runWebBuild(wd=None, dev=False, npm='npm', allPlugins=False, plugins=None, p
     :type coreOnly: bool
     """
     if coreOnly:
-        plugins = ['']
+        plugins = []
     elif isinstance(plugins, six.string_types):
         plugins = plugins.split(',')
 

--- a/girder/utility/install.py
+++ b/girder/utility/install.py
@@ -320,19 +320,26 @@ def main():
 
     web.add_argument('--npm', default='npm',
                      help='specify the full path to the npm executable.')
-    web.add_argument('--all-plugins', action='store_true',
-                     help='build all available plugins rather than just enabled ones')
-    web.add_argument('--plugins', default=None, help='comma-separated list of plugins to build')
+
     web.add_argument('--watch', action='store_true',
                      help='watch for changes and rebuild girder core library in dev mode')
+
     web.add_argument('--watch-plugin', default='',
                      help='watch for changes and rebuild a specific plugin in dev mode')
 
-    web.add_argument('--plugin-prefix', default='plugin',
-                     help='prefix of the generated plugin bundle')
+    pluginGroup = web.add_mutually_exclusive_group()
 
-    web.add_argument('--core-only', action='store_true',
-                     help='build only the girder web with no additional plugins')
+    pluginGroup.add_argument('--all-plugins', action='store_true',
+                             help='build all available plugins rather than just enabled ones')
+
+    pluginGroup.add_argument('--plugins', default=None,
+                             help='comma-separated list of plugins to build')
+
+    pluginGroup.add_argument('--plugin-prefix', default='plugin',
+                             help='prefix of the generated plugin bundle')
+
+    pluginGroup.add_argument('--core-only', action='store_true',
+                             help='build only the girder web with no additional plugins')
 
     web.set_defaults(func=install_web)
 

--- a/girder/utility/install.py
+++ b/girder/utility/install.py
@@ -122,7 +122,8 @@ def _pipeOutputToProgress(proc, progress):
             proc.wait()
 
 
-def runWebBuild(wd=None, dev=False, npm='npm', allPlugins=False, plugins=None, progress=None):
+def runWebBuild(wd=None, dev=False, npm='npm', allPlugins=False, plugins=None, progress=None,
+                coreOnly=False):
     """
     Use this to run `npm install` inside the package. Also builds the web code
     using `npm run build`.
@@ -138,8 +139,12 @@ def runWebBuild(wd=None, dev=False, npm='npm', allPlugins=False, plugins=None, p
     :type plugins: str, list or None
     :param progress: A progress context for reporting output of the tasks.
     :type progress: ``girder.utility.progress.ProgressContext`` or None
+    :param coreOnly: Enable this to build the girder web with no additional plugins.
+    :type coreOnly: bool
     """
-    if isinstance(plugins, six.string_types) and plugins:
+    if coreOnly:
+        plugins = ['']
+    elif isinstance(plugins, six.string_types):
         plugins = plugins.split(',')
 
     if shutil.which(npm) is None:
@@ -206,7 +211,7 @@ def install_web(opts=None):
     else:
         runWebBuild(
             dev=opts.development, npm=opts.npm, allPlugins=opts.all_plugins,
-            plugins=opts.plugins)
+            plugins=opts.plugins, coreOnly=opts.core_only)
 
 
 def install_plugin(opts):
@@ -317,7 +322,7 @@ def main():
                      help='specify the full path to the npm executable.')
     web.add_argument('--all-plugins', action='store_true',
                      help='build all available plugins rather than just enabled ones')
-    web.add_argument('--plugins', default='', help='comma-separated list of plugins to build')
+    web.add_argument('--plugins', default=None, help='comma-separated list of plugins to build')
     web.add_argument('--watch', action='store_true',
                      help='watch for changes and rebuild girder core library in dev mode')
     web.add_argument('--watch-plugin', default='',
@@ -325,6 +330,9 @@ def main():
 
     web.add_argument('--plugin-prefix', default='plugin',
                      help='prefix of the generated plugin bundle')
+
+    web.add_argument('--core-only', action='store_true',
+                     help='build only the girder web with no additional plugins')
 
     web.set_defaults(func=install_web)
 

--- a/tests/cases/install_test.py
+++ b/tests/cases/install_test.py
@@ -33,7 +33,7 @@ pluginRoot = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'test_plug
 class PluginOpts():
     def __init__(self, plugin=None, force=False, symlink=False, dev=False, npm='npm',
                  skip_requirements=False, all_plugins=False, plugins=None, watch=False,
-                 watch_plugin=None, plugin_prefix='plugin'):
+                 watch_plugin=None, plugin_prefix='plugin', core_only=False):
         self.plugin = plugin
         self.force = force
         self.symlink = symlink
@@ -45,6 +45,7 @@ class PluginOpts():
         self.watch = watch
         self.watch_plugin = watch_plugin
         self.plugin_prefix = plugin_prefix
+        self.core_only = core_only
 
 
 class ProcMock(object):

--- a/tests/cases/install_test.py
+++ b/tests/cases/install_test.py
@@ -295,6 +295,12 @@ class InstallTestCase(base.TestCase):
         with mock.patch('subprocess.Popen', return_value=ProcMock(keyboardInterrupt=True)):
             install.install_web(PluginOpts(watch=True))
 
+        # Test "--plugins=" and --core-only
+        with mock.patch('girder.utility.install.model_importer.ModelImporter.model') as p:
+            install.install_web(PluginOpts(plugins=''))
+            install.install_web(PluginOpts(core_only=True))
+            self.assertEqual(len(p.mock_calls), 0)
+
     def testStaticDependencies(self):
         for p in ('does_nothing', 'has_deps', 'has_static_deps', 'has_webroot', 'test_plugin'):
             install.install_plugin(PluginOpts(plugin=[

--- a/tests/cases/install_test.py
+++ b/tests/cases/install_test.py
@@ -33,7 +33,7 @@ pluginRoot = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'test_plug
 class PluginOpts():
     def __init__(self, plugin=None, force=False, symlink=False, dev=False, npm='npm',
                  skip_requirements=False, all_plugins=False, plugins=None, watch=False,
-                 watch_plugin=None, plugin_prefix='plugin', core_only=False):
+                 watch_plugin=None, plugin_prefix='plugin', no_plugins=False):
         self.plugin = plugin
         self.force = force
         self.symlink = symlink
@@ -45,7 +45,7 @@ class PluginOpts():
         self.watch = watch
         self.watch_plugin = watch_plugin
         self.plugin_prefix = plugin_prefix
-        self.core_only = core_only
+        self.no_plugins = no_plugins
 
 
 class ProcMock(object):
@@ -295,10 +295,10 @@ class InstallTestCase(base.TestCase):
         with mock.patch('subprocess.Popen', return_value=ProcMock(keyboardInterrupt=True)):
             install.install_web(PluginOpts(watch=True))
 
-        # Test "--plugins=" and --core-only
+        # Test "--plugins=" and --no-plugins
         with mock.patch('girder.utility.install.model_importer.ModelImporter.model') as p:
             install.install_web(PluginOpts(plugins=''))
-            install.install_web(PluginOpts(core_only=True))
+            install.install_web(PluginOpts(no_plugins=True))
             self.assertEqual(len(p.mock_calls), 0)
 
     def testStaticDependencies(self):


### PR DESCRIPTION
See issue: #2089 

`--plugins=` as well as `--plugins=,` now results in girder web being built with no additional plugins.
`--core-only` has the same result.

Neither require access to Mongo. 