### PR TITLE
Add a Link header to paged results

### DIFF
--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -609,7 +609,7 @@ class autoDescribeRoute(describeRoute):  # noqa: class name
                 sortdir = kwargs.pop('sortdir', None) or kwargs['params'].pop('sortdir', None)
                 kwargs['sort'] = [(kwargs['sort'], sortdir)]
 
-            self._addPagingHeaders()
+            self._addPagingHeaders(kwargs)
 
             return fun(*args, **kwargs)
 
@@ -619,19 +619,19 @@ class autoDescribeRoute(describeRoute):  # noqa: class name
             wrapped.description = self.description
         return wrapped
 
-    def _addPagingHeaders(self):
+    def _addPagingHeaders(self, params):
         """
         Inject a "Link" header when this is a paged request.
 
         Follows: https://tools.ietf.org/html/rfc5988
         """
-        if not self.description.hasPagingParams:
+        if not self.description.hasPagingParams or \
+           not cherrypy.request.method == 'GET':
             return
 
-        params = cherrypy.lib.httputil.parse_query_string(cherrypy.request.query_string)
-        offset = int(params.get('offset', 0))
-        limit = int(params.get('limit', 50))
-        qs = dict(**params)
+        qs = cherrypy.lib.httputil.parse_query_string(cherrypy.request.query_string)
+        offset = params['offset']
+        limit = params['limit']
         link = []
 
         qs['offset'] = 0

