### PR TITLE
Terms of Use plugin

### DIFF
--- a/clients/web/src/templates/widgets/editCollectionWidget.pug
+++ b/clients/web/src/templates/widgets/editCollectionWidget.pug
@@ -4,10 +4,10 @@
       .modal-header
         button.close(data-dismiss="modal", aria-hidden="true", type="button") &times;
         h4.modal-title
-          if (collection)
-            | Edit collection
-          else
+          if (create)
             | Create collection
+          else
+            | Edit collection
       .modal-body
         .form-group
           label.control-label(for="g-name") Name
@@ -19,9 +19,9 @@
       .modal-footer
         a.btn.btn-small.btn-default(data-dismiss="modal") Cancel
         button.g-save-collection.btn.btn-small.btn-primary(type="submit")
-          if (collection)
-            i.icon-edit
-            | Save
-          else
+          if (create)
             i.icon-plus-squared
             | Create
+          else
+            i.icon-edit
+            | Save

--- a/clients/web/src/views/widgets/EditCollectionWidget.js
+++ b/clients/web/src/views/widgets/EditCollectionWidget.js
@@ -13,30 +13,37 @@ import 'girder/utilities/jquery/girderModal';
 /**
  * This widget is used to create a new collection or edit an existing one.
  */
-var EditCollectionWidget = View.extend({
+const EditCollectionWidget = View.extend({
     events: {
         'submit #g-collection-edit-form': function (e) {
             e.preventDefault();
 
-            var fields = {
+            const fields = {
                 name: this.$('#g-name').val(),
                 description: this.descriptionEditor.val()
             };
 
-            if (this.model) {
-                this.updateCollection(fields);
-            } else {
-                this.createCollection(fields);
-            }
-
             this.descriptionEditor.saveText();
             this.$('button.g-save-collection').girderEnable(false);
             this.$('.g-validation-failed-message').text('');
+
+            this._saveCollection(fields)
+                .always(() => {
+                    this.$('button.g-save-collection').girderEnable(true);
+                })
+                .done(() => {
+                    this.$el.modal('hide');
+                })
+                .fail((err) => {
+                    this.$('.g-validation-failed-message').text(err.responseJSON.message);
+                    this.$('#g-' + err.responseJSON.field).focus();
+                });
         }
     },
 
     initialize: function (settings) {
-        this.model = settings.model || null;
+        this.create = !settings.model;
+        this.model = settings.model || new CollectionModel();
         this.descriptionEditor = new MarkdownWidget({
             text: this.model ? this.model.get('description') : '',
             prefix: 'collection-description',
@@ -47,61 +54,49 @@ var EditCollectionWidget = View.extend({
     },
 
     render: function () {
-        var modal = this.$el.html(EditCollectionWidgetTemplate({
+        this.$el.html(EditCollectionWidgetTemplate({
+            create: this.create,
             collection: this.model
-        })).girderModal(this).on('shown.bs.modal', () => {
-            this.$('#g-name').focus();
-        }).on('hidden.bs.modal', () => {
-            if (this.create) {
-                handleClose('create');
-            } else {
-                handleClose('edit');
-            }
-        }).on('ready.girder.modal', () => {
-            if (this.model) {
-                this.$('#g-name').val(this.model.get('name'));
-                this.$('#g-description').val(this.model.get('description'));
-                this.create = false;
-            } else {
-                this.create = true;
-            }
-        });
+        }));
+        const modal = this.$el
+            .girderModal(this)
+            .on('shown.bs.modal', () => {
+                this.$('#g-name').focus();
+            })
+            .on('hidden.bs.modal', () => {
+                handleClose(this.create ? 'create' : 'edit');
+            })
+            .on('ready.girder.modal', () => {
+                if (!this.create) {
+                    this.$('#g-name').val(this.model.get('name'));
+                    this.$('#g-description').val(this.model.get('description'));
+                }
+            });
         modal.trigger($.Event('ready.girder.modal', {relatedTarget: modal}));
         this.descriptionEditor.setElement(this.$('.g-description-editor-container')).render();
         this.$('#g-name').focus();
 
-        if (this.model) {
-            handleOpen('edit');
-        } else {
-            handleOpen('create');
-        }
+        handleOpen(this.create ? 'create' : 'edit');
 
         return this;
     },
 
     createCollection: function (fields) {
-        var collection = new CollectionModel();
-        collection.set(fields);
-        collection.on('g:saved', function () {
-            this.$el.modal('hide');
-            this.trigger('g:saved', collection);
-        }, this).off('g:error').on('g:error', function (err) {
-            this.$('.g-validation-failed-message').text(err.responseJSON.message);
-            this.$('button.g-save-collection').girderEnable(true);
-            this.$('#g-' + err.responseJSON.field).focus();
-        }, this).save();
+        console.warn('The createCollection method is deprecated; use _saveCollection instead');
+        this._saveCollection(fields);
     },
 
     updateCollection: function (fields) {
+        console.warn('The updateCollection method is deprecated; use _saveCollection instead');
+        this._saveCollection(fields);
+    },
+
+    _saveCollection: function (fields) {
         this.model.set(fields);
-        this.model.on('g:saved', function () {
-            this.$el.modal('hide');
-            this.trigger('g:saved', this.model);
-        }, this).off('g:error').on('g:error', function (err) {
-            this.$('.g-validation-failed-message').text(err.responseJSON.message);
-            this.$('button.g-save-collection').girderEnable(true);
-            this.$('#g-' + err.responseJSON.field).focus();
-        }, this).save();
+        return this.model.save()
+            .done(() => {
+                this.trigger('g:saved', this.model);
+            });
     }
 });
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -428,6 +428,15 @@ the Girder API, which will compute and store the correct Gravatar URL, and then
 redirect to it. The next time that user document is sent over the REST API,
 it should contain the computed ``gravatar_baseUrl`` field.
 
+Terms of Use
+------------
+
+This plugin allows collection admins to define a set of textual "Terms of Use", which other users
+must accept before browsing within the collection. The terms may be set with markdown-formatted
+text, and users will be required to re-accept the terms whenever the content changes. Logged-in
+users have their acceptances stored and remembered permanently, while anonymous users have their
+acceptances stored only on the local browser.
+
 Javascript clients
 ******************
 

--- a/plugins/.gitignore
+++ b/plugins/.gitignore
@@ -23,6 +23,7 @@
 !mongo_search/
 !oauth/
 !provenance/
+!terms/
 !thumbnails/
 !user_quota/
 !vega/

--- a/plugins/terms/plugin.cmake
+++ b/plugins/terms/plugin.cmake
@@ -1,0 +1,1 @@
+add_standard_plugin_tests()

--- a/plugins/terms/plugin.yml
+++ b/plugins/terms/plugin.yml
@@ -1,0 +1,7 @@
+name: Terms of Use
+description: Allows Girder collections to require users to accept terms of use before browsing.
+url: http://girder.readthedocs.io/en/latest/plugins.html#terms-of-use
+version: 0.1.0
+npm:
+  dependencies:
+    sha.js: ~2.4.8

--- a/plugins/terms/plugin_tests/termsSpec.js
+++ b/plugins/terms/plugin_tests/termsSpec.js
@@ -1,0 +1,407 @@
+girderTest.importPlugin('terms');
+girderTest.startApp();
+
+describe('Create and log in to a user for testing', function () {
+    it('create an admin user', girderTest.createUser('rocky', 'rocky@phila.pa.us', 'Robert', 'Balboa', 'adrian'));
+
+    it('allow all users to create collections', function () {
+        var settingSaved;
+        runs(function () {
+            settingSaved = false;
+            girder.rest.restRequest({
+                path: 'system/setting',
+                type: 'PUT',
+                data: {
+                    key: 'core.collection_create_policy',
+                    value: JSON.stringify({groups: [], open: true, users: []})
+                }
+            })
+                .done(function () {
+                    settingSaved = true;
+                });
+        });
+        waitsFor(function () {
+            return settingSaved;
+        });
+    });
+
+    it('logout', girderTest.logout());
+
+    it('create a collection admin user', girderTest.createUser('creed', 'creed@la.ca.us', 'Apollo', 'Creed', 'the1best'));
+});
+
+describe('Ensure that basic collections still work', function () {
+    it('go to collections page', function () {
+        runs(function () {
+            $('a.g-nav-link[g-target="collections"]').click();
+        });
+        waitsFor(function () {
+            return $('.g-collection-create-button:visible').length > 0;
+        });
+        runs(function () {
+            expect($('.g-collection-list-entry').length).toBe(0);
+        });
+    });
+
+    it('create a basic collection', girderTest.createCollection('Basic Collection', 'Some description.', 'Basic Folder'));
+});
+
+describe('Navigate to a non-collection folder and item', function () {
+    it('navigate to user folders page', function () {
+        runs(function () {
+            $('a.g-my-folders').click();
+        });
+        waitsFor(function () {
+            return $('.g-user-header').length > 0 && $('.g-folder-list-entry').length > 0;
+        });
+    });
+
+    it('navigate to the Public folder', function () {
+        runs(function () {
+            var folderLink = $('.g-folder-list-link:contains("Public")');
+            expect(folderLink.length).toBe(1);
+            folderLink.click();
+        });
+        waitsFor(function () {
+            return $('.g-item-count-container:visible').length === 1;
+        });
+        runs(function () {
+            expect($('.g-hierarchy-breadcrumb-bar>.breadcrumb>.active').text()).toBe('Public');
+            var folderId = window.location.hash.split('/')[3];
+            expect(folderId).toMatch(/[0-9a-f]{24}/);
+            window.location.assign('#folder/' + folderId);
+        });
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('.g-item-count-container:visible').length === 1;
+        });
+    });
+
+    it('create an item', function () {
+        runs(function () {
+            return $('.g-create-item').click();
+        });
+        // This causes the test to fail
+        // girderTest.waitForDialog();
+        waitsFor(function () {
+            return $('.modal-body input#g-name').length > 0;
+        });
+        runs(function () {
+            $('#g-name').val('User Item');
+            $('.g-save-item').click();
+        });
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('.g-item-list-link').length > 0;
+        });
+    });
+
+    it('navigate to the new item', function () {
+        runs(function () {
+            var itemLink = $('.g-item-list-link:contains("User Item")');
+            expect(itemLink.length).toBe(1);
+            itemLink.click();
+        });
+        waitsFor(function () {
+            return $('.g-item-header').length > 0;
+        });
+        runs(function () {
+            expect($('.g-item-header .g-item-name').text()).toBe('User Item');
+            termsItemId = window.location.hash.split('/')[1];
+            expect(termsItemId).toMatch(/[0-9a-f]{24}/);
+        });
+    });
+});
+
+var termsCollectionId, termsFolderId, termsItemId;
+describe('Create a collection with terms', function () {
+    it('go to collections page', function () {
+        runs(function () {
+            $('a.g-nav-link[g-target="collections"]').click();
+        });
+        waitsFor(function () {
+            return $('.g-collection-create-button:visible').length > 0;
+        });
+    });
+
+    it('open the create collection dialog', function () {
+        waitsFor(function () {
+            return $('.g-collection-create-button').is(':enabled');
+        });
+        runs(function () {
+            $('.g-collection-create-button').click();
+        });
+        girderTest.waitForDialog();
+        waitsFor(function () {
+            return $('#collection-terms-write .g-markdown-text').is(':visible');
+        });
+    });
+
+    it('fill and submit the create collection dialog', function () {
+        runs(function () {
+            $('#g-name').val('Terms Collection');
+            $('#collection-description-write .g-markdown-text').val('Some other description.');
+            $('#collection-terms-write .g-markdown-text').val('# Sample Terms of Use\n\n**\u00af\\\\\\_(\u30c4)\\_/\u00af**');
+            $('.g-save-collection').click();
+        });
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('.g-collection-header').length > 0;
+        });
+        runs(function () {
+            expect($('.g-collection-header .g-collection-name').text()).toBe('Terms Collection');
+            termsCollectionId = window.location.hash.split('/')[1];
+            expect(termsCollectionId).toMatch(/[0-9a-f]{24}/);
+        });
+    });
+
+    it('make the collection public', function () {
+        runs(function () {
+            $('.g-edit-access').click();
+        });
+        girderTest.waitForDialog();
+        runs(function () {
+            $('#g-access-public').click();
+            $('.g-save-access-list').click();
+        });
+        girderTest.waitForLoad();
+    });
+
+    it('check the collection info dialog', function () {
+        runs(function () {
+            $('.g-collection-info-button').click();
+        });
+        girderTest.waitForDialog();
+        waitsFor(function () {
+            return $('.g-terms-info').length > 0;
+        });
+        runs(function () {
+            expect($('.g-terms-info>h1').text()).toBe('Sample Terms of Use');
+        });
+        runs(function () {
+            $('.modal-header .close').click();
+        });
+        girderTest.waitForLoad();
+    });
+
+    it('create a folder', function () {
+        runs(function () {
+            return $('.g-create-subfolder').click();
+        });
+        girderTest.waitForDialog();
+        waitsFor(function () {
+            return $('.modal-body input#g-name').length > 0;
+        });
+        runs(function () {
+            $('#g-name').val('Terms Folder');
+            $('.g-save-folder').click();
+        });
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('.g-folder-list-link').length > 0;
+        });
+    });
+
+    it('navigate to the new folder', function () {
+        runs(function () {
+            var folderLink = $('.g-folder-list-link:contains("Terms Folder")');
+            expect(folderLink.length).toBe(1);
+            folderLink.click();
+        });
+        waitsFor(function () {
+            return $('.g-item-count-container:visible').length === 1;
+        });
+        runs(function () {
+            expect($('.g-hierarchy-breadcrumb-bar>.breadcrumb>.active').text()).toBe('Terms Folder');
+            termsFolderId = window.location.hash.split('/')[3];
+            expect(termsFolderId).toMatch(/[0-9a-f]{24}/);
+        });
+    });
+
+    it('create an item', function () {
+        runs(function () {
+            return $('.g-create-item').click();
+        });
+        girderTest.waitForDialog();
+        waitsFor(function () {
+            return $('.modal-body input#g-name').length > 0;
+        });
+        runs(function () {
+            $('#g-name').val('Terms Item');
+            $('.g-save-item').click();
+        });
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('.g-item-list-link').length > 0;
+        });
+    });
+
+    it('navigate to the new item', function () {
+        runs(function () {
+            var itemLink = $('.g-item-list-link:contains("Terms Item")');
+            expect(itemLink.length).toBe(1);
+            itemLink.click();
+        });
+        waitsFor(function () {
+            return $('.g-item-header').length > 0;
+        });
+        runs(function () {
+            expect($('.g-item-header .g-item-name').text()).toBe('Terms Item');
+            termsItemId = window.location.hash.split('/')[1];
+            expect(termsItemId).toMatch(/[0-9a-f]{24}/);
+        });
+    });
+});
+
+// TODO: rerun this whole suite while logged in
+describe('Ensure that anonymous users are presented with terms', function () {
+    beforeEach(function () {
+        window.localStorage.clear();
+    });
+
+    it('logout', girderTest.logout());
+
+    it('navigate to the collection page, rejecting terms', function () {
+        runs(function () {
+            window.location.assign('#collection/' + termsCollectionId);
+        });
+        waitsFor(function () {
+            return $('.g-terms-container').length > 0;
+        });
+        runs(function () {
+            expect($('.g-terms-info>h1').text()).toBe('Sample Terms of Use');
+            $('#g-terms-reject').click();
+        });
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('.g-frontpage-header').length > 0;
+        });
+    });
+
+    it('navigate to the collection page', function () {
+        runs(function () {
+            window.location.assign('#collection/' + termsCollectionId);
+        });
+        waitsFor(function () {
+            return $('.g-terms-container').length > 0;
+        });
+        runs(function () {
+            expect($('.g-terms-info>h1').text()).toBe('Sample Terms of Use');
+            $('#g-terms-accept').click();
+        });
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('.g-collection-header').length > 0;
+        });
+        runs(function () {
+            expect($('.g-collection-header .g-collection-name').text()).toBe('Terms Collection');
+        });
+    });
+
+    it('navigate to the folder page', function () {
+        runs(function () {
+            window.location.assign('#folder/' + termsFolderId);
+        });
+        waitsFor(function () {
+            return $('.g-terms-container').length > 0;
+        });
+        runs(function () {
+            expect($('.g-terms-info>h1').text()).toBe('Sample Terms of Use');
+            $('#g-terms-accept').click();
+        });
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('.g-item-count-container:visible').length === 1;
+        });
+        runs(function () {
+            expect($('.g-hierarchy-breadcrumb-bar>.breadcrumb>.active').text()).toBe('Terms Folder');
+        });
+    });
+
+    it('navigate to the item page', function () {
+        runs(function () {
+            window.location.assign('#item/' + termsItemId);
+        });
+        waitsFor(function () {
+            return $('.g-terms-container').length > 0;
+        });
+        runs(function () {
+            expect($('.g-terms-info>h1').text()).toBe('Sample Terms of Use');
+            $('#g-terms-accept').click();
+        });
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('.g-item-header').length > 0;
+        });
+        runs(function () {
+            expect($('.g-item-header .g-item-name').text()).toBe('Terms Item');
+        });
+    });
+});
+
+// TODO: edit the collection with WRITE permissions only
+
+describe('Change the terms', function () {
+    it('login as collection admin', girderTest.login('creed', 'Apollo', 'Creed', 'the1best'));
+
+    it('navigate to the terms collection', function () {
+        runs(function () {
+            $('a.g-nav-link[g-target="collections"]').click();
+        });
+        waitsFor(function () {
+            return $('.g-collection-list-entry').length > 0;
+        });
+        runs(function () {
+            $('.g-collection-link:contains("Terms Collection")').click();
+        });
+        waitsFor(function () {
+            return $('.g-collection-header').length > 0;
+        });
+    });
+
+    it('edit the collection terms', function () {
+        runs(function () {
+            $('.g-edit-folder').click();
+        });
+        girderTest.waitForDialog();
+        waitsFor(function () {
+            return $('#collection-terms-write .g-markdown-text').is(':visible');
+        });
+        runs(function () {
+            $('#collection-terms-write .g-markdown-text').val('# New Terms of Use\n\nThese have changed.');
+            $('.g-save-collection').click();
+        });
+        girderTest.waitForLoad();
+        runs(function () {
+            expect($('.g-collection-header .g-collection-name').text()).toBe('Terms Collection');
+        });
+    });
+});
+
+describe('Ensure that anonymous users need to re-accept the updated terms', function () {
+    it('logout', girderTest.logout());
+
+    it('ensure that the old terms acceptance is still stored', function () {
+        expect(window.localStorage.length).toBe(1);
+    });
+
+    it('navigate to the collection page', function () {
+        runs(function () {
+            window.location.assign('#collection/' + termsCollectionId);
+        });
+        waitsFor(function () {
+            return $('.g-terms-container').length > 0;
+        });
+        runs(function () {
+            expect($('.g-terms-info>h1').text()).toBe('New Terms of Use');
+            $('#g-terms-accept').click();
+        });
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('.g-collection-header').length > 0;
+        });
+        runs(function () {
+            expect($('.g-collection-header .g-collection-name').text()).toBe('Terms Collection');
+        });
+    });
+});

