### PR TITLE
Add a cookiecutter template for a Girder plugin

### DIFF
--- a/devops/cookiecutter-girder-plugin/cookiecutter.json
+++ b/devops/cookiecutter-girder-plugin/cookiecutter.json
@@ -1,0 +1,7 @@
+{
+    "plugin_nice_name": "My Girder Plugin",
+    "plugin_name": "{{ cookiecutter.plugin_nice_name.lower().replace(' ', '_') }}",
+    "plugin_camel_case": "{{ cookiecutter.plugin_nice_name.lower()|title|replace(' ', '') }}",
+    "plugin_description": "Do Girder things.",
+    "version": "0.0.1"
+}

--- a/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/plugin.cmake
+++ b/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/plugin.cmake
@@ -1,0 +1,1 @@
+add_standard_plugin_tests()

--- a/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/plugin.json
+++ b/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/plugin.json
@@ -1,0 +1,5 @@
+{
+    "name": "{{ cookiecutter.plugin_nice_name }}",
+    "description": "{{ cookiecutter.plugin_description }}",
+    "version": "{{ cookiecutter.version }}"
+}

--- a/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/plugin_tests/{{ cookiecutter.plugin_camel_case }}Spec.js
+++ b/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/plugin_tests/{{ cookiecutter.plugin_camel_case }}Spec.js
@@ -1,0 +1,19 @@
+girderTest.addScripts([
+    '/clients/web/static/built/plugins/{{ cookiecutter.plugin_name }}/plugin.min.js'
+]);
+
+girderTest.startApp();
+
+$(function () {
+    describe('{{ cookiecutter.plugin_name }} homepage test', function () {
+        it('verifies greeting is added to homepage', function () {
+            waitsFor(function () {
+                return girder.rest.numberOutstandingRestRequests() === 0;
+            }, 'rest requests to finish');
+
+            runs(function () {
+                expect($('#g-app-body-container').find('p:contains("Hi from {{ cookiecutter.plugin_nice_name }}")').length).toBe(1);
+            });
+        });
+    });
+});

--- a/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/plugin_tests/{{ cookiecutter.plugin_name }}_test.py
+++ b/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/plugin_tests/{{ cookiecutter.plugin_name }}_test.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from tests import base
+from girder.models.model_base import ValidationException
+
+
+# For more on testing your Python plugins, see:
+# http://girder.readthedocs.io/en/latest/plugin-development.html#automated-testing-for-plugins
+def setUpModule():
+    base.enabledPlugins.append('{{ cookiecutter.plugin_name }}')
+    base.startServer()
+
+
+def tearDownModule():
+    base.stopServer()
+
+
+class {{ cookiecutter.plugin_camel_case }}Test(base.TestCase):
+    def setUp(self):
+        super({{ cookiecutter.plugin_camel_case }}Test, self).setUp()
+
+        self.admin_user = self.model('user').createUser('test', 'testpass', 'test',
+                                                        'test', 'test@test.test', admin=True)
+
+    def testItemMetadataGetsAdded(self):
+        pass
+        # item = self.model('item').createItem('test item', self.admin_user, )
+        # self.assert
+
+    def testItemMetadataFailureGetsLogged(self):
+        pass
+
+    def testItemMetadataValidates(self):
+        from girder.plugins.{{ cookiecutter.plugin_name }}.constants import PluginSettings
+
+        with self.assertRaises(ValidationException):
+            self.model('setting').set(PluginSettings.ITEM_METADATA, '')
+
+    def testItemMetadataRetrieval(self):
+        from girder.plugins.{{ cookiecutter.plugin_name }}.constants import PluginSettings
+
+        # Test default value is retrieved
+        resp = self.request('/{{ cookiecutter.plugin_name }}/item_metadata', user=self.admin_user)
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, 'default_value')
+
+        # Change the value and test the new value is retrieved
+        self.model('setting').set(PluginSettings.ITEM_METADATA, 'new_value')
+        resp = self.request('/{{ cookiecutter.plugin_name }}/item_metadata', user=self.admin_user)
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, 'new_value')

--- a/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/server/__init__.py
+++ b/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/server/__init__.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from girder import events, logger
+from girder.utility.model_importer import ModelImporter
+from .constants import PluginSettings
+from .rest import {{ cookiecutter.plugin_camel_case }}
+from .settings import defaultItemMetadata, validateItemMetadata  # noqa
+
+
+# For more information on the events system, see:
+# http://girder.readthedocs.io/en/latest/plugin-development.html#the-events-system
+def addItemMeta(event):
+    try:
+        item = event.info
+        item_metadata = ModelImporter.model('setting').get(PluginSettings.ITEM_METADATA)
+        ModelImporter.model('item').setMetadata(item, {
+            '{{ cookiecutter.plugin_name }}': item_metadata
+        })
+    except Exception:
+        logger.warn('Failed to set metadata %s on item %s' % ('{{ cookiecutter.plugin_name }}',
+                                                              str(item['_id'])))
+
+
+# For more information on loading custom plugins, see:
+# http://girder.readthedocs.io/en/latest/plugin-development.html#extending-the-server-side-application
+def load(info):
+    info['apiRoot'].{{ cookiecutter.plugin_name }} = {{ cookiecutter.plugin_camel_case }}()
+
+    events.bind('model.item.save.after', 'add_{{ cookiecutter.plugin_name }}_item_meta', addItemMeta)

