### PR TITLE
Add a Girder shell utility

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -63,6 +63,17 @@ With ``watch`` option, *sourcemaps* will be generated, which helps debugging fro
 When you want to end the watch process, press Ctrl+C (or however you would normally terminate a
 process in your terminal).
 
+Girder Shell
+^^^^^^^^^^^^
+
+To test various functionality in a typical REPL (Python, IPython, etc) some bootstrapping
+is required to configure the Girder server. This sets up an "embedded" server, meaning no TCP ports
+are actually bound but requests can still be performed via Python. Bootstrapping the server
+involves running ``girder.utility.server.configureServer`` with the plugins to be enabled.
+
+Girder provides a utility script for entering into a shell with the server preconfigured. Once
+Girder is installed the script can be run using ``girder-shell`` which optionally takes a comma
+separated list of plugins to enable.
 
 Utilities
 ---------

--- a/girder/utility/plugin_utilities.py
+++ b/girder/utility/plugin_utilities.py
@@ -204,44 +204,43 @@ def loadPlugin(name, root, appconf, apiRoot=None):
 
     moduleName = '.'.join((ROOT_PLUGINS_PACKAGE, name))
 
-    if moduleName not in sys.modules:
-        fp = None
-        try:
-            # @todo this query is run for every plugin that's loaded
-            setting = model_importer.ModelImporter().model('setting')
-            routeTable = setting.get(SettingKey.ROUTE_TABLE)
+    fp = None
+    try:
+        # @todo this query is run for every plugin that's loaded
+        setting = model_importer.ModelImporter().model('setting')
+        routeTable = setting.get(SettingKey.ROUTE_TABLE)
 
-            info = {
-                'name': name,
-                'config': appconf,
-                'serverRoot': root,
-                'serverRootPath': routeTable[GIRDER_ROUTE_ID],
-                'apiRoot': apiRoot,
-                'staticRoot': routeTable[GIRDER_STATIC_ROUTE_ID],
-                'pluginRootDir': os.path.abspath(pluginDir)
-            }
+        info = {
+            'name': name,
+            'config': appconf,
+            'serverRoot': root,
+            'serverRootPath': routeTable[GIRDER_ROUTE_ID],
+            'apiRoot': apiRoot,
+            'staticRoot': routeTable[GIRDER_STATIC_ROUTE_ID],
+            'pluginRootDir': os.path.abspath(pluginDir)
+        }
 
-            if pluginLoadMethod is None:
-                fp, pathname, description = imp.find_module(
-                    'server', [pluginDir]
-                )
-                module = imp.load_module(moduleName, fp, pathname, description)
-                module.PLUGIN_ROOT_DIR = pluginDir
-                girder.plugins.__dict__[name] = module
-                pluginLoadMethod = getattr(module, 'load', None)
+        if pluginLoadMethod is None:
+            fp, pathname, description = imp.find_module(
+                'server', [pluginDir]
+            )
+            module = imp.load_module(moduleName, fp, pathname, description)
+            module.PLUGIN_ROOT_DIR = pluginDir
+            girder.plugins.__dict__[name] = module
+            pluginLoadMethod = getattr(module, 'load', None)
 
-            if pluginLoadMethod is not None:
-                sys.modules[moduleName] = module
-                pluginLoadMethod(info)
+        if pluginLoadMethod is not None:
+            sys.modules[moduleName] = module
+            pluginLoadMethod(info)
 
-            root, appconf, apiRoot = (
-                info['serverRoot'], info['config'], info['apiRoot'])
+        root, appconf, apiRoot = (
+            info['serverRoot'], info['config'], info['apiRoot'])
 
-        finally:
-            if fp:
-                fp.close()
+    finally:
+        if fp:
+            fp.close()
 
-        return root, appconf, apiRoot
+    return root, appconf, apiRoot
 
 
 def getPluginDir():

--- a/girder/utility/shell.py
+++ b/girder/utility/shell.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+import click
+import girder
+
+from girder.utility.server import configureServer
+
+
+def _launchShell(context):
+    """
+    Launches a Python shell with the given context.
+
+    :param context: A dictionary containing key value pairs
+    of variable name -> value to be set in the newly
+    launched shell.
+    """
+    header = 'Girder %s' % girder.__version__
+    header += '\nThe current context provides the variables webroot and appconf for use.'
+
+    try:
+        from IPython import embed
+        return embed(header=header, user_ns=context)
+    except ImportError:
+        import code
+        return code.interact(banner=header, local=context)
+
+
+@click.command(context_settings=dict(help_option_names=['-h', '--help']))
+@click.option('--plugins', default=None, help='Comma separated list of plugins to import.')
+def main(plugins):
+    if plugins is not None:
+        plugins = plugins.split(',')
+
+    webroot, appconf = configureServer(plugins=plugins)
+
+    _launchShell({
+        'webroot': webroot,
+        'appconf': appconf
+    })
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ install_reqs = [
     'bcrypt',
     'boto3',
     'CherryPy',
+    'click',
     'filelock',
     'jsonschema',
     'Mako',
@@ -158,7 +159,8 @@ setup(
         'console_scripts': [
             'girder-server = girder.__main__:main',
             'girder-install = girder.utility.install:main',
-            'girder-sftpd = girder.api.sftp:_main'
+            'girder-sftpd = girder.api.sftp:_main',
+            'girder-shell = girder.utility.shell:main'
         ]
     }
 )


### PR DESCRIPTION
This PR adds a girder-shell console script which drops the user into a python repl with a configured webroot, giving the user the ability to import from any of the plugins specified. This should aid in development/debugging and make it more obvious how batch operations can be performed with Girder.

This first commit in this PR fixes #1302, which was the result of `loadPlugin` raising an exception when called more than once.

This is WIP since I still need to make sure altering `loadPlugin` didn't break anything.