### PR TITLE
Fix uploading into HDFS assetstore using new upload mode

### DIFF
--- a/girder/utility/__init__.py
+++ b/girder/utility/__init__.py
@@ -149,6 +149,8 @@ class RequestBodyStream(object):
     """
     Wraps a cherrypy request body into a more abstract file-like object.
     """
+    _ITER_CHUNK_LEN = 65536
+
     def __init__(self, stream, size=None):
         self.stream = stream
         self.size = size
@@ -158,6 +160,18 @@ class RequestBodyStream(object):
 
     def close(self, *args, **kwargs):
         pass
+
+    def __iter__(self):
+        return self
+
+    def next(self):
+        data = self.read(self._ITER_CHUNK_LEN)
+        if not data:
+            raise StopIteration
+        return data
+
+    def __next__(self):
+        return self.next()
 
     def getSize(self):
         """

--- a/plugins/hdfs_assetstore/plugin_tests/hdfs_assetstore_test.py
+++ b/plugins/hdfs_assetstore/plugin_tests/hdfs_assetstore_test.py
@@ -377,7 +377,7 @@ class HdfsAssetstoreTest(base.TestCase):
             elif url.netloc == 'localhost:50075':
                 # Write the contents
                 with open(absPath, 'a') as f:
-                    f.write(request.body.read())
+                    f.write(b''.join(request.body))
                 return {
                     'status_code': 200
                 }
@@ -401,10 +401,11 @@ class HdfsAssetstoreTest(base.TestCase):
             self.assertStatusOk(resp)
             self.assertEqual(resp.json['offset'], len(chunk1))
 
-            fields = [('offset', len(chunk1)), ('uploadId', upload['_id'])]
-            files = [('chunk', 'testUpload.txt', chunk2)]
-            resp = self.multipartRequest(
-                path='/file/chunk', user=self.admin, fields=fields, files=files)
+            resp = self.request(
+                path='/file/chunk', method='POST', user=self.admin, body=chunk2, params={
+                    'offset': len(chunk1),
+                    'uploadId': upload['_id']
+                }, type='text/plain')
             self.assertStatusOk(resp)
             file = resp.json
 

--- a/plugins/hdfs_assetstore/web_client/templates/newAssetstoreWidgetCreate.pug
+++ b/plugins/hdfs_assetstore/web_client/templates/newAssetstoreWidgetCreate.pug
@@ -4,7 +4,8 @@
       data-target="#g-create-hdfs-tab")
     .panel-title
       a
-        i.icon-share Create new #[b HDFS] assetstore
+        i.icon-share
+        | Create new #[b HDFS] assetstore
   #g-create-hdfs-tab.panel-collapse.collapse
     .panel-body
       p.


### PR DESCRIPTION
Our new upload mode was not being tested on HDFS assetstores, and it was broken because the RequestBodyStream object is not properly handled by requests as a valid `data` field. By wrapping it in an iterator, everything works.