### PR TITLE
Fix static analysis of plugin test files

### DIFF
--- a/clients/web/test/spec/.eslintrc
+++ b/clients/web/test/spec/.eslintrc
@@ -1,5 +1,0 @@
-{
-  "globals": {
-    "_prepareTestUpload": true
-  }
-}

--- a/clients/web/test/spec/collectionBaseClassSpec.js
+++ b/clients/web/test/spec/collectionBaseClassSpec.js
@@ -1,4 +1,3 @@
-
 function canary() {
     var isDone = false;
     var result = function done() {

--- a/clients/web/test/spec/itemSpec.js
+++ b/clients/web/test/spec/itemSpec.js
@@ -221,7 +221,7 @@ describe('Test item creation, editing, and deletion', function () {
         girderTest.waitForDialog();
 
         runs(function () {
-            _prepareTestUpload();
+            girderTest._prepareTestUpload();
             girderTest._uploadDataExtra = 0;
             girderTest.sendFile('clients/web/test/testFile.txt');
         });

--- a/clients/web/test/spec/widgetsSpec.js
+++ b/clients/web/test/spec/widgetsSpec.js
@@ -1,5 +1,3 @@
-/* globals girderTest, runs, waitsFor, expect, describe, it */
-
 /**
  * Start the girder backbone app.
  */

--- a/plugins/authorized_upload/plugin_tests/authorizedUploadSpec.js
+++ b/plugins/authorized_upload/plugin_tests/authorizedUploadSpec.js
@@ -6,7 +6,7 @@ girderTest.startApp();
 
 describe('Create an authorized upload.', function () {
     it('register a user', girderTest.createUser(
-        'admin', 'admin@email.com', 'Admin', 'Admin',  'passwd'));
+        'admin', 'admin@email.com', 'Admin', 'Admin', 'passwd'));
 
     it('go to the authorize upload page', function () {
         runs(function () {
@@ -43,7 +43,6 @@ describe('Create an authorized upload.', function () {
         waitsFor(function () {
             return $('btn.g-create-authorized-upload').length > 0;
         }, 'authorize upload page to display');
-
     });
 
     it('create an authorized upload', function () {
@@ -58,7 +57,7 @@ describe('Create an authorized upload.', function () {
         runs(function () {
             secureUrl = $('.g-authorized-upload-url-target').val();
             expect(secureUrl).toMatch(/.*#authorized_upload\/[a-f0-9]+\/[a-zA-Z0-9]/);
-        })
+        });
     });
 
     it('logout', girderTest.logout());
@@ -82,7 +81,7 @@ describe('Perform authorized upload', function () {
 
         waitsFor(function () {
             return $('.g-complete-wrapper:visible').length > 0;
-        }, 'upload completion message to appear')
+        }, 'upload completion message to appear');
 
         runs(function () {
             window.callPhantom({
@@ -92,4 +91,3 @@ describe('Perform authorized upload', function () {
         });
     });
 });
-

--- a/plugins/authorized_upload/plugin_tests/authorizedUploadSpec.js
+++ b/plugins/authorized_upload/plugin_tests/authorizedUploadSpec.js
@@ -73,7 +73,7 @@ describe('Perform authorized upload', function () {
         }, 'authorized upload page to display');
 
         runs(function () {
-            _prepareTestUpload();
+            girderTest._prepareTestUpload();
             girderTest.sendFile('clients/web/test/testFile.txt');
             $('#g-files').parent().addClass('hide');
             $('.g-start-upload').click();

--- a/plugins/authorized_upload/plugin_tests/authorizedUploadSpec.js
+++ b/plugins/authorized_upload/plugin_tests/authorizedUploadSpec.js
@@ -1,5 +1,3 @@
-/* globals girderTest, describe, expect, it, runs, waitsFor  */
-
 var secureUrl = null;
 
 girderTest.importPlugin('authorized_upload');

--- a/plugins/autojoin/plugin_tests/autojoinSpec.js
+++ b/plugins/autojoin/plugin_tests/autojoinSpec.js
@@ -1,5 +1,3 @@
-/* globals girderTest, describe, it, runs, expect, waitsFor */
-
 girderTest.importPlugin('autojoin');
 
 girderTest.startApp();

--- a/plugins/candela/plugin_tests/candelaSpec.js
+++ b/plugins/candela/plugin_tests/candelaSpec.js
@@ -1,5 +1,3 @@
-/* globals girderTest, describe, expect, it, runs, waitsFor  */
-
 girderTest.importPlugin('candela');
 
 girderTest.startApp();

--- a/plugins/curation/plugin_tests/curationSpec.js
+++ b/plugins/curation/plugin_tests/curationSpec.js
@@ -1,5 +1,3 @@
-/* globals girderTest, describe, it, runs, expect, waitsFor */
-
 girderTest.importPlugin('curation');
 
 girderTest.startApp();

--- a/plugins/geospatial/plugin_tests/geospatialSpec.js
+++ b/plugins/geospatial/plugin_tests/geospatialSpec.js
@@ -1,5 +1,3 @@
-/* globals girderTest, describe, it, runs, expect, waitsFor */
-
 girderTest.importPlugin('geospatial');
 
 girderTest.startApp();

--- a/plugins/hashsum_download/plugin_tests/hashsumSpec.js
+++ b/plugins/hashsum_download/plugin_tests/hashsumSpec.js
@@ -1,5 +1,3 @@
-/* globals girderTest, describe, it, runs, expect, waitsFor */
-
 girderTest.importPlugin('hashsum_download');
 
 girder.events.trigger('g:appload.before');

--- a/plugins/homepage/plugin_tests/homepageSpec.js
+++ b/plugins/homepage/plugin_tests/homepageSpec.js
@@ -1,5 +1,3 @@
-/* globals girder, girderTest, describe, expect, it, runs, waitsFor */
-
 girderTest.importPlugin('homepage');
 
 girderTest.startApp();

--- a/plugins/item_licenses/plugin_tests/itemLicensesSpec.js
+++ b/plugins/item_licenses/plugin_tests/itemLicensesSpec.js
@@ -1,5 +1,3 @@
-/* globals girderTest, describe, expect, it, runs, waitsFor, _prepareTestUpload  */
-
 girderTest.importPlugin('item_licenses');
 
 girderTest.startApp();

--- a/plugins/item_licenses/plugin_tests/itemLicensesSpec.js
+++ b/plugins/item_licenses/plugin_tests/itemLicensesSpec.js
@@ -207,7 +207,7 @@ $(function () {
             // Upload file
             // XXX: add support to test uploading multiple files
             runs(function () {
-                _prepareTestUpload();
+                girderTest._prepareTestUpload();
                 girderTest._uploadDataExtra = 0;
                 girderTest.sendFile('clients/web/test/testFile.txt');
             });

--- a/plugins/item_tasks/plugin.cmake
+++ b/plugins/item_tasks/plugin.cmake
@@ -12,7 +12,8 @@ if (BUILD_JAVASCRIPT_TESTS)
     set_property(TEST web_client_item_tasks.tasks PROPERTY RUN_SERIAL ON)
 endif()
 
-add_eslint_test(${_pluginName}_tests "${_pluginDir}/plugin_tests/plugin_tests")
+add_eslint_test(${_pluginName}_tests "${_pluginDir}/plugin_tests/plugin_tests"
+    ESLINT_CONFIG_FILE "${PROJECT_SOURCE_DIR}/clients/web/test/.eslintrc")
 
 if(ANSIBLE_TESTS)
   find_program(VAGRANT_EXECUTABLE vagrant)

--- a/plugins/item_tasks/plugin_tests/tasksSpec.js
+++ b/plugins/item_tasks/plugin_tests/tasksSpec.js
@@ -1,5 +1,3 @@
-/* global girderTest describe it runs waitsFor expect */
-
 girderTest.importPlugin('jobs', 'worker', 'item_tasks');
 
 girderTest.startApp();

--- a/plugins/item_tasks/plugin_tests/widgetsSpec.js
+++ b/plugins/item_tasks/plugin_tests/widgetsSpec.js
@@ -1,5 +1,3 @@
-/* global girder girderTest describe it expect Backbone beforeEach afterEach */
-
 girderTest.importPlugin('jobs', 'worker', 'item_tasks');
 
 girderTest.promise.done(function () {

--- a/plugins/jobs/plugin_tests/jobsSpec.js
+++ b/plugins/jobs/plugin_tests/jobsSpec.js
@@ -1,5 +1,3 @@
-/* globals girderTest, describe, expect, it, runs, waitsFor, girder, _ */
-
 girderTest.importPlugin('jobs');
 
 girder.events.trigger('g:appload.before');
@@ -168,7 +166,7 @@ $(function () {
                 widget.collection.add(jobs);
 
                 // job list should re-render when collection is updated
-                expect($('.g-jobs-list-table>tbody>tr').length).toBe(3)
+                expect($('.g-jobs-list-table>tbody>tr').length).toBe(3);
             });
 
             runs(function () {

--- a/plugins/provenance/plugin_tests/provenanceSpec.js
+++ b/plugins/provenance/plugin_tests/provenanceSpec.js
@@ -1,5 +1,3 @@
-/* globals girderTest, describe, expect, it, runs, waitsFor  */
-
 girderTest.importPlugin('provenance');
 
 girderTest.startApp();

--- a/plugins/thumbnails/plugin_tests/thumbnailsSpec.js
+++ b/plugins/thumbnails/plugin_tests/thumbnailsSpec.js
@@ -1,5 +1,3 @@
-/* globals girderTest, describe, expect, it, runs, waitsFor  */
-
 girderTest.importPlugin('jobs', 'thumbnails');
 
 girderTest.startApp();

--- a/plugins/user_quota/plugin_tests/userQuotaSpec.js
+++ b/plugins/user_quota/plugin_tests/userQuotaSpec.js
@@ -1,5 +1,3 @@
-/* globals girderTest, runs, waitsFor, expect, describe, it */
-
 girderTest.importPlugin('user_quota');
 
 girderTest.startApp();

--- a/plugins/user_quota/plugin_tests/userQuotaSpec.js
+++ b/plugins/user_quota/plugin_tests/userQuotaSpec.js
@@ -122,7 +122,7 @@ $(function () {
             return $('.g-validation-failed-message').text().indexOf('Invalid quota') >= 0;
         }, 'an error message to appear');
         runs(function () {
-            $('#g-sizeValue').val(capacity ? capacity : '');
+            $('#g-sizeValue').val(capacity || '');
         });
         runs(function () {
             $('.g-save-policies').click();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -165,7 +165,8 @@ macro(add_standard_plugin_tests)
       string(REGEX REPLACE "Spec\\.js$" "" _clientTestName "${_clientTestFileName}")
       add_web_client_test(${_clientTestName} "${_clientTestFile}" PLUGIN ${_pluginName})
     endforeach()
-    add_eslint_test(${_pluginName}_tests "${_pluginDir}/plugin_tests")
+    add_eslint_test(${_pluginName}_tests "${_pluginDir}/plugin_tests"
+      ESLINT_CONFIG_FILE "${PROJECT_SOURCE_DIR}/clients/web/test/.eslintrc")
   endif()
 endmacro()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -165,7 +165,7 @@ macro(add_standard_plugin_tests)
       string(REGEX REPLACE "Spec\\.js$" "" _clientTestName "${_clientTestFileName}")
       add_web_client_test(${_clientTestName} "${_clientTestFile}" PLUGIN ${_pluginName})
     endforeach()
-    add_eslint_test(${_pluginName}_tests "${_pluginDir}/plugin_tests/plugin_tests")
+    add_eslint_test(${_pluginName}_tests "${_pluginDir}/plugin_tests")
   endif()
 endmacro()
 


### PR DESCRIPTION
Static analysis tests on plugin test specs was previously broken. This fixes the issue, and removes some extra boilerplate from plugin test files.

* Fix an incorrect path, which prevented plugin test static analysis from running
* Use additional eslint rules for plugin test files
* Remove unnecessary eslint overrides from test files
* Fix style errors in tests
* Rename the "_prepareTestUpload" function to "girderTest._prepareTestUpload"