### PR TITLE
WIP: Fix race condition when setting the job status

### DIFF
--- a/plugins/worker/server/__init__.py
+++ b/plugins/worker/server/__init__.py
@@ -78,6 +78,9 @@ def schedule(event):
 
         task = job.get('celeryTaskName', 'girder_worker.run')
 
+        # Set the job status to queued
+        ModelImporter.model('job', 'jobs').updateJob(job, status=JobStatus.QUEUED)
+
         # Send the task to celery
         asyncResult = getCeleryApp().send_task(
             task, job['args'], job['kwargs'], queue=job.get('celeryQueue'), headers={
@@ -85,8 +88,8 @@ def schedule(event):
                 'apiUrl': getWorkerApiUrl()
             })
 
-        # Set the job status to queued and record the task ID from celery.
-        ModelImporter.model('job', 'jobs').updateJob(job, status=JobStatus.QUEUED, otherFields={
+        # Record the task ID from celery.
+        ModelImporter.model('job', 'jobs').updateJob(job, otherFields={
             'celeryTaskId': asyncResult.task_id
         })
 


### PR DESCRIPTION
It turns out there were instances in which calling send_task would
execute the GW prerun signal *before* updating the job status to
queued. The prerun signal sets the job status to running, so this
resulted in tasks whose timeline was running -> queued -> success|fail.

I think.