### PR TITLE
Limit size of XHR log in testing

### DIFF
--- a/clients/web/test/specRunner.js
+++ b/clients/web/test/specRunner.js
@@ -70,9 +70,9 @@ page.onConsoleMessage = function (msg) {
         if (env['PHANTOMJS_OUTPUT_AJAX_TRACE'] === undefined ||
             env['PHANTOMJS_OUTPUT_AJAX_TRACE'] === 1 ||
             env['PHANTOMJS_OUTPUT_AJAX_TRACE'] === true) {
-            console.log('Dumping ajax trace:');
             console.log(page.evaluate(function () {
-                return JSON.stringify(girderTest.ajaxLog(true), null, '  ');
+                var log = girderTest.ajaxLog(true);
+                return 'XHR log (last ' + log.length + '):\n' + JSON.stringify(log, null, '  ');
             }));
         }
         return;

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -1167,6 +1167,8 @@ girderTest.anonymousLoadPage = function (logoutFirst, fragment, hasLoginDialog, 
  * so we can print the log after a test failure.
  */
 (function () {
+    var MAX_AJAX_LOG_SIZE = 20;
+    var i = 0;
     var ajaxCalls = [];
     var backboneAjax = Backbone.ajax;
 
@@ -1187,7 +1189,8 @@ girderTest.anonymousLoadPage = function (logoutFirst, fragment, hasLoginDialog, 
             opts: opts
         };
 
-        ajaxCalls.push(record);
+        ajaxCalls[i] = record;
+        i = (i + 1) % MAX_AJAX_LOG_SIZE;
 
         return backboneAjax(opts).done(
             function (data, textStatus) {
@@ -1202,9 +1205,13 @@ girderTest.anonymousLoadPage = function (logoutFirst, fragment, hasLoginDialog, 
     };
 
     girderTest.ajaxLog = function (reset) {
-        var calls = ajaxCalls;
+        var calls = [];
+        for (var idx = i, o = 0; o < ajaxCalls.length; idx++, o++) {
+            calls[o] = ajaxCalls[idx % ajaxCalls.length];
+        }
         if (reset) {
             ajaxCalls = [];
+            i = 0;
         }
         return calls;
     };

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -1168,7 +1168,7 @@ girderTest.anonymousLoadPage = function (logoutFirst, fragment, hasLoginDialog, 
  */
 (function () {
     var MAX_AJAX_LOG_SIZE = 20;
-    var i = 0;
+    var logIndex = 0;
     var ajaxCalls = [];
     var backboneAjax = Backbone.ajax;
 
@@ -1189,8 +1189,8 @@ girderTest.anonymousLoadPage = function (logoutFirst, fragment, hasLoginDialog, 
             opts: opts
         };
 
-        ajaxCalls[i] = record;
-        i = (i + 1) % MAX_AJAX_LOG_SIZE;
+        ajaxCalls[logIndex] = record;
+        logIndex = (logIndex + 1) % MAX_AJAX_LOG_SIZE;
 
         return backboneAjax(opts).done(
             function (data, textStatus) {
@@ -1205,13 +1205,10 @@ girderTest.anonymousLoadPage = function (logoutFirst, fragment, hasLoginDialog, 
     };
 
     girderTest.ajaxLog = function (reset) {
-        var calls = [];
-        for (var idx = i, o = 0; o < ajaxCalls.length; idx++, o++) {
-            calls[o] = ajaxCalls[idx % ajaxCalls.length];
-        }
+        var calls = ajaxCalls.slice(logIndex, ajaxCalls.length).concat(ajaxCalls.slice(0, logIndex));
         if (reset) {
             ajaxCalls = [];
-            i = 0;
+            logIndex = 0;
         }
         return calls;
     };


### PR DESCRIPTION
This uses a circular buffer to enforce an upper bound on the number of XHRs that we log during testing. We've seen cases where the OOM-killer is invoked on web client tests in low-memory environments, and it often happens during an attempt to report this log.