### PR TITLE
WIP: Add pytest compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ __pycache__
 .eslintcache
 /npm-debug.log
 **/*.retry
+/.cache

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,10 @@ Sphinx==1.4.3
 sphinx_rtd_theme==0.1.9
 virtualenv==15.0.2
 
+# pytest
+pytest==3.1.1
+pytest-cov==2.5.1
+
 # dependencies of flake8
 mccabe==0.6.1
 pep8==1.7.0

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,7 +44,11 @@ if(RUN_CORE_TESTS)
   add_python_test(hash_state)
   add_python_test(install)
   add_python_test(item)
-  add_python_test(logging_config)
+
+  # Logging tests do special capturing of stdout/stderr, disable the default
+  # pytest capturing.
+  # Note: when this test is switched to pytest, the capsys fixture can be used.
+  add_python_test(logging_config PYTEST_ARGS "--capture=no")
   add_python_test(mail)
   add_python_test(model)
   add_python_test(routetable)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,8 +68,8 @@ if(RUN_CORE_TESTS)
   add_python_test(path_utilities)
   add_python_test(setup_database)
 
-  add_python_test(py_client.cli BIND_SERVER RESOURCE_LOCKS py_client_test_dir)
-  add_python_test(py_client.lib BIND_SERVER RESOURCE_LOCKS py_client_test_dir)
+  add_python_test(py_client.cli BIND_SERVER RESOURCE_LOCKS py_client_test_dir TEST_FILE "py_client/cli_test.py")
+  add_python_test(py_client.lib BIND_SERVER RESOURCE_LOCKS py_client_test_dir TEST_FILE "py_client/lib_test.py")
 
   add_web_client_test(data_filesystem "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE filesystem)
   add_web_client_test(data_gridfs "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE gridfs)

--- a/tests/PythonTests.cmake
+++ b/tests/PythonTests.cmake
@@ -83,7 +83,7 @@ function(add_python_test case)
   set(_options BIND_SERVER PY2_ONLY RUN_SERIAL)
   set(_args DBNAME PLUGIN SUBMODULE TEST_FILE)
   set(_multival_args RESOURCE_LOCKS TIMEOUT EXTERNAL_DATA REQUIRED_FILES COVERAGE_PATHS
-                     ENVIRONMENT SETUP_DATABASE)
+                     ENVIRONMENT SETUP_DATABASE PYTEST_ARGS)
   cmake_parse_arguments(fn "${_options}" "${_args}" "${_multival_args}" ${ARGN})
 
   if(fn_PY2_ONLY AND PYTHON_VERSION MATCHES "^3")
@@ -134,7 +134,7 @@ function(add_python_test case)
     add_test(
       NAME ${name}
       WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-      COMMAND "${PYTHON_EXECUTABLE}" -m pytest -v ${test_file}
+      COMMAND "${PYTHON_EXECUTABLE}" -m pytest -v ${fn_PYTEST_ARGS} ${test_file}
     )
   endif()
 

--- a/tests/girder.coveragerc.in
+++ b/tests/girder.coveragerc.in
@@ -1,6 +1,7 @@
 # Configuration for python coverage
 [run]
 branch = @_py_branch_cov@
+parallel = True
 
 [report]
 omit = @_omit_python_covg@


### PR DESCRIPTION
Since pytest is capable of running unittest test cases (see https://docs.pytest.org/en/latest/unittest.html), this PR adds drop-in support for using pytest.

This means existing unittest tests can use regular asserts, and we can fully use pytest+fixtures for tests that don't require a CherryPy app (this is demonstrated by rewriting the token test module). As part of 3.0, we should visit converting our base test class into pytest-style fixtures and general test utility functions.

This is WIP since I still need to verify things are working 100%, also it's currently outputting coverage tables for every single test which should be changed to match the current behavior on master.