--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -632,7 +632,10 @@ class autoDescribeRoute(describeRoute):  # noqa: class name
         Note: This is isolated from the __call__ method to prevent exceeding
         the cyclomatic complexity limit.
         """
-        addLinkHeader = getattr(self.description, 'addLinkHeader', False)
+        # We disable paging behavior when limit == 0 because it is a special
+        # case meaning "get all documents".
+        addLinkHeader = getattr(self.description, 'addLinkHeader', False) and \
+            kwargs.get('limit', 0) > 0
         if addLinkHeader:
             kwargs['limit'] += 1
 

--- a/girder/api/v1/api_key.py
+++ b/girder/api/v1/api_key.py
@@ -40,7 +40,7 @@ class ApiKey(Resource):
         .notes('Only site administrators may list keys for other users. If no '
                'userId parameter is passed, lists keys for the current user.')
         .param('userId', 'ID of the user whose keys to list.', required=False)
-        .pagingParams(defaultSort='name')
+        .pagingParams(defaultSort='name', linkHeader=True)
         .errorResponse()
     )
     def listKeys(self, userId, limit, offset, sort, params):

--- a/girder/api/v1/assetstore.py
+++ b/girder/api/v1/assetstore.py
@@ -54,7 +54,7 @@ class Assetstore(Resource):
     @access.admin
     @autoDescribeRoute(
         Description('List assetstores.')
-        .pagingParams(defaultSort='name')
+        .pagingParams(defaultSort='name', linkHeader=True)
         .errorResponse()
         .errorResponse('You are not an administrator.', 403)
     )
@@ -246,7 +246,7 @@ class Assetstore(Resource):
     @autoDescribeRoute(
         Description('Get a list of files controlled by an assetstore.')
         .modelParam('id', model='assetstore')
-        .pagingParams(defaultSort='_id')
+        .pagingParams(defaultSort='_id', linkHeader=True)
         .errorResponse()
         .errorResponse('You are not an administrator.', 403)
     )

--- a/girder/api/v1/collection.py
+++ b/girder/api/v1/collection.py
@@ -47,7 +47,7 @@ class Collection(Resource):
         Description('List or search for collections.')
         .responseClass('Collection', array=True)
         .param('text', 'Pass this to perform a text search for collections.', required=False)
-        .pagingParams(defaultSort='name')
+        .pagingParams(defaultSort='name', linkHeader=True)
     )
     def find(self, text, limit, offset, sort, params):
         user = self.getCurrentUser()

--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -57,7 +57,7 @@ class Folder(Resource):
         .param('text', 'Pass to perform a text search.', required=False)
         .param('name', 'Pass to lookup a folder by exact name match. Must '
                'pass parentType and parentId as well when using this.', required=False)
-        .pagingParams(defaultSort='lowerName')
+        .pagingParams(defaultSort='lowerName', linkHeader=True)
         .errorResponse()
         .errorResponse('Read access was denied on the parent resource.', 403)
     )

--- a/girder/api/v1/group.py
+++ b/girder/api/v1/group.py
@@ -53,7 +53,7 @@ class Group(Resource):
         .param('text', 'Pass this to perform a full-text search for groups.', required=False)
         .param('exact', 'If true, only return exact name matches. This is '
                'case sensitive.', required=False, dataType='boolean', default=False)
-        .pagingParams(defaultSort='name')
+        .pagingParams(defaultSort='name', linkHeader=True)
         .errorResponse()
     )
     def find(self, text, exact, limit, offset, sort, params):
@@ -123,7 +123,7 @@ class Group(Resource):
         Description('Show outstanding invitations for a group.')
         .responseClass('Group')
         .modelParam('id', model='group', level=AccessType.READ)
-        .pagingParams(defaultSort='lastName')
+        .pagingParams(defaultSort='lastName', linkHeader=True)
         .errorResponse()
         .errorResponse('Read access was denied for the group.', 403)
     )
@@ -182,7 +182,7 @@ class Group(Resource):
     @autoDescribeRoute(
         Description('List members of a group.')
         .modelParam('id', model='group', level=AccessType.READ)
-        .pagingParams(defaultSort='lastName')
+        .pagingParams(defaultSort='lastName', linkHeader=True)
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the group.', 403)
     )

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -52,7 +52,7 @@ class Item(Resource):
                required=False)
         .param('name', 'Pass to lookup an item by exact name match. Must '
                'pass folderId as well when using this.', required=False)
-        .pagingParams(defaultSort='lowerName')
+        .pagingParams(defaultSort='lowerName', linkHeader=True)
         .errorResponse()
         .errorResponse('Read access was denied on the parent folder.', 403)
     )
@@ -209,7 +209,7 @@ class Item(Resource):
         Description('Get the files within an item.')
         .responseClass('File', array=True)
         .modelParam('id', model='item', level=AccessType.READ)
-        .pagingParams(defaultSort='name')
+        .pagingParams(defaultSort='name', linkHeader=True)
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -61,7 +61,7 @@ class User(Resource):
         Description('List or search for users.')
         .responseClass('User', array=True)
         .param('text', "Pass this to perform a full text search for items.", required=False)
-        .pagingParams(defaultSort='lastName')
+        .pagingParams(defaultSort='lastName', linkHeader=True)
     )
     def find(self, text, limit, offset, sort, params):
         return list(self.model('user').search(

--- a/plugins/item_tasks/plugin_tests/tasks_test.py
+++ b/plugins/item_tasks/plugin_tests/tasks_test.py
@@ -630,3 +630,6 @@ class TasksTest(base.TestCase):
 
         self.assertEqual(
             job['itemTaskBindings']['outputs']['--DetectedPoints']['itemId'], file['itemId'])
+
+    def testPagingHeaders(self):
+        self.runPagingTest('/item_task', user=self.admin)

--- a/plugins/item_tasks/server/rest.py
+++ b/plugins/item_tasks/server/rest.py
@@ -33,7 +33,7 @@ class ItemTask(Resource):
     @access.public
     @autoDescribeRoute(
         Description('List all available tasks that can be executed.')
-        .pagingParams(defaultSort='name')
+        .pagingParams(defaultSort='name', linkHeader=True)
     )
     @filtermodel(model='item')
     def listTasks(self, limit, offset, sort, params):

--- a/plugins/jobs/plugin_tests/jobs_test.py
+++ b/plugins/jobs/plugin_tests/jobs_test.py
@@ -614,3 +614,7 @@ class JobsTestCase(base.TestCase):
                              params={'title': 'job', 'type': 'job'})
         # If user has the necessary token status is 200
         self.assertStatus(resp2, 200)
+
+    def testPagingHeaders(self):
+        self.runPagingTest('/job', user=self.users[0])
+        self.runPagingTest('/job/all', user=self.users[0])

--- a/plugins/jobs/server/job_rest.py
+++ b/plugins/jobs/server/job_rest.py
@@ -52,7 +52,7 @@ class Job(Resource):
                     destName='parentJob', paramType='query', required=False)
         .jsonParam('types', 'Filter for type', requireArray=True, required=False)
         .jsonParam('statuses', 'Filter for status', requireArray=True, required=False)
-        .pagingParams(defaultSort='created', defaultSortDir=SortDir.DESCENDING)
+        .pagingParams(defaultSort='created', defaultSortDir=SortDir.DESCENDING, linkHeader=True)
     )
     def listJobs(self, userId, parentJob, types, statuses, limit, offset, sort,
                  params):
@@ -110,7 +110,7 @@ class Job(Resource):
         Description('List all jobs.')
         .jsonParam('types', 'Filter for type', requireArray=True, required=False)
         .jsonParam('statuses', 'Filter for status', requireArray=True, required=False)
-        .pagingParams(defaultSort='created', defaultSortDir=SortDir.DESCENDING)
+        .pagingParams(defaultSort='created', defaultSortDir=SortDir.DESCENDING, linkHeader=True)
     )
     def listAllJobs(self, types, statuses, limit, offset, sort, params):
         currentUser = self.getCurrentUser()

--- a/tests/base.py
+++ b/tests/base.py
@@ -25,6 +25,7 @@ import json
 import logging
 import mock
 import os
+import re
 import shutil
 import signal
 import six
@@ -33,6 +34,7 @@ import unittest
 import uuid
 import warnings
 
+from requests.utils import parse_header_links
 from six import BytesIO
 from six.moves import urllib
 from girder.utility import model_importer, plugin_utilities
@@ -375,6 +377,69 @@ class TestCase(unittest.TestCase, model_importer.ModelImporter):
         """
         self.assertEqual('Parameter "%s" is required.' % param, response.json.get('message', ''))
         self.assertStatus(response, 400)