--- a/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/server/constants.py
+++ b/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/server/constants.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+class PluginSettings(object):
+    ITEM_METADATA = '{{ cookiecutter.plugin_name }}.item_metadata'

--- a/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/server/rest.py
+++ b/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/server/rest.py
@@ -1,0 +1,24 @@
+from girder.api import access
+from girder.api.describe import Description, autoDescribeRoute
+from girder.api.rest import Resource
+from girder.utility.model_importer import ModelImporter
+from .constants import PluginSettings
+
+
+# For more information on adding new resources to the Web API, see:
+# http://girder.readthedocs.io/en/latest/plugin-development.html#adding-a-new-resource-type-to-the-web-api
+class {{ cookiecutter.plugin_camel_case }}(Resource):
+    def __init__(self):
+        super({{ cookiecutter.plugin_camel_case }}, self).__init__()
+        self.resourceName = '{{ cookiecutter.plugin_name }}'
+
+        self.route('GET', ('item_metadata',), self.getItemMetadata)
+
+    # For more information on adding routes to the Web API, see:
+    # http://girder.readthedocs.io/en/latest/plugin-development.html#adding-a-new-route-to-the-web-api
+    @access.public
+    @autoDescribeRoute(
+        Description('Retrieve item metadata value.'))
+    def getItemMetadata(self, params):
+        settingModel = ModelImporter.model('setting')
+        return settingModel.get(PluginSettings.ITEM_METADATA)

--- a/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/server/settings.py
+++ b/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/server/settings.py
@@ -1,0 +1,17 @@
+from girder.models.model_base import ValidationException
+from girder.utility import setting_utilities
+
+from .constants import PluginSettings
+
+
+@setting_utilities.default(PluginSettings.ITEM_METADATA)
+def defaultItemMetadata():
+    return 'default_value'
+
+
+@setting_utilities.validator(PluginSettings.ITEM_METADATA)
+def validateItemMetadata(settingDoc):
+    settingValue = settingDoc['value']
+
+    if not len(settingValue):
+        raise ValidationException('Item metadata is required.', 'value')

--- a/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/web_client/index.js
+++ b/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/web_client/index.js
@@ -1,0 +1,5 @@
+import * as views from './views';
+
+export {
+    views
+};

--- a/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/web_client/main.js
+++ b/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/web_client/main.js
@@ -1,0 +1,8 @@
+import './routes';
+import './views/FrontPageView';
+
+import { registerPluginNamespace } from 'girder/pluginUtils';
+
+import * as {{ cookiecutter.plugin_camel_case }} from './index';
+
+registerPluginNamespace('{{ cookiecutter.plugin_name }}', {{ cookiecutter.plugin_camel_case }});

--- a/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/web_client/routes.js
+++ b/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/web_client/routes.js
@@ -1,0 +1,11 @@
+import router from 'girder/router';
+import events from 'girder/events';
+import { exposePluginConfig } from 'girder/utilities/PluginUtils';
+
+import ConfigView from './views/ConfigView';
+
+exposePluginConfig('{{ cookiecutter.plugin_name }}', 'plugins/{{ cookiecutter.plugin_name }}/config');
+
+router.route('plugins/{{ cookiecutter.plugin_name }}/config', '{{ cookiecutter.plugin_camel_case }}Config', function () {
+    events.trigger('g:navigateTo', ConfigView);
+});

--- a/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/web_client/templates/configView.pug
+++ b/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/web_client/templates/configView.pug
@@ -1,0 +1,13 @@
+{% set plugin_name_dashed = cookiecutter.plugin_name|replace("_", "-") -%}
+.g-config-breadcrumb-container
+
+p.
+  Configure settings for {{ cookiecutter.plugin_nice_name }}.
+
+form#{{ plugin_name_dashed}}-settings-form(role="form")
+  .form-group
+    label.control-label(for="{{ plugin_name_dashed}}-item-metadata") Item metadata value
+    input.input-sm.form-control#{{ plugin_name_dashed}}-item-metadata(
+      type="text", placeholder="My Setting (default: default_value)")
+  p#{{ plugin_name_dashed}}-settings-error-message.g-validation-failed-message
+  input.btn.btn-sm.btn-primary(type="submit", value="Save")

