### PR TITLE
Test girder installation through cli 

### DIFF
--- a/tests/cases/install_test.py
+++ b/tests/cases/install_test.py
@@ -18,6 +18,7 @@
 ###############################################################################
 
 import mock
+import sys
 import os
 import six
 import shutil
@@ -226,26 +227,6 @@ class InstallTestCase(base.TestCase):
         self.assertFalse(os.path.islink(os.path.join(self.pluginDir, 'has_grunt_deps')))
 
     def testWebInstall(self):
-        with mock.patch('subprocess.Popen', return_value=ProcMock(rc=2)) as p,\
-                six.assertRaisesRegex(self, Exception, 'npm install .* returned 2'):
-            install.install_web()
-
-            self.assertEqual(len(p.mock_calls), 1)
-            self.assertEqual(p.mock_calls[0][1][0][:2], ('npm', 'install'))
-            self.assertEqual(p.mock_calls[0][2]['cwd'], constants.PACKAGE_DIR)
-
-        with mock.patch('subprocess.Popen', return_value=ProcMock()):
-            install.install_web()
-
-        with mock.patch('subprocess.Popen', return_value=ProcMock()) as p:
-            install.install_web()
-            self.assertIn('--production', p.mock_calls[0][1][0])
-
-        with mock.patch('subprocess.Popen', return_value=ProcMock()) as p:
-            install.install_web(PluginOpts(dev=True))
-
-            self.assertNotIn('--production', p.mock_calls[0][1][0])
-
         # Test initiation of web install via the REST API
         user = self.model('user').createUser(
             login='admin', firstName='admin', lastName='admin', email='a@foo.com',
@@ -274,15 +255,39 @@ class InstallTestCase(base.TestCase):
         })
         self.assertStatusOk(resp)
 
+    def testWebInstallCli(self):
+        def invokeCli(argList):
+            args = ['girder-install']
+            args += list(argList)
+            with mock.patch.object(sys, 'argv', args):
+                install.main()
+
+        # Test web install
+        with mock.patch('subprocess.Popen', return_value=ProcMock(rc=2)) as p,\
+                six.assertRaisesRegex(self, Exception, 'npm install .* returned 2'):
+            invokeCli(['web'])
+
+            self.assertEqual(len(p.mock_calls), 1)
+            self.assertEqual(p.mock_calls[0][1][0][:2], ('npm', 'install'))
+            self.assertEqual(p.mock_calls[0][2]['cwd'], constants.PACKAGE_DIR)
+
+        with mock.patch('subprocess.Popen', return_value=ProcMock()) as p:
+            invokeCli(['web'])
+            self.assertIn('--production', p.mock_calls[0][1][0])
+
+        with mock.patch('subprocess.Popen', return_value=ProcMock()) as p:
+            invokeCli(['web', '--dev'])
+            self.assertNotIn('--production', p.mock_calls[0][1][0])
+
         # Test watch commands
         with mock.patch('subprocess.Popen', return_value=ProcMock()) as p:
-            install.install_web(PluginOpts(watch=True))
+            invokeCli(['web', '--watch'])
 
             self.assertEqual(len(p.mock_calls), 1)
             self.assertEqual(list(p.mock_calls[0][1][0]), ['npm', 'run', 'watch'])
 
         with mock.patch('subprocess.Popen', return_value=ProcMock()) as p:
-            install.install_web(PluginOpts(watch_plugin='jobs'))
+            invokeCli(['web', '--watch-plugin=jobs'])
 
             self.assertEqual(len(p.mock_calls), 1)
             self.assertEqual(
@@ -293,12 +298,14 @@ class InstallTestCase(base.TestCase):
 
         # Keyboard interrupt should be handled gracefully
         with mock.patch('subprocess.Popen', return_value=ProcMock(keyboardInterrupt=True)):
-            install.install_web(PluginOpts(watch=True))
+            invokeCli(['web', '--watch'])
 
         # Test "--plugins=" and --no-plugins
-        with mock.patch('girder.utility.install.model_importer.ModelImporter.model') as p:
-            install.install_web(PluginOpts(plugins=''))
-            install.install_web(PluginOpts(no_plugins=True))
+        with mock.patch('girder.utility.install.model_importer.ModelImporter.model') as p,\
+                mock.patch('subprocess.Popen', return_value=ProcMock()):
+            invokeCli(['web', '--no-plugins'])
+            invokeCli(['web', '--plugins='])
+            invokeCli(['web', '--plugins=,'])
             self.assertEqual(len(p.mock_calls), 0)
 
     def testStaticDependencies(self):


### PR DESCRIPTION
This changes the install tests to install with command line arguments rather than calling the internal installation fictions directly. 

I think this is a better approach as it actually tests the cli arguments. This also increases the test coverage of the file significantly. 