+
+    def assertPagingLink(self, link, path, offset=0, **params):
+        """
+        Assert the paging headers were correctly added to response.
+        """
+        self.assertEqual(re.sub('.*/api/v1', '', link['path']), path)
+        self.assertEqual(int(link['query'].get('offset')), offset)
+
+        self.assertHasKeys(link['query'], params.keys())
+        for param, value in six.iteritems(params):
+            if param != 'offset':
+                self.assertEqual(link['query'][param], value)
+
+    def runPagingTest(self, path, user=None, params=None):
+        """
+        Run a series of requests on a paged resource asserting that the
+        headers are set correctly.
+
+        :param path: The resource path (e.g. '/collection')
+        :param user: A user model to run the requests as
+        :param params: A dictionary of extra parameters in the request
+        """
+        params = params or {}
+
+        links = self.getPagingLinks(
+            self.request(path, user=user, params=params)
+        )
+        self.assertHasKeys(links, ['next', 'first'])
+        self.assertPagingLink(links['next'], path, offset=50)
+        self.assertPagingLink(links['first'], path, offset=0)
+
+        links = self.getPagingLinks(
+            self.request(path, user=user, params=dict(params, limit=10, offset=10))
+        )
+        self.assertHasKeys(links, ['next', 'first', 'prev'])
+        self.assertPagingLink(links['next'], path, offset=20, limit='10')
+        self.assertPagingLink(links['prev'], path, offset=0, limit='10')
+        self.assertPagingLink(links['first'], path, offset=0, limit='10')
+
+        links = self.getPagingLinks(
+            self.request(path, user=user, params=dict(params, limit=10, offset=5))
+        )
+        self.assertHasKeys(links, ['next', 'first', 'prev'])
+        self.assertPagingLink(links['next'], path, offset=15, limit='10')
+        self.assertPagingLink(links['prev'], path, offset=0, limit='10')
+        self.assertPagingLink(links['first'], path, offset=0, limit='10')
+
+    def getPagingLinks(self, response):
+        """
+        Get a dictionary containing parsed links in a response header.
+        """
+        self.assertStatusOk(response)
+        links = {}
+        for link in parse_header_links(response.headers.get('Link', '')):
+            rel = link.get('rel')
+            if rel:
+                parsed = urllib.parse.urlparse(link['url'])
+                links[rel] = {
+                    'url': link['url'],
+                    'path': parsed.path,
+                    'query': cherrypy.lib.httputil.parse_query_string(parsed.query)
+                }
+        return links
 
     def getSseMessages(self, resp):
         messages = self.getBody(resp).strip().split('\n\n')

--- a/tests/base.py
+++ b/tests/base.py
@@ -400,27 +400,27 @@ class TestCase(unittest.TestCase, model_importer.ModelImporter):
         :param params: A dictionary of extra parameters in the request
         """
         params = params or {}
+        resp = self.request(path, user=user, params=params)
+        links = self.getPagingLinks(resp)
 
-        links = self.getPagingLinks(
-            self.request(path, user=user, params=params)
-        )
-        self.assertHasKeys(links, ['next', 'first'])
-        self.assertPagingLink(links['next'], path, offset=50)
+        self.assertHasKeys(links, ['first'])
+        self.assertNotHasKeys(links, ['prev'])
         self.assertPagingLink(links['first'], path, offset=0)
 
-        links = self.getPagingLinks(
-            self.request(path, user=user, params=dict(params, limit=10, offset=10))
-        )
-        self.assertHasKeys(links, ['next', 'first', 'prev'])
-        self.assertPagingLink(links['next'], path, offset=20, limit='10')
-        self.assertPagingLink(links['prev'], path, offset=0, limit='10')
-        self.assertPagingLink(links['first'], path, offset=0, limit='10')
+        resp = self.request(path, user=user, params=dict(params, limit=1, offset=1))
+        links = self.getPagingLinks(resp)
+        self.assertHasKeys(links, ['first', 'prev'])
+        self.assertPagingLink(links['prev'], path, offset=0, limit='1')
+        self.assertPagingLink(links['first'], path, offset=0, limit='1')
+        if len(resp.json):
+            self.assertPagingLink(links['next'], path, offset=2, limit='1')
+        else:
+            self.assertNotHasKeys(links, ['next'])
 
         links = self.getPagingLinks(
             self.request(path, user=user, params=dict(params, limit=10, offset=5))
         )
-        self.assertHasKeys(links, ['next', 'first', 'prev'])
-        self.assertPagingLink(links['next'], path, offset=15, limit='10')
+        self.assertHasKeys(links, ['first', 'prev'])
         self.assertPagingLink(links['prev'], path, offset=0, limit='10')
         self.assertPagingLink(links['first'], path, offset=0, limit='10')
 

--- a/tests/cases/api_key_test.py
+++ b/tests/cases/api_key_test.py
@@ -197,3 +197,6 @@ class ApiKeyTestCase(base.TestCase):
         self.assertStatusOk(resp)
         count = self.model('token').find(q).count()
         self.assertEqual(count, 0)
+
+    def testPagingHeaders(self):
+        self.runPagingTest('/api_key', user=self.user)

--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -1025,3 +1025,6 @@ class AssetstoreTestCase(base.TestCase):
         resp = self.request(
             path='/file/%s/download' % file['_id'], user=self.admin, isJson=False)
         self.assertStatusOk(resp)
+
+    def testPagingHeaders(self):
+        self.runPagingTest('/assetstore', user=self.admin)

--- a/tests/cases/collection_test.py
+++ b/tests/cases/collection_test.py
@@ -408,3 +408,6 @@ class CollectionTestCase(base.TestCase):
         # Changes should have been saved to the database
         coll = collModel.load(coll['_id'], force=True)
         self.assertEqual(acl, coll['access'])
+
+    def testPagingHeaders(self):
+        self.runPagingTest('/collection', user=self.user)

--- a/tests/cases/collection_test.py
+++ b/tests/cases/collection_test.py
@@ -410,4 +410,4 @@ class CollectionTestCase(base.TestCase):
         self.assertEqual(acl, coll['access'])
 
     def testPagingHeaders(self):
-        self.runPagingTest('/collection', user=self.user)
+        self.runPagingTest('/collection', user=self.user, total=1)

--- a/tests/cases/folder_test.py
+++ b/tests/cases/folder_test.py
@@ -695,3 +695,10 @@ class FolderTestCase(base.TestCase):
                 'parentType': 'folder',
                 'parentId': str(subFolder['_id'])})
         self.assertStatusOk(resp)
+
+    def testPagingHeaders(self):
+        params = {
+            'parentType': 'user',
+            'parentId': self.user['_id']
+        }
+        self.runPagingTest('/folder', user=self.user, params=params)

--- a/tests/cases/group_test.py
+++ b/tests/cases/group_test.py
@@ -560,3 +560,6 @@ class GroupTestCase(base.TestCase):
                     else:
                         self.assertStatus(resp, 403)
         self.model('setting').unset(SettingKey.ADD_TO_GROUP_POLICY)
+
+    def testPagingHeaders(self):
+        self.runPagingTest('/group')

--- a/tests/cases/item_test.py
+++ b/tests/cases/item_test.py
@@ -743,8 +743,14 @@ class ItemTestCase(base.TestCase):
         self.assertEqual(item2['name'], 'to be reused (1)')
         self.assertEqual(item3['name'], 'to be reused')
 
-    def testPagingHeaders(self):
+    def testItemPagingHeaders(self):
         params = {
             'folderId': self.publicFolder['_id']
         }
         self.runPagingTest('/item', user=self.users[0], params=params)
+
+    def testFilesPagingHeaders(self):
+        curItem = self._createItem(self.publicFolder['_id'],
+                                   'test_for_paging', '',
+                                   self.users[0])
+        self.runPagingTest('/item/' + curItem['_id'] + '/files', user=self.users[0])

--- a/tests/cases/item_test.py
+++ b/tests/cases/item_test.py
@@ -747,7 +747,11 @@ class ItemTestCase(base.TestCase):
         params = {
             'folderId': self.publicFolder['_id']
         }
-        self.runPagingTest('/item', user=self.users[0], params=params)
+        for i in range(10):
+            self._createItem(self.publicFolder['_id'],
+                             'test_for_paging_%i' % i, '',
+                             self.users[0])
+        self.runPagingTest('/item', user=self.users[0], params=params, total=10)
 
     def testFilesPagingHeaders(self):
         curItem = self._createItem(self.publicFolder['_id'],

--- a/tests/cases/item_test.py
+++ b/tests/cases/item_test.py
@@ -742,3 +742,9 @@ class ItemTestCase(base.TestCase):
         self.assertEqual(item1['_id'], item3['_id'])
         self.assertEqual(item2['name'], 'to be reused (1)')
         self.assertEqual(item3['name'], 'to be reused')
+
+    def testPagingHeaders(self):
+        params = {
+            'folderId': self.publicFolder['_id']
+        }
+        self.runPagingTest('/item', user=self.users[0], params=params)

--- a/tests/cases/system_test.py
+++ b/tests/cases/system_test.py
@@ -765,6 +765,3 @@ class SystemTestCase(base.TestCase):
         self.assertEqual(resp.json['users'][0]['id'], str(self.users[0]['_id']))
         self.assertEqual(resp.json['users'][0]['login'], str(self.users[0]['login']))
         self.assertEqual(resp.json['groups'][0]['id'], str(self.group['_id']))
-
-    def testPagingHeaders(self):
-        self.runPagingTest('/system/uploads', user=self.users[0])

--- a/tests/cases/system_test.py
+++ b/tests/cases/system_test.py
@@ -765,3 +765,6 @@ class SystemTestCase(base.TestCase):
         self.assertEqual(resp.json['users'][0]['id'], str(self.users[0]['_id']))
         self.assertEqual(resp.json['users'][0]['login'], str(self.users[0]['login']))
         self.assertEqual(resp.json['groups'][0]['id'], str(self.group['_id']))
+
+    def testPagingHeaders(self):
+        self.runPagingTest('/system/uploads', user=self.users[0])

--- a/tests/cases/user_test.py
+++ b/tests/cases/user_test.py
@@ -856,3 +856,6 @@ class UserTestCase(base.TestCase):
             path='/file/chunk', user=pvt, fields=fields, files=files)
         self.assertStatusOk(resp)
         self.assertEqual(resp.json['itemId'], itemId)
+
+    def testPagingHeaders(self):
+        self.runPagingTest('/user')


### PR DESCRIPTION
This follows [RFC5988](https://tools.ietf.org/html/rfc5988) adding a `Link` header for navigating paged results from our rest API when using `pagingParams` in `autoDescribeRoute`.  There is a description of how this works with the Github API here: https://developer.github.com/v3/guides/traversing-with-pagination/.