--- a/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/web_client/views/ConfigView.js
+++ b/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/web_client/views/ConfigView.js
@@ -1,0 +1,77 @@
+import _ from 'underscore';
+
+import PluginConfigBreadcrumbWidget from 'girder/views/widgets/PluginConfigBreadcrumbWidget';
+import View from 'girder/views/View';
+import events from 'girder/events';
+import { restRequest } from 'girder/rest';
+
+import ConfigViewTemplate from '../templates/configView.pug';
+
+{% set plugin_name_dashed = cookiecutter.plugin_name|replace("_", "-") -%}
+var ConfigView = View.extend({
+    events: {
+        'submit #{{ plugin_name_dashed }}-settings-form': function (event) {
+            event.preventDefault();
+            this.$('#{{ plugin_name_dashed }}-settings-error-message').empty();
+
+            this._saveSettings([{
+                key: '{{ cookiecutter.plugin_name }}.item_metadata',
+                value: this.$('#{{ plugin_name_dashed }}-item-metadata').val().trim()
+            }]);
+        }
+    },
+
+    initialize: function () {
+        restRequest({
+            type: 'GET',
+            path: 'system/setting',
+            data: {
+                list: JSON.stringify([
+                    '{{ cookiecutter.plugin_name }}.item_metadata'
+                ])
+            }
+        }).done(_.bind(function (resp) {
+            this.render();
+            this.$('#{{ plugin_name_dashed}}-item-metadata').val(resp['{{ cookiecutter.plugin_name }}.item_metadata']);
+        }, this));
+    },
+
+    render: function () {
+        this.$el.html(ConfigViewTemplate());
+
+        if (!this.breadcrumb) {
+            this.breadcrumb = new PluginConfigBreadcrumbWidget({
+                pluginName: '{{ cookiecutter.plugin_nice_name }}',
+                el: this.$('.g-config-breadcrumb-container'),
+                parentView: this
+            });
+        }
+
+        this.breadcrumb.render();
+
+        return this;
+    },
+
+    _saveSettings: function (settings) {
+        restRequest({
+            type: 'PUT',
+            path: 'system/setting',
+            data: {
+                list: JSON.stringify(settings)
+            },
+            error: null
+        }).done(_.bind(function (resp) {
+            events.trigger('g:alert', {
+                icon: 'ok',
+                text: 'Settings saved.',
+                type: 'success',
+                timeout: 4000
+            });
+        }, this)).error(_.bind(function (resp) {
+            this.$('#{{ plugin_name_dashed }}-settings-error-message').text(
+                resp.responseJSON.message);
+        }, this));
+    }
+});
+
+export default ConfigView;

--- a/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/web_client/views/FrontPageView.js
+++ b/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/web_client/views/FrontPageView.js
@@ -1,0 +1,15 @@
+import FrontPageView from 'girder/views/body/FrontPageView';
+import { wrap } from 'girder/utilities/PluginUtils';
+
+// For more information on creating new views, see:
+// http://girder.readthedocs.io/en/latest/development.html#client-development
+
+// For more information on wrapping views, see:
+// http://girder.readthedocs.io/en/latest/plugin-development.html#javascript-extension-capabilities
+wrap(FrontPageView, 'render', function (render) {
+    render.call(this);
+
+    this.$el.append('<p>Hi from {{ cookiecutter.plugin_nice_name }}</p>');
+
+    return this;
+});

--- a/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/web_client/views/index.js
+++ b/devops/cookiecutter-girder-plugin/{{ cookiecutter.plugin_name }}/web_client/views/index.js
@@ -1,0 +1,7 @@
+import ConfigView from './ConfigView';
+import FrontPageView from './FrontPageView';
+
+export {
+    ConfigView,
+    FrontPageView
+};


### PR DESCRIPTION
Note: I'm resurrecting a somewhat old branch, as a result this might already use some outdated practices. Open for criticism on the code, what the scope of such a plugin should be, missing documentation pointers, etc. Some parts may be rough, but I think it's ready for a first pass from someone.

I think this can close out #1005, and an analog for an external plugin should be created (see #1680).

This PR introduces a template for a popular python scaffolding tool
called cookiecutter: https://github.com/audreyr/cookiecutter

The main goal of such a template is to demonstrate best practices for
building a Girder plugin, and pointing the user to more in depth
resources for the various parts of the code. This means as new
features and practices of coding are developed for Girder, they must
be reflected in the template.

The built plugin demonstrates the following:
- Writing a client side test
- Writing a server side test
- Binding to server-side events
- Working with server-side models
- Adding a REST endpoint
- Adding a custom setting with a default and validator
- Adding a custom configuration view for changing said setting
-- Exercising the REST API from JavaScript
-- Listening to events in JavaScript
-- Rendering a Pug template
- Wrapping an existing client-side view

To make use of this, perform the following commands from Girder root:
pip install cookiecutter
cookiecutter devops/cookiecutter-girder-plugin
girder-install plugin -s your-cookiecutter-plugin