### PR TITLE
Add a new girderTest.importPlugin function

### DIFF
--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -670,6 +670,14 @@ girderTest.importStylesheet = function (css) {
 };
 
 /**
+ * Import the JS and CSS files for a plugin.
+ */
+girderTest.importPlugin = function (pluginName) {
+    girderTest.addScript('/static/built/plugins/' + pluginName + '/plugin.min.js');
+    girderTest.importStylesheet('/static/built/plugins/' + pluginName + '/plugin.min.css');
+};
+
+/**
  * For the current folder, check if it is public or private and take an action.
  * :param current: either 'public' or 'private': expect this value to match.
  * :param action: if 'public' or 'private', switch to that setting.

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -629,7 +629,7 @@ girderTest.waitForDialog = function (desc) {
 girderTest.promise = $.Deferred().resolve().promise();
 
 /**
- * Import a javascript file and.
+ * Import a javascript file.
  */
 girderTest.addScript = function (url) {
     girderTest.promise = girderTest.promise
@@ -640,19 +640,7 @@ girderTest.addScript = function (url) {
 };
 
 /**
- * An alias to addScript for backwards compatibility.
- */
-girderTest.addCoveredScript = girderTest.addScript;
-
-/**
- * Import a list of covered scripts. Order will be respected.
- */
-girderTest.addCoveredScripts = function (scripts) {
-    _.each(scripts, girderTest.addCoveredScript);
-};
-
-/**
- * Import a list of non-covered scripts. Order will be respected.
+ * Import a list of scripts. Order will be respected.
  */
 girderTest.addScripts = function (scripts) {
     _.each(scripts, girderTest.addScript);
@@ -675,6 +663,24 @@ girderTest.importStylesheet = function (css) {
 girderTest.importPlugin = function (pluginName) {
     girderTest.addScript('/static/built/plugins/' + pluginName + '/plugin.min.js');
     girderTest.importStylesheet('/static/built/plugins/' + pluginName + '/plugin.min.css');
+};
+
+/**
+ * An alias to addScript for backwards compatibility.
+ * @deprecated
+ */
+girderTest.addCoveredScript = function (url) {
+    console.warn('girderTest.addCoveredScript is deprecated, use girderTest.addScript instead');
+    girderTest.addScript(url);
+};
+
+/**
+ * An alias to addScripts for backwards compatibility.
+ * @deprecated
+ */
+girderTest.addCoveredScripts = function (scripts) {
+    console.warn('girderTest.addCoveredScripts is deprecated, use girderTest.addScripts instead');
+    girderTest.addScripts(scripts);
 };
 
 /**

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -659,10 +659,15 @@ girderTest.importStylesheet = function (css) {
 
 /**
  * Import the JS and CSS files for a plugin.
+ *
+ * @param {...string} pluginNames A plugin name. Multiple arguments may be passed, to import
+ *                                multiple plugins in order.
  */
 girderTest.importPlugin = function (pluginName) {
-    girderTest.addScript('/static/built/plugins/' + pluginName + '/plugin.min.js');
-    girderTest.importStylesheet('/static/built/plugins/' + pluginName + '/plugin.min.css');
+    _.each(arguments, function (pluginName) {
+        girderTest.addScript('/static/built/plugins/' + pluginName + '/plugin.min.js');
+        girderTest.importStylesheet('/static/built/plugins/' + pluginName + '/plugin.min.css');
+    });
 };
 
 /**

--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -69,7 +69,7 @@ Web client changes
       on all desired plugins via the switches, click the **Rebuild web code** button, and once that
       finishes, click the button to restart the server.
 * **Jade** |ra| **Pug** rename: Due to trademark issues, our upstream HTML templating engine was renamed from
-  jade to pug. In addition, this rename coincides with a major version bump in the language which comes
+  Jade to Pug. In addition, this rename coincides with a major version bump in the language which comes
   with notable breaking changes.
 
     * Template files should now end in ``.pug`` instead of ``.jade``. This affects how they are imported as modules
@@ -100,9 +100,7 @@ Web client changes
 
       .. code-block:: javascript
 
-        girderTest.addCoveredScripts([
-            '/clients/web/static/built/plugins/jobs/plugin.min.js'
-        ]);
+        girderTest.importPlugin('jobs');
 
 * **Build system overhaul**: Girder web client code is now built with `Webpack <https://webpack.github.io/>`_
   instead of uglify, and we use the `Babel <https://babeljs.io/>`_ loader to enable ES2015 language support.

--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -909,7 +909,20 @@ Testing Client-Side Code
 Web client components may also be tested, using the
 `Jasmine 1.3 test framework <https://jasmine.github.io/1.3/introduction>`_.
 
-For example, the cats plugin would define tests in a ``plugin_tests/catSpec.js`` file.
+At the start of a plugin client test file, the built plugin files must be explicitly loaded,
+typically with the ``girderTest.importPlugin`` function.
+
+.. note:: Plugin dependency resolution will not take place when loading built plugin files in the
+          test environment. If your plugin has dependencies on other Girder plugins, you should
+          make multiple calls to ``girderTest.importPlugin``, loading any dependant plugins in
+          topologically sorted order, before loading your plugin with ``girderTest.importPlugin``
+          last.
+
+For example, the cats plugin would define tests in a ``plugin_tests/catSpec.js`` file, like:
+
+.. code-block:: javascript
+
+    girderTest.importPlugin('cats');
 
 Using External Data Artifacts
 *****************************

--- a/grunt_tasks/dev.js
+++ b/grunt_tasks/dev.js
@@ -40,12 +40,19 @@ module.exports = function (grunt) {
                 }
             }
         },
+        copy: {
+            test: {
+                src: 'clients/web/test/lib/jasmine-1.3.1/jasmine.css',
+                dest: 'clients/web/static/built/testing/testing.min.css'
+            }
+        },
 
         default: {
             'test-env-html': {
-                dependencies: ['build', 'uglify:test']
+                dependencies: ['build', 'uglify:test', 'copy:test']
             },
-            'uglify:test': {}
+            'uglify:test': {},
+            'copy:test': {}
         }
     });
 
@@ -59,15 +66,15 @@ module.exports = function (grunt) {
         });
         fs.writeFileSync('clients/web/static/built/testing/testEnv.html', fn({
             cssFiles: [
-                '/clients/web/static/built/fontello/css/fontello.css',
-                '/clients/web/static/built/girder_lib.min.css',
-                '/clients/web/static/built/girder_app.min.css',
-                '/clients/web/test/lib/jasmine-1.3.1/jasmine.css'
+                '/static/built/fontello/css/fontello.css',
+                '/static/built/girder_lib.min.css',
+                '/static/built/girder_app.min.css',
+                '/static/built/testing.min.css'
             ],
             jsFiles: [
-                '/clients/web/static/built/girder_lib.min.js',
-                '/clients/web/static/built/girder_app.min.js',
-                '/clients/web/static/built/testing/testing.min.js'
+                '/static/built/girder_lib.min.js',
+                '/static/built/girder_app.min.js',
+                '/static/built/testing/testing.min.js'
             ],
             staticRoot: '/static',
             apiRoot: '/api/v1'

--- a/plugins/authorized_upload/plugin_tests/authorizedUploadSpec.js
+++ b/plugins/authorized_upload/plugin_tests/authorizedUploadSpec.js
@@ -2,13 +2,7 @@
 
 var secureUrl = null;
 
-girderTest.addCoveredScripts([
-    '/clients/web/static/built/plugins/authorized_upload/plugin.min.js'
-]);
-
-girderTest.importStylesheet(
-    '/static/built/plugins/authorized_upload/plugin.min.css'
-);
+girderTest.importPlugin('authorized_upload');
 
 girderTest.startApp();
 

--- a/plugins/autojoin/plugin_tests/autojoinSpec.js
+++ b/plugins/autojoin/plugin_tests/autojoinSpec.js
@@ -1,8 +1,6 @@
 /* globals girderTest, describe, it, runs, expect, waitsFor */
 
-girderTest.addCoveredScripts([
-    '/clients/web/static/built/plugins/autojoin/plugin.min.js'
-]);
+girderTest.importPlugin('autojoin');
 
 girderTest.startApp();
 

--- a/plugins/candela/plugin_tests/candelaSpec.js
+++ b/plugins/candela/plugin_tests/candelaSpec.js
@@ -1,8 +1,6 @@
 /* globals girderTest, describe, expect, it, runs, waitsFor  */
 
-girderTest.addCoveredScripts([
-    '/clients/web/static/built/plugins/candela/plugin.min.js'
-]);
+girderTest.importPlugin('candela');
 
 girderTest.startApp();
 

--- a/plugins/curation/plugin_tests/curationSpec.js
+++ b/plugins/curation/plugin_tests/curationSpec.js
@@ -1,8 +1,6 @@
 /* globals girderTest, describe, it, runs, expect, waitsFor */
 
-girderTest.addCoveredScripts([
-    '/clients/web/static/built/plugins/curation/plugin.min.js'
-]);
+girderTest.importPlugin('curation');
 
 girderTest.startApp();
 

--- a/plugins/geospatial/plugin_tests/geospatialSpec.js
+++ b/plugins/geospatial/plugin_tests/geospatialSpec.js
@@ -1,8 +1,6 @@
 /* globals girderTest, describe, it, runs, expect, waitsFor */
 
-girderTest.addCoveredScripts([
-    '/clients/web/static/built/plugins/geospatial/plugin.min.js'
-]);
+girderTest.importPlugin('geospatial');
 
 girderTest.startApp();
 

--- a/plugins/hashsum_download/plugin_tests/hashsumSpec.js
+++ b/plugins/hashsum_download/plugin_tests/hashsumSpec.js
@@ -1,8 +1,6 @@
 /* globals girderTest, describe, it, runs, expect, waitsFor */
 
-girderTest.addCoveredScripts([
-    '/clients/web/static/built/plugins/hashsum_download/plugin.min.js'
-]);
+girderTest.importPlugin('hashsum_download');
 
 girder.events.trigger('g:appload.before');
 var app = new girder.views.App({

--- a/plugins/homepage/plugin_tests/homepageSpec.js
+++ b/plugins/homepage/plugin_tests/homepageSpec.js
@@ -1,8 +1,6 @@
 /* globals girder, girderTest, describe, expect, it, runs, waitsFor */
 
-girderTest.addCoveredScripts([
-    '/clients/web/static/built/plugins/homepage/plugin.min.js'
-]);
+girderTest.importPlugin('homepage');
 
 girderTest.startApp();
 

--- a/plugins/item_licenses/plugin_tests/itemLicensesSpec.js
+++ b/plugins/item_licenses/plugin_tests/itemLicensesSpec.js
@@ -1,8 +1,6 @@
 /* globals girderTest, describe, expect, it, runs, waitsFor, _prepareTestUpload  */
 
-girderTest.addCoveredScripts([
-    '/clients/web/static/built/plugins/item_licenses/plugin.min.js'
-]);
+girderTest.importPlugin('item_licenses');
 
 girderTest.startApp();
 

--- a/plugins/item_tasks/plugin_tests/tasksSpec.js
+++ b/plugins/item_tasks/plugin_tests/tasksSpec.js
@@ -1,8 +1,6 @@
 /* global girderTest describe it runs waitsFor expect */
 
-girderTest.importPlugin('jobs');
-girderTest.importPlugin('worker');
-girderTest.importPlugin('item_tasks');
+girderTest.importPlugin('jobs', 'worker', 'item_tasks');
 
 girderTest.startApp();
 

--- a/plugins/item_tasks/plugin_tests/tasksSpec.js
+++ b/plugins/item_tasks/plugin_tests/tasksSpec.js
@@ -1,14 +1,8 @@
 /* global girderTest describe it runs waitsFor expect */
 
-girderTest.addCoveredScripts([
-    '/clients/web/static/built/plugins/jobs/plugin.min.js',
-    '/clients/web/static/built/plugins/worker/plugin.min.js',
-    '/clients/web/static/built/plugins/item_tasks/plugin.min.js'
-]);
-
-girderTest.importStylesheet('/static/built/plugins/jobs/plugin.min.css');
-girderTest.importStylesheet('/static/built/plugins/worker/plugin.min.css');
-girderTest.importStylesheet('/static/built/plugins/item_tasks/plugin.min.css');
+girderTest.importPlugin('jobs');
+girderTest.importPlugin('worker');
+girderTest.importPlugin('item_tasks');
 
 girderTest.startApp();
 

--- a/plugins/item_tasks/plugin_tests/widgetsSpec.js
+++ b/plugins/item_tasks/plugin_tests/widgetsSpec.js
@@ -1,8 +1,6 @@
 /* global girder girderTest describe it expect Backbone beforeEach afterEach */
 
-girderTest.importPlugin('jobs');
-girderTest.importPlugin('worker');
-girderTest.importPlugin('item_tasks');
+girderTest.importPlugin('jobs', 'worker', 'item_tasks');
 
 girderTest.promise.done(function () {
     var itemTasks = girder.plugins.item_tasks;

--- a/plugins/item_tasks/plugin_tests/widgetsSpec.js
+++ b/plugins/item_tasks/plugin_tests/widgetsSpec.js
@@ -1,10 +1,8 @@
 /* global girder girderTest describe it expect Backbone beforeEach afterEach */
 
-girderTest.addCoveredScripts([
-    '/clients/web/static/built/plugins/jobs/plugin.min.js',
-    '/clients/web/static/built/plugins/worker/plugin.min.js',
-    '/clients/web/static/built/plugins/item_tasks/plugin.min.js'
-]);
+girderTest.importPlugin('jobs');
+girderTest.importPlugin('worker');
+girderTest.importPlugin('item_tasks');
 
 girderTest.promise.done(function () {
     var itemTasks = girder.plugins.item_tasks;

--- a/plugins/jobs/plugin_tests/jobsSpec.js
+++ b/plugins/jobs/plugin_tests/jobsSpec.js
@@ -1,12 +1,6 @@
 /* globals girderTest, describe, expect, it, runs, waitsFor, girder, _ */
 
-girderTest.addCoveredScripts([
-    '/clients/web/static/built/plugins/jobs/plugin.min.js'
-]);
-
-girderTest.importStylesheet(
-    '/static/built/plugins/jobs/plugin.min.css'
-);
+girderTest.importPlugin('jobs');
 
 girder.events.trigger('g:appload.before');
 var app = new girder.views.App({

--- a/plugins/provenance/plugin_tests/provenanceSpec.js
+++ b/plugins/provenance/plugin_tests/provenanceSpec.js
@@ -1,8 +1,6 @@
 /* globals girderTest, describe, expect, it, runs, waitsFor  */
 
-girderTest.addCoveredScripts([
-    '/clients/web/static/built/plugins/provenance/plugin.min.js'
-]);
+girderTest.importPlugin('provenance');
 
 girderTest.startApp();
 

--- a/plugins/thumbnails/plugin_tests/thumbnailsSpec.js
+++ b/plugins/thumbnails/plugin_tests/thumbnailsSpec.js
@@ -1,8 +1,7 @@
 /* globals girderTest, describe, expect, it, runs, waitsFor  */
 
-girderTest.addCoveredScripts([
-    '/clients/web/static/built/plugins/thumbnails/plugin.min.js'
-]);
+girderTest.importPlugin('jobs');
+girderTest.importPlugin('thumbnails');
 
 girderTest.startApp();
 

--- a/plugins/thumbnails/plugin_tests/thumbnailsSpec.js
+++ b/plugins/thumbnails/plugin_tests/thumbnailsSpec.js
@@ -1,7 +1,6 @@
 /* globals girderTest, describe, expect, it, runs, waitsFor  */
 
-girderTest.importPlugin('jobs');
-girderTest.importPlugin('thumbnails');
+girderTest.importPlugin('jobs', 'thumbnails');
 
 girderTest.startApp();
 

--- a/plugins/user_quota/plugin_tests/userQuotaSpec.js
+++ b/plugins/user_quota/plugin_tests/userQuotaSpec.js
@@ -1,8 +1,6 @@
 /* globals girderTest, runs, waitsFor, expect, describe, it */
 
-girderTest.addCoveredScripts([
-    '/clients/web/static/built/plugins/user_quota/plugin.min.js'
-]);
+girderTest.importPlugin('user_quota');
 
 girderTest.startApp();
 


### PR DESCRIPTION
This simplifies boilerplate code in web client plugin tests.

* Add a new `girderTest.importPlugin` function, to load plugin JS and CSS
* Deprecate `girderTest.addCoveredScript` and `girderTest.addCoveredScripts`
* Serve all plugin test files from `/static/built` URLs
* Add documentation on the use of `girderTest.importPlugin`