### PR TITLE
Capture stdout/stderr to logs only when starting the server.

### DIFF
--- a/girder/__init__.py
+++ b/girder/__init__.py
@@ -108,7 +108,7 @@ class StreamToLogger:
     def write(self, buf):
         if not self.logger._girderLogHandlerOutput:
             self.logger._girderLogHandlerOutput = True
-            _originalStdOut.write(buf)
+            self.stream.write(buf)
             for line in buf.rstrip().splitlines():
                 self.logger.log(self.level, line.rstrip())
             self.logger._girderLogHandlerOutput = False
@@ -203,9 +203,6 @@ def _setupLogger():
     ih.setFormatter(fmt)
     logger.addHandler(ih)
 
-    sys.stdout = StreamToLogger(_originalStdOut, logger, logging.INFO)
-    sys.stderr = StreamToLogger(_originalStdErr, logger, logging.ERROR)
-
     # Log http accesses to the screen and/or the info log.
     accessLog = logCfg.get('log_access', 'screen')
     if not isinstance(accessLog, (tuple, list, set)):
@@ -219,6 +216,12 @@ def _setupLogger():
 
 
 logger = _setupLogger()
+
+
+def logStdoutStderr():
+    if _originalStdOut == sys.stdout:
+        sys.stdout = StreamToLogger(_originalStdOut, logger, logging.INFO)
+        sys.stderr = StreamToLogger(_originalStdErr, logger, logging.ERROR)
 
 
 def logprint(*args, **kwargs):

--- a/girder/utility/server.py
+++ b/girder/utility/server.py
@@ -26,7 +26,7 @@ import posixpath
 import six
 
 import girder.events
-from girder import constants, logprint, __version__
+from girder import constants, logprint, __version__, logStdoutStderr
 from girder.utility import plugin_utilities, model_importer
 from girder.utility import config
 from . import webroot
@@ -225,6 +225,8 @@ def setup(test=False, plugins=None, curConfig=None):
     :param plugins: List of plugins to enable.
     :param curConfig: The config object to update.
     """
+    logStdoutStderr()
+
     pluginWebroots = plugin_utilities.getPluginWebroots()
     girderWebroot, appconf = configureServer(test, plugins, curConfig)
     routeTable = loadRouteTable(reconcileRoutes=True)


### PR DESCRIPTION
Otherwise, importing girder by itself affects being able to use REPL.

Fixes #2131.