--- a/plugins/terms/plugin_tests/terms_test.py
+++ b/plugins/terms/plugin_tests/terms_test.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+from girder.constants import SettingKey
+
+from tests import base
+
+
+def setUpModule():
+    base.enabledPlugins.append('terms')
+    base.startServer()
+
+
+def tearDownModule():
+    base.stopServer()
+
+
+class TermsTest(base.TestCase):
+    def setUp(self):
+        base.TestCase.setUp(self)
+
+        self.siteAdminUser = self.model('user').createUser(
+            email='rocky@phila.pa.us',
+            login='rocky',
+            firstName='Robert',
+            lastName='Balboa',
+            password='adrian'
+        )
+        self.creatorUser = self.model('user').createUser(
+            email='creed@la.ca.us',
+            login='creed',
+            firstName='Apollo',
+            lastName='Creed',
+            password='the1best'
+        )
+        creationSetting = self.model('setting').getDefault(SettingKey.COLLECTION_CREATE_POLICY)
+        creationSetting['open'] = True
+        self.model('setting').set(SettingKey.COLLECTION_CREATE_POLICY, creationSetting)
+
+    def testTerms(self):
+        # Ensure that ordinary collections still work
+        resp = self.request('/collection', method='POST', user=self.creatorUser, params={
+            'name': 'Basic Collection',
+            'description': 'Some description.',
+            'public': True
+        })
+        self.assertStatusOk(resp)
+        self.assertDictContainsSubset({
+            'name': 'Basic Collection',
+            'description': 'Some description.',
+            'public': True,
+            'size': 0,
+            '_modelType': 'collection',
+            'terms': None
+        }, resp.json)
+        basicCollectionId = resp.json['_id']
+
+        # Try to accept the terms, on a collection with no terms
+        resp = self.request(
+            '/collection/%s/acceptTerms' % basicCollectionId, method='POST', user=self.creatorUser,
+            params={
+                # This is the hash of an empty string
+                'termsHash': '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
+            })
+        self.assertStatus(resp, 400)
+
+        # Create a collection with unicode terms
+        resp = self.request('/collection', method='POST', user=self.creatorUser, params={
+            'name': 'Terms Collection',
+            'description': 'Some other description.',
+            'public': True,
+            'terms': u'# Sample Terms of Use\n\n**\u00af\\\\\\_(\u30c4)\\_/\u00af**'.encode('utf-8')
+        })
+        self.assertStatusOk(resp)
+        self.assertDictContainsSubset({
+            'name': 'Terms Collection',
+            'description': 'Some other description.',
+            'public': True,
+            'size': 0,
+            '_modelType': 'collection',
+            'terms': u'# Sample Terms of Use\n\n**\u00af\\\\\\_(\u30c4)\\_/\u00af**'
+        }, resp.json)
+        termsCollectionId = resp.json['_id']
+
+        # Fetch the terms on a collection, ensuring they're saved
+        resp = self.request(
+            '/collection/%s' % termsCollectionId, method='GET', user=self.creatorUser)
+        self.assertStatusOk(resp)
+        self.assertDictContainsSubset({
+            'name': 'Terms Collection',
+            'description': 'Some other description.',
+            'public': True,
+            'size': 0,
+            '_modelType': 'collection',
+            'terms': u'# Sample Terms of Use\n\n**\u00af\\\\\\_(\u30c4)\\_/\u00af**'
+        }, resp.json)
+
+        # Ensure that the user has not yet accepted any terms
+        resp = self.request('/user/me', method='GET', user=self.creatorUser)
+        self.assertStatusOk(resp)
+        self.assertNotHasKeys(resp.json, {'terms'})
+
+        # Try to accept the terms, with the wrong hash
+        resp = self.request(
+            '/collection/%s/acceptTerms' % termsCollectionId, method='POST', user=self.creatorUser,
+            params={
+                'termsHash': 'gargTz1mz476PQf9oUVbtob7OS3ban/3aHqOdLgcHA0='.replace('g', 'f')
+            })
+        self.assertStatus(resp, 400)
+
+        # Accept the terms
+        resp = self.request(
+            '/collection/%s/acceptTerms' % termsCollectionId, method='POST', user=self.creatorUser,
+            params={
+                'termsHash': 'gargTz1mz476PQf9oUVbtob7OS3ban/3aHqOdLgcHA0='
+            })
+        self.assertStatusOk(resp)
+
+        # Check that the user has accepted the terms
+        resp = self.request('/user/me', method='GET', user=self.creatorUser)
+        self.assertStatusOk(resp)
+        self.assertDictContainsSubset({
+            'terms': {
+                'collection': {
+                    termsCollectionId: 'gargTz1mz476PQf9oUVbtob7OS3ban/3aHqOdLgcHA0='
+                }
+            }},
+            resp.json)
+
+        # Ensure that other users cannot read term acceptances
+        resp = self.request('/user/%s' % self.creatorUser['_id'], method='GET')
+        self.assertStatusOk(resp)
+        self.assertNotHasKeys(resp.json, {'terms'})
+
+        # Modify a collection to have new terms
+        resp = self.request(
+            '/collection/%s' % termsCollectionId, method='PUT', user=self.creatorUser, params={
+                'description': 'A new description.',
+                'terms': '# New Terms of Use\n\nThese have changed.'
+            })
+        self.assertStatusOk(resp)
+        self.assertDictContainsSubset({
+            'name': 'Terms Collection',
+            'description': 'A new description.',
+            'public': True,
+            'size': 0,
+            '_modelType': 'collection',
+            'terms': '# New Terms of Use\n\nThese have changed.'
+        }, resp.json)
+
+        # Fetch the terms on a collection, while anonymous
+        resp = self.request('/collection/%s' % termsCollectionId, method='GET')
+        self.assertStatusOk(resp)
+        self.assertDictContainsSubset({
+            'name': 'Terms Collection',
+            'description': 'A new description.',
+            'public': True,
+            'size': 0,
+            '_modelType': 'collection',
+            'terms': '# New Terms of Use\n\nThese have changed.'
+        }, resp.json)

--- a/plugins/terms/plugin_tests/terms_test.py
+++ b/plugins/terms/plugin_tests/terms_test.py
@@ -135,13 +135,10 @@ class TermsTest(base.TestCase):
         # Check that the user has accepted the terms
         resp = self.request('/user/me', method='GET', user=self.creatorUser)
         self.assertStatusOk(resp)
-        self.assertDictContainsSubset({
-            'terms': {
-                'collection': {
-                    termsCollectionId: 'gargTz1mz476PQf9oUVbtob7OS3ban/3aHqOdLgcHA0='
-                }
-            }},
-            resp.json)
+        self.assertDictContainsSubset(
+            {'hash': 'gargTz1mz476PQf9oUVbtob7OS3ban/3aHqOdLgcHA0='},
+            resp.json.get('terms', {}).get('collection', {}).get(termsCollectionId, {})
+        )
 
         # Ensure that other users cannot read term acceptances
         resp = self.request('/user/%s' % self.creatorUser['_id'], method='GET')

--- a/plugins/terms/plugin_tests/terms_test.py
+++ b/plugins/terms/plugin_tests/terms_test.py
@@ -76,7 +76,7 @@ class TermsTest(base.TestCase):
             '/collection/%s/acceptTerms' % basicCollectionId, method='POST', user=self.creatorUser,
             params={
                 # This is the hash of an empty string
-                'termsHash': '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
+                'termsHash': 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
             })
         self.assertStatus(resp, 400)
 
@@ -120,7 +120,9 @@ class TermsTest(base.TestCase):
         resp = self.request(
             '/collection/%s/acceptTerms' % termsCollectionId, method='POST', user=self.creatorUser,
             params={
-                'termsHash': 'gargTz1mz476PQf9oUVbtob7OS3ban/3aHqOdLgcHA0='.replace('g', 'f')
+                'termsHash':
+                    '81aae04f3d66cf8efa3d07fda1455bb686fb392ddb6a7ff7687a8e74b81c1c0d'
+                    .replace('8', '2')
             })
         self.assertStatus(resp, 400)
 
@@ -128,7 +130,7 @@ class TermsTest(base.TestCase):
         resp = self.request(
             '/collection/%s/acceptTerms' % termsCollectionId, method='POST', user=self.creatorUser,
             params={
-                'termsHash': 'gargTz1mz476PQf9oUVbtob7OS3ban/3aHqOdLgcHA0='
+                'termsHash': '81aae04f3d66cf8efa3d07fda1455bb686fb392ddb6a7ff7687a8e74b81c1c0d'
             })
         self.assertStatusOk(resp)
 
@@ -136,7 +138,7 @@ class TermsTest(base.TestCase):
         resp = self.request('/user/me', method='GET', user=self.creatorUser)
         self.assertStatusOk(resp)
         self.assertDictContainsSubset(
-            {'hash': 'gargTz1mz476PQf9oUVbtob7OS3ban/3aHqOdLgcHA0='},
+            {'hash': '81aae04f3d66cf8efa3d07fda1455bb686fb392ddb6a7ff7687a8e74b81c1c0d'},
             resp.json.get('terms', {}).get('collection', {}).get(termsCollectionId, {})
         )
 

--- a/plugins/terms/server/__init__.py
+++ b/plugins/terms/server/__init__.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+import base64
+import hashlib
+
+from girder import events
+from girder.api import access
+from girder.api.describe import Description, autoDescribeRoute
+from girder.api.rest import boundHandler, RestException
+from girder.api.v1.collection import Collection
+from girder.constants import AccessType, TokenScope
+from girder.models.model_base import ModelImporter
+
+
+@access.user(scope=TokenScope.DATA_READ)
+@boundHandler
+@autoDescribeRoute(
+    Description('Accept a collection\'s Terms of Use for the current user.')
+    .modelParam('id', model='collection', level=AccessType.READ)
+    .param('termsHash', 'The SHA-256 hash of this collection\'s terms, encoded in Base64.')
+)
+def acceptCollectionTerms(self, collection, termsHash):
+    if not collection.get('terms'):
+        raise RestException('This collection currently has no terms.')
+
+    # termsHash should be encoded to a bytes object, but storing bytes into MongoDB behaves
+    # differently in Python 2 vs 3. Additionally, serializing a bytes to JSON behaves differently
+    # in Python 2 vs 3. So, just keep it as a unicode (or ordinary Python 2 str).
+    realTermsHash = base64.b64encode(
+        hashlib.sha256(collection['terms'].encode('utf-8')).digest()
+    ).decode('utf-8')
+    if termsHash != realTermsHash:
+        # This "proves" that the client has at least accessed the terms
+        raise RestException(
+            'The submitted "termsHash" does not correspond to the collection\'s current terms.')
+
+    ModelImporter.model('user').update(
+        {'_id': self.getCurrentUser()['_id']},
+        {'$set': {'terms.collection.%s' % collection['_id']: termsHash}}
+    )
+
+
+def afterPostPutCollection(event):
+    # This will only trigger if no exceptions (for access, invalid id, etc.) are thrown
+    extraParams = event.info['params']
+    if 'terms' in extraParams:
+        collectionResponse = event.info['returnVal']
+        collectionId = collectionResponse['_id']
+        terms = extraParams['terms']
+
+        ModelImporter.model('collection').update(
+            {'_id': collectionId},
+            {'$set': {'terms': terms}}
+        )
+
+        collectionResponse['terms'] = terms
+        event.addResponse(collectionResponse)
+
+
+def load(info):
+    # Augment the collection creation and edit routes to accept a terms field
+    events.bind('rest.post.collection.after', 'terms', afterPostPutCollection)
+    events.bind('rest.put.collection/:id.after', 'terms', afterPostPutCollection)
+    for handler in [
+        Collection.createCollection,
+        Collection.updateCollection
+    ]:
+        handler.description.param('terms', 'The Terms of Use for the collection.', required=False)
+
+    # Expose the terms field on all collections
+    ModelImporter.model('collection').exposeFields(level=AccessType.READ, fields={'terms'})
+
+    # Add endpoint for registered users to accept terms
+    info['apiRoot'].collection.route('POST', (':id', 'acceptTerms'), acceptCollectionTerms)
+
+    # Expose the terms field on all users
+    ModelImporter.model('user').exposeFields(level=AccessType.ADMIN, fields={'terms'})

--- a/plugins/terms/server/__init__.py
+++ b/plugins/terms/server/__init__.py
@@ -18,6 +18,7 @@
 ###############################################################################
 
 import base64
+import datetime
 import hashlib
 
 from girder import events
@@ -53,7 +54,12 @@ def acceptCollectionTerms(self, collection, termsHash):
 
     ModelImporter.model('user').update(
         {'_id': self.getCurrentUser()['_id']},
-        {'$set': {'terms.collection.%s' % collection['_id']: termsHash}}
+        {'$set': {
+            'terms.collection.%s' % collection['_id']: {
+                'hash': termsHash,
+                'accepted': datetime.datetime.now()
+            }
+        }}
     )
 
 

--- a/plugins/terms/server/__init__.py
+++ b/plugins/terms/server/__init__.py
@@ -17,7 +17,6 @@
 #  limitations under the License.
 ###############################################################################
 
-import base64
 import datetime
 import hashlib
 
@@ -35,7 +34,7 @@ from girder.models.model_base import ModelImporter
 @autoDescribeRoute(
     Description('Accept a collection\'s Terms of Use for the current user.')
     .modelParam('id', model='collection', level=AccessType.READ)
-    .param('termsHash', 'The SHA-256 hash of this collection\'s terms, encoded in Base64.')
+    .param('termsHash', 'The SHA-256 hash of this collection\'s terms, encoded in hexadecimal.')
 )
 def acceptCollectionTerms(self, collection, termsHash):
     if not collection.get('terms'):
@@ -44,9 +43,7 @@ def acceptCollectionTerms(self, collection, termsHash):
     # termsHash should be encoded to a bytes object, but storing bytes into MongoDB behaves
     # differently in Python 2 vs 3. Additionally, serializing a bytes to JSON behaves differently
     # in Python 2 vs 3. So, just keep it as a unicode (or ordinary Python 2 str).
-    realTermsHash = base64.b64encode(
-        hashlib.sha256(collection['terms'].encode('utf-8')).digest()
-    ).decode('utf-8')
+    realTermsHash = hashlib.sha256(collection['terms'].encode('utf-8')).hexdigest()
     if termsHash != realTermsHash:
         # This "proves" that the client has at least accessed the terms
         raise RestException(

--- a/plugins/terms/web_client/main.js
+++ b/plugins/terms/web_client/main.js
@@ -1,0 +1,4 @@
+import './views/EditCollectionWidget';
+import './views/CollectionInfoWidget';
+import './models/CollectionModel';
+import './routes';

--- a/plugins/terms/web_client/models/CollectionModel.js
+++ b/plugins/terms/web_client/models/CollectionModel.js
@@ -17,8 +17,11 @@ CollectionModel.prototype.currentUserHasAcceptedTerms = function () {
     const currentUser = getCurrentUser();
     if (currentUser) {
         const userAcceptedTerms = currentUser.get('terms');
-        return userAcceptedTerms && userAcceptedTerms.collection &&
-            (userAcceptedTerms.collection[this.id] === termsHash);
+        // Lodash's _.get would be nice here
+        return userAcceptedTerms &&
+            userAcceptedTerms.collection &&
+            userAcceptedTerms.collection[this.id] &&
+            (userAcceptedTerms.collection[this.id].hash === termsHash);
     } else {
         const storageKey = `terms.collection.${this.id}`;
         return (window.localStorage.getItem(storageKey) === termsHash) ||

--- a/plugins/terms/web_client/models/CollectionModel.js
+++ b/plugins/terms/web_client/models/CollectionModel.js
@@ -1,0 +1,67 @@
+import $ from 'jquery';
+import createHash from 'sha.js';
+
+import { getCurrentUser } from 'girder/auth';
+import CollectionModel from 'girder/models/CollectionModel';
+import { restRequest } from 'girder/rest';
+
+const termsAcceptedFallback = {};
+
+CollectionModel.prototype.hasTerms = function () {
+    // An empty string also means there are no terms.
+    return Boolean(this.get('terms'));
+};
+
+CollectionModel.prototype.currentUserHasAcceptedTerms = function () {
+    const termsHash = this._hashTerms();
+    const currentUser = getCurrentUser();
+    if (currentUser) {
+        const userAcceptedTerms = currentUser.get('terms');
+        return userAcceptedTerms && userAcceptedTerms.collection &&
+            (userAcceptedTerms.collection[this.id] === termsHash);
+    } else {
+        const storageKey = `terms.collection.${this.id}`;
+        return (window.localStorage.getItem(storageKey) === termsHash) ||
+               (termsAcceptedFallback[this.id] === termsHash);
+    }
+};
+
+CollectionModel.prototype.currentUserSetAcceptTerms = function () {
+    const termsHash = this._hashTerms();
+    const currentUser = getCurrentUser();
+    if (currentUser) {
+        return restRequest({
+            url: `collection/${this.id}/acceptTerms`,
+            method: 'POST',
+            data: {
+                termsHash: termsHash
+            }
+        })
+            .done(() => {
+                // Even if this endpoint returned an updated copy of the user document, it wouldn't
+                // be safe to just "setCurrentUser" with that document here, since the login method
+                // performs some special transformations (e.g. setting a "token" attribute) before
+                // instantiating a new UserModel, and it would be too fragile to reproduce those
+                // here. We also don't want to trigger a brand-new login. So, just update the
+                // currentUser's "terms" attribute in-place, triggering a "change" event.
+                const userAcceptedTerms = currentUser.get('terms') || {};
+                // This code would be much cleaner with _.merge from Lodash.
+                userAcceptedTerms.collection = userAcceptedTerms.collection || {};
+                userAcceptedTerms.collection[this.id] = termsHash;
+                currentUser.set('terms', userAcceptedTerms);
+            });
+    } else {
+        const storageKey = `terms.collection.${this.id}`;
+        try {
+            window.localStorage.setItem(storageKey, termsHash);
+        } catch (e) {
+            termsAcceptedFallback[this.id] = termsHash;
+        }
+        return $.Deferred().resolve().promise();
+    }
+};
+
+CollectionModel.prototype._hashTerms = function () {
+    window.hex = createHash('sha256').update(this.get('terms'));
+    return createHash('sha256').update(this.get('terms')).digest('base64');
+};

--- a/plugins/terms/web_client/models/CollectionModel.js
+++ b/plugins/terms/web_client/models/CollectionModel.js
@@ -53,7 +53,7 @@ CollectionModel.prototype.currentUserSetAcceptTerms = function () {
                 userAcceptedTerms.collection[this.id] = {
                     hash: termsHash,
                     // 'accepted' is from a server-set timestamp, so we don't know it here. However,
-                    // its value is irreverent, as it's for auditing purposes only.
+                    // its value is irrelevant, as it's for auditing purposes only.
                     accepted: null
                 };
                 currentUser.set('terms', userAcceptedTerms);

--- a/plugins/terms/web_client/models/CollectionModel.js
+++ b/plugins/terms/web_client/models/CollectionModel.js
@@ -50,7 +50,12 @@ CollectionModel.prototype.currentUserSetAcceptTerms = function () {
                 const userAcceptedTerms = currentUser.get('terms') || {};
                 // This code would be much cleaner with _.merge from Lodash.
                 userAcceptedTerms.collection = userAcceptedTerms.collection || {};
-                userAcceptedTerms.collection[this.id] = termsHash;
+                userAcceptedTerms.collection[this.id] = {
+                    hash: termsHash,
+                    // 'accepted' is from a server-set timestamp, so we don't know it here. However,
+                    // its value is irreverent, as it's for auditing purposes only.
+                    accepted: null
+                };
                 currentUser.set('terms', userAcceptedTerms);
             });
     } else {

--- a/plugins/terms/web_client/models/CollectionModel.js
+++ b/plugins/terms/web_client/models/CollectionModel.js
@@ -71,5 +71,5 @@ CollectionModel.prototype.currentUserSetAcceptTerms = function () {
 
 CollectionModel.prototype._hashTerms = function () {
     window.hex = createHash('sha256').update(this.get('terms'));
-    return createHash('sha256').update(this.get('terms')).digest('base64');
+    return createHash('sha256').update(this.get('terms')).digest('hex');
 };

--- a/plugins/terms/web_client/routes.js
+++ b/plugins/terms/web_client/routes.js
@@ -1,0 +1,89 @@
+import _ from 'underscore';
+
+import events from 'girder/events';
+import CollectionModel from 'girder/models/CollectionModel';
+import FolderModel from 'girder/models/FolderModel';
+import ItemModel from 'girder/models/ItemModel';
+import CollectionView from 'girder/views/body/CollectionView';
+import FolderView from 'girder/views/body/FolderView';
+import ItemView from 'girder/views/body/ItemView';
+
+import TermsAcceptanceView from './views/TermsAcceptanceView';
+
+CollectionView.fetchAndInit = function (cid, params) {
+    const collection = new CollectionModel({_id: cid});
+    collection.fetch()
+        .done(() => {
+            if (collection.hasTerms() && !collection.currentUserHasAcceptedTerms()) {
+                events.trigger(
+                    'g:navigateTo',
+                    TermsAcceptanceView,
+                    {collection: collection}
+                );
+            } else {
+                events.trigger(
+                    'g:navigateTo',
+                    CollectionView,
+                    _.extend({collection: collection}, params || {})
+                );
+            }
+        });
+};
+
+FolderView.fetchAndInit = function (id, params) {
+    let collection;
+    const folder = new FolderModel({_id: id});
+    folder.fetch()
+        .then(() => {
+            if (folder.get('baseParentType') === 'collection') {
+                collection = new CollectionModel({_id: folder.get('baseParentId')});
+                return collection.fetch();
+            } else {
+                return undefined;
+            }
+        })
+        .done(() => {
+            if (collection && collection.hasTerms() && !collection.currentUserHasAcceptedTerms()) {
+                events.trigger(
+                    'g:navigateTo',
+                    TermsAcceptanceView,
+                    {collection: collection}
+                );
+            } else {
+                events.trigger(
+                    'g:navigateTo',
+                    FolderView,
+                    _.extend({folder: folder}, params || {})
+                );
+            }
+        });
+};
+
+ItemView.fetchAndInit = function (itemId, params) {
+    let collection;
+    const item = new ItemModel({_id: itemId});
+    item.fetch()
+        .then(() => {
+            if (item.get('baseParentType') === 'collection') {
+                collection = new CollectionModel({_id: item.get('baseParentId')});
+                return collection.fetch();
+            } else {
+                return undefined;
+            }
+        })
+        .done(() => {
+            if (collection && collection.hasTerms() && !collection.currentUserHasAcceptedTerms()) {
+                events.trigger(
+                    'g:navigateTo',
+                    TermsAcceptanceView,
+                    {collection: collection}
+                );
+            } else {
+                events.trigger(
+                    'g:navigateTo',
+                    ItemView,
+                    _.extend({item: item}, params || {})
+                );
+            }
+        });
+};

--- a/plugins/terms/web_client/stylesheets/collectionInfoWidget.styl
+++ b/plugins/terms/web_client/stylesheets/collectionInfoWidget.styl
@@ -1,0 +1,6 @@
+.g-modal-content
+  .g-terms-info
+    background-color #f4f4f4
+    padding 5px
+    max-height 20em
+    overflow-y auto

--- a/plugins/terms/web_client/stylesheets/editCollectionTermsWidget.styl
+++ b/plugins/terms/web_client/stylesheets/editCollectionTermsWidget.styl
@@ -1,0 +1,4 @@
+.g-terms-editor-group
+  .alert
+    margin-top 5px
+    padding 10px

--- a/plugins/terms/web_client/stylesheets/termsAcceptance.styl
+++ b/plugins/terms/web_client/stylesheets/termsAcceptance.styl
@@ -1,0 +1,5 @@
+.g-terms-container
+  .g-terms-info
+    background-color #f4f4f4
+    padding 5px
+    margin-bottom 10px

--- a/plugins/terms/web_client/templates/collectionInfoWidget.pug
+++ b/plugins/terms/web_client/templates/collectionInfoWidget.pug
@@ -1,0 +1,3 @@
+.g-info-dialog-description
+  label Terms of Use
+  .g-terms-info!= renderMarkdown(collection.get('terms'))

--- a/plugins/terms/web_client/templates/editCollectionTermsWidget.pug
+++ b/plugins/terms/web_client/templates/editCollectionTermsWidget.pug
@@ -1,0 +1,8 @@
+.g-terms-editor-group.form-group
+  label.control-label Terms of Use (optional)
+  .g-terms-editor-container
+  .alert.alert-info
+    i.icon-info-circled
+    span.
+      If the Terms of Use is non-empty, users will be required to agree to it before accessing
+      anything in this collection.

--- a/plugins/terms/web_client/templates/termsAcceptance.pug
+++ b/plugins/terms/web_client/templates/termsAcceptance.pug
@@ -1,0 +1,8 @@
+.g-terms-container
+  .g-body-title= collection.name()
+  label Terms of Use
+  .g-terms-info!= renderMarkdown(collection.get('terms'))
+
+  .btn-toolbar
+    button#g-terms-accept.btn.btn-primary.btn-md I Accept
+    button#g-terms-reject.btn.btn-primary.btn-md I Decline

--- a/plugins/terms/web_client/views/CollectionInfoWidget.js
+++ b/plugins/terms/web_client/views/CollectionInfoWidget.js
@@ -1,0 +1,22 @@
+import $ from 'jquery';
+
+import { renderMarkdown } from 'girder/misc';
+import CollectionInfoWidget from 'girder/views/widgets/CollectionInfoWidget';
+import { wrap } from 'girder/utilities/PluginUtils';
+
+import CollectionInfoWidgetTemplate from '../templates/collectionInfoWidget.pug';
+import '../stylesheets/collectionInfoWidget.styl';
+
+wrap(CollectionInfoWidget, 'render', function (render) {
+    render.call(this);
+
+    if (this.model.get('terms')) {
+        const newEl = $(CollectionInfoWidgetTemplate({
+            collection: this.model,
+            renderMarkdown: renderMarkdown
+        }));
+        this.$('.modal-body>.g-info-dialog-description').after(newEl);
+    }
+
+    return this;
+});

--- a/plugins/terms/web_client/views/EditCollectionWidget.js
+++ b/plugins/terms/web_client/views/EditCollectionWidget.js
@@ -1,0 +1,66 @@
+import $ from 'jquery';
+
+import { AccessType } from 'girder/constants';
+import EditCollectionWidget from 'girder/views/widgets/EditCollectionWidget';
+import MarkdownWidget from 'girder/views/widgets/MarkdownWidget';
+import { wrap } from 'girder/utilities/PluginUtils';
+
+import EditCollectionTermsWidgetTemplate from '../templates/editCollectionTermsWidget.pug';
+import '../stylesheets/editCollectionTermsWidget.styl';
+
+wrap(EditCollectionWidget, 'initialize', function (initialize, ...args) {
+    initialize.apply(this, args);
+
+    // Only render if creating a new collection or editing one with admin
+    if (this.create || this.model.getAccessLevel() >= AccessType.ADMIN) {
+        this.termsEditor = new MarkdownWidget({
+            text: this.model ? this.model.get('terms') : '',
+            prefix: 'collection-terms',
+            placeholder: 'Enter collection Terms of Use',
+            enableUploads: false,
+            parentView: this
+        });
+    }
+});
+
+wrap(EditCollectionWidget, 'render', function (render) {
+    render.call(this);
+
+    if (this.termsEditor) {
+        const newEl = $(EditCollectionTermsWidgetTemplate({
+            enabled: true
+        }));
+        this.termsEditor
+            .setElement(newEl.find('.g-terms-editor-container'))
+            .render();
+
+        this.$('.modal-body>.g-validation-failed-message').before(newEl);
+    }
+
+    return this;
+});
+
+wrap(EditCollectionWidget, '_saveCollection', function (_saveCollection, fields) {
+    if (this.termsEditor) {
+        fields.terms = this.termsEditor.val();
+        // Don't call though to _saveCollection, since we want the current user to accept the terms
+        // before 'g:saved' gets triggered on EditCollectionWidget (which causes routing when a
+        // new collection is created).
+        this.model.set(fields);
+        return this.model.save()
+            .then(() => {
+                if (this.model.hasTerms()) {
+                    // Any user that can successfully set the terms should be considered to have
+                    // accepted them
+                    return this.model.currentUserSetAcceptTerms();
+                } else {
+                    return undefined;
+                }
+            })
+            .done(() => {
+                this.trigger('g:saved', this.model);
+            });
+    } else {
+        return _saveCollection.call(this, fields);
+    }
+});

--- a/plugins/terms/web_client/views/TermsAcceptanceView.js
+++ b/plugins/terms/web_client/views/TermsAcceptanceView.js
@@ -1,0 +1,48 @@
+import Backbone from 'backbone';
+
+import { renderMarkdown } from 'girder/misc';
+import router from 'girder/router';
+import View from 'girder/views/View';
+
+import TermsAcceptanceTemplate from '../templates/termsAcceptance.pug';
+import '../stylesheets/termsAcceptance.styl';
+
+const TermsAcceptanceView = View.extend({
+    events: {
+        'click #g-terms-accept': function (event) {
+            const buttons = this.$('button');
+            buttons.girderEnable(false);
+
+            this.model.currentUserSetAcceptTerms()
+                // This is never expected to fail, but use "always" for safety
+                .always(() => {
+                    buttons.girderEnable(true);
+                    // Re-route to the current page, without reloading the DOM
+                    Backbone.history.loadUrl(Backbone.history.getHash());
+                });
+        },
+        'click #g-terms-reject': function (event) {
+            // Route to home page
+            router.navigate('', {trigger: true});
+        }
+    },
+
+    /**
+     * @param {CollectionModel} settings.collection - The collection to display the terms for.
+     */
+    initialize: function (settings) {
+        this.model = settings.collection;
+        this.render();
+    },
+
+    render: function () {
+        this.$el.html(TermsAcceptanceTemplate({
+            collection: this.model,
+            renderMarkdown: renderMarkdown
+        }));
+
+        return this;
+    }
+});
+
+export default TermsAcceptanceView;


### PR DESCRIPTION
This adds a new "Terms of Use" plugin. From the documentation:
> This plugin allows collection admins to define a set of textual "Terms of Use", which other users must accept before browsing within the collection. The terms may be set with markdown-formatted text, and users will be required to re-accept the terms whenever the content changes. Logged-in users have their acceptances stored and remembered permanently, while anonymous users have their acceptances stored only on the local browser.

![create](https://user-images.githubusercontent.com/1282879/28302154-af700d2a-6b59-11e7-9a51-c10e7afbc4d6.png)
![prompt](https://user-images.githubusercontent.com/1282879/28302096-5d07a5e8-6b59-11e7-92aa-64016bb3d2b4.png)
![info](https://user-images.githubusercontent.com/1282879/28302104-61e42564-6b59-11e7-99db-2a4699f6f073.png)

Remaining TODO:
* [ ] Finish client-side tests, increasing coverage