### PR TITLE
Add support for Elastic Beanstalk

### DIFF
--- a/devops/beanstalk/.ebextensions/logging.config
+++ b/devops/beanstalk/.ebextensions/logging.config
@@ -1,0 +1,19 @@
+files:
+  "/etc/awslogs/config/girderlogs.conf":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      [/var/log/girder/error.log]
+      log_group_name = `{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/girder/error.log"]]}`
+      log_stream_name = {instance_id}
+      datetime_format = [%Y-%m-%d %H:%M:%S,%f]
+      multi_line_start_pattern = {datetime_format}
+      file = /var/log/girder/error.log*
+
+      [/var/log/girder/info.log]
+      log_group_name = `{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/girder/info.log"]]}`
+      log_stream_name = {instance_id}
+      datetime_format = [%Y-%m-%d %H:%M:%S,%f]
+      multi_line_start_pattern = {datetime_format}
+      file = /var/log/girder/info.log*

--- a/devops/beanstalk/.ebextensions/packages.config
+++ b/devops/beanstalk/.ebextensions/packages.config
@@ -1,0 +1,22 @@
+option_settings:
+  aws:elasticbeanstalk:container:python:staticfiles:
+    "/static/": "clients/web/static/"
+
+packages:
+  yum:
+    curl: []
+    gcc-c++: []
+    git: []
+    libffi-devel: []
+    make: []
+    openssl-devel: []
+    libjpeg-turbo-devel: []
+    zlib-devel: []
+    openldap-devel: []
+
+commands:
+  01_make_log_root:
+    command: 'sudo mkdir -p /var/log/girder'
+
+  02_chown_log_root:
+    command: 'sudo chown wsgi:wsgi /var/log/girder'

--- a/devops/beanstalk/.ebextensions/wsgi.config
+++ b/devops/beanstalk/.ebextensions/wsgi.config
@@ -1,0 +1,3 @@
+option_settings:
+  aws:elasticbeanstalk:container:python:
+    WSGIPath: "girder/wsgi.py"

--- a/devops/beanstalk/.ebignore
+++ b/devops/beanstalk/.ebignore
@@ -1,0 +1,36 @@
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml
+
+# From .gitignore
+*.py[cod]
+node_modules
+docs/_build
+docs/_output
+.coverage*
+girder.egg-info
+.DS_Store
+.*.swp
+.*.swo
+.vagrant
+phantom-*.png
+phantom_*.png
+girder-*.tar.gz
+__pycache__
+### PyCharm ###
+.idea/
+.PyCharm50/
+.eslintcache
+/npm-debug.log
+**/*.retry
+
+/clients/python
+/clients/jquery
+/clients/web-external
+/cmake
+/devops
+/docs
+/node_modules
+/scripts
+/tests

--- a/devops/beanstalk/girder.cfg
+++ b/devops/beanstalk/girder.cfg
@@ -1,0 +1,6 @@
+[server]
+mode = "production"
+cherrypy_server = False
+
+[logging]
+log_root = "/var/log/girder"

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -243,3 +243,71 @@ After everything starts, which may take a few minutes, you should be able
 to visit your Girder instance at ``http://X.X.X.X`` where ``X.X.X.X`` is the
 IP address in the container description above. Congratulations, you
 have a full Girder instance available on Google Container Engine!
+
+Elastic Beanstalk
+-----------------
+
+Girder comes with pre-packaged configurations for deploying onto Elastic Beanstalk's
+`Python platform <http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/concepts.platforms.html#concepts.platforms.python>`_
+(both 2.7 and 3.4).
+
+The configurations live within ``devops/beanstalk`` and are designed to be copied into your working Girder directory
+at deploy time.
+
+The following assumes you have a checked out copy of Girder (using git) and an existing MongoDB instance which
+can be accessed by your Beanstalk application.
+
+.. note:: It is **highly** recommended to perform the following steps in an isolated virtual
+	  environment using pip. For more see the documentation for `Virtualenv <https://virtualenv.pypa.io/en/stable/>`_.
+
+From within the checked out copy of Girder, install and configure the CLI tools: ::
+
+  $ pip install awscli awsebcli
+  $ aws configure
+
+Initialize the Beanstalk application with a custom name. This is an interactive process
+that will ask various questions about your setup (see above for supported platforms): ::
+
+  $ eb init my-beanstalk-app
+
+Build Girder and its client-side assets locally: ::
+
+  $ pip install -e .[plugins]  # optionally build specific plugins
+  $ girder-install web --all-plugins  # optionally build specific plugins with --plugins
+
+.. seealso::
+
+   `Building specific plugins with pip <http://girder.readthedocs.io/en/latest/installation.html#installing-extra-dependencies-with-pip>`_.
+
+.. note:: Since Girder is unable to restart and load plugins in the Beanstalk environment,
+	  plugins may be enabled/disabled but will require a restart of Beanstalk application
+	  servers to take effect. Restarting application servers can be performed from the
+	  `Environment Management Console <http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environments-console.html>`_.
+
+Create a requirements.txt for the Beanstalk application, overwriting the default Girder requirements.txt: ::
+
+  $ pip freeze | grep -v '^girder\|^awscli\|^awsebcli' > requirements.txt
+
+Copy the pre-packaged configurations for Beanstalk into the current directory: ::
+
+  $ cp -r devops/beanstalk/. .
+
+.. note:: These are just the default tested Beanstalk configurations. It's likely that these will have to
+	  be modified to suit individual deployments.
+
+Beanstalk deploys code based on commits, so create a git commit with the newly added configurations: ::
+
+  $ git add . && git commit -m "Add Beanstalk configurations"
+
+Create an environment to deploy code to: ::
+
+  $ eb create my-env-name --envvars \
+    GIRDER_CONFIG=/opt/python/current/app/girder.cfg,GIRDER_MONGO_URI=mongodb://my-mongo-uri:27017/girder
+
+At this point running ``eb open my-env-name`` should open a functioning Girder instance
+in your browser. Additionally, running ``eb terminate`` will terminate the newly created environment.
+
+.. seealso::
+
+   It may be useful when deploying to AWS to make use of the built-in Girder support
+   for `S3 Assetstores <http://girder.readthedocs.io/en/latest/user-guide.html#assetstores>`_.

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -307,6 +307,10 @@ Create an environment to deploy code to: ::
 At this point running ``eb open my-env-name`` should open a functioning Girder instance
 in your browser. Additionally, running ``eb terminate`` will terminate the newly created environment.
 
+.. note:: The pre-packaged configurations work with Amazon CloudWatch for aggregating log streams
+	  across many application servers. For this to work, the EC2 instances will need the proper
+	  policy attached to write to CloudWatch.
+
 .. seealso::
 
    It may be useful when deploying to AWS to make use of the built-in Girder support


### PR DESCRIPTION
This PR adds pre-packaged configurations for running Girder on Elastic Beanstalk.

I expect these configurations to change a bit in the coming weeks/months, but for now they are working in a stable enough fashion that I think it should be merged.