### PR TITLE
Fixes #2081. Fix excessive item list fetches in hierarchy widget

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,7 +22,7 @@ dependencies:
     - ./scripts/install_cmake.sh
     - npm install -g npm
     - npm config set progress false
-    - npm update; npm prune
+    - npm update --no-save
     - set -o pipefail; pyenv exec pip install -U pip setuptools | cat
     - set -o pipefail; pyenv exec pip install -r requirements-dev.txt -e .[plugins,sftp] -e clients/python | cat
     - pyenv rehash

--- a/clients/web/src/models/FolderModel.js
+++ b/clients/web/src/models/FolderModel.js
@@ -2,9 +2,16 @@ import _ from 'underscore';
 
 import AccessControlledModel from 'girder/models/AccessControlledModel';
 import MetadataMixin from 'girder/models/MetadataMixin';
+import { restRequest } from 'girder/rest';
 
 var FolderModel = AccessControlledModel.extend({
-    resourceName: 'folder'
+    resourceName: 'folder',
+
+    getRootPath: function () {
+        return restRequest({
+            path: `${this.resourceName}/${this.id}/rootpath`
+        });
+    }
 });
 
 _.extend(FolderModel.prototype, MetadataMixin);

--- a/clients/web/src/views/widgets/HierarchyWidget.js
+++ b/clients/web/src/views/widgets/HierarchyWidget.js
@@ -180,14 +180,9 @@ var HierarchyWidget = View.extend({
                 }, this);
 
         if (this.parentModel.resourceName === 'folder') {
-            this._initFolderViewSubwidgets();
-        } else {
-            this.itemCount = 0;
-        }
-
-        if (this.parentModel.resourceName === 'folder') {
             this._fetchToRoot(this.parentModel);
         } else {
+            this.itemCount = 0;
             this.render();
         }
         events.on('g:login', () => {
@@ -212,30 +207,34 @@ var HierarchyWidget = View.extend({
      * is a folder type.
      */
     _initFolderViewSubwidgets: function () {
-        this.itemListView = new ItemListWidget({
-            itemFilter: this._itemFilter,
-            folderId: this.parentModel.get('_id'),
-            public: this.parentModel.get('public'),
-            accessLevel: this.parentModel.getAccessLevel(),
-            checkboxes: this._checkboxes,
-            downloadLinks: this._downloadLinks,
-            viewLinks: this._viewLinks,
-            showSizes: this._showSizes,
-            parentView: this
-        });
-        this.itemListView.on('g:itemClicked', this._onItemClick, this)
-            .off('g:checkboxesChanged')
-            .on('g:checkboxesChanged', this.updateChecked, this)
-            .off('g:changed').on('g:changed', function () {
-                this.itemCount = this.itemListView.collection.length;
-                this._childCountCheck();
-            }, this);
+        if (!this.itemListView) {
+            this.itemListView = new ItemListWidget({
+                itemFilter: this._itemFilter,
+                folderId: this.parentModel.id,
+                public: this.parentModel.get('public'),
+                accessLevel: this.parentModel.getAccessLevel(),
+                checkboxes: this._checkboxes,
+                downloadLinks: this._downloadLinks,
+                viewLinks: this._viewLinks,
+                showSizes: this._showSizes,
+                parentView: this
+            });
+            this.itemListView.on('g:itemClicked', this._onItemClick, this)
+                .off('g:checkboxesChanged')
+                .on('g:checkboxesChanged', this.updateChecked, this)
+                .off('g:changed').on('g:changed', function () {
+                    this.itemCount = this.itemListView.collection.length;
+                    this._childCountCheck();
+                }, this);
+        }
 
-        this.metadataWidget = new MetadataWidget({
-            item: this.parentModel,
-            parentView: this,
-            accessLevel: this.parentModel.getAccessLevel()
-        });
+        if (!this.metadataWidget) {
+            this.metadataWidget = new MetadataWidget({
+                item: this.parentModel,
+                parentView: this,
+                accessLevel: this.parentModel.getAccessLevel()
+            });
+        }
     },
 
     _setRoute: function () {

--- a/clients/web/src/views/widgets/HierarchyWidget.js
+++ b/clients/web/src/views/widgets/HierarchyWidget.js
@@ -219,13 +219,12 @@ var HierarchyWidget = View.extend({
                 showSizes: this._showSizes,
                 parentView: this
             });
-            this.itemListView.on('g:itemClicked', this._onItemClick, this)
-                .off('g:checkboxesChanged')
-                .on('g:checkboxesChanged', this.updateChecked, this)
-                .off('g:changed').on('g:changed', function () {
-                    this.itemCount = this.itemListView.collection.length;
-                    this._childCountCheck();
-                }, this);
+            this.listenTo(this.itemListView, 'g:itemClicked', this._onItemClick);
+            this.listenTo(this.itemListView, 'g:checkboxesChanged', this.updateChecked);
+            this.listenTo(this.itemListView, 'g:changed', () => {
+                this.itemCount = this.itemListView.collection.length;
+                this._childCountCheck();
+            });
         }
 
         if (!this.metadataWidget) {
@@ -251,7 +250,7 @@ var HierarchyWidget = View.extend({
 
     _fetchToRoot: function (folder) {
         folder.getRootPath().done((path) => {
-            const breadcrumbs = path.map(r => new allModels[getModelClassByName(r.type)](r.object));
+            const breadcrumbs = path.map((r) => new allModels[getModelClassByName(r.type)](r.object));
             this.breadcrumbs.unshift(...breadcrumbs);
             this.render();
         });

--- a/clients/web/src/views/widgets/HierarchyWidget.js
+++ b/clients/web/src/views/widgets/HierarchyWidget.js
@@ -250,25 +250,11 @@ var HierarchyWidget = View.extend({
     },
 
     _fetchToRoot: function (folder) {
-        var parentId = folder.get('parentId');
-        var parentType = folder.get('parentCollection');
-        var modelName = getModelClassByName(parentType);
-        if (allModels[modelName]) {
-            var parent = new allModels[modelName]();
-            parent.set({
-                _id: parentId
-            }).once('g:fetched', function () {
-                this.breadcrumbs.push(parent);
-                if (parentType === 'folder') {
-                    this._fetchToRoot(parent);
-                } else {
-                    this.breadcrumbs.reverse();
-                    this.render();
-                }
-            }, this).fetch();
-        } else {
-            throw new Error('No such model: ' + modelName);
-        }
+        folder.getRootPath().done((path) => {
+            const breadcrumbs = path.map(r => new allModels[getModelClassByName(r.type)](r.object));
+            this.breadcrumbs.unshift(...breadcrumbs);
+            this.render();
+        });
     },
 
     render: function () {

--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -38,6 +38,7 @@ class Folder(Resource):
         self.route('GET', (':id', 'details'), self.getFolderDetails)
         self.route('GET', (':id', 'access'), self.getFolderAccess)
         self.route('GET', (':id', 'download'), self.downloadFolder)
+        self.route('GET', (':id', 'rootpath'), self.rootpath)
         self.route('POST', (), self.createFolder)
         self.route('PUT', (':id',), self.updateFolder)
         self.route('PUT', (':id', 'access'), self.updateFolderAccess)
@@ -378,3 +379,13 @@ class Folder(Resource):
     )
     def deleteMetadata(self, folder, fields, params):
         return self.model('folder').deleteMetadata(folder, fields)
+
+    @access.public(scope=TokenScope.DATA_READ)
+    @autoDescribeRoute(
+        Description('Get the path to the root of the folder\'s hierarchy.')
+        .modelParam('id', model='folder', level=AccessType.READ)
+        .errorResponse('ID was invalid.')
+        .errorResponse('Read access was denied for the folder.', 403)
+    )
+    def rootpath(self, folder, params):
+        return self.model('folder').parentsToRoot(folder, user=self.getCurrentUser())


### PR DESCRIPTION
This topic contains two commits that both improve performance and reduce XHRs from the HierarchyWidget. 

5be0cc6 fixes #2081; prior to this change, the item list was being fetched three times on
each folder view. Lazy-instantiating the item list widget fixed this.

7e043bc changes the implementation of fetching the breadcrumb path back to the root resource. Rather than make sequential requests for each subsequent ancestor, they're now all fetched with a single request with a new rootpath endpoint that mirrors the one we have for items. This only affects initial loading of the widget, not descending into subfolders.