### PR TITLE
Support single POST uploads.

### DIFF
--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -71,8 +71,8 @@ class File(Resource):
                'The data for the first chunk of the file can be included with '
                'this query by sending it as the body of the request using an '
                'appropriate content-type and with the other parameters as '
-               'part of the query string.  If the entire file is uploaded as '
-               'a single via this call, the resulting file is returned.')
+               'part of the query string.  If the entire file is uploaded via '
+               'this call, the resulting file is returned.')
         .responseClass('Upload')
         .param('parentType', 'Type being uploaded into.', enum=['folder', 'item'])
         .param('parentId', 'The ID of the parent.')
@@ -126,7 +126,7 @@ class File(Resource):
                 chunk = None
 
             try:
-                # This can be made more efficient by adding
+                # TODO: This can be made more efficient by adding
                 #    save=chunk is None
                 # to the createUpload call parameters.  However, since this is
                 # a breaking change, that should be deferred until a major

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -67,6 +67,12 @@ class File(Resource):
     @access.user(scope=TokenScope.DATA_WRITE)
     @autoDescribeRoute(
         Description('Start a new upload or create an empty or link file.')
+        .notes('Use POST /file/chunk to send the contents of the file.  '
+               'The data for the first chunk of the file can be included with '
+               'this query by sending it as the body of the request using an '
+               'appropriate content-type and with the other parameters as '
+               'part of the query string.  If the entire file is uploaded as '
+               'a single via this call, the resulting file is returned.')
         .responseClass('Upload')
         .param('parentType', 'Type being uploaded into.', enum=['folder', 'item'])
         .param('parentId', 'The ID of the parent.')
@@ -197,6 +203,12 @@ class File(Resource):
     @access.user(scope=TokenScope.DATA_WRITE)
     @autoDescribeRoute(
         Description('Upload a chunk of a file.')
+        .notes('The data for the chunk should be sent as the body of the '
+               'request using an appropriate content-type and with the other '
+               'parameters as part of the query string.  Alternately, the '
+               'data can be sent as a file in the "chunk" field in multipart '
+               'form data.  Multipart uploads are much less efficient and '
+               'their use is deprecated.')
         .modelParam('uploadId', paramType='formData')
         .param('offset', 'Offset of the chunk in the file.', dataType='integer',
                paramType='formData')

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -123,7 +123,7 @@ class File(Resource):
                 upload = self.model('upload').createUpload(
                     user=user, name=name, parentType=parentType, parent=parent, size=size,
                     mimeType=mimeType, reference=reference, assetstore=assetstore,
-                    saveUpload=chunk is None)
+                    save=chunk is None)
             except OSError as exc:
                 if exc.errno == errno.EACCES:
                     raise GirderException(

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -111,15 +111,7 @@ class File(Resource):
                 assetstore = self.model('assetstore').load(assetstoreId)
 
             chunk = None
-            if 'chunk' in params:
-                chunk = params['chunk']
-                if isinstance(chunk, cherrypy._cpreqbody.Part):
-                    # Seek is the only obvious way to get the length of the part
-                    chunk.file.seek(0, os.SEEK_END)
-                    chunkSize = chunk.file.tell()
-                    chunk.file.seek(0, os.SEEK_SET)
-                    chunk = RequestBodyStream(chunk.file, size=chunkSize)
-            elif size > 0 and cherrypy.request.headers.get('Content-Length'):
+            if size > 0 and cherrypy.request.headers.get('Content-Length'):
                 ct = cherrypy.request.body.content_type.value
                 if (ct not in cherrypy.request.body.processors and
                         ct.split('/', 1)[0] not in cherrypy.request.body.processors):

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -120,10 +120,14 @@ class File(Resource):
                 chunk = None
 
             try:
+                # This can be made more efficient by adding
+                #    save=chunk is None
+                # to the createUpload call parameters.  However, since this is
+                # a breaking change, that should be deferred until a major
+                # version upgrade.
                 upload = self.model('upload').createUpload(
                     user=user, name=name, parentType=parentType, parent=parent, size=size,
-                    mimeType=mimeType, reference=reference, assetstore=assetstore,
-                    save=chunk is None)
+                    mimeType=mimeType, reference=reference, assetstore=assetstore)
             except OSError as exc:
                 if exc.errno == errno.EACCES:
                     raise GirderException(

--- a/girder/models/upload.py
+++ b/girder/models/upload.py
@@ -309,7 +309,7 @@ class Upload(Model):
 
     def createUpload(self, user, name, parentType, parent, size, mimeType=None,
                      reference=None, assetstore=None, attachParent=False,
-                     saveUpload=True):
+                     save=True):
         """
         Creates a new upload record, and creates its temporary file
         that the chunks will be written into. Chunks should then be sent
@@ -339,6 +339,8 @@ class Upload(Model):
             appear as direct children of the parent, but are still associated
             with it.
         :type attachParent: boolean
+        :param save: if True, save the document after it is created.
+        :type save: boolean
         :returns: The upload document that was created.
         """
         assetstore = self.getTargetAssetstore(parentType, parent, assetstore)
@@ -374,7 +376,7 @@ class Upload(Model):
             upload['userId'] = None
 
         upload = adapter.initUpload(upload)
-        if saveUpload:
+        if save:
             upload = self.save(upload)
         return upload
 

--- a/girder/models/upload.py
+++ b/girder/models/upload.py
@@ -141,7 +141,9 @@ class Upload(Model):
         assetstore = self.model('assetstore').load(upload['assetstoreId'])
         adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
 
-        upload = self.save(adapter.uploadChunk(upload, chunk))
+        upload = adapter.uploadChunk(upload, chunk)
+        if '_id' in upload or upload['received'] != upload['size']:
+            upload = self.save(upload)
 
         # If upload is finished, we finalize it
         if upload['received'] == upload['size']:
@@ -228,7 +230,8 @@ class Upload(Model):
         events.trigger('model.file.finalizeUpload.before', event_document)
         file = self.model('file').save(file)
         events.trigger('model.file.finalizeUpload.after', event_document)
-        self.remove(upload)
+        if '_id' in upload:
+            self.remove(upload)
 
         # Add an async event for handlers that wish to process this file.
         eventParams = {
@@ -305,7 +308,8 @@ class Upload(Model):
         return self.save(upload)
 
     def createUpload(self, user, name, parentType, parent, size, mimeType=None,
-                     reference=None, assetstore=None, attachParent=False):
+                     reference=None, assetstore=None, attachParent=False,
+                     saveUpload=True):
         """
         Creates a new upload record, and creates its temporary file
         that the chunks will be written into. Chunks should then be sent
@@ -370,7 +374,9 @@ class Upload(Model):
             upload['userId'] = None
 
         upload = adapter.initUpload(upload)
-        return self.save(upload)
+        if saveUpload:
+            upload = self.save(upload)
+        return upload
 
     def moveFileToAssetstore(self, file, user, assetstore, progress=noProgress):
         """
@@ -468,7 +474,8 @@ class Upload(Model):
             except ValidationException:
                 # this assetstore is currently unreachable, so skip it
                 pass
-        self.model('upload').remove(upload)
+        if '_id' in upload:
+            self.model('upload').remove(upload)
 
     def untrackedUploads(self, action='list', assetstoreId=None):
         """

--- a/girder/utility/filesystem_assetstore_adapter.py
+++ b/girder/utility/filesystem_assetstore_adapter.py
@@ -219,8 +219,9 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
 
         # Store the hash in the upload so that deleting a file won't delete
         # this file
-        upload['sha512'] = hash
-        self.model('upload').update({'_id': upload['_id']}, update={'$set': {'sha512': hash}})
+        if '_id' in upload:
+            upload['sha512'] = hash
+            self.model('upload').update({'_id': upload['_id']}, update={'$set': {'sha512': hash}})
 
         mkdir(absdir)
 

--- a/tests/cases/upload_test.py
+++ b/tests/cases/upload_test.py
@@ -330,7 +330,7 @@ class UploadTestCase(base.TestCase):
         self.assertStatusOk(resp)
         foundUploads = resp.json
         self.assertEqual(len(foundUploads), len(partialUploads))
-        # Check that no upload model is saved when we are using one chunk
+        # Check that the upload model is saved when we are using one chunk
         self._uploadWasSaved = 0
 
         def trackUploads(*args, **kwargs):
@@ -338,7 +338,9 @@ class UploadTestCase(base.TestCase):
 
         events.bind('model.upload.save', 'uploadWithInitialChunk', trackUploads)
         self._uploadFileWithInitialChunk('upload4', oneChunk=True)
-        self.assertEqual(self._uploadWasSaved, 0)
+        # This can be changed to assertEqual if one chunk uploads aren't saved
+        self.assertGreater(self._uploadWasSaved, 0)
+        self._uploadWasSaved = 0
         # But that it is saved when using multiple chunks
         self._uploadFileWithInitialChunk('upload5')
         self.assertGreater(self._uploadWasSaved, 0)

--- a/tests/cases/upload_test.py
+++ b/tests/cases/upload_test.py
@@ -170,6 +170,69 @@ class UploadTestCase(base.TestCase):
             _send_s3_request(resp.json['s3FinalizeRequest'])
         return upload
 
+    def _uploadFileWithInitialChunk(self, name, partial=False, largeFile=False,
+                                    oneChunk=False, multipart=True):
+        """
+        Upload a file either completely or partially, sending the first chunk
+        with the initial POST.
+
+        :param name: the name of the file to upload.
+        :param partial: the number of steps to complete in the uploads: 1
+                        uploads 1 chunk.  False to complete the upload.
+        :param largeFile: if True, upload a file that is > 32Mb
+        :param oneChunk: if True, upload everything as one chunk.  Otherwise,
+            upload one chunk when creating the upload and one via the
+            file/chunk endpoint.
+        :param multipart: True for multipart uploads, False for using a single
+            body with the main data and the remaining parameters in the url.
+        :returns: the upload record which includes the upload id.
+        """
+        if not largeFile:
+            chunk1 = Chunk1
+            chunk2 = Chunk2
+        else:
+            chunk1 = '-' * (1024 * 1024 * 32)
+            chunk2 = '-' * (1024 * 1024 * 1)
+        if oneChunk:
+            chunk1 += chunk2
+            chunk2 = ''
+        params = {
+            'parentType': 'folder',
+            'parentId': str(self.folder['_id']),
+            'name': name,
+            'size': len(chunk1) + len(chunk2),
+            'mimeType': 'text/plain',
+        }
+        files = [('chunk', 'helloWorld.txt', chunk1)]
+        if multipart:
+            resp = self.multipartRequest(
+                path='/file', user=self.user,
+                fields=list(six.iteritems(params)), files=files)
+        else:
+            resp = self.request(
+                path='/file', method='POST', user=self.user,
+                params=params, body=files[0][-1], type='text/plain')
+        self.assertStatusOk(resp)
+        if partial is not False:
+            return resp.json
+        if not oneChunk:
+            upload = resp.json
+            params = {'offset': len(chunk1), 'uploadId': upload['_id']}
+            files = [('chunk', 'helloWorld.txt', chunk2)]
+            if multipart:
+                resp = self.multipartRequest(
+                    path='/file/chunk', user=self.user,
+                    fields=list(six.iteritems(params)), files=files)
+            else:
+                resp = self.request(
+                    path='/file/chunk', method='POST', user=self.user,
+                    params=params, body=files[0][-1], type='text/plain')
+            self.assertStatusOk(resp)
+        else:
+            upload = None
+        self.assertEqual(resp.json['_modelType'], 'file')
+        return upload
+
     def _testUpload(self):
         """
         Upload a file to the server and several partial files.  Test that we
@@ -253,6 +316,51 @@ class UploadTestCase(base.TestCase):
         resp = self.request(path='/system/uploads', method='GET',
                             user=self.admin)
         self.assertEqual(resp.json, [])
+
+    def testUploadWithInitialChunk(self):
+        """
+        Upload a file to the server and several partial files.  Test that we
+        can delete a partial upload but not a completed upload. Test that we
+        can delete partial uploads that are older than a certain date.
+        """
+        self._uploadFileWithInitialChunk('upload1')
+        self._uploadFileWithInitialChunk('upload2', oneChunk=True)
+        # test uploading large files
+        self._uploadFileWithInitialChunk('upload3', largeFile=True)
+        partialUploads = []
+        for largeFile in (False, True):
+            for partial in range(1, 3):
+                partialUploads.append(self._uploadFileWithInitialChunk(
+                    'partial_upload_%d_%s' % (partial, str(largeFile)),
+                    partial, largeFile))
+        # check that a user cannot list partial uploads
+        resp = self.request(path='/system/uploads', method='GET',
+                            user=self.user)
+        self.assertStatus(resp, 403)
+        # The admin user should see all of the partial uploads, but not the
+        # complete upload
+        resp = self.request(path='/system/uploads', method='GET',
+                            user=self.admin)
+        self.assertStatusOk(resp)
+        foundUploads = resp.json
+        self.assertEqual(len(foundUploads), len(partialUploads))
+        # Now try with non-multipart uploads
+        self._uploadFileWithInitialChunk('upload4', multipart=False)
+        self._uploadFileWithInitialChunk('upload5', oneChunk=True, multipart=False)
+        self._uploadFileWithInitialChunk('upload6', largeFile=True, multipart=False)
+        # Check that no upload model is saved when we are using one chunk
+        self._uploadWasSaved = 0
+
+        def trackUploads(*args, **kwargs):
+            self._uploadWasSaved += 1
+
+        events.bind('model.upload.save', 'uploadWithInitialChunk', trackUploads)
+        self._uploadFileWithInitialChunk('upload7', oneChunk=True, multipart=False)
+        self.assertEqual(self._uploadWasSaved, 0)
+        # But that it is saved when using multiple chunks
+        self._uploadFileWithInitialChunk('upload8', multipart=False)
+        self.assertGreater(self._uploadWasSaved, 0)
+        events.unbind('model.upload.save', 'uploadWithInitialChunk')
 
     def testFilesystemAssetstoreUpload(self):
         self._testUpload()


### PR DESCRIPTION
If the parameters on a `POST /file` endpoint are included in the URL and the body is not processed by cherrypy and exists, then use the body as the first chunk of the upload.  Alternately, if there is a `chunk` parameter, use that as the first chunk of the upload.

If multiple chunks are needed, the first can be sent via `POST /file`, and the rest must be sent via `POST /file/chunk`.

If the file is completely uploaded, `POST /file` will return a file resource.  Otherwise, it will return an upload resource.

Skip saving an upload model when the file is uploaded as a single chunk via the `POST /file` endpoint.  If only the first chunk of multiple chunks is sent via the `POST /file` endpoint, then the upload model will be saved at the end of saving the first chunk.

Once this is merged to Girder master and there exists a new version, the girder client can be modified to use a single POST for small uploads (or always start with a POST for the first part of an upload).

This resolves issue #2088.