### PR TITLE
Cleanup and document client test startup procedure

### DIFF
--- a/clients/web/test/spec/adminSpec.js
+++ b/clients/web/test/spec/adminSpec.js
@@ -1,6 +1,3 @@
-/**
- * Start the girder backbone app.
- */
 girderTest.startApp();
 
 describe('Create an admin and non-admin user', function () {

--- a/clients/web/test/spec/browserSpec.js
+++ b/clients/web/test/spec/browserSpec.js
@@ -1,5 +1,3 @@
-// girderTest.startApp();
-
 describe('Test the hierarchy browser modal', function () {
     var testEl;
     var requestArgs = [];

--- a/clients/web/test/spec/collectionBaseClassSpec.js
+++ b/clients/web/test/spec/collectionBaseClassSpec.js
@@ -1,3 +1,5 @@
+girderTest.startApp();
+
 function canary() {
     var isDone = false;
     var result = function done() {
@@ -15,11 +17,6 @@ function canary() {
 var failIfError = function (error) { expect(error).toBeUndefined(); };
 
 var reFiltered = /filterTest(\d+)/;
-
-/**
- * Start the girder backbone app.
- */
-girderTest.startApp();
 
 describe('Pre-test setup', function () {
     it('register a user (first is admin)',

--- a/clients/web/test/spec/collectionSpec.js
+++ b/clients/web/test/spec/collectionSpec.js
@@ -1,6 +1,3 @@
-/**
- * Start the girder backbone app.
- */
 girderTest.startApp();
 
 describe('Test collection actions', function () {

--- a/clients/web/test/spec/customWidgetsSpec.js
+++ b/clients/web/test/spec/customWidgetsSpec.js
@@ -1,800 +1,798 @@
-(function () {
-    var user, folder, subfolder, item, widget;
+var user, folder, subfolder, item, widget;
 
-    describe('Test upload widget non-standard options', function () {
-        it('create the widget', function () {
-            runs(function () {
-                $('body').off();
+describe('Test upload widget non-standard options', function () {
+    it('create the widget', function () {
+        runs(function () {
+            $('body').off();
 
-                new girder.views.widgets.UploadWidget({
-                    noParent: true,
-                    modal: false,
-                    title: null,
-                    el: 'body',
-                    parentView: null
-                }).render();
+            new girder.views.widgets.UploadWidget({
+                noParent: true,
+                modal: false,
+                title: null,
+                el: 'body',
+                parentView: null
+            }).render();
 
-                expect($('.modal').length).toBe(0);
-                expect($('#g-upload-form h4').length).toBe(0);
-                expect($('.g-dialog-subtitle').length).toBe(0);
-                expect($('.g-drop-zone:visible').length).toBe(1);
-                expect($('.g-start-upload.btn.disabled:visible').length).toBe(1);
-                expect($('.g-overall-progress-message').text()).toBe('No files selected');
+            expect($('.modal').length).toBe(0);
+            expect($('#g-upload-form h4').length).toBe(0);
+            expect($('.g-dialog-subtitle').length).toBe(0);
+            expect($('.g-drop-zone:visible').length).toBe(1);
+            expect($('.g-start-upload.btn.disabled:visible').length).toBe(1);
+            expect($('.g-overall-progress-message').text()).toBe('No files selected');
+        });
+    });
+});
+
+describe('Test hierarchy widget non-standard options', function () {
+    it('register a user', function () {
+        runs(function () {
+            var _user = new girder.models.UserModel({
+                login: 'mylogin',
+                password: 'mypassword',
+                email: 'email@email.com',
+                firstName: 'First',
+                lastName: 'Last'
+            }).on('g:saved', function () {
+                user = _user;
             });
+
+            _user.save();
+        });
+
+        waitsFor(function () {
+            return !!user;
+        }, 'user registration');
+    });
+
+    it('create top level folder', function () {
+        runs(function () {
+            var _folder = new girder.models.FolderModel({
+                parentType: 'user',
+                parentId: user.get('_id'),
+                name: 'top level folder'
+            }).on('g:saved', function () {
+                folder = _folder;
+            });
+
+            _folder.save();
+        });
+
+        waitsFor(function () {
+            return !!folder;
+        }, 'folder creation');
+    });
+
+    it('create subfolder', function () {
+        runs(function () {
+            var _subfolder = new girder.models.FolderModel({
+                parentType: 'folder',
+                parentId: folder.get('_id'),
+                name: 'subfolder'
+            }).on('g:saved', function () {
+                subfolder = _subfolder;
+            });
+
+            _subfolder.save();
+        });
+
+        waitsFor(function () {
+            return !!subfolder;
+        }, 'subfolder creation');
+    });
+
+    it('create item', function () {
+        runs(function () {
+            var _item = new girder.models.ItemModel({
+                folderId: folder.get('_id'),
+                name: 'an item'
+            }).on('g:saved', function () {
+                item = _item;
+            });
+
+            _item.save();
+        });
+
+        waitsFor(function () {
+            return !!item;
+        }, 'item creation');
+    });
+
+    it('test custom hierarchy widget options', function () {
+        runs(function () {
+            $('body').off();
+
+            widget = new girder.views.widgets.HierarchyWidget({
+                el: 'body',
+                parentModel: folder,
+                onItemClick: function (item) {
+                    widget.selectItem(item);
+                },
+                showActions: false,
+                parentView: null
+            });
+        });
+
+        waitsFor(function () {
+            return $('.g-hierarchy-widget').length > 0 &&
+                   $('.g-folder-list-link').length > 0 &&
+                   $('.g-item-list-link').length > 0;
+        }, 'the hierarchy widget to display');
+
+        runs(function () {
+            expect($('.g-upload-here-button').length).toBe(0);
+            expect($('.g-hierarchy-actions-header').length).toBe(0);
+            expect($('.g-list-checkbox').length).toBe(2);
+            expect($('.g-select-all').length).toBe(0);
+            expect($('.g-folder-list-link').text()).toBe('subfolder');
+            expect($('.g-item-list-link').text()).toBe('an item');
+            expect(widget.getSelectedItem()).toBe(null);
+
+            $('.g-item-list-link').click();
+        });
+
+        waitsFor(function () {
+            var selected = widget.getSelectedItem();
+            return selected && selected.get('_id') === item.get('_id');
+        }, 'item to be selected');
+
+        runs(function () {
+            expect($('.g-item-list-entry.g-selected').length).toBe(1);
+
+            $('body').empty().off();
+
+            return new girder.views.widgets.HierarchyWidget({
+                el: 'body',
+                parentModel: folder,
+                checkboxes: false,
+                parentView: null,
+                showItems: false
+            });
+        });
+
+        waitsFor(function () {
+            return $('.g-hierarchy-widget').length > 0 &&
+                   $('.g-folder-list-link').length > 0;
+        }, 'the hierarchy widget with no checkboxes to display');
+
+        runs(function () {
+            expect($('.g-upload-here-button').length).toBe(1);
+            expect($('.g-hierarchy-actions-header').length).toBe(1);
+            expect($('.g-list-checkbox').length).toBe(0);
+            expect($('.g-select-all').length).toBe(0);
+            expect($('.g-checked-actions-buttons').length).toBe(0);
+            expect($('.g-folder-list-link').text()).toBe('subfolder');
+            expect($('.g-item-list-link').length).toBe(0);
+        });
+
+        runs(function () {
+            $('body').empty().off();
+
+            return new girder.views.widgets.HierarchyWidget({
+                el: 'body',
+                parentModel: folder,
+                downloadLinks: false,
+                showActions: false,
+                parentView: null
+            });
+        });
+
+        waitsFor(function () {
+            return $('.g-hierarchy-widget').length > 0 &&
+                   $('.g-folder-list-link').length > 0 &&
+                   $('.g-item-list-link').length > 0;
+        }, 'the hierarchy widget to display without download links');
+
+        runs(function () {
+            expect($('.g-upload-here-button').length).toBe(0);
+            expect($('.g-hierarchy-actions-header').length).toBe(0);
+            expect($('.g-list-checkbox').length).toBe(2);
+            expect($('.g-select-all').length).toBe(0);
+            expect($('a[title="Download item"]').length).toBe(0);
+        });
+
+        runs(function () {
+            $('body').empty().off();
+
+            return new girder.views.widgets.HierarchyWidget({
+                el: 'body',
+                parentModel: folder,
+                viewLinks: false,
+                showActions: false,
+                parentView: null
+            });
+        });
+
+        waitsFor(function () {
+            return $('.g-hierarchy-widget').length > 0 &&
+                   $('.g-folder-list-link').length > 0 &&
+                   $('.g-item-list-link').length > 0;
+        }, 'the hierarchy widget to display without view links');
+
+        runs(function () {
+            expect($('.g-upload-here-button').length).toBe(0);
+            expect($('.g-hierarchy-actions-header').length).toBe(0);
+            expect($('.g-list-checkbox').length).toBe(2);
+            expect($('.g-select-all').length).toBe(0);
+            expect($('.g-view-inline').length).toBe(0);
+        });
+
+        runs(function () {
+            $('body').empty().off();
+
+            return new girder.views.widgets.HierarchyWidget({
+                el: 'body',
+                parentModel: folder,
+                downloadLinks: false,
+                viewLinks: false,
+                showActions: false,
+                parentView: null
+            });
+        });
+
+        waitsFor(function () {
+            return $('.g-hierarchy-widget').length > 0 &&
+                   $('.g-folder-list-link').length > 0 &&
+                   $('.g-item-list-link').length > 0;
+        }, ('the hierarchy widget to display neither ' +
+            'view nor download links'));
+
+        runs(function () {
+            expect($('.g-upload-here-button').length).toBe(0);
+            expect($('.g-hierarchy-actions-header').length).toBe(0);
+            expect($('.g-list-checkbox').length).toBe(2);
+            expect($('.g-select-all').length).toBe(0);
+            expect($('.g-view-inline').length).toBe(0);
+            expect($('a[title="Download item"]').length).toBe(0);
+
+            /* no border shown when there are no links */
+            expect($('.g-right-border').length).toBe(0);
+        });
+
+        runs(function () {
+            $('body').empty().off();
+
+            return new girder.views.widgets.HierarchyWidget({
+                el: 'body',
+                parentModel: folder,
+                showMetadata: false,
+                showActions: false,
+                parentView: null
+            });
+        });
+
+        waitsFor(function () {
+            return $('.g-hierarchy-widget').length > 0 &&
+                   $('.g-folder-list-link').length > 0 &&
+                   $('.g-item-list-link').length > 0;
+        }, 'the hierarchy widget to display without the metadata widget');
+
+        runs(function () {
+            expect($('.g-upload-here-button').length).toBe(0);
+            expect($('.g-hierarchy-actions-header').length).toBe(0);
+            expect($('.g-list-checkbox').length).toBe(2);
+            expect($('.g-select-all').length).toBe(0);
+            expect($('.g-folder-metadata').length).toBe(0);
+        });
+
+        runs(function () {
+            $('body').empty().off();
+
+            return new girder.views.widgets.HierarchyWidget({
+                el: 'body',
+                parentModel: folder,
+                showSizes: false,
+                showActions: false,
+                parentView: null
+            });
+        });
+
+        waitsFor(function () {
+            return $('.g-hierarchy-widget').length > 0 &&
+                   $('.g-folder-list-link').length > 0 &&
+                   $('.g-item-list-link').length > 0;
+        }, 'the hierarchy widget to display without item sizes');
+
+        runs(function () {
+            expect($('.g-upload-here-button').length).toBe(0);
+            expect($('.g-hierarchy-actions-header').length).toBe(0);
+            expect($('.g-list-checkbox').length).toBe(2);
+            expect($('.g-select-all').length).toBe(0);
+            expect($('.g-item-size').length).toBe(0);
+        });
+
+        var folderSelected = false;
+        runs(function () {
+            $('body').empty().off();
+
+            return new girder.views.widgets.HierarchyWidget({
+                el: 'body',
+                parentModel: folder,
+                checkboxes: false,
+                parentView: null,
+                showItems: false,
+                onFolderSelect: function (parent) { folderSelected = true; }
+            });
+        });
+
+        waitsFor(function () {
+            return $('.g-hierarchy-widget').length > 0 &&
+                   $('.g-folder-list-link').length > 0;
+        }, 'the hierarchy widget to display with the folder select button');
+
+        runs(function () {
+            expect($('.g-upload-here-button').length).toBe(1);
+            expect($('.g-hierarchy-actions-header').length).toBe(1);
+            expect($('.g-list-checkbox').length).toBe(0);
+            expect($('.g-select-all').length).toBe(0);
+            expect($('.g-checked-actions-buttons').length).toBe(0);
+            expect($('.g-folder-list-link').text()).toBe('subfolder');
+            expect($('.g-item-list-link').length).toBe(0);
+            expect($('button.g-select-folder').length).toBe(1);
+
+            $('button.g-select-folder').click();
+        });
+
+        waitsFor(
+          function () { return folderSelected; },
+          'the folder select button to be clicked');
+
+        runs(function () {
+            $('body').empty().off();
+
+            return new girder.views.widgets.HierarchyWidget({
+                el: 'body',
+                parentModel: folder,
+                checkboxes: false,
+                parentView: null,
+                showItems: false
+            });
+        });
+
+        waitsFor(
+          function () {
+              return $('.g-hierarchy-widget').length > 0 &&
+                     $('.g-folder-list-link').length > 0;
+          },
+          'the hierarchy widget to display without the folder select button'
+        );
+
+        runs(function () {
+            expect($('.g-upload-here-button').length).toBe(1);
+            expect($('.g-hierarchy-actions-header').length).toBe(1);
+            expect($('.g-list-checkbox').length).toBe(0);
+            expect($('.g-select-all').length).toBe(0);
+            expect($('.g-checked-actions-buttons').length).toBe(0);
+            expect($('.g-folder-list-link').text()).toBe('subfolder');
+            expect($('.g-item-list-link').length).toBe(0);
+            expect($('button.g-select-folder').length).toBe(0);
+        });
+    });
+});
+
+describe('Test access widget with non-standard options', function () {
+    var widget;
+    it('test non-modal rendering', function () {
+        runs(function () {
+            widget = new girder.views.widgets.AccessWidget({
+                el: 'body',
+                modal: false,
+                model: folder,
+                modelType: 'folder',
+                parentView: null
+            });
+        });
+
+        waitsFor(function () {
+            return $('.g-public-container').length === 1;
+        }, 'the access widget to render');
+
+        runs(function () {
+            expect($('#g-access-private').attr('checked')).toBe('checked');
+            expect($('#g-access-public').attr('checked')).toBe(undefined);
+            expect($('.g-save-access-list').length).toBe(1);
+            expect($('.g-ac-list').length).toBe(1);
+            expect($('.g-grant-access-container').length).toBe(1);
+            expect($('.g-recursive-container .radio').length).toBe(2);
         });
     });
 
-    describe('Test hierarchy widget non-standard options', function () {
-        it('register a user', function () {
-            runs(function () {
-                var _user = new girder.models.UserModel({
-                    login: 'mylogin',
-                    password: 'mypassword',
-                    email: 'email@email.com',
-                    firstName: 'First',
-                    lastName: 'Last'
-                }).on('g:saved', function () {
-                    user = _user;
-                });
+    it('test hiding elements', function () {
+        runs(function () {
+            $('body').empty().off();
 
-                _user.save();
+            return new girder.views.widgets.AccessWidget({
+                el: 'body',
+                modal: false,
+                model: folder,
+                modelType: 'folder',
+                hideRecurseOption: true,
+                hideSaveButton: true,
+                parentView: null
             });
-
-            waitsFor(function () {
-                return !!user;
-            }, 'user registration');
         });
 
-        it('create top level folder', function () {
-            runs(function () {
-                var _folder = new girder.models.FolderModel({
-                    parentType: 'user',
-                    parentId: user.get('_id'),
-                    name: 'top level folder'
-                }).on('g:saved', function () {
-                    folder = _folder;
-                });
+        waitsFor(function () {
+            return $('.g-public-container').length === 1;
+        }, 'the access widget to render');
 
-                _folder.save();
-            });
-
-            waitsFor(function () {
-                return !!folder;
-            }, 'folder creation');
+        runs(function () {
+            expect($('#g-access-private').attr('checked')).toBe('checked');
+            expect($('#g-access-public').attr('checked')).toBe(undefined);
+            expect($('.g-save-access-list').length).toBe(0);
+            expect($('.g-ac-list').length).toBe(1);
+            expect($('.g-grant-access-container').length).toBe(1);
+            expect($('.g-recursive-container').length).toBe(0);
         });
+    });
 
-        it('create subfolder', function () {
-            runs(function () {
-                var _subfolder = new girder.models.FolderModel({
-                    parentType: 'folder',
-                    parentId: folder.get('_id'),
-                    name: 'subfolder'
-                }).on('g:saved', function () {
-                    subfolder = _subfolder;
-                });
-
-                _subfolder.save();
-            });
-
-            waitsFor(function () {
-                return !!subfolder;
-            }, 'subfolder creation');
-        });
-
-        it('create item', function () {
-            runs(function () {
-                var _item = new girder.models.ItemModel({
-                    folderId: folder.get('_id'),
-                    name: 'an item'
-                }).on('g:saved', function () {
-                    item = _item;
-                });
-
-                _item.save();
-            });
-
-            waitsFor(function () {
-                return !!item;
-            }, 'item creation');
-        });
-
-        it('test custom hierarchy widget options', function () {
-            runs(function () {
-                $('body').off();
-
-                widget = new girder.views.widgets.HierarchyWidget({
-                    el: 'body',
-                    parentModel: folder,
-                    onItemClick: function (item) {
-                        widget.selectItem(item);
+    it('test custom access flags UI', function () {
+        var xhr, saved = false;
+        runs(function () {
+            // Register a couple access flags in the system
+            xhr = girder.rest.restRequest({
+                path: 'webclienttest/access_flag',
+                type: 'POST',
+                contentType: 'application/json',
+                data: JSON.stringify({
+                    openFlag: {
+                        name: 'Open flag',
+                        description: 'Anyone can set this flag',
+                        admin: false
                     },
-                    showActions: false,
-                    parentView: null
-                });
+                    adminFlag: {
+                        name: 'Admin-only flag',
+                        description: 'Only admins may enable this flag',
+                        admin: true
+                    }
+                })
             });
+        });
 
-            waitsFor(function () {
-                return $('.g-hierarchy-widget').length > 0 &&
-                       $('.g-folder-list-link').length > 0 &&
-                       $('.g-item-list-link').length > 0;
-            }, 'the hierarchy widget to display');
+        waitsFor(function () {
+            return xhr.status !== undefined;
+        }, 'register access flag XHR to return');
 
-            runs(function () {
-                expect($('.g-upload-here-button').length).toBe(0);
-                expect($('.g-hierarchy-actions-header').length).toBe(0);
-                expect($('.g-list-checkbox').length).toBe(2);
-                expect($('.g-select-all').length).toBe(0);
-                expect($('.g-folder-list-link').text()).toBe('subfolder');
-                expect($('.g-item-list-link').text()).toBe('an item');
-                expect(widget.getSelectedItem()).toBe(null);
-
-                $('.g-item-list-link').click();
+        runs(function () {
+            // Re-render the access widget
+            widget.destroy();
+            widget = new girder.views.widgets.AccessWidget({
+                el: 'body',
+                modal: false,
+                model: folder,
+                modelType: 'folder',
+                parentView: null
             });
+        });
 
-            waitsFor(function () {
-                var selected = widget.getSelectedItem();
-                return selected && selected.get('_id') === item.get('_id');
-            }, 'item to be selected');
+        waitsFor(function () {
+            return $('.g-public-container').length === 1;
+        }, 'the access widget to render');
 
-            runs(function () {
-                expect($('.g-item-list-entry.g-selected').length).toBe(1);
+        runs(function () {
+            // Flag control for specific user should be visible, but public flag control
+            // should not be since this resource is set to private.
+            expect($('.g-access-action-container a.g-action-manage-flags').length).toBe(1);
+            expect($('.g-action-manage-public-flags:visible').length).toBe(0);
 
-                $('body').empty().off();
+            // Switching resource to public should show public flags link
+            $('#g-access-public').click();
+            expect($('.g-action-manage-public-flags:visible').length).toBe(1);
 
-                return new girder.views.widgets.HierarchyWidget({
-                    el: 'body',
-                    parentModel: folder,
-                    checkboxes: false,
-                    parentView: null,
-                    showItems: false
-                });
+            $('.g-action-manage-public-flags').click();
+        });
+
+        waitsFor(function () {
+            return $('.popover input.g-public-flag-checkbox').length > 0;
+        }, 'public flag popover to display');
+
+        runs(function () {
+            var countSel = '.g-action-manage-public-flags .g-flag-count-indicator';
+            // Make sure the public flags popover rendered properly
+            expect($('.popover input.g-public-flag-checkbox').length).toBe(2);
+            expect($(countSel).text()).toBe('0');
+            expect($(countSel).is(':visible')).toBe(false);
+
+            var adminCheckbox = $('.popover input.g-public-flag-checkbox[flag="adminFlag"]');
+            var openCheckbox = $('.popover .g-public-flag-checkbox[flag="openFlag"]');
+            expect(adminCheckbox.parent().text()).toBe('Admin-only flag');
+            expect(openCheckbox.parent().text()).toBe('Open flag');
+            expect(adminCheckbox.is(':checked')).toBe(false);
+            expect(openCheckbox.is(':checked')).toBe(false);
+            expect(adminCheckbox.is(':disabled')).toBe(true);
+            expect(openCheckbox.is(':disabled')).toBe(false);
+
+            // Enable the open flag and close the popover
+            openCheckbox.click();
+            expect($(countSel).text()).toBe('1');
+            expect($(countSel).is(':visible')).toBe(true);
+
+            $('.popover .g-close-public-flags-popover').click();
+        });
+
+        waitsFor(function () {
+            return $('.popover').length === 0;
+        }, 'public flags popover to disappear');
+
+        runs(function () {
+            $('.g-action-manage-flags').click();
+        });
+
+        waitsFor(function () {
+            return $('.popover input.g-flag-checkbox').length > 0;
+        }, 'individual user flag popover to display');
+
+        runs(function () {
+            var countSel = '.g-action-manage-flags .g-flag-count-indicator';
+            // Make sure the per-user flag checkbox rendered properly
+            expect($('.popover input.g-flag-checkbox').length).toBe(2);
+            expect($(countSel).text()).toBe('0');
+            expect($(countSel).is(':visible')).toBe(false);
+
+            var adminCheckbox = $('.popover input.g-flag-checkbox[flag="adminFlag"]');
+            var openCheckbox = $('.popover .g-flag-checkbox[flag="openFlag"]');
+            expect(adminCheckbox.parent().text()).toBe('Admin-only flag');
+            expect(openCheckbox.parent().text()).toBe('Open flag');
+            expect(adminCheckbox.is(':checked')).toBe(false);
+            expect(openCheckbox.is(':checked')).toBe(false);
+            expect(adminCheckbox.is(':disabled')).toBe(true);
+            expect(openCheckbox.is(':disabled')).toBe(false);
+
+            openCheckbox.click();
+
+            expect($(countSel).text()).toBe('1');
+            expect($(countSel).is(':visible')).toBe(true);
+            $('.popover .g-close-flags-popover').click();
+        });
+
+        waitsFor(function () {
+            return $('.popover').length === 0;
+        }, 'user flags popover to disappear');
+
+        runs(function () {
+            widget.once('g:accessListSaved', function () {
+                saved = true;
             });
+            $('.g-save-access-list').click();
+        });
 
-            waitsFor(function () {
-                return $('.g-hierarchy-widget').length > 0 &&
-                       $('.g-folder-list-link').length > 0;
-            }, 'the hierarchy widget with no checkboxes to display');
+        waitsFor(function () {
+            return saved;
+        }, 'access list to be saved to the server');
 
-            runs(function () {
-                expect($('.g-upload-here-button').length).toBe(1);
-                expect($('.g-hierarchy-actions-header').length).toBe(1);
-                expect($('.g-list-checkbox').length).toBe(0);
-                expect($('.g-select-all').length).toBe(0);
-                expect($('.g-checked-actions-buttons').length).toBe(0);
-                expect($('.g-folder-list-link').text()).toBe('subfolder');
-                expect($('.g-item-list-link').length).toBe(0);
+        runs(function () {
+            // force re-fetch of access list of folder
+            xhr = folder.fetchAccess(true);
+        });
+
+        waitsFor(function () {
+            return xhr.status !== undefined;
+        }, 'access fetch to be complete');
+
+        runs(function () {
+            var access = folder.get('access');
+            expect(access.users.length).toBe(1);
+            expect(access.users[0].level).toBe(girder.constants.AccessType.ADMIN);
+            expect(access.users[0].flags).toEqual(['openFlag']);
+
+            expect(folder.get('publicFlags')).toEqual(['openFlag']);
+            expect(folder.get('public')).toBe(true);
+        });
+
+        runs(function () {
+            // Re-render the access widget
+            widget.destroy();
+            widget = new girder.views.widgets.AccessWidget({
+                el: 'body',
+                modal: false,
+                model: folder,
+                modelType: 'folder',
+                parentView: null
             });
+        });
+        waitsFor(function () {
+            return $('.g-public-container').length === 1;
+        }, 'the access widget to render');
 
-            runs(function () {
-                $('body').empty().off();
+        runs(function () {
+            $('.g-action-manage-flags').click();
+        });
 
-                return new girder.views.widgets.HierarchyWidget({
-                    el: 'body',
-                    parentModel: folder,
-                    downloadLinks: false,
-                    showActions: false,
-                    parentView: null
-                });
-            });
+        waitsFor(function () {
+            return $('.popover input.g-flag-checkbox').length > 0;
+        }, 'individual user flag popover to display');
 
-            waitsFor(function () {
-                return $('.g-hierarchy-widget').length > 0 &&
-                       $('.g-folder-list-link').length > 0 &&
-                       $('.g-item-list-link').length > 0;
-            }, 'the hierarchy widget to display without download links');
+        runs(function () {
+            // Make sure enabled flags render properly
+            expect($('.popover input.g-flag-checkbox').length).toBe(2);
 
-            runs(function () {
-                expect($('.g-upload-here-button').length).toBe(0);
-                expect($('.g-hierarchy-actions-header').length).toBe(0);
-                expect($('.g-list-checkbox').length).toBe(2);
-                expect($('.g-select-all').length).toBe(0);
-                expect($('a[title="Download item"]').length).toBe(0);
-            });
-
-            runs(function () {
-                $('body').empty().off();
-
-                return new girder.views.widgets.HierarchyWidget({
-                    el: 'body',
-                    parentModel: folder,
-                    viewLinks: false,
-                    showActions: false,
-                    parentView: null
-                });
-            });
-
-            waitsFor(function () {
-                return $('.g-hierarchy-widget').length > 0 &&
-                       $('.g-folder-list-link').length > 0 &&
-                       $('.g-item-list-link').length > 0;
-            }, 'the hierarchy widget to display without view links');
-
-            runs(function () {
-                expect($('.g-upload-here-button').length).toBe(0);
-                expect($('.g-hierarchy-actions-header').length).toBe(0);
-                expect($('.g-list-checkbox').length).toBe(2);
-                expect($('.g-select-all').length).toBe(0);
-                expect($('.g-view-inline').length).toBe(0);
-            });
-
-            runs(function () {
-                $('body').empty().off();
-
-                return new girder.views.widgets.HierarchyWidget({
-                    el: 'body',
-                    parentModel: folder,
-                    downloadLinks: false,
-                    viewLinks: false,
-                    showActions: false,
-                    parentView: null
-                });
-            });
-
-            waitsFor(function () {
-                return $('.g-hierarchy-widget').length > 0 &&
-                       $('.g-folder-list-link').length > 0 &&
-                       $('.g-item-list-link').length > 0;
-            }, ('the hierarchy widget to display neither ' +
-                'view nor download links'));
-
-            runs(function () {
-                expect($('.g-upload-here-button').length).toBe(0);
-                expect($('.g-hierarchy-actions-header').length).toBe(0);
-                expect($('.g-list-checkbox').length).toBe(2);
-                expect($('.g-select-all').length).toBe(0);
-                expect($('.g-view-inline').length).toBe(0);
-                expect($('a[title="Download item"]').length).toBe(0);
-
-                /* no border shown when there are no links */
-                expect($('.g-right-border').length).toBe(0);
-            });
-
-            runs(function () {
-                $('body').empty().off();
-
-                return new girder.views.widgets.HierarchyWidget({
-                    el: 'body',
-                    parentModel: folder,
-                    showMetadata: false,
-                    showActions: false,
-                    parentView: null
-                });
-            });
-
-            waitsFor(function () {
-                return $('.g-hierarchy-widget').length > 0 &&
-                       $('.g-folder-list-link').length > 0 &&
-                       $('.g-item-list-link').length > 0;
-            }, 'the hierarchy widget to display without the metadata widget');
-
-            runs(function () {
-                expect($('.g-upload-here-button').length).toBe(0);
-                expect($('.g-hierarchy-actions-header').length).toBe(0);
-                expect($('.g-list-checkbox').length).toBe(2);
-                expect($('.g-select-all').length).toBe(0);
-                expect($('.g-folder-metadata').length).toBe(0);
-            });
-
-            runs(function () {
-                $('body').empty().off();
-
-                return new girder.views.widgets.HierarchyWidget({
-                    el: 'body',
-                    parentModel: folder,
-                    showSizes: false,
-                    showActions: false,
-                    parentView: null
-                });
-            });
-
-            waitsFor(function () {
-                return $('.g-hierarchy-widget').length > 0 &&
-                       $('.g-folder-list-link').length > 0 &&
-                       $('.g-item-list-link').length > 0;
-            }, 'the hierarchy widget to display without item sizes');
-
-            runs(function () {
-                expect($('.g-upload-here-button').length).toBe(0);
-                expect($('.g-hierarchy-actions-header').length).toBe(0);
-                expect($('.g-list-checkbox').length).toBe(2);
-                expect($('.g-select-all').length).toBe(0);
-                expect($('.g-item-size').length).toBe(0);
-            });
-
-            var folderSelected = false;
-            runs(function () {
-                $('body').empty().off();
-
-                return new girder.views.widgets.HierarchyWidget({
-                    el: 'body',
-                    parentModel: folder,
-                    checkboxes: false,
-                    parentView: null,
-                    showItems: false,
-                    onFolderSelect: function (parent) { folderSelected = true; }
-                });
-            });
-
-            waitsFor(function () {
-                return $('.g-hierarchy-widget').length > 0 &&
-                       $('.g-folder-list-link').length > 0;
-            }, 'the hierarchy widget to display with the folder select button');
-
-            runs(function () {
-                expect($('.g-upload-here-button').length).toBe(1);
-                expect($('.g-hierarchy-actions-header').length).toBe(1);
-                expect($('.g-list-checkbox').length).toBe(0);
-                expect($('.g-select-all').length).toBe(0);
-                expect($('.g-checked-actions-buttons').length).toBe(0);
-                expect($('.g-folder-list-link').text()).toBe('subfolder');
-                expect($('.g-item-list-link').length).toBe(0);
-                expect($('button.g-select-folder').length).toBe(1);
-
-                $('button.g-select-folder').click();
-            });
-
-            waitsFor(
-              function () { return folderSelected; },
-              'the folder select button to be clicked');
-
-            runs(function () {
-                $('body').empty().off();
-
-                return new girder.views.widgets.HierarchyWidget({
-                    el: 'body',
-                    parentModel: folder,
-                    checkboxes: false,
-                    parentView: null,
-                    showItems: false
-                });
-            });
-
-            waitsFor(
-              function () {
-                  return $('.g-hierarchy-widget').length > 0 &&
-                         $('.g-folder-list-link').length > 0;
-              },
-              'the hierarchy widget to display without the folder select button'
-            );
-
-            runs(function () {
-                expect($('.g-upload-here-button').length).toBe(1);
-                expect($('.g-hierarchy-actions-header').length).toBe(1);
-                expect($('.g-list-checkbox').length).toBe(0);
-                expect($('.g-select-all').length).toBe(0);
-                expect($('.g-checked-actions-buttons').length).toBe(0);
-                expect($('.g-folder-list-link').text()).toBe('subfolder');
-                expect($('.g-item-list-link').length).toBe(0);
-                expect($('button.g-select-folder').length).toBe(0);
-            });
+            var adminCheckbox = $('.popover input.g-flag-checkbox[flag="adminFlag"]');
+            var openCheckbox = $('.popover .g-flag-checkbox[flag="openFlag"]');
+            expect(adminCheckbox.parent().text()).toBe('Admin-only flag');
+            expect(openCheckbox.parent().text()).toBe('Open flag');
+            expect(adminCheckbox.is(':checked')).toBe(false);
+            expect(openCheckbox.is(':checked')).toBe(true);
+            expect(adminCheckbox.is(':disabled')).toBe(true);
+            expect(openCheckbox.is(':disabled')).toBe(false);
         });
     });
 
-    describe('Test access widget with non-standard options', function () {
+    it('test hide component options', function () {
+        runs(function () {
+            // create the widget will all hide options
+            widget.destroy();
+            widget = new girder.views.widgets.AccessWidget({
+                el: 'body',
+                modal: false,
+                model: folder,
+                modelType: 'folder',
+                parentView: null,
+                hideRecurseOption: true,
+                hideSaveButton: true,
+                hidePrivacyEditor: true,
+                hideAccessType: true,
+                noAccessFlag: true
+            });
+        });
+
+        waitsFor(function () {
+            return widget.$('#g-ac-list-users').children().length === 1 &&
+                widget.$('.g-public-container').length === 0 &&
+                widget.$('.g-recursive-container').length === 0 &&
+                widget.$('.g-user-access-entry select').length === 0;
+        }, 'check if all component are hidden');
+    });
+});
+
+describe('Test search widget with non-standard options', function () {
+    it('test fixed search mode', function () {
+        runs(function () {
+            $('body').empty().off();
+
+            new girder.views.widgets.SearchFieldWidget({
+                el: 'body',
+                modes: 'prefix',
+                types: ['folder'],
+                parentView: null,
+                placeholder: 'test ph'
+            }).render();
+
+            expect($('input.g-search-field[placeholder="test ph"]').length).toBe(1);
+            expect($('.g-search-mode-choose').length).toBe(0);
+
+            $('.g-search-field').val('to').trigger('input');
+        });
+
+        waitsFor(function () {
+            return $('.g-search-results').hasClass('open');
+        }, 'prefix folder search to return');
+
+        runs(function () {
+            var results = $('li.g-search-result');
+            expect(results.length).toBe(1);
+            expect(results.find('a[resourcetype="folder"]').text()).toContain('top level folder');
+        });
+    });
+
+    it('test multiple search modes', function () {
+        runs(function () {
+            $('body').empty().off();
+
+            new girder.views.widgets.SearchFieldWidget({
+                el: 'body',
+                modes: ['text', 'prefix'],
+                types: ['folder'],
+                parentView: null
+            }).render();
+
+            expect($('.g-search-mode-choose').length).toBe(1);
+            $('.g-search-field').val('to').trigger('input');
+        });
+
+        waitsFor(function () {
+            return $('.g-search-results:visible').hasClass('open');
+        }, 'folder text search to return');
+
+        runs(function () {
+            expect($('li.g-search-result').length).toBe(0);
+            expect($('li.g-no-search-results.disabled').length).toBe(1);
+
+            $('.g-search-mode-choose').click();
+        });
+
+        waitsFor(function () {
+            return $('.popover-content:visible').length === 1;
+        }, 'search mode select popover to appear');
+
+        runs(function () {
+            expect($('.popover-content p').text()).toContain('Choose search mode');
+            expect($('.popover-content .radio').length).toBe(2);
+            expect($('.popover-content .g-search-mode-radio[value="prefix"]:checked').length).toBe(0);
+            expect($('.popover-content .g-search-mode-radio[value="text"]:checked').length).toBe(1);
+
+            $('.popover-content .g-search-mode-radio[value="prefix"]').click();
+        });
+
+        waitsFor(function () {
+            return $('li.g-search-result').length > 0;
+        }, 'prefix search to be automatically run');
+
+        runs(function () {
+            expect($('li.g-search-result').text()).toContain('top level folder');
+        });
+    });
+});
+
+describe('Test metadata widget with non-standard options', function () {
+    it('test editing custom field with custom callbacks', function () {
         var widget;
-        it('test non-modal rendering', function () {
-            runs(function () {
-                widget = new girder.views.widgets.AccessWidget({
-                    el: 'body',
-                    modal: false,
-                    model: folder,
-                    modelType: 'folder',
-                    parentView: null
-                });
+        var model = new girder.models.FolderModel({
+            customMeta: {}
+        });
+        var addCbCalled = false;
+        var editCbCalled = false;
+
+        var addCb = function (key, value, success, err) {
+            model.get('customMeta')[key] = value;
+            addCbCalled = true;
+            success();
+        };
+        var editCb = function (newKey, oldKey, value, success, err) {
+            var meta = model.get('customMeta');
+            delete meta[oldKey];
+            meta[newKey] = value;
+            editCbCalled = true;
+            success();
+        };
+
+        runs(function () {
+            widget = new girder.views.widgets.MetadataWidget({
+                el: 'body',
+                parentView: null,
+                item: model,
+                accessLevel: girder.constants.AccessType.WRITE,
+                onMetadataAdded: addCb,
+                onMetadataEdited: editCb,
+                fieldName: 'customMeta'
             });
 
-            waitsFor(function () {
-                return $('.g-public-container').length === 1;
-            }, 'the access widget to render');
+            expect($('.g-widget-metadata-row').length).toBe(0);
+            expect($('.g-widget-metadata-add-button').length).toBe(1);
+            expect(addCbCalled).toBe(false);
+            expect(editCbCalled).toBe(false);
 
-            runs(function () {
-                expect($('#g-access-private').attr('checked')).toBe('checked');
-                expect($('#g-access-public').attr('checked')).toBe(undefined);
-                expect($('.g-save-access-list').length).toBe(1);
-                expect($('.g-ac-list').length).toBe(1);
-                expect($('.g-grant-access-container').length).toBe(1);
-                expect($('.g-recursive-container .radio').length).toBe(2);
-            });
+            $('.g-widget-metadata-add-button').click();
         });
 
-        it('test hiding elements', function () {
-            runs(function () {
-                $('body').empty().off();
+        waitsFor(function () {
+            return $('.g-add-simple-metadata:visible').length > 0;
+        }, 'metadata type dropdown to appear');
 
-                return new girder.views.widgets.AccessWidget({
-                    el: 'body',
-                    modal: false,
-                    model: folder,
-                    modelType: 'folder',
-                    hideRecurseOption: true,
-                    hideSaveButton: true,
-                    parentView: null
-                });
-            });
+        runs(function () {
+            // Save a metadata key, make sure add callback was called
+            $('.g-add-simple-metadata').click();
+            expect($('.g-widget-metadata-row').length).toBe(1);
+            $('.g-widget-metadata-key-input').val('foo');
+            $('.g-widget-metadata-value-input').val('bar');
+            $('.g-widget-metadata-save-button').click();
+            expect(addCbCalled).toBe(true);
+            expect(editCbCalled).toBe(false);
+            expect($('.g-widget-metadata-key-input').length).toBe(0);
+            expect(_.keys(model.get('customMeta')).length).toBe(1);
+            expect(model.get('customMeta').foo).toBe('bar');
 
-            waitsFor(function () {
-                return $('.g-public-container').length === 1;
-            }, 'the access widget to render');
+            // Re-render the widget, make sure it displays properly
+            widget.render();
+            expect($('.g-widget-metadata-row').length).toBe(1);
+            expect($('.g-widget-metadata-key').text()).toBe('foo');
+            expect($('.g-widget-metadata-value').text()).toBe('bar');
 
-            runs(function () {
-                expect($('#g-access-private').attr('checked')).toBe('checked');
-                expect($('#g-access-public').attr('checked')).toBe(undefined);
-                expect($('.g-save-access-list').length).toBe(0);
-                expect($('.g-ac-list').length).toBe(1);
-                expect($('.g-grant-access-container').length).toBe(1);
-                expect($('.g-recursive-container').length).toBe(0);
-            });
-        });
-
-        it('test custom access flags UI', function () {
-            var xhr, saved = false;
-            runs(function () {
-                // Register a couple access flags in the system
-                xhr = girder.rest.restRequest({
-                    path: 'webclienttest/access_flag',
-                    type: 'POST',
-                    contentType: 'application/json',
-                    data: JSON.stringify({
-                        openFlag: {
-                            name: 'Open flag',
-                            description: 'Anyone can set this flag',
-                            admin: false
-                        },
-                        adminFlag: {
-                            name: 'Admin-only flag',
-                            description: 'Only admins may enable this flag',
-                            admin: true
-                        }
-                    })
-                });
-            });
-
-            waitsFor(function () {
-                return xhr.status !== undefined;
-            }, 'register access flag XHR to return');
-
-            runs(function () {
-                // Re-render the access widget
-                widget.destroy();
-                widget = new girder.views.widgets.AccessWidget({
-                    el: 'body',
-                    modal: false,
-                    model: folder,
-                    modelType: 'folder',
-                    parentView: null
-                });
-            });
-
-            waitsFor(function () {
-                return $('.g-public-container').length === 1;
-            }, 'the access widget to render');
-
-            runs(function () {
-                // Flag control for specific user should be visible, but public flag control
-                // should not be since this resource is set to private.
-                expect($('.g-access-action-container a.g-action-manage-flags').length).toBe(1);
-                expect($('.g-action-manage-public-flags:visible').length).toBe(0);
-
-                // Switching resource to public should show public flags link
-                $('#g-access-public').click();
-                expect($('.g-action-manage-public-flags:visible').length).toBe(1);
-
-                $('.g-action-manage-public-flags').click();
-            });
-
-            waitsFor(function () {
-                return $('.popover input.g-public-flag-checkbox').length > 0;
-            }, 'public flag popover to display');
-
-            runs(function () {
-                var countSel = '.g-action-manage-public-flags .g-flag-count-indicator';
-                // Make sure the public flags popover rendered properly
-                expect($('.popover input.g-public-flag-checkbox').length).toBe(2);
-                expect($(countSel).text()).toBe('0');
-                expect($(countSel).is(':visible')).toBe(false);
-
-                var adminCheckbox = $('.popover input.g-public-flag-checkbox[flag="adminFlag"]');
-                var openCheckbox = $('.popover .g-public-flag-checkbox[flag="openFlag"]');
-                expect(adminCheckbox.parent().text()).toBe('Admin-only flag');
-                expect(openCheckbox.parent().text()).toBe('Open flag');
-                expect(adminCheckbox.is(':checked')).toBe(false);
-                expect(openCheckbox.is(':checked')).toBe(false);
-                expect(adminCheckbox.is(':disabled')).toBe(true);
-                expect(openCheckbox.is(':disabled')).toBe(false);
-
-                // Enable the open flag and close the popover
-                openCheckbox.click();
-                expect($(countSel).text()).toBe('1');
-                expect($(countSel).is(':visible')).toBe(true);
-
-                $('.popover .g-close-public-flags-popover').click();
-            });
-
-            waitsFor(function () {
-                return $('.popover').length === 0;
-            }, 'public flags popover to disappear');
-
-            runs(function () {
-                $('.g-action-manage-flags').click();
-            });
-
-            waitsFor(function () {
-                return $('.popover input.g-flag-checkbox').length > 0;
-            }, 'individual user flag popover to display');
-
-            runs(function () {
-                var countSel = '.g-action-manage-flags .g-flag-count-indicator';
-                // Make sure the per-user flag checkbox rendered properly
-                expect($('.popover input.g-flag-checkbox').length).toBe(2);
-                expect($(countSel).text()).toBe('0');
-                expect($(countSel).is(':visible')).toBe(false);
-
-                var adminCheckbox = $('.popover input.g-flag-checkbox[flag="adminFlag"]');
-                var openCheckbox = $('.popover .g-flag-checkbox[flag="openFlag"]');
-                expect(adminCheckbox.parent().text()).toBe('Admin-only flag');
-                expect(openCheckbox.parent().text()).toBe('Open flag');
-                expect(adminCheckbox.is(':checked')).toBe(false);
-                expect(openCheckbox.is(':checked')).toBe(false);
-                expect(adminCheckbox.is(':disabled')).toBe(true);
-                expect(openCheckbox.is(':disabled')).toBe(false);
-
-                openCheckbox.click();
-
-                expect($(countSel).text()).toBe('1');
-                expect($(countSel).is(':visible')).toBe(true);
-                $('.popover .g-close-flags-popover').click();
-            });
-
-            waitsFor(function () {
-                return $('.popover').length === 0;
-            }, 'user flags popover to disappear');
-
-            runs(function () {
-                widget.once('g:accessListSaved', function () {
-                    saved = true;
-                });
-                $('.g-save-access-list').click();
-            });
-
-            waitsFor(function () {
-                return saved;
-            }, 'access list to be saved to the server');
-
-            runs(function () {
-                // force re-fetch of access list of folder
-                xhr = folder.fetchAccess(true);
-            });
-
-            waitsFor(function () {
-                return xhr.status !== undefined;
-            }, 'access fetch to be complete');
-
-            runs(function () {
-                var access = folder.get('access');
-                expect(access.users.length).toBe(1);
-                expect(access.users[0].level).toBe(girder.constants.AccessType.ADMIN);
-                expect(access.users[0].flags).toEqual(['openFlag']);
-
-                expect(folder.get('publicFlags')).toEqual(['openFlag']);
-                expect(folder.get('public')).toBe(true);
-            });
-
-            runs(function () {
-                // Re-render the access widget
-                widget.destroy();
-                widget = new girder.views.widgets.AccessWidget({
-                    el: 'body',
-                    modal: false,
-                    model: folder,
-                    modelType: 'folder',
-                    parentView: null
-                });
-            });
-            waitsFor(function () {
-                return $('.g-public-container').length === 1;
-            }, 'the access widget to render');
-
-            runs(function () {
-                $('.g-action-manage-flags').click();
-            });
-
-            waitsFor(function () {
-                return $('.popover input.g-flag-checkbox').length > 0;
-            }, 'individual user flag popover to display');
-
-            runs(function () {
-                // Make sure enabled flags render properly
-                expect($('.popover input.g-flag-checkbox').length).toBe(2);
-
-                var adminCheckbox = $('.popover input.g-flag-checkbox[flag="adminFlag"]');
-                var openCheckbox = $('.popover .g-flag-checkbox[flag="openFlag"]');
-                expect(adminCheckbox.parent().text()).toBe('Admin-only flag');
-                expect(openCheckbox.parent().text()).toBe('Open flag');
-                expect(adminCheckbox.is(':checked')).toBe(false);
-                expect(openCheckbox.is(':checked')).toBe(true);
-                expect(adminCheckbox.is(':disabled')).toBe(true);
-                expect(openCheckbox.is(':disabled')).toBe(false);
-            });
-        });
-
-        it('test hide component options', function () {
-            runs(function () {
-                // create the widget will all hide options
-                widget.destroy();
-                widget = new girder.views.widgets.AccessWidget({
-                    el: 'body',
-                    modal: false,
-                    model: folder,
-                    modelType: 'folder',
-                    parentView: null,
-                    hideRecurseOption: true,
-                    hideSaveButton: true,
-                    hidePrivacyEditor: true,
-                    hideAccessType: true,
-                    noAccessFlag: true
-                });
-            });
-
-            waitsFor(function () {
-                return widget.$('#g-ac-list-users').children().length === 1 &&
-                    widget.$('.g-public-container').length === 0 &&
-                    widget.$('.g-recursive-container').length === 0 &&
-                    widget.$('.g-user-access-entry select').length === 0;
-            }, 'check if all component are hidden');
+            // Edit the existing field, make sure edit callback was called
+            $('.g-widget-metadata-edit-button').click();
+            $('.g-widget-metadata-value-input').val('baz');
+            $('.g-widget-metadata-save-button').click();
+            expect($('.g-widget-metadata-row').length).toBe(1);
+            expect($('.g-widget-metadata-key').text()).toBe('foo');
+            expect($('.g-widget-metadata-value').text()).toBe('baz');
         });
     });
-
-    describe('Test search widget with non-standard options', function () {
-        it('test fixed search mode', function () {
-            runs(function () {
-                $('body').empty().off();
-
-                new girder.views.widgets.SearchFieldWidget({
-                    el: 'body',
-                    modes: 'prefix',
-                    types: ['folder'],
-                    parentView: null,
-                    placeholder: 'test ph'
-                }).render();
-
-                expect($('input.g-search-field[placeholder="test ph"]').length).toBe(1);
-                expect($('.g-search-mode-choose').length).toBe(0);
-
-                $('.g-search-field').val('to').trigger('input');
-            });
-
-            waitsFor(function () {
-                return $('.g-search-results').hasClass('open');
-            }, 'prefix folder search to return');
-
-            runs(function () {
-                var results = $('li.g-search-result');
-                expect(results.length).toBe(1);
-                expect(results.find('a[resourcetype="folder"]').text()).toContain('top level folder');
-            });
-        });
-
-        it('test multiple search modes', function () {
-            runs(function () {
-                $('body').empty().off();
-
-                new girder.views.widgets.SearchFieldWidget({
-                    el: 'body',
-                    modes: ['text', 'prefix'],
-                    types: ['folder'],
-                    parentView: null
-                }).render();
-
-                expect($('.g-search-mode-choose').length).toBe(1);
-                $('.g-search-field').val('to').trigger('input');
-            });
-
-            waitsFor(function () {
-                return $('.g-search-results:visible').hasClass('open');
-            }, 'folder text search to return');
-
-            runs(function () {
-                expect($('li.g-search-result').length).toBe(0);
-                expect($('li.g-no-search-results.disabled').length).toBe(1);
-
-                $('.g-search-mode-choose').click();
-            });
-
-            waitsFor(function () {
-                return $('.popover-content:visible').length === 1;
-            }, 'search mode select popover to appear');
-
-            runs(function () {
-                expect($('.popover-content p').text()).toContain('Choose search mode');
-                expect($('.popover-content .radio').length).toBe(2);
-                expect($('.popover-content .g-search-mode-radio[value="prefix"]:checked').length).toBe(0);
-                expect($('.popover-content .g-search-mode-radio[value="text"]:checked').length).toBe(1);
-
-                $('.popover-content .g-search-mode-radio[value="prefix"]').click();
-            });
-
-            waitsFor(function () {
-                return $('li.g-search-result').length > 0;
-            }, 'prefix search to be automatically run');
-
-            runs(function () {
-                expect($('li.g-search-result').text()).toContain('top level folder');
-            });
-        });
-    });
-
-    describe('Test metadata widget with non-standard options', function () {
-        it('test editing custom field with custom callbacks', function () {
-            var widget;
-            var model = new girder.models.FolderModel({
-                customMeta: {}
-            });
-            var addCbCalled = false;
-            var editCbCalled = false;
-
-            var addCb = function (key, value, success, err) {
-                model.get('customMeta')[key] = value;
-                addCbCalled = true;
-                success();
-            };
-            var editCb = function (newKey, oldKey, value, success, err) {
-                var meta = model.get('customMeta');
-                delete meta[oldKey];
-                meta[newKey] = value;
-                editCbCalled = true;
-                success();
-            };
-
-            runs(function () {
-                widget = new girder.views.widgets.MetadataWidget({
-                    el: 'body',
-                    parentView: null,
-                    item: model,
-                    accessLevel: girder.constants.AccessType.WRITE,
-                    onMetadataAdded: addCb,
-                    onMetadataEdited: editCb,
-                    fieldName: 'customMeta'
-                });
-
-                expect($('.g-widget-metadata-row').length).toBe(0);
-                expect($('.g-widget-metadata-add-button').length).toBe(1);
-                expect(addCbCalled).toBe(false);
-                expect(editCbCalled).toBe(false);
-
-                $('.g-widget-metadata-add-button').click();
-            });
-
-            waitsFor(function () {
-                return $('.g-add-simple-metadata:visible').length > 0;
-            }, 'metadata type dropdown to appear');
-
-            runs(function () {
-                // Save a metadata key, make sure add callback was called
-                $('.g-add-simple-metadata').click();
-                expect($('.g-widget-metadata-row').length).toBe(1);
-                $('.g-widget-metadata-key-input').val('foo');
-                $('.g-widget-metadata-value-input').val('bar');
-                $('.g-widget-metadata-save-button').click();
-                expect(addCbCalled).toBe(true);
-                expect(editCbCalled).toBe(false);
-                expect($('.g-widget-metadata-key-input').length).toBe(0);
-                expect(_.keys(model.get('customMeta')).length).toBe(1);
-                expect(model.get('customMeta').foo).toBe('bar');
-
-                // Re-render the widget, make sure it displays properly
-                widget.render();
-                expect($('.g-widget-metadata-row').length).toBe(1);
-                expect($('.g-widget-metadata-key').text()).toBe('foo');
-                expect($('.g-widget-metadata-value').text()).toBe('bar');
-
-                // Edit the existing field, make sure edit callback was called
-                $('.g-widget-metadata-edit-button').click();
-                $('.g-widget-metadata-value-input').val('baz');
-                $('.g-widget-metadata-save-button').click();
-                expect($('.g-widget-metadata-row').length).toBe(1);
-                expect($('.g-widget-metadata-key').text()).toBe('foo');
-                expect($('.g-widget-metadata-value').text()).toBe('baz');
-            });
-        });
-    });
-})();
+});

--- a/clients/web/test/spec/dataSpec.js
+++ b/clients/web/test/spec/dataSpec.js
@@ -1,3 +1,5 @@
+girderTest.startApp();
+
 /**
  * As of v1.9.9, phantomJS does not correctly support sending Blobs in XHRs,
  * and the FormData API is extremely limited (i.e. does not support anything
@@ -50,11 +52,6 @@ function _setMinimumChunkSize(minSize) {
         girderTest._redirect = url;
     };
 }());
-
-/**
- * Start the girder backbone app.
- */
-girderTest.startApp();
 
 describe('Create a data hierarchy', function () {
     it('register a user',

--- a/clients/web/test/spec/emptyLayoutSpec.js
+++ b/clients/web/test/spec/emptyLayoutSpec.js
@@ -1,6 +1,3 @@
-/**
- * Start the girder backbone app.
- */
 girderTest.startApp();
 
 describe('Test empty and default layouts', function () {

--- a/clients/web/test/spec/folderSpec.js
+++ b/clients/web/test/spec/folderSpec.js
@@ -1,6 +1,3 @@
-/**
- * Start the girder backbone app.
- */
 girderTest.startApp();
 
 /* Show the folder edit dialog and click a button.

--- a/clients/web/test/spec/groupSpec.js
+++ b/clients/web/test/spec/groupSpec.js
@@ -1,6 +1,3 @@
-/**
- * Start the girder backbone app.
- */
 girderTest.startApp();
 
 /* Search for a name on the members search panel, and invite or add the first

--- a/clients/web/test/spec/itemSpec.js
+++ b/clients/web/test/spec/itemSpec.js
@@ -1,6 +1,3 @@
-/**
- * Start the girder backbone app.
- */
 girderTest.startApp();
 
 /* Show the item edit dialog and click a button.

--- a/clients/web/test/spec/modelSpec.js
+++ b/clients/web/test/spec/modelSpec.js
@@ -1,3 +1,5 @@
+girderTest.startApp();
+
 /**
  * Intercept window.location.assign calls so we can test the behavior of,
  * e.g. download directives that occur from js.
@@ -7,11 +9,6 @@
         girderTest._redirect = url;
     };
 }());
-
-/**
- * Start the girder backbone app.
- */
-girderTest.startApp();
 
 describe('Test the model class', function () {
     var lastRequest, triggerRestError = false, requestCount = 0;

--- a/clients/web/test/spec/routingSpec.js
+++ b/clients/web/test/spec/routingSpec.js
@@ -1,6 +1,3 @@
-/**
- * Start the girder backbone app.
- */
 girderTest.startApp();
 
 function _getFirstId(Collection, ids, key, fetchParamsFunc) {

--- a/clients/web/test/spec/setApiSpec.js
+++ b/clients/web/test/spec/setApiSpec.js
@@ -1,6 +1,3 @@
-/**
- * Start the girder backbone app.
- */
 girderTest.startApp();
 
 describe('Test setApiRoot() and setStaticRoot() functions', function () {

--- a/clients/web/test/spec/swaggerSpec.js
+++ b/clients/web/test/spec/swaggerSpec.js
@@ -1,40 +1,38 @@
-$(function () {
-    describe('Test the swagger pages', function () {
-        it('Test swagger', function () {
-            waitsFor(function () {
-                return $('li#resource_system.resource').length > 0;
-            }, 'swagger docs to appear');
-            runs(function () {
-                expect($('li#resource_system.resource .heading h2 a').text()).toBe('system');
-            });
-            // There seems to be some delay between the link showing and when swaggerUi actually
-            // binds the event handler. We don't have a good hook into that binding, so we hack
-            // it with a 0.1s delay instead.
-            waits(100);
-            runs(function () {
-                $('li#resource_system.resource .heading h2 a').click();
-            });
-            waitsFor(function () {
-                return $('#system_system_getVersion:visible').length > 0;
-            }, 'end points to be visible');
-            runs(function () {
-                $('#system_system_getVersion h3 a').click();
-            });
-            waitsFor(function () {
-                return $('#system_system_getVersion .sandbox_header input.submit:visible').length > 0;
-            }, 'version try out button to be visible');
-            runs(function () {
-                $('#system_system_getVersion .sandbox_header input.submit').click();
-            });
-            waitsFor(function () {
-                return $('#system_system_getVersion .response_body.json').text().indexOf('apiVersion') >= 0;
-            }, 'version information was returned');
+describe('Test the swagger pages', function () {
+    it('Test swagger', function () {
+        waitsFor(function () {
+            return $('li#resource_system.resource').length > 0;
+        }, 'swagger docs to appear');
+        runs(function () {
+            expect($('li#resource_system.resource .heading h2 a').text()).toBe('system');
         });
+        // There seems to be some delay between the link showing and when swaggerUi actually
+        // binds the event handler. We don't have a good hook into that binding, so we hack
+        // it with a 0.1s delay instead.
+        waits(100);
+        runs(function () {
+            $('li#resource_system.resource .heading h2 a').click();
+        });
+        waitsFor(function () {
+            return $('#system_system_getVersion:visible').length > 0;
+        }, 'end points to be visible');
+        runs(function () {
+            $('#system_system_getVersion h3 a').click();
+        });
+        waitsFor(function () {
+            return $('#system_system_getVersion .sandbox_header input.submit:visible').length > 0;
+        }, 'version try out button to be visible');
+        runs(function () {
+            $('#system_system_getVersion .sandbox_header input.submit').click();
+        });
+        waitsFor(function () {
+            return $('#system_system_getVersion .response_body.json').text().indexOf('apiVersion') >= 0;
+        }, 'version information was returned');
     });
-
-    var jasmineEnv = jasmine.getEnv();
-    var consoleReporter = new jasmine.ConsoleReporter();
-    window.jasmine_phantom_reporter = consoleReporter;
-    jasmineEnv.addReporter(consoleReporter);
-    jasmineEnv.execute();
 });
+
+var jasmineEnv = jasmine.getEnv();
+var consoleReporter = new jasmine.ConsoleReporter();
+window.jasmine_phantom_reporter = consoleReporter;
+jasmineEnv.addReporter(consoleReporter);
+jasmineEnv.execute();

--- a/clients/web/test/spec/userSpec.js
+++ b/clients/web/test/spec/userSpec.js
@@ -1,6 +1,3 @@
-/**
- * Start the girder backbone app.
- */
 girderTest.startApp();
 
 var registeredUsers = [];

--- a/clients/web/test/spec/versionSpec.js
+++ b/clients/web/test/spec/versionSpec.js
@@ -1,6 +1,3 @@
-/**
- * Start the girder backbone app.
- */
 girderTest.startApp();
 
 describe('Test version reporting', function () {

--- a/clients/web/test/spec/widgetsSpec.js
+++ b/clients/web/test/spec/widgetsSpec.js
@@ -1,6 +1,3 @@
-/**
- * Start the girder backbone app.
- */
 girderTest.startApp();
 
 function _setProgress(test, duration, resourceId, resourceName) {

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -1241,47 +1241,48 @@ $(function () {
 });
 
 /**
- * Wait for all of the sources to load and then start the main girder application.
- * This will also delay the invocation of the jasmine test suite until after the
+ * Wait for all of the sources to load and then start the main Girder application.
+ * This will also delay the invocation of the Jasmine test suite until after the
  * application is running.  This method returns a promise that resolves with the
  * application object.
  */
 girderTest.startApp = function () {
-    var defer = new $.Deferred();
-    girderTest.promise.done(function () {
-        /* Track bootstrap transitions.  This is largely a duplicate of the
-         * Bootstrap emulateTransitionEnd function, with the only change being
-         * our tracking of the transition.  This still relies on the browser
-         * possibly firing css transition end events, with this function as a
-         * fail-safe. */
-        $.fn.emulateTransitionEnd = function (duration) {
-            girder._inTransition = true;
-            var called = false;
-            var $el = this;
-            $(this).one('bsTransitionEnd', function () { called = true; });
-            var callback = function () {
-                if (!called) {
-                    $($el).trigger($.support.transition.end);
-                }
-                girder._inTransition = false;
+    var app;
+    girderTest.promise = girderTest.promise
+        .then(function () {
+            /* Track bootstrap transitions.  This is largely a duplicate of the
+             * Bootstrap emulateTransitionEnd function, with the only change being
+             * our tracking of the transition.  This still relies on the browser
+             * possibly firing css transition end events, with this function as a
+             * fail-safe. */
+            $.fn.emulateTransitionEnd = function (duration) {
+                girder._inTransition = true;
+                var called = false;
+                var $el = this;
+                $(this).one('bsTransitionEnd', function () {
+                    called = true;
+                });
+                var callback = function () {
+                    if (!called) {
+                        $($el).trigger($.support.transition.end);
+                    }
+                    girder._inTransition = false;
+                };
+                setTimeout(callback, duration);
+                return this;
             };
-            setTimeout(callback, duration);
-            return this;
-        };
 
-        girder.events.trigger('g:appload.before');
-        var app = new girder.views.App({
-            el: 'body',
-            parentView: null,
-            start: false
-        });
-        app.start().done(function () {
+            girder.events.trigger('g:appload.before');
+            app = new girder.views.App({
+                el: 'body',
+                parentView: null,
+                start: false
+            });
+            return app.start();
+        })
+        .then(function () {
             girder.events.trigger('g:appload.after');
-            defer.resolve(app);
+            return app;
         });
-    }).fail(function () {
-        defer.reject.apply(defer, arguments);
-    });
-    girderTest.promise = defer.promise();
     return girderTest.promise;
 };

--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -918,11 +918,28 @@ typically with the ``girderTest.importPlugin`` function.
           topologically sorted order, before loading your plugin with ``girderTest.importPlugin``
           last.
 
+If the plugin test requires an instance of the Girder client app to be running, it can be
+started with ``girderTest.startApp()`` immediately after plugins are imported. Plugin tests that
+perform only unit tests or standalone instantiation of views may be able to skip starting the Girder
+client app.
+
+Jasmine specs (defined with ``it``) are not run until the plugin (and app, if started) are fully
+loaded, so they should be defined directly inside a suite (defined with ``describe``) at the
+top-level.
+
 For example, the cats plugin would define tests in a ``plugin_tests/catSpec.js`` file, like:
 
 .. code-block:: javascript
 
     girderTest.importPlugin('cats');
+    girderTest.startApp();
+
+    describe("Test the cats plugin", function() {
+        it("tests some new functionality", function() {
+            ...
+        });
+    });
+
 
 Using External Data Artifacts
 *****************************

--- a/plugins/authorized_upload/plugin_tests/authorizedUploadSpec.js
+++ b/plugins/authorized_upload/plugin_tests/authorizedUploadSpec.js
@@ -1,9 +1,7 @@
-var secureUrl = null;
-
 girderTest.importPlugin('authorized_upload');
-
 girderTest.startApp();
 
+var secureUrl = null;
 describe('Create an authorized upload.', function () {
     it('register a user', girderTest.createUser(
         'admin', 'admin@email.com', 'Admin', 'Admin', 'passwd'));

--- a/plugins/autojoin/plugin_tests/autojoinSpec.js
+++ b/plugins/autojoin/plugin_tests/autojoinSpec.js
@@ -1,107 +1,105 @@
 girderTest.importPlugin('autojoin');
 girderTest.startApp();
 
-$(function () {
-    describe('test the autojoin ui', function () {
-        it('register an admin', girderTest.createUser(
-            'admin', 'admin@example.com', 'Joe', 'Admin', 'password'
-        ));
+describe('test the autojoin ui', function () {
+    it('register an admin', girderTest.createUser(
+        'admin', 'admin@example.com', 'Joe', 'Admin', 'password'
+    ));
 
-        var group1, group2, group3;
+    var group1, group2, group3;
 
-        it('go to groups page', girderTest.goToGroupsPage());
-        it('create a group', girderTest.createGroup('group1', '', false));
-        it('assign group 1', function () {
-            group1 = window.location.hash.split('/')[1];
+    it('go to groups page', girderTest.goToGroupsPage());
+    it('create a group', girderTest.createGroup('group1', '', false));
+    it('assign group 1', function () {
+        group1 = window.location.hash.split('/')[1];
+    });
+
+    it('go to groups page', girderTest.goToGroupsPage());
+    it('create a group', girderTest.createGroup('group2', '', false));
+    it('assign group 2', function () {
+        group2 = window.location.hash.split('/')[1];
+    });
+
+    it('go to groups page', girderTest.goToGroupsPage());
+    it('create a group', girderTest.createGroup('group3', '', false));
+
+    it('assign group 3', function () {
+        group3 = window.location.hash.split('/')[1];
+    });
+
+    it('go to auto join plugin settings', function () {
+        waitsFor(function () {
+            return $('a[g-target="admin"]:visible').length > 0;
+        }, 'admin console link to display');
+
+        runs(function () {
+            $('a[g-target="admin"]:visible').click();
         });
 
-        it('go to groups page', girderTest.goToGroupsPage());
-        it('create a group', girderTest.createGroup('group2', '', false));
-        it('assign group 2', function () {
-            group2 = window.location.hash.split('/')[1];
+        waitsFor(function () {
+            return $('.g-plugins-config:visible').length > 0;
+        }, 'admin console to display');
+
+        runs(function () {
+            $('.g-plugins-config:visible').click();
         });
 
-        it('go to groups page', girderTest.goToGroupsPage());
-        it('create a group', girderTest.createGroup('group3', '', false));
+        waitsFor(function () {
+            return $('a[g-route="plugins/autojoin/config"]:visible').length > 0;
+        }, 'plugins page to display');
 
-        it('assign group 3', function () {
-            group3 = window.location.hash.split('/')[1];
+        runs(function () {
+            $('a[g-route="plugins/autojoin/config"]:visible').click();
         });
 
-        it('go to auto join plugin settings', function () {
-            waitsFor(function () {
-                return $('a[g-target="admin"]:visible').length > 0;
-            }, 'admin console link to display');
+        waitsFor(function () {
+            return $('#g-autojoin-group>option').length === 4;
+        }, 'group dropdown to appear');
+    });
 
-            runs(function () {
-                $('a[g-target="admin"]:visible').click();
-            });
+    it('create auto join rules', function () {
+        runs(function () {
+            $('#g-autojoin-pattern').val('@test.com');
+            $('#g-autojoin-group').val(group1);
+            $('#g-autojoin-level').val(2);
+            $('#g-autojoin-add').click();
 
-            waitsFor(function () {
-                return $('.g-plugins-config:visible').length > 0;
-            }, 'admin console to display');
+            $('#g-autojoin-pattern').val('@example.com');
+            $('#g-autojoin-group').val(group2);
+            $('#g-autojoin-level').val(1);
+            $('#g-autojoin-add').click();
 
-            runs(function () {
-                $('.g-plugins-config:visible').click();
-            });
+            $('#g-autojoin-pattern').val('@example.com');
+            $('#g-autojoin-group').val(group3);
+            $('#g-autojoin-level').val(0);
+            $('#g-autojoin-add').click();
 
-            waitsFor(function () {
-                return $('a[g-route="plugins/autojoin/config"]:visible').length > 0;
-            }, 'plugins page to display');
-
-            runs(function () {
-                $('a[g-route="plugins/autojoin/config"]:visible').click();
-            });
-
-            waitsFor(function () {
-                return $('#g-autojoin-group>option').length === 4;
-            }, 'group dropdown to appear');
+            $('#g-autojoin-save').click();
         });
+        waitsFor(function () {
+            return $('#g-alerts-container').text().indexOf('Settings saved') !== -1;
+        }, 'settings to be saved');
+    });
 
-        it('create auto join rules', function () {
-            runs(function () {
-                $('#g-autojoin-pattern').val('@test.com');
-                $('#g-autojoin-group').val(group1);
-                $('#g-autojoin-level').val(2);
-                $('#g-autojoin-add').click();
+    it('logout', girderTest.logout());
+    it('register a user', girderTest.createUser(
+        'user1', 'user1@example.com', 'Joe', 'User', 'password'
+    ));
+    it('go to groups page', girderTest.goToGroupsPage());
+    it('verify correct groups', function () {
+        expect($('.g-group-title:contains("group1")').length).toBe(0);
+        expect($('.g-group-title:contains("group2")').length).toBe(1);
+        expect($('.g-group-title:contains("group3")').length).toBe(1);
+    });
 
-                $('#g-autojoin-pattern').val('@example.com');
-                $('#g-autojoin-group').val(group2);
-                $('#g-autojoin-level').val(1);
-                $('#g-autojoin-add').click();
-
-                $('#g-autojoin-pattern').val('@example.com');
-                $('#g-autojoin-group').val(group3);
-                $('#g-autojoin-level').val(0);
-                $('#g-autojoin-add').click();
-
-                $('#g-autojoin-save').click();
-            });
-            waitsFor(function () {
-                return $('#g-alerts-container').text().indexOf('Settings saved') !== -1;
-            }, 'settings to be saved');
-        });
-
-        it('logout', girderTest.logout());
-        it('register a user', girderTest.createUser(
-            'user1', 'user1@example.com', 'Joe', 'User', 'password'
-        ));
-        it('go to groups page', girderTest.goToGroupsPage());
-        it('verify correct groups', function () {
-            expect($('.g-group-title:contains("group1")').length).toBe(0);
-            expect($('.g-group-title:contains("group2")').length).toBe(1);
-            expect($('.g-group-title:contains("group3")').length).toBe(1);
-        });
-
-        it('logout', girderTest.logout());
-        it('register a user', girderTest.createUser(
-            'user2', 'user2@test.com', 'Joe', 'User', 'password'
-        ));
-        it('go to groups page', girderTest.goToGroupsPage());
-        it('verify correct groups', function () {
-            expect($('.g-group-title:contains("group1")').length).toBe(1);
-            expect($('.g-group-title:contains("group2")').length).toBe(0);
-            expect($('.g-group-title:contains("group3")').length).toBe(0);
-        });
+    it('logout', girderTest.logout());
+    it('register a user', girderTest.createUser(
+        'user2', 'user2@test.com', 'Joe', 'User', 'password'
+    ));
+    it('go to groups page', girderTest.goToGroupsPage());
+    it('verify correct groups', function () {
+        expect($('.g-group-title:contains("group1")').length).toBe(1);
+        expect($('.g-group-title:contains("group2")').length).toBe(0);
+        expect($('.g-group-title:contains("group3")').length).toBe(0);
     });
 });

--- a/plugins/autojoin/plugin_tests/autojoinSpec.js
+++ b/plugins/autojoin/plugin_tests/autojoinSpec.js
@@ -1,5 +1,4 @@
 girderTest.importPlugin('autojoin');
-
 girderTest.startApp();
 
 $(function () {

--- a/plugins/candela/plugin_tests/candelaSpec.js
+++ b/plugins/candela/plugin_tests/candelaSpec.js
@@ -1,5 +1,4 @@
 girderTest.importPlugin('candela');
-
 girderTest.startApp();
 
 $(function () {

--- a/plugins/candela/plugin_tests/candelaSpec.js
+++ b/plugins/candela/plugin_tests/candelaSpec.js
@@ -1,182 +1,180 @@
 girderTest.importPlugin('candela');
 girderTest.startApp();
 
-$(function () {
-    describe('Test the candela UI.', function () {
-        it('register a user', girderTest.createUser(
-            'johndoe', 'john.doe@email.com', 'John', 'Doe', 'password!'
-        ));
+describe('Test the candela UI.', function () {
+    it('register a user', girderTest.createUser(
+        'johndoe', 'john.doe@email.com', 'John', 'Doe', 'password!'
+    ));
 
-        it('visits the configuration page', function () {
-            girderTest.waitForLoad();
+    it('visits the configuration page', function () {
+        girderTest.waitForLoad();
 
-            waitsFor(function () {
-                return $('a.g-nav-link[g-target="admin"]:visible').length > 0;
-            }, 'admin nav link to appear');
+        waitsFor(function () {
+            return $('a.g-nav-link[g-target="admin"]:visible').length > 0;
+        }, 'admin nav link to appear');
 
-            runs(function () {
-                $('a.g-nav-link[g-target="admin"]').click();
-            });
-
-            waitsFor(function () {
-                return $('.g-plugins-config').length > 0;
-            }, 'navigate to admin page');
-
-            runs(function () {
-                $('.g-plugins-config').click();
-            });
-
-            waitsFor(function () {
-                return $('.g-plugin-config-link[g-route="plugins/candela/config"]').length > 0;
-            }, 'navigate to plugins page');
-
-            runs(function () {
-                $('.g-plugin-config-link[g-route="plugins/candela/config"]').click();
-            });
-
-            waitsFor(function () {
-                return $('.g-config-breadcrumb-container').length > 0;
-            }, 'navigate to candela plugin config page');
-
-            runs(function () {
-                expect($('.g-default-layout').children().eq(1).find('a').attr('href')).toBe('http://candela.readthedocs.io/');
-            });
+        runs(function () {
+            $('a.g-nav-link[g-target="admin"]').click();
         });
 
-        it('uploads the data file', function () {
-            runs(function () {
-                expect($('#g-user-action-menu.open').length).toBe(0);
-                $('.g-user-text>a:first').click();
-            });
-            girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('.g-plugins-config').length > 0;
+        }, 'navigate to admin page');
 
-            runs(function () {
-                expect($('#g-user-action-menu.open').length).toBe(1);
-                $('a.g-my-folders').click();
-            });
-            girderTest.waitForLoad();
-
-            runs(function () {
-                $('a.g-folder-list-link:last').click();
-            });
-            girderTest.waitForLoad();
-
-            waitsFor(function () {
-                return $('ol.breadcrumb>li.active').text() === 'Public' &&
-                       $('.g-empty-parent-message:visible').length === 1;
-            }, 'descending into Public folder');
-
-            girderTest.binaryUpload('clients/web/test/testFile.csv');
-
-            runs(function () {
-                $('.g-item-list-link:first').click();
-            });
+        runs(function () {
+            $('.g-plugins-config').click();
         });
 
-        it('sets up candela inputs and renders the visualization', function () {
-            waitsFor(function () {
-                return $('.g-item-candela-component').length === 1;
-            }, 'the candela component selector to appear');
+        waitsFor(function () {
+            return $('.g-plugin-config-link[g-route="plugins/candela/config"]').length > 0;
+        }, 'navigate to plugins page');
 
-            runs(function () {
-                expect($('.g-item-candela-component option').length).toBeGreaterThan(18);
-                $('.g-item-candela-component').val('BarChart').change();
-            });
-
-            waitsFor(function () {
-                var inputs = $('.g-candela-inputs-container').children().eq(1).children().children();
-                return inputs.length === 6;
-            }, 'the bar chart options to be available');
-
-            runs(function () {
-                var inputs = $('.g-candela-inputs-container').children().eq(1).children().children();
-                expect(inputs.eq(0).find('label').text()).toBe('Width');
-                expect(inputs.eq(1).find('label').text()).toBe('Height');
-                expect(inputs.eq(2).find('label').text()).toBe('x');
-                var values = [];
-                for (var i = 0; i < 4; i += 1) {
-                    values.push(inputs.eq(2).find('option').eq(i).text());
-                }
-                values.sort();
-                expect(values).toEqual(['(none)', 'a_b', 'c', 'id']);
-                expect(inputs.eq(3).find('label').text()).toBe('y');
-                expect(inputs.eq(4).find('label').text()).toBe('color');
-                expect(inputs.eq(5).find('label').text()).toBe('hover');
-                $('.g-candela-update-vis').click();
-            });
-
-            waitsFor(function () {
-                return $('.g-candela-vis').find('canvas').length === 1;
-            }, 'the vis canvas to be drawn');
-
-            runs(function () {
-                $('.g-item-candela-component').val('TreeHeatmap').change();
-            });
-
-            waitsFor(function () {
-                var inputs = $('.g-candela-inputs-container').children().eq(1).children().children();
-                return inputs.length === 9;
-            }, 'the visualization type to change to TreeHeatmap');
-
-            runs(function () {
-                var inputs = $('.g-candela-inputs-container').children().eq(1).children().children();
-                expect(inputs.eq(2).find('label').text()).toBe('Identifier column');
-                expect(inputs.eq(3).find('label').text()).toBe('Color scale');
-                expect(inputs.eq(3).find('option').eq(1).text()).toBe('row');
-            });
-
-            runs(function () {
-                $('.g-item-candela-component').val('BulletChart').change();
-            });
-
-            waitsFor(function () {
-                var inputs = $('.g-candela-inputs-container').children().eq(1).children().children();
-                return inputs.length === 5;
-            }, 'the visualization type to change to BulletChart');
-
-            runs(function () {
-                var inputs = $('.g-candela-inputs-container').children().eq(1).children().children();
-                expect(inputs.eq(3).find('label').text()).toBe('title');
-                expect(inputs.eq(4).find('label').text()).toBe('subtitle');
-            });
+        runs(function () {
+            $('.g-plugin-config-link[g-route="plugins/candela/config"]').click();
         });
 
-        it('uploads a bad data file', function () {
-            runs(function () {
-                expect($('#g-user-action-menu.open').length).toBe(0);
-                $('.g-user-text>a:first').click();
-            });
-            girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('.g-config-breadcrumb-container').length > 0;
+        }, 'navigate to candela plugin config page');
 
-            runs(function () {
-                expect($('#g-user-action-menu.open').length).toBe(1);
-                $('a.g-my-folders').click();
-            });
-            girderTest.waitForLoad();
+        runs(function () {
+            expect($('.g-default-layout').children().eq(1).find('a').attr('href')).toBe('http://candela.readthedocs.io/');
+        });
+    });
 
-            runs(function () {
-                $('a.g-folder-list-link:last').click();
-            });
-            girderTest.waitForLoad();
+    it('uploads the data file', function () {
+        runs(function () {
+            expect($('#g-user-action-menu.open').length).toBe(0);
+            $('.g-user-text>a:first').click();
+        });
+        girderTest.waitForLoad();
 
-            waitsFor(function () {
-                return $('ol.breadcrumb>li.active').text() === 'Public' &&
-                       $('.g-item-list-link').length === 1;
-            }, 'descending into Public folder');
+        runs(function () {
+            expect($('#g-user-action-menu.open').length).toBe(1);
+            $('a.g-my-folders').click();
+        });
+        girderTest.waitForLoad();
 
-            girderTest.binaryUpload('clients/web/test/testFileBad.csv');
+        runs(function () {
+            $('a.g-folder-list-link:last').click();
+        });
+        girderTest.waitForLoad();
 
-            runs(function () {
-                $('.g-item-list-link').eq(1).click();
-            });
+        waitsFor(function () {
+            return $('ol.breadcrumb>li.active').text() === 'Public' &&
+                   $('.g-empty-parent-message:visible').length === 1;
+        }, 'descending into Public folder');
 
-            waitsFor(function () {
-                return $('.alert-danger').length === 1;
-            }, 'the error message to appear');
+        girderTest.binaryUpload('clients/web/test/testFile.csv');
 
-            runs(function () {
-                expect($('.alert-danger').text()).toContain('An error occurred while attempting to read and parse the data file.');
-            });
+        runs(function () {
+            $('.g-item-list-link:first').click();
+        });
+    });
+
+    it('sets up candela inputs and renders the visualization', function () {
+        waitsFor(function () {
+            return $('.g-item-candela-component').length === 1;
+        }, 'the candela component selector to appear');
+
+        runs(function () {
+            expect($('.g-item-candela-component option').length).toBeGreaterThan(18);
+            $('.g-item-candela-component').val('BarChart').change();
+        });
+
+        waitsFor(function () {
+            var inputs = $('.g-candela-inputs-container').children().eq(1).children().children();
+            return inputs.length === 6;
+        }, 'the bar chart options to be available');
+
+        runs(function () {
+            var inputs = $('.g-candela-inputs-container').children().eq(1).children().children();
+            expect(inputs.eq(0).find('label').text()).toBe('Width');
+            expect(inputs.eq(1).find('label').text()).toBe('Height');
+            expect(inputs.eq(2).find('label').text()).toBe('x');
+            var values = [];
+            for (var i = 0; i < 4; i += 1) {
+                values.push(inputs.eq(2).find('option').eq(i).text());
+            }
+            values.sort();
+            expect(values).toEqual(['(none)', 'a_b', 'c', 'id']);
+            expect(inputs.eq(3).find('label').text()).toBe('y');
+            expect(inputs.eq(4).find('label').text()).toBe('color');
+            expect(inputs.eq(5).find('label').text()).toBe('hover');
+            $('.g-candela-update-vis').click();
+        });
+
+        waitsFor(function () {
+            return $('.g-candela-vis').find('canvas').length === 1;
+        }, 'the vis canvas to be drawn');
+
+        runs(function () {
+            $('.g-item-candela-component').val('TreeHeatmap').change();
+        });
+
+        waitsFor(function () {
+            var inputs = $('.g-candela-inputs-container').children().eq(1).children().children();
+            return inputs.length === 9;
+        }, 'the visualization type to change to TreeHeatmap');
+
+        runs(function () {
+            var inputs = $('.g-candela-inputs-container').children().eq(1).children().children();
+            expect(inputs.eq(2).find('label').text()).toBe('Identifier column');
+            expect(inputs.eq(3).find('label').text()).toBe('Color scale');
+            expect(inputs.eq(3).find('option').eq(1).text()).toBe('row');
+        });
+
+        runs(function () {
+            $('.g-item-candela-component').val('BulletChart').change();
+        });
+
+        waitsFor(function () {
+            var inputs = $('.g-candela-inputs-container').children().eq(1).children().children();
+            return inputs.length === 5;
+        }, 'the visualization type to change to BulletChart');
+
+        runs(function () {
+            var inputs = $('.g-candela-inputs-container').children().eq(1).children().children();
+            expect(inputs.eq(3).find('label').text()).toBe('title');
+            expect(inputs.eq(4).find('label').text()).toBe('subtitle');
+        });
+    });
+
+    it('uploads a bad data file', function () {
+        runs(function () {
+            expect($('#g-user-action-menu.open').length).toBe(0);
+            $('.g-user-text>a:first').click();
+        });
+        girderTest.waitForLoad();
+
+        runs(function () {
+            expect($('#g-user-action-menu.open').length).toBe(1);
+            $('a.g-my-folders').click();
+        });
+        girderTest.waitForLoad();
+
+        runs(function () {
+            $('a.g-folder-list-link:last').click();
+        });
+        girderTest.waitForLoad();
+
+        waitsFor(function () {
+            return $('ol.breadcrumb>li.active').text() === 'Public' &&
+                   $('.g-item-list-link').length === 1;
+        }, 'descending into Public folder');
+
+        girderTest.binaryUpload('clients/web/test/testFileBad.csv');
+
+        runs(function () {
+            $('.g-item-list-link').eq(1).click();
+        });
+
+        waitsFor(function () {
+            return $('.alert-danger').length === 1;
+        }, 'the error message to appear');
+
+        runs(function () {
+            expect($('.alert-danger').text()).toContain('An error occurred while attempting to read and parse the data file.');
         });
     });
 });

--- a/plugins/curation/plugin_tests/curationSpec.js
+++ b/plugins/curation/plugin_tests/curationSpec.js
@@ -1,5 +1,4 @@
 girderTest.importPlugin('curation');
-
 girderTest.startApp();
 
 function _goToCurationDialog() {

--- a/plugins/geospatial/plugin_tests/geospatialSpec.js
+++ b/plugins/geospatial/plugin_tests/geospatialSpec.js
@@ -1,60 +1,58 @@
 girderTest.importPlugin('geospatial');
 girderTest.startApp();
 
-$(function () {
-    describe('a test for the geospatial plugin', function () {
-        it('creates the admin user', girderTest.createUser('geospatial',
-                                                           'geospatial@girder.org',
-                                                           'Geospatial', 'Plugin',
-                                                           'fuprEsuxAth2S7ac'));
+describe('a test for the geospatial plugin', function () {
+    it('creates the admin user', girderTest.createUser('geospatial',
+                                                       'geospatial@girder.org',
+                                                       'Geospatial', 'Plugin',
+                                                       'fuprEsuxAth2S7ac'));
 
-        it('creates an item and displays the geospatial info widget', function () {
-            waitsFor(function () {
-                return $('a.g-my-folders').length > 0;
-            }, 'my folders link to load');
-            runs(function () {
-                $('a.g-my-folders').click();
-            });
-            waitsFor(function () {
-                return $('a.g-folder-list-link:contains(Public)').length > 0;
-            }, 'the folders list to load');
-            runs(function () {
-                $('a.g-folder-list-link:contains(Public)').click();
-            });
-            waitsFor(function () {
-                return $('button.g-folder-actions-button:visible').length === 1;
-            }, 'folder actions button to be visible');
-            runs(function () {
-                $('button.g-folder-actions-button:visible').click();
-            });
-            waitsFor(function () {
-                return $('a.g-create-item:visible').length === 1;
-            }, 'create item here link to be visible');
-            runs(function () {
-                $('a.g-create-item:visible').click();
-            });
-            waitsFor(function () {
-                return Backbone.history.fragment.slice(-18) === '?dialog=itemcreate';
-            }, 'the URL state to change');
-            waitsFor(function () {
-                return $('button.g-save-item:visible').text() === 'Create';
-            }, 'the create item dialog to appear');
-            runs(function () {
-                $('input#g-name').val('Geospatial Item');
-                $('button.g-save-item').click();
-            });
-            waitsFor(function () {
-                return $('a.g-item-list-link:contains(Geospatial Item)').length === 1;
-            }, 'the created item to appear in the folders list');
-            runs(function () {
-                $('a.g-item-list-link:contains(Geospatial Item)').click();
-            });
-            waitsFor(function () {
-                return $('.g-item-name:contains(Geospatial Item)').length === 1;
-            }, 'the item page to load');
-            waitsFor(function () {
-                return $('.g-item-geospatial').length > 0;
-            }, 'the geospatial widget to appear in the item view');
+    it('creates an item and displays the geospatial info widget', function () {
+        waitsFor(function () {
+            return $('a.g-my-folders').length > 0;
+        }, 'my folders link to load');
+        runs(function () {
+            $('a.g-my-folders').click();
         });
+        waitsFor(function () {
+            return $('a.g-folder-list-link:contains(Public)').length > 0;
+        }, 'the folders list to load');
+        runs(function () {
+            $('a.g-folder-list-link:contains(Public)').click();
+        });
+        waitsFor(function () {
+            return $('button.g-folder-actions-button:visible').length === 1;
+        }, 'folder actions button to be visible');
+        runs(function () {
+            $('button.g-folder-actions-button:visible').click();
+        });
+        waitsFor(function () {
+            return $('a.g-create-item:visible').length === 1;
+        }, 'create item here link to be visible');
+        runs(function () {
+            $('a.g-create-item:visible').click();
+        });
+        waitsFor(function () {
+            return Backbone.history.fragment.slice(-18) === '?dialog=itemcreate';
+        }, 'the URL state to change');
+        waitsFor(function () {
+            return $('button.g-save-item:visible').text() === 'Create';
+        }, 'the create item dialog to appear');
+        runs(function () {
+            $('input#g-name').val('Geospatial Item');
+            $('button.g-save-item').click();
+        });
+        waitsFor(function () {
+            return $('a.g-item-list-link:contains(Geospatial Item)').length === 1;
+        }, 'the created item to appear in the folders list');
+        runs(function () {
+            $('a.g-item-list-link:contains(Geospatial Item)').click();
+        });
+        waitsFor(function () {
+            return $('.g-item-name:contains(Geospatial Item)').length === 1;
+        }, 'the item page to load');
+        waitsFor(function () {
+            return $('.g-item-geospatial').length > 0;
+        }, 'the geospatial widget to appear in the item view');
     });
 });

--- a/plugins/geospatial/plugin_tests/geospatialSpec.js
+++ b/plugins/geospatial/plugin_tests/geospatialSpec.js
@@ -1,5 +1,4 @@
 girderTest.importPlugin('geospatial');
-
 girderTest.startApp();
 
 $(function () {

--- a/plugins/hashsum_download/plugin_tests/hashsumSpec.js
+++ b/plugins/hashsum_download/plugin_tests/hashsumSpec.js
@@ -1,11 +1,9 @@
 girderTest.importPlugin('hashsum_download');
-
-girder.events.trigger('g:appload.before');
-var app = new girder.views.App({
-    el: 'body',
-    parentView: null
-});
-girder.events.trigger('g:appload.after');
+var app;
+girderTest.startApp()
+    .done(function (startedApp) {
+        app = startedApp;
+    });
 
 describe('Unit test the file view augmentation', function () {
     var file;

--- a/plugins/homepage/plugin_tests/homepageSpec.js
+++ b/plugins/homepage/plugin_tests/homepageSpec.js
@@ -42,64 +42,62 @@ function _verifyMarkdownContent(elem) {
     expect(elem.find('a[href="https://girder.readthedocs.io/"]:contains("link to Girder!")').length).toBe(1);
 }
 
-$(function () {
-    describe('homepage plugin test ', function () {
-        it('registers an admin user', girderTest.createUser(
-            'admin', 'admin@example.com', 'Mark', 'Down', 'password'
-        ));
+describe('homepage plugin test ', function () {
+    it('registers an admin user', girderTest.createUser(
+        'admin', 'admin@example.com', 'Mark', 'Down', 'password'
+    ));
 
-        it('goes to homepage plugin settings', _goToHomepagePluginSettings);
+    it('goes to homepage plugin settings', _goToHomepagePluginSettings);
 
-        it('sets, previews, and saves homepage markdown content', function () {
-            runs(function () {
-                $('textarea.g-markdown-text').val(
-                    'It\'s very easy to make some words **bold** and other words *italic* with ' +
-                        'Markdown. You can even [link to Girder!](https://girder.readthedocs.io/)'
-                );
-
-                $('a.g-preview-link').click();
-
-                _verifyMarkdownContent($('.g-markdown-preview'));
-
-                $('#g-homepage-form').submit();
-            });
-
-            waitsFor(function () {
-                return girder.rest.numberOutstandingRestRequests() === 0;
-            }, 'rest requests to finish');
-        });
-
-        it('verifies homepage content as admin user', function () {
-            runs(function () {
-                $('.g-app-title').click();
-            });
-
-            waitsFor(function () {
-                return girder.rest.numberOutstandingRestRequests() === 0;
-            }, 'rest requests to finish');
-
-            runs(function () {
-                _verifyMarkdownContent($('#g-app-body-container'));
-            });
-        });
-
-        it('goes back to homepage plugin settings', _goToHomepagePluginSettings);
-
-        it('verifies previously set homepage markdown content', function () {
-            runs(function () {
-                expect($('textarea.g-markdown-text').val()).toEqual(
-                    'It\'s very easy to make some words **bold** and other words *italic* with ' +
+    it('sets, previews, and saves homepage markdown content', function () {
+        runs(function () {
+            $('textarea.g-markdown-text').val(
+                'It\'s very easy to make some words **bold** and other words *italic* with ' +
                     'Markdown. You can even [link to Girder!](https://girder.readthedocs.io/)'
-                );
-            });
+            );
+
+            $('a.g-preview-link').click();
+
+            _verifyMarkdownContent($('.g-markdown-preview'));
+
+            $('#g-homepage-form').submit();
         });
 
-        it('logs out admin', girderTest.logout());
+        waitsFor(function () {
+            return girder.rest.numberOutstandingRestRequests() === 0;
+        }, 'rest requests to finish');
+    });
 
-        it('verifies homepage content as anonymous user', function () {
-            runs(function () {
-                _verifyMarkdownContent($('#g-app-body-container'));
-            });
+    it('verifies homepage content as admin user', function () {
+        runs(function () {
+            $('.g-app-title').click();
+        });
+
+        waitsFor(function () {
+            return girder.rest.numberOutstandingRestRequests() === 0;
+        }, 'rest requests to finish');
+
+        runs(function () {
+            _verifyMarkdownContent($('#g-app-body-container'));
+        });
+    });
+
+    it('goes back to homepage plugin settings', _goToHomepagePluginSettings);
+
+    it('verifies previously set homepage markdown content', function () {
+        runs(function () {
+            expect($('textarea.g-markdown-text').val()).toEqual(
+                'It\'s very easy to make some words **bold** and other words *italic* with ' +
+                'Markdown. You can even [link to Girder!](https://girder.readthedocs.io/)'
+            );
+        });
+    });
+
+    it('logs out admin', girderTest.logout());
+
+    it('verifies homepage content as anonymous user', function () {
+        runs(function () {
+            _verifyMarkdownContent($('#g-app-body-container'));
         });
     });
 });

--- a/plugins/homepage/plugin_tests/homepageSpec.js
+++ b/plugins/homepage/plugin_tests/homepageSpec.js
@@ -1,5 +1,4 @@
 girderTest.importPlugin('homepage');
-
 girderTest.startApp();
 
 function _goToHomepagePluginSettings() {

--- a/plugins/item_licenses/plugin_tests/itemLicensesSpec.js
+++ b/plugins/item_licenses/plugin_tests/itemLicensesSpec.js
@@ -1,411 +1,409 @@
 girderTest.importPlugin('item_licenses');
 girderTest.startApp();
 
-$(function () {
-    describe('item_licenses plugin test', function () {
-        it('registers admin user',
-            girderTest.createUser('admin',
-                                  'admin@email.com',
-                                  'Admin',
-                                  'User',
-                                  'CxV`%EOsq9'));
+describe('item_licenses plugin test', function () {
+    it('registers admin user',
+        girderTest.createUser('admin',
+                              'admin@email.com',
+                              'Admin',
+                              'User',
+                              'CxV`%EOsq9'));
 
-        it('logs out', girderTest.logout());
+    it('logs out', girderTest.logout());
 
-        it('registers normal user',
-            girderTest.createUser('user',
-                                  'user@email.com',
-                                  'Normal',
-                                  'User',
-                                  'a*z/Swb?td'));
+    it('registers normal user',
+        girderTest.createUser('user',
+                              'user@email.com',
+                              'Normal',
+                              'User',
+                              'a*z/Swb?td'));
 
-        it('creates an item with a license', function () {
-            waitsFor(function () {
-                return $('a.g-my-folders').length > 0;
-            }, 'my folders link to load');
-            runs(function () {
-                $('a.g-my-folders').click();
-            });
-            girderTest.waitForLoad();
+    it('creates an item with a license', function () {
+        waitsFor(function () {
+            return $('a.g-my-folders').length > 0;
+        }, 'my folders link to load');
+        runs(function () {
+            $('a.g-my-folders').click();
+        });
+        girderTest.waitForLoad();
 
-            waitsFor(function () {
-                return $('a.g-folder-list-link:contains(Public)').length > 0;
-            }, 'the folders list to load');
-            runs(function () {
-                $('a.g-folder-list-link:contains(Public)').click();
-            });
-            girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('a.g-folder-list-link:contains(Public)').length > 0;
+        }, 'the folders list to load');
+        runs(function () {
+            $('a.g-folder-list-link:contains(Public)').click();
+        });
+        girderTest.waitForLoad();
 
-            waitsFor(function () {
-                return $('button.g-folder-actions-button:visible').length === 1;
-            }, 'folder actions button to be visible');
-            runs(function () {
-                $('button.g-folder-actions-button:visible').click();
-            });
-            girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('button.g-folder-actions-button:visible').length === 1;
+        }, 'folder actions button to be visible');
+        runs(function () {
+            $('button.g-folder-actions-button:visible').click();
+        });
+        girderTest.waitForLoad();
 
-            waitsFor(function () {
-                return $('a.g-create-item:visible').length === 1;
-            }, 'create item here link to be visible');
-            runs(function () {
-                $('a.g-create-item:visible').click();
-            });
-
-            waitsFor(function () {
-                return Backbone.history.fragment.slice(-18) === '?dialog=itemcreate';
-            }, 'the URL state to change');
-            girderTest.waitForDialog();
-            waitsFor(function () {
-                return $('button.g-save-item:visible').text() === 'Create';
-            }, 'the create item dialog to appear');
-            runs(function () {
-                // Should list groups of licenses, plus "Unspecified" in dropdown
-                expect($('#g-license optgroup').length).toBe(2);
-                expect($('#g-license option').length).toBe(22);
-
-                // "Unspecified" license should be selected by default (value is
-                // empty string)
-                expect($('#g-license').val()).toBe('');
-
-                // Set item info and save
-                $('input#g-name').val('Test Item');
-                $('#g-license').val('The MIT License (MIT)');
-                $('button.g-save-item').click();
-            });
-            girderTest.waitForLoad();
-
-            waitsFor(function () {
-                return $('a.g-item-list-link:contains(Test Item)').length === 1;
-            }, 'the created item to appear in the items list');
-            runs(function () {
-                $('a.g-item-list-link:contains(Test Item)').click();
-            });
-            girderTest.waitForLoad();
-
-            waitsFor(function () {
-                return $('.g-item-name').length === 1 && $('.g-item-license').length === 1;
-            }, 'the item page and license field to load');
-            girderTest.waitForLoad();
-
-            runs(function () {
-                // Item info should show license
-                expect($('.g-item-license').length).toBe(1);
-                expect($('.g-item-license').text()).toContain('The MIT License (MIT)');
-            });
+        waitsFor(function () {
+            return $('a.g-create-item:visible').length === 1;
+        }, 'create item here link to be visible');
+        runs(function () {
+            $('a.g-create-item:visible').click();
         });
 
-        it('edits an item\'s license', function () {
-            waitsFor(function () {
-                return $('.g-item-actions-button:visible').length === 1;
-            }, 'the item actions button to appear');
-            runs(function () {
-                $('.g-item-actions-button').click();
-            });
-            girderTest.waitForLoad();
+        waitsFor(function () {
+            return Backbone.history.fragment.slice(-18) === '?dialog=itemcreate';
+        }, 'the URL state to change');
+        girderTest.waitForDialog();
+        waitsFor(function () {
+            return $('button.g-save-item:visible').text() === 'Create';
+        }, 'the create item dialog to appear');
+        runs(function () {
+            // Should list groups of licenses, plus "Unspecified" in dropdown
+            expect($('#g-license optgroup').length).toBe(2);
+            expect($('#g-license option').length).toBe(22);
 
-            waitsFor(function () {
-                return $('.g-edit-item:visible').length === 1;
-            }, 'the item edit action to appear');
-            runs(function () {
-                $('.g-edit-item').click();
-            });
+            // "Unspecified" license should be selected by default (value is
+            // empty string)
+            expect($('#g-license').val()).toBe('');
 
-            waitsFor(function () {
-                return Backbone.history.fragment.slice(-16) === '?dialog=itemedit';
-            }, 'the url state to change');
-            girderTest.waitForDialog();
-            waitsFor(function () {
-                return $('#g-name').val() !== '' && $('button.g-save-item:visible').text() === 'Save';
-            }, 'the dialog to be populated');
+            // Set item info and save
+            $('input#g-name').val('Test Item');
+            $('#g-license').val('The MIT License (MIT)');
+            $('button.g-save-item').click();
+        });
+        girderTest.waitForLoad();
 
-            runs(function () {
-                // Should list groups of licenses, plus "Unspecified" in dropdown
-                expect($('#g-license optgroup').length).toBe(2);
-                expect($('#g-license option').length).toBe(22);
+        waitsFor(function () {
+            return $('a.g-item-list-link:contains(Test Item)').length === 1;
+        }, 'the created item to appear in the items list');
+        runs(function () {
+            $('a.g-item-list-link:contains(Test Item)').click();
+        });
+        girderTest.waitForLoad();
 
-                // The item's license should be selected by default
-                expect($('#g-license').val()).toBe('The MIT License (MIT)');
+        waitsFor(function () {
+            return $('.g-item-name').length === 1 && $('.g-item-license').length === 1;
+        }, 'the item page and license field to load');
+        girderTest.waitForLoad();
 
-                // Change the item's license
-                $('#g-license').val('Apache License 2');
-                $('button.g-save-item').click();
-            });
-            girderTest.waitForLoad();
+        runs(function () {
+            // Item info should show license
+            expect($('.g-item-license').length).toBe(1);
+            expect($('.g-item-license').text()).toContain('The MIT License (MIT)');
+        });
+    });
 
-            waitsFor(function () {
-                return $('.g-item-name').length === 1 && $('.g-item-license').length === 1;
-            }, 'the item page and license field to load');
-            girderTest.waitForLoad();
-            runs(function () {
-                // Item info should show license
-                expect($('.g-item-license').length).toBe(1);
-                expect($('.g-item-license').text()).toContain('Apache License 2');
-            });
+    it('edits an item\'s license', function () {
+        waitsFor(function () {
+            return $('.g-item-actions-button:visible').length === 1;
+        }, 'the item actions button to appear');
+        runs(function () {
+            $('.g-item-actions-button').click();
+        });
+        girderTest.waitForLoad();
+
+        waitsFor(function () {
+            return $('.g-edit-item:visible').length === 1;
+        }, 'the item edit action to appear');
+        runs(function () {
+            $('.g-edit-item').click();
         });
 
-        it('verifies upload into an item dialog doesn\'t show license selection widget', function () {
-            waitsFor(function () {
-                return $('.g-upload-into-item:visible').length === 1;
-            }, 'the upload into item action to appear');
-            runs(function () {
-                $('.g-upload-into-item').click();
-            });
+        waitsFor(function () {
+            return Backbone.history.fragment.slice(-16) === '?dialog=itemedit';
+        }, 'the url state to change');
+        girderTest.waitForDialog();
+        waitsFor(function () {
+            return $('#g-name').val() !== '' && $('button.g-save-item:visible').text() === 'Save';
+        }, 'the dialog to be populated');
 
-            waitsFor(function () {
-                return Backbone.history.fragment.slice(-14) === '?dialog=upload';
-            }, 'the url state to change');
-            girderTest.waitForDialog();
-            waitsFor(function () {
-                return $('.g-start-upload:visible').text().indexOf('Start Upload') !== -1;
-            }, 'the start upload button to appear');
-            runs(function () {
-                // Should not show license selection widget
-                expect($('#g-license').length).toBe(0);
-            });
+        runs(function () {
+            // Should list groups of licenses, plus "Unspecified" in dropdown
+            expect($('#g-license optgroup').length).toBe(2);
+            expect($('#g-license option').length).toBe(22);
 
-            // Close dialog and return to Public folder listing
-            waitsFor(function () {
-                return $('button.close:visible').length === 1;
-            }, 'the dialog close button to appear');
-            runs(function () {
-                $('button.close').click();
-            });
-            girderTest.waitForLoad();
-            waitsFor(function () {
-                return $('a.g-item-breadcrumb-link:contains(Public):visible').length === 1;
-            }, 'the breadcrumb link to the public folder to appear');
-            runs(function () {
-                $('a.g-item-breadcrumb-link:contains(Public)').click();
-            });
-            girderTest.waitForLoad();
+            // The item's license should be selected by default
+            expect($('#g-license').val()).toBe('The MIT License (MIT)');
+
+            // Change the item's license
+            $('#g-license').val('Apache License 2');
+            $('button.g-save-item').click();
+        });
+        girderTest.waitForLoad();
+
+        waitsFor(function () {
+            return $('.g-item-name').length === 1 && $('.g-item-license').length === 1;
+        }, 'the item page and license field to load');
+        girderTest.waitForLoad();
+        runs(function () {
+            // Item info should show license
+            expect($('.g-item-license').length).toBe(1);
+            expect($('.g-item-license').text()).toContain('Apache License 2');
+        });
+    });
+
+    it('verifies upload into an item dialog doesn\'t show license selection widget', function () {
+        waitsFor(function () {
+            return $('.g-upload-into-item:visible').length === 1;
+        }, 'the upload into item action to appear');
+        runs(function () {
+            $('.g-upload-into-item').click();
         });
 
-        it('uploads an item, specifying a license', function () {
-            waitsFor(function () {
-                return $('.g-upload-here-button:visible').length === 1;
-            }, 'the upload here button to appear');
-            runs(function () {
-                $('.g-upload-here-button').click();
-            });
-
-            waitsFor(function () {
-                return Backbone.history.fragment.slice(-14) === '?dialog=upload';
-            }, 'the url state to change');
-            girderTest.waitForDialog();
-            waitsFor(function () {
-                return $('.g-start-upload:visible').text().indexOf('Start Upload') !== -1;
-            }, 'the start upload button to appear');
-            runs(function () {
-                // Should show license selection widget
-                expect($('#g-license').length).toBe(1);
-
-                // Select a license
-                $('#g-license').val('Apache License 2');
-            });
-
-            // Upload file
-            // XXX: add support to test uploading multiple files
-            runs(function () {
-                girderTest._prepareTestUpload();
-                girderTest._uploadDataExtra = 0;
-                girderTest.sendFile('clients/web/test/testFile.txt');
-            });
-            waitsFor(function () {
-                return $('.g-overall-progress-message i.icon-ok').length > 0;
-            }, 'the filesChanged event to happen');
-            runs(function () {
-                $('#g-files').parent().addClass('hide');
-                $('.g-start-upload').click();
-            });
-            waitsFor(function () {
-                return $('.modal-content:visible').length === 0 &&
-                       $('.g-item-list-entry').length === 2;
-            }, 'the upload to finish');
-            girderTest.waitForLoad();
-
-            // Verify license of uploaded file
-            waitsFor(function () {
-                return $('a.g-item-list-link:contains(testFile.txt)').length === 1;
-            }, 'the uploaded file to appear in the items list');
-            runs(function () {
-                $('a.g-item-list-link:contains(testFile.txt)').click();
-            });
-            girderTest.waitForLoad();
-            waitsFor(function () {
-                return $('.g-item-name').length === 1 && $('.g-item-license').length === 1;
-            }, 'the item page and license field to load');
-            girderTest.waitForLoad();
-            runs(function () {
-                expect($('.g-item-name').text()).toBe('testFile.txt');
-                expect($('.g-item-license').length).toBe(1);
-                expect($('.g-item-license').text()).toContain('Apache License 2');
-            });
-
-            // Return to Public folder listing
-            waitsFor(function () {
-                return $('a.g-item-breadcrumb-link:contains(Public):visible').length === 1;
-            }, 'the breadcrumb link to the public folder to appear');
-            runs(function () {
-                $('a.g-item-breadcrumb-link:contains(Public)').click();
-            });
-            girderTest.waitForLoad();
+        waitsFor(function () {
+            return Backbone.history.fragment.slice(-14) === '?dialog=upload';
+        }, 'the url state to change');
+        girderTest.waitForDialog();
+        waitsFor(function () {
+            return $('.g-start-upload:visible').text().indexOf('Start Upload') !== -1;
+        }, 'the start upload button to appear');
+        runs(function () {
+            // Should not show license selection widget
+            expect($('#g-license').length).toBe(0);
         });
 
-        it('creates an item with an unspecified license', function () {
-            waitsFor(function () {
-                return $('button.g-folder-actions-button:visible').length === 1;
-            }, 'folder actions button to be visible');
-            runs(function () {
-                $('button.g-folder-actions-button:visible').click();
-            });
-            girderTest.waitForLoad();
+        // Close dialog and return to Public folder listing
+        waitsFor(function () {
+            return $('button.close:visible').length === 1;
+        }, 'the dialog close button to appear');
+        runs(function () {
+            $('button.close').click();
+        });
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('a.g-item-breadcrumb-link:contains(Public):visible').length === 1;
+        }, 'the breadcrumb link to the public folder to appear');
+        runs(function () {
+            $('a.g-item-breadcrumb-link:contains(Public)').click();
+        });
+        girderTest.waitForLoad();
+    });
 
-            waitsFor(function () {
-                return $('a.g-create-item:visible').length === 1;
-            }, 'create item here link to be visible');
-            runs(function () {
-                $('a.g-create-item:visible').click();
-            });
-
-            waitsFor(function () {
-                return Backbone.history.fragment.slice(-18) === '?dialog=itemcreate';
-            }, 'the URL state to change');
-            waitsFor(function () {
-                return $('button.g-save-item:visible').text() === 'Create';
-            }, 'the create item dialog to appear');
-            girderTest.waitForDialog();
-            runs(function () {
-                // Should list groups of licenses, plus "Unspecified" in dropdown
-                expect($('#g-license optgroup').length).toBe(2);
-                expect($('#g-license option').length).toBe(22);
-
-                // Set item info and save
-                $('input#g-name').val('Test Item 2');
-                $('#g-license').val('');
-                $('button.g-save-item').click();
-            });
-            girderTest.waitForLoad();
-
-            waitsFor(function () {
-                return $('a.g-item-list-link:contains(Test Item 2)').length === 1;
-            }, 'the created item to appear in the items list');
-            runs(function () {
-                $('a.g-item-list-link:contains(Test Item 2)').click();
-            });
-            girderTest.waitForLoad();
-
-            waitsFor(function () {
-                return $('.g-item-name').length === 1 && $('.g-item-license').length === 1;
-            }, 'the item page and license field to load');
-            girderTest.waitForLoad();
-
-            runs(function () {
-                // Item info should show that license is unspecified
-                expect($('.g-item-license').length).toBe(1);
-                expect($('.g-item-license').text()).toContain('Unspecified');
-            });
+    it('uploads an item, specifying a license', function () {
+        waitsFor(function () {
+            return $('.g-upload-here-button:visible').length === 1;
+        }, 'the upload here button to appear');
+        runs(function () {
+            $('.g-upload-here-button').click();
         });
 
-        it('edits an item that has an unspecified license', function () {
-            waitsFor(function () {
-                return $('.g-item-actions-button:visible').length === 1;
-            }, 'the item actions button to appear');
-            runs(function () {
-                $('.g-item-actions-button').click();
-            });
-            girderTest.waitForLoad();
+        waitsFor(function () {
+            return Backbone.history.fragment.slice(-14) === '?dialog=upload';
+        }, 'the url state to change');
+        girderTest.waitForDialog();
+        waitsFor(function () {
+            return $('.g-start-upload:visible').text().indexOf('Start Upload') !== -1;
+        }, 'the start upload button to appear');
+        runs(function () {
+            // Should show license selection widget
+            expect($('#g-license').length).toBe(1);
 
-            waitsFor(function () {
-                return $('.g-edit-item:visible').length === 1;
-            }, 'the item edit action to appear');
-            runs(function () {
-                $('.g-edit-item').click();
-            });
-
-            waitsFor(function () {
-                return Backbone.history.fragment.slice(-16) === '?dialog=itemedit';
-            }, 'the url state to change');
-            girderTest.waitForDialog();
-            waitsFor(function () {
-                return $('#g-name').val() !== '';
-            }, 'the dialog to be populated');
-            waitsFor(function () {
-                return $('button.g-save-item:visible').text() === 'Save';
-            }, 'the edit item dialog to appear');
-            runs(function () {
-                // Should list groups of licenses, plus "Unspecified" in dropdown
-                expect($('#g-license optgroup').length).toBe(2);
-                expect($('#g-license option').length).toBe(22);
-
-                // The unspecified license should be selected by default
-                expect($('#g-license').val()).toBe('');
-
-                // Change the item's license
-                $('#g-license').val('The MIT License (MIT)');
-                $('button.g-save-item').click();
-            });
-            girderTest.waitForLoad();
-
-            waitsFor(function () {
-                return $('.g-item-name').length === 1 && $('.g-item-license').length === 1;
-            }, 'the item page and license field to load');
-            girderTest.waitForLoad();
-            runs(function () {
-                // Item info should show license
-                expect($('.g-item-license').length).toBe(1);
-                expect($('.g-item-license').text()).toContain('The MIT License (MIT)');
-            });
+            // Select a license
+            $('#g-license').val('Apache License 2');
         });
 
-        it('edits an item to have an unspecified license', function () {
-            waitsFor(function () {
-                return $('.g-item-actions-button:visible').length === 1;
-            }, 'the item actions button to appear');
-            runs(function () {
-                $('.g-item-actions-button').click();
-            });
-            girderTest.waitForLoad();
+        // Upload file
+        // XXX: add support to test uploading multiple files
+        runs(function () {
+            girderTest._prepareTestUpload();
+            girderTest._uploadDataExtra = 0;
+            girderTest.sendFile('clients/web/test/testFile.txt');
+        });
+        waitsFor(function () {
+            return $('.g-overall-progress-message i.icon-ok').length > 0;
+        }, 'the filesChanged event to happen');
+        runs(function () {
+            $('#g-files').parent().addClass('hide');
+            $('.g-start-upload').click();
+        });
+        waitsFor(function () {
+            return $('.modal-content:visible').length === 0 &&
+                   $('.g-item-list-entry').length === 2;
+        }, 'the upload to finish');
+        girderTest.waitForLoad();
 
-            waitsFor(function () {
-                return $('.g-edit-item:visible').length === 1;
-            }, 'the item edit action to appear');
-            runs(function () {
-                $('.g-edit-item').click();
-            });
+        // Verify license of uploaded file
+        waitsFor(function () {
+            return $('a.g-item-list-link:contains(testFile.txt)').length === 1;
+        }, 'the uploaded file to appear in the items list');
+        runs(function () {
+            $('a.g-item-list-link:contains(testFile.txt)').click();
+        });
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('.g-item-name').length === 1 && $('.g-item-license').length === 1;
+        }, 'the item page and license field to load');
+        girderTest.waitForLoad();
+        runs(function () {
+            expect($('.g-item-name').text()).toBe('testFile.txt');
+            expect($('.g-item-license').length).toBe(1);
+            expect($('.g-item-license').text()).toContain('Apache License 2');
+        });
 
-            waitsFor(function () {
-                return Backbone.history.fragment.slice(-16) === '?dialog=itemedit';
-            }, 'the url state to change');
-            girderTest.waitForDialog();
-            waitsFor(function () {
-                return $('#g-name').val() !== '';
-            }, 'the dialog to be populated');
-            waitsFor(function () {
-                return $('button.g-save-item:visible').text() === 'Save';
-            }, 'the edit item dialog to appear');
-            runs(function () {
-                // Should list groups of licenses, plus "Unspecified" in dropdown
-                expect($('#g-license optgroup').length).toBe(2);
-                expect($('#g-license option').length).toBe(22);
+        // Return to Public folder listing
+        waitsFor(function () {
+            return $('a.g-item-breadcrumb-link:contains(Public):visible').length === 1;
+        }, 'the breadcrumb link to the public folder to appear');
+        runs(function () {
+            $('a.g-item-breadcrumb-link:contains(Public)').click();
+        });
+        girderTest.waitForLoad();
+    });
 
-                // The item's license should be selected by default
-                expect($('#g-license').val()).toBe('The MIT License (MIT)');
+    it('creates an item with an unspecified license', function () {
+        waitsFor(function () {
+            return $('button.g-folder-actions-button:visible').length === 1;
+        }, 'folder actions button to be visible');
+        runs(function () {
+            $('button.g-folder-actions-button:visible').click();
+        });
+        girderTest.waitForLoad();
 
-                // Change the item's license
-                $('#g-license').val('');
-                $('button.g-save-item').click();
-            });
-            girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('a.g-create-item:visible').length === 1;
+        }, 'create item here link to be visible');
+        runs(function () {
+            $('a.g-create-item:visible').click();
+        });
 
-            waitsFor(function () {
-                return $('.g-item-name').length === 1 && $('.g-item-license').length === 1;
-            }, 'the item page and license field to load');
-            girderTest.waitForLoad();
-            runs(function () {
-                // Item info should show that license is unspecified
-                expect($('.g-item-license').length).toBe(1);
-                expect($('.g-item-license').text()).toContain('Unspecified');
-            });
+        waitsFor(function () {
+            return Backbone.history.fragment.slice(-18) === '?dialog=itemcreate';
+        }, 'the URL state to change');
+        waitsFor(function () {
+            return $('button.g-save-item:visible').text() === 'Create';
+        }, 'the create item dialog to appear');
+        girderTest.waitForDialog();
+        runs(function () {
+            // Should list groups of licenses, plus "Unspecified" in dropdown
+            expect($('#g-license optgroup').length).toBe(2);
+            expect($('#g-license option').length).toBe(22);
+
+            // Set item info and save
+            $('input#g-name').val('Test Item 2');
+            $('#g-license').val('');
+            $('button.g-save-item').click();
+        });
+        girderTest.waitForLoad();
+
+        waitsFor(function () {
+            return $('a.g-item-list-link:contains(Test Item 2)').length === 1;
+        }, 'the created item to appear in the items list');
+        runs(function () {
+            $('a.g-item-list-link:contains(Test Item 2)').click();
+        });
+        girderTest.waitForLoad();
+
+        waitsFor(function () {
+            return $('.g-item-name').length === 1 && $('.g-item-license').length === 1;
+        }, 'the item page and license field to load');
+        girderTest.waitForLoad();
+
+        runs(function () {
+            // Item info should show that license is unspecified
+            expect($('.g-item-license').length).toBe(1);
+            expect($('.g-item-license').text()).toContain('Unspecified');
+        });
+    });
+
+    it('edits an item that has an unspecified license', function () {
+        waitsFor(function () {
+            return $('.g-item-actions-button:visible').length === 1;
+        }, 'the item actions button to appear');
+        runs(function () {
+            $('.g-item-actions-button').click();
+        });
+        girderTest.waitForLoad();
+
+        waitsFor(function () {
+            return $('.g-edit-item:visible').length === 1;
+        }, 'the item edit action to appear');
+        runs(function () {
+            $('.g-edit-item').click();
+        });
+
+        waitsFor(function () {
+            return Backbone.history.fragment.slice(-16) === '?dialog=itemedit';
+        }, 'the url state to change');
+        girderTest.waitForDialog();
+        waitsFor(function () {
+            return $('#g-name').val() !== '';
+        }, 'the dialog to be populated');
+        waitsFor(function () {
+            return $('button.g-save-item:visible').text() === 'Save';
+        }, 'the edit item dialog to appear');
+        runs(function () {
+            // Should list groups of licenses, plus "Unspecified" in dropdown
+            expect($('#g-license optgroup').length).toBe(2);
+            expect($('#g-license option').length).toBe(22);
+
+            // The unspecified license should be selected by default
+            expect($('#g-license').val()).toBe('');
+
+            // Change the item's license
+            $('#g-license').val('The MIT License (MIT)');
+            $('button.g-save-item').click();
+        });
+        girderTest.waitForLoad();
+
+        waitsFor(function () {
+            return $('.g-item-name').length === 1 && $('.g-item-license').length === 1;
+        }, 'the item page and license field to load');
+        girderTest.waitForLoad();
+        runs(function () {
+            // Item info should show license
+            expect($('.g-item-license').length).toBe(1);
+            expect($('.g-item-license').text()).toContain('The MIT License (MIT)');
+        });
+    });
+
+    it('edits an item to have an unspecified license', function () {
+        waitsFor(function () {
+            return $('.g-item-actions-button:visible').length === 1;
+        }, 'the item actions button to appear');
+        runs(function () {
+            $('.g-item-actions-button').click();
+        });
+        girderTest.waitForLoad();
+
+        waitsFor(function () {
+            return $('.g-edit-item:visible').length === 1;
+        }, 'the item edit action to appear');
+        runs(function () {
+            $('.g-edit-item').click();
+        });
+
+        waitsFor(function () {
+            return Backbone.history.fragment.slice(-16) === '?dialog=itemedit';
+        }, 'the url state to change');
+        girderTest.waitForDialog();
+        waitsFor(function () {
+            return $('#g-name').val() !== '';
+        }, 'the dialog to be populated');
+        waitsFor(function () {
+            return $('button.g-save-item:visible').text() === 'Save';
+        }, 'the edit item dialog to appear');
+        runs(function () {
+            // Should list groups of licenses, plus "Unspecified" in dropdown
+            expect($('#g-license optgroup').length).toBe(2);
+            expect($('#g-license option').length).toBe(22);
+
+            // The item's license should be selected by default
+            expect($('#g-license').val()).toBe('The MIT License (MIT)');
+
+            // Change the item's license
+            $('#g-license').val('');
+            $('button.g-save-item').click();
+        });
+        girderTest.waitForLoad();
+
+        waitsFor(function () {
+            return $('.g-item-name').length === 1 && $('.g-item-license').length === 1;
+        }, 'the item page and license field to load');
+        girderTest.waitForLoad();
+        runs(function () {
+            // Item info should show that license is unspecified
+            expect($('.g-item-license').length).toBe(1);
+            expect($('.g-item-license').text()).toContain('Unspecified');
         });
     });
 });

--- a/plugins/item_licenses/plugin_tests/itemLicensesSpec.js
+++ b/plugins/item_licenses/plugin_tests/itemLicensesSpec.js
@@ -1,5 +1,4 @@
 girderTest.importPlugin('item_licenses');
-
 girderTest.startApp();
 
 $(function () {

--- a/plugins/item_tasks/plugin_tests/tasksSpec.js
+++ b/plugins/item_tasks/plugin_tests/tasksSpec.js
@@ -1,5 +1,4 @@
 girderTest.importPlugin('jobs', 'worker', 'item_tasks');
-
 girderTest.startApp();
 
 describe('Create an item task', function () {

--- a/plugins/item_tasks/plugin_tests/widgetsSpec.js
+++ b/plugins/item_tasks/plugin_tests/widgetsSpec.js
@@ -1,398 +1,670 @@
 girderTest.importPlugin('jobs', 'worker', 'item_tasks');
 // This is a unit test, so do not start the app
 
-
+var itemTasks;
 girderTest.promise.done(function () {
-    var itemTasks = girder.plugins.item_tasks;
+    itemTasks = girder.plugins.item_tasks;
+});
 
-    describe('widget model', function () {
-        // test different widget types
-        it('range', function () {
-            var w = new itemTasks.models.WidgetModel({
+describe('widget model', function () {
+    // test different widget types
+    it('range', function () {
+        var w = new itemTasks.models.WidgetModel({
+            type: 'range',
+            title: 'Range widget',
+            min: -10,
+            max: 10,
+            step: 0.5
+        });
+        expect(w.isNumeric()).toBe(true);
+        expect(w.isBoolean()).toBe(false);
+        expect(w.isVector()).toBe(false);
+        expect(w.isColor()).toBe(false);
+        expect(w.isEnumeration()).toBe(false);
+        expect(w.isFile()).toBe(false);
+
+        w.set('value', '0.5');
+        expect(w.value()).toBe(0.5);
+        expect(w.isValid()).toBe(true);
+
+        w.set('value', 'a number');
+        expect(w.isValid()).toBe(false);
+
+        w.set('value', -11);
+        expect(w.isValid()).toBe(false);
+
+        w.set('value', 0.75);
+        expect(w.isValid()).toBe(false);
+
+        w.set('value', 0);
+        expect(w.isValid()).toBe(true);
+    });
+    it('basic number', function () {
+        var w = new itemTasks.models.WidgetModel({
+            type: 'number',
+            title: 'Number widget'
+        });
+        expect(w.isNumeric()).toBe(true);
+        expect(w.isBoolean()).toBe(false);
+        expect(w.isVector()).toBe(false);
+        expect(w.isColor()).toBe(false);
+        expect(w.isEnumeration()).toBe(false);
+        expect(w.isFile()).toBe(false);
+
+        w.set('value', '0.5');
+        expect(w.value()).toBe(0.5);
+        expect(w.isValid()).toBe(true);
+
+        w.set('value', 'a number');
+        expect(w.isValid()).toBe(false);
+    });
+    it('integer number', function () {
+        var w = new itemTasks.models.WidgetModel({
+            type: 'number',
+            title: 'Number widget',
+            step: 1
+        });
+        w.set('value', '0.5');
+        expect(w.value()).toBe(0.5);
+        expect(w.isValid()).toBe(false);
+
+        w.set('value', '-11');
+        expect(w.isValid()).toBe(true);
+    });
+    it('explicit integer type', function () {
+        var w = new itemTasks.models.WidgetModel({
+            type: 'integer',
+            title: 'Integer widget',
+            min: 2,
+            max: 10
+        });
+        w.set('value', 'not a number');
+        expect(w.value()).toBeNaN();
+        expect(w.isValid()).toBe(false);
+
+        w.set('value', '3.5');
+        expect(w.value()).toBe(3.5);
+        expect(w.isValid()).toBe(false);
+
+        w.set('value', '-11');
+        expect(w.value()).toBe(-11);
+        expect(w.isValid()).toBe(false);
+
+        w.set('value', '8');
+        expect(w.isValid()).toBe(true);
+
+        // ensure that minimum values are coerced into integers
+        w = new itemTasks.models.WidgetModel({
+            type: 'integer',
+            title: 'Integer widget',
+            min: 2.5,
+            max: 10
+        });
+        expect(w.get('min')).toBe(3);
+    });
+    it('float number', function () {
+        var w = new itemTasks.models.WidgetModel({
+            type: 'number',
+            title: 'Number widget'
+        });
+        w.set('value', '1e-10');
+        expect(w.value()).toBe(1e-10);
+        expect(w.isValid()).toBe(true);
+    });
+    it('boolean', function () {
+        var w = new itemTasks.models.WidgetModel({
+            type: 'boolean',
+            title: 'Boolean widget',
+            value: false
+        });
+        expect(w.isNumeric()).toBe(false);
+        expect(w.isBoolean()).toBe(true);
+        expect(w.isVector()).toBe(false);
+        expect(w.isColor()).toBe(false);
+        expect(w.isEnumeration()).toBe(false);
+        expect(w.isFile()).toBe(false);
+
+        expect(w.value()).toBe(false);
+        expect(w.isValid()).toBe(true);
+
+        w.set('value', {});
+        expect(w.value()).toBe(true);
+        expect(w.isValid()).toBe(true);
+    });
+    it('string', function () {
+        var w = new itemTasks.models.WidgetModel({
+            type: 'string',
+            title: 'String widget',
+            value: 'Default value'
+        });
+        expect(w.isNumeric()).toBe(false);
+        expect(w.isBoolean()).toBe(false);
+        expect(w.isVector()).toBe(false);
+        expect(w.isColor()).toBe(false);
+        expect(w.isEnumeration()).toBe(false);
+        expect(w.isFile()).toBe(false);
+
+        expect(w.value()).toBe('Default value');
+        expect(w.isValid()).toBe(true);
+
+        w.set('value', 1);
+        expect(w.value()).toBe('1');
+        expect(w.isValid()).toBe(true);
+    });
+    it('color', function () {
+        var w = new itemTasks.models.WidgetModel({
+            type: 'color',
+            title: 'Color widget'
+        });
+        expect(w.isNumeric()).toBe(false);
+        expect(w.isBoolean()).toBe(false);
+        expect(w.isVector()).toBe(false);
+        expect(w.isColor()).toBe(true);
+        expect(w.isEnumeration()).toBe(false);
+        expect(w.isFile()).toBe(false);
+
+        w.set('value', '#ffffff');
+        expect(w.value()).toBe('#ffffff');
+        expect(w.isValid()).toBe(true);
+
+        w.set('value', 'red');
+        expect(w.value()).toBe('#ff0000');
+        expect(w.isValid()).toBe(true);
+
+        w.set('value', 'rgb(0, 255, 0)');
+        expect(w.value()).toBe('#00ff00');
+        expect(w.isValid()).toBe(true);
+
+        w.set('value', [255, 255, 0]);
+        expect(w.value()).toBe('#ffff00');
+        expect(w.isValid()).toBe(true);
+    });
+    it('string-vector', function () {
+        var w = new itemTasks.models.WidgetModel({
+            type: 'string-vector',
+            title: 'String vector widget'
+        });
+        expect(w.isNumeric()).toBe(false);
+        expect(w.isBoolean()).toBe(false);
+        expect(w.isVector()).toBe(true);
+        expect(w.isColor()).toBe(false);
+        expect(w.isEnumeration()).toBe(false);
+        expect(w.isFile()).toBe(false);
+
+        w.set('value', 'a,b,c');
+        expect(w.value()).toEqual(['a', 'b', 'c']);
+        expect(w.isValid()).toBe(true);
+
+        w.set('value', ['a', 1, '2']);
+        expect(w.value()).toEqual(['a', '1', '2']);
+        expect(w.isValid()).toBe(true);
+    });
+    it('number-vector', function () {
+        var w = new itemTasks.models.WidgetModel({
+            type: 'number-vector',
+            title: 'Number vector widget'
+        });
+        expect(w.isNumeric()).toBe(true);
+        expect(w.isBoolean()).toBe(false);
+        expect(w.isVector()).toBe(true);
+        expect(w.isColor()).toBe(false);
+        expect(w.isEnumeration()).toBe(false);
+        expect(w.isFile()).toBe(false);
+
+        w.set('value', 'a,b,c');
+        expect(w.isValid()).toBe(false);
+
+        w.set('value', ['a', 1, '2']);
+        expect(w.isValid()).toBe(false);
+
+        w.set('value', '1,2,3');
+        expect(w.value()).toEqual([1, 2, 3]);
+        expect(w.isValid()).toBe(true);
+
+        w.set('value', ['0', 1, '2']);
+        expect(w.value()).toEqual([0, 1, 2]);
+        expect(w.isValid()).toBe(true);
+    });
+    it('string-enumeration', function () {
+        var w = new itemTasks.models.WidgetModel({
+            type: 'string-enumeration',
+            title: 'String enumeration widget',
+            values: [
+                'value 1',
+                'value 2',
+                'value 3'
+            ]
+        });
+        expect(w.isNumeric()).toBe(false);
+        expect(w.isBoolean()).toBe(false);
+        expect(w.isVector()).toBe(false);
+        expect(w.isColor()).toBe(false);
+        expect(w.isEnumeration()).toBe(true);
+        expect(w.isFile()).toBe(false);
+
+        w.set('value', 'value 1');
+        expect(w.isValid()).toBe(true);
+
+        w.set('value', 'value 4');
+        expect(w.isValid()).toBe(false);
+
+        w.set('value', 'value 3');
+        expect(w.isValid()).toBe(true);
+    });
+    it('number-enumeration', function () {
+        var w = new itemTasks.models.WidgetModel({
+            type: 'number-enumeration',
+            title: 'Number enumeration widget',
+            values: [
+                11,
+                12,
+                '13'
+            ]
+        });
+        expect(w.isNumeric()).toBe(true);
+        expect(w.isBoolean()).toBe(false);
+        expect(w.isVector()).toBe(false);
+        expect(w.isColor()).toBe(false);
+        expect(w.isEnumeration()).toBe(true);
+        expect(w.isFile()).toBe(false);
+
+        w.set('value', '11');
+        expect(w.isValid()).toBe(true);
+
+        w.set('value', 0);
+        expect(w.isValid()).toBe(false);
+
+        w.set('value', 13);
+        expect(w.isValid()).toBe(true);
+    });
+    it('file', function () {
+        var w = new itemTasks.models.WidgetModel({
+            type: 'file',
+            title: 'File widget'
+        });
+        expect(w.isNumeric()).toBe(false);
+        expect(w.isBoolean()).toBe(false);
+        expect(w.isVector()).toBe(false);
+        expect(w.isColor()).toBe(false);
+        expect(w.isEnumeration()).toBe(false);
+        expect(w.isFile()).toBe(true);
+    });
+    it('invalid', function () {
+        var w = new itemTasks.models.WidgetModel({
+            type: 'invalid type',
+            title: 'Invalid widget'
+        });
+        expect(w.isNumeric()).toBe(false);
+        expect(w.isBoolean()).toBe(false);
+        expect(w.isVector()).toBe(false);
+        expect(w.isColor()).toBe(false);
+        expect(w.isEnumeration()).toBe(false);
+        expect(w.isFile()).toBe(false);
+
+        expect(w.isValid()).toBe(false);
+    });
+});
+
+describe('widget collection', function () {
+    it('values', function () {
+        var c = new itemTasks.collections.WidgetCollection([
+            {type: 'range', id: 'range', value: 0},
+            {type: 'number', id: 'number', value: '1'},
+            {type: 'boolean', id: 'boolean', value: 'yes'},
+            {type: 'string', id: 'string', value: 0},
+            {type: 'color', id: 'color', value: 'red'},
+            {type: 'string-vector', id: 'string-vector', value: 'a,b,c'},
+            {type: 'number-vector', id: 'number-vector', value: '1,2,3'},
+            {type: 'string-enumeration', id: 'string-enumeration', values: ['a'], value: 'a'},
+            {type: 'number-enumeration', id: 'number-enumeration', values: [1], value: '1'},
+            {type: 'file', id: 'file', value: new Backbone.Model({id: 'a'})},
+            {type: 'new-file', id: 'new-file', value: new Backbone.Model({name: 'a', folderId: 'b'})},
+            {type: 'image', id: 'image', value: new Backbone.Model({id: 'c'})}
+        ]);
+
+        expect(c.values()).toEqual({
+            range: '0',
+            number: '1',
+            boolean: 'true',
+            string: '"0"',
+            color: '"#ff0000"',
+            'string-vector': '["a","b","c"]',
+            'number-vector': '[1,2,3]',
+            'string-enumeration': '"a"',
+            'number-enumeration': '1',
+            'file_girderItemId': 'a',
+            'new-file_girderFolderId': 'b',
+            'new-file_name': 'a',
+            'image_girderFileId': 'c'
+        });
+    });
+});
+
+describe('control widget view', function () {
+    var $el, hInit, hRender, hProto, parentView = {
+            registerChildView: function () {}
+        };
+
+    function checkWidgetCommon(widget) {
+        var model = widget.model;
+        expect(widget.$('label[for="' + model.id + '"]').text())
+            .toBe(model.get('title'));
+        if (widget.model.isEnumeration()) {
+            expect(widget.$('select#' + model.id).length).toBe(1);
+        } else {
+            expect(widget.$('input#' + model.id).length).toBe(1);
+        }
+    }
+
+    beforeEach(function () {
+        hProto = girder.views.widgets.BrowserWidget.prototype;
+        hInit = hProto.initialize;
+        hRender = hProto.render;
+
+        $el = $('<div/>').appendTo('body');
+    });
+
+    afterEach(function () {
+        hProto.initialize = hInit;
+        hProto.render = hRender;
+        $el.remove();
+    });
+
+    it('range', function () {
+        var w = new itemTasks.views.ControlWidget({
+            parentView: parentView,
+            el: $el.get(0),
+            model: new itemTasks.models.WidgetModel({
                 type: 'range',
-                title: 'Range widget',
-                min: -10,
+                title: 'Title',
+                id: 'range-widget',
+                value: 2,
+                min: 0,
                 max: 10,
-                step: 0.5
-            });
-            expect(w.isNumeric()).toBe(true);
-            expect(w.isBoolean()).toBe(false);
-            expect(w.isVector()).toBe(false);
-            expect(w.isColor()).toBe(false);
-            expect(w.isEnumeration()).toBe(false);
-            expect(w.isFile()).toBe(false);
-
-            w.set('value', '0.5');
-            expect(w.value()).toBe(0.5);
-            expect(w.isValid()).toBe(true);
-
-            w.set('value', 'a number');
-            expect(w.isValid()).toBe(false);
-
-            w.set('value', -11);
-            expect(w.isValid()).toBe(false);
-
-            w.set('value', 0.75);
-            expect(w.isValid()).toBe(false);
-
-            w.set('value', 0);
-            expect(w.isValid()).toBe(true);
+                step: 2
+            })
         });
-        it('basic number', function () {
-            var w = new itemTasks.models.WidgetModel({
+
+        w.render();
+
+        checkWidgetCommon(w);
+        expect(w.$('input').val()).toBe('2');
+        w.$('input').val('4').trigger('change');
+        expect(w.model.value()).toBe(4);
+    });
+
+    it('number', function () {
+        var w = new itemTasks.views.ControlWidget({
+            parentView: parentView,
+            el: $el.get(0),
+            model: new itemTasks.models.WidgetModel({
                 type: 'number',
-                title: 'Number widget'
-            });
-            expect(w.isNumeric()).toBe(true);
-            expect(w.isBoolean()).toBe(false);
-            expect(w.isVector()).toBe(false);
-            expect(w.isColor()).toBe(false);
-            expect(w.isEnumeration()).toBe(false);
-            expect(w.isFile()).toBe(false);
-
-            w.set('value', '0.5');
-            expect(w.value()).toBe(0.5);
-            expect(w.isValid()).toBe(true);
-
-            w.set('value', 'a number');
-            expect(w.isValid()).toBe(false);
+                title: 'Title',
+                id: 'number-widget',
+                value: 2,
+                min: 0,
+                max: 10,
+                step: 2
+            })
         });
-        it('integer number', function () {
-            var w = new itemTasks.models.WidgetModel({
-                type: 'number',
-                title: 'Number widget',
-                step: 1
-            });
-            w.set('value', '0.5');
-            expect(w.value()).toBe(0.5);
-            expect(w.isValid()).toBe(false);
 
-            w.set('value', '-11');
-            expect(w.isValid()).toBe(true);
-        });
-        it('explicit integer type', function () {
-            var w = new itemTasks.models.WidgetModel({
-                type: 'integer',
-                title: 'Integer widget',
-                min: 2,
-                max: 10
-            });
-            w.set('value', 'not a number');
-            expect(w.value()).toBeNaN();
-            expect(w.isValid()).toBe(false);
+        w.render();
 
-            w.set('value', '3.5');
-            expect(w.value()).toBe(3.5);
-            expect(w.isValid()).toBe(false);
+        checkWidgetCommon(w);
+        expect(w.$('input').val()).toBe('2');
+        w.$('input').val('4').trigger('change');
+        expect(w.model.value()).toBe(4);
 
-            w.set('value', '-11');
-            expect(w.value()).toBe(-11);
-            expect(w.isValid()).toBe(false);
+        w.$('input').val('not a number').trigger('change');
+        expect(w.$('.form-group').hasClass('has-error')).toBe(true);
 
-            w.set('value', '8');
-            expect(w.isValid()).toBe(true);
+        w.$('input').val('4').trigger('change');
+        expect(w.$('.form-group').hasClass('has-error')).toBe(false);
+    });
 
-            // ensure that minimum values are coerced into integers
-            w = new itemTasks.models.WidgetModel({
-                type: 'integer',
-                title: 'Integer widget',
-                min: 2.5,
-                max: 10
-            });
-            expect(w.get('min')).toBe(3);
-        });
-        it('float number', function () {
-            var w = new itemTasks.models.WidgetModel({
-                type: 'number',
-                title: 'Number widget'
-            });
-            w.set('value', '1e-10');
-            expect(w.value()).toBe(1e-10);
-            expect(w.isValid()).toBe(true);
-        });
-        it('boolean', function () {
-            var w = new itemTasks.models.WidgetModel({
+    it('boolean', function () {
+        var w = new itemTasks.views.ControlWidget({
+            parentView: parentView,
+            el: $el.get(0),
+            model: new itemTasks.models.WidgetModel({
                 type: 'boolean',
-                title: 'Boolean widget',
-                value: false
-            });
-            expect(w.isNumeric()).toBe(false);
-            expect(w.isBoolean()).toBe(true);
-            expect(w.isVector()).toBe(false);
-            expect(w.isColor()).toBe(false);
-            expect(w.isEnumeration()).toBe(false);
-            expect(w.isFile()).toBe(false);
-
-            expect(w.value()).toBe(false);
-            expect(w.isValid()).toBe(true);
-
-            w.set('value', {});
-            expect(w.value()).toBe(true);
-            expect(w.isValid()).toBe(true);
+                title: 'Title',
+                id: 'boolean-widget'
+            })
         });
-        it('string', function () {
-            var w = new itemTasks.models.WidgetModel({
+
+        w.render();
+
+        checkWidgetCommon(w);
+        expect(w.$('input').prop('checked')).toBe(false);
+
+        w.$('input').click();
+        expect(w.model.value()).toBe(true);
+    });
+
+    it('string', function () {
+        var w = new itemTasks.views.ControlWidget({
+            parentView: parentView,
+            el: $el.get(0),
+            model: new itemTasks.models.WidgetModel({
                 type: 'string',
-                title: 'String widget',
-                value: 'Default value'
-            });
-            expect(w.isNumeric()).toBe(false);
-            expect(w.isBoolean()).toBe(false);
-            expect(w.isVector()).toBe(false);
-            expect(w.isColor()).toBe(false);
-            expect(w.isEnumeration()).toBe(false);
-            expect(w.isFile()).toBe(false);
-
-            expect(w.value()).toBe('Default value');
-            expect(w.isValid()).toBe(true);
-
-            w.set('value', 1);
-            expect(w.value()).toBe('1');
-            expect(w.isValid()).toBe(true);
+                title: 'Title',
+                id: 'string-widget',
+                value: 'default'
+            })
         });
-        it('color', function () {
-            var w = new itemTasks.models.WidgetModel({
+
+        w.render();
+
+        checkWidgetCommon(w);
+        expect(w.$('input').val()).toBe('default');
+
+        w.$('input').val('new value').trigger('change');
+        expect(w.model.value()).toBe('new value');
+    });
+
+    it('color', function () {
+        var w = new itemTasks.views.ControlWidget({
+            parentView: parentView,
+            el: $el.get(0),
+            model: new itemTasks.models.WidgetModel({
                 type: 'color',
-                title: 'Color widget'
-            });
-            expect(w.isNumeric()).toBe(false);
-            expect(w.isBoolean()).toBe(false);
-            expect(w.isVector()).toBe(false);
-            expect(w.isColor()).toBe(true);
-            expect(w.isEnumeration()).toBe(false);
-            expect(w.isFile()).toBe(false);
-
-            w.set('value', '#ffffff');
-            expect(w.value()).toBe('#ffffff');
-            expect(w.isValid()).toBe(true);
-
-            w.set('value', 'red');
-            expect(w.value()).toBe('#ff0000');
-            expect(w.isValid()).toBe(true);
-
-            w.set('value', 'rgb(0, 255, 0)');
-            expect(w.value()).toBe('#00ff00');
-            expect(w.isValid()).toBe(true);
-
-            w.set('value', [255, 255, 0]);
-            expect(w.value()).toBe('#ffff00');
-            expect(w.isValid()).toBe(true);
+                title: 'Title',
+                id: 'color-widget',
+                value: 'red'
+            })
         });
-        it('string-vector', function () {
-            var w = new itemTasks.models.WidgetModel({
+
+        w.render();
+
+        checkWidgetCommon(w);
+        expect(w.model.value()).toBe('#ff0000');
+
+        w.$('.input-group-addon').click();
+        expect($('.colorpicker-visible').length).toBe(1);
+
+        w.$('input').val('#ffffff').trigger('change');
+        expect(w.model.value()).toBe('#ffffff');
+    });
+
+    it('string-vector', function () {
+        var w = new itemTasks.views.ControlWidget({
+            parentView: parentView,
+            el: $el.get(0),
+            model: new itemTasks.models.WidgetModel({
                 type: 'string-vector',
-                title: 'String vector widget'
-            });
-            expect(w.isNumeric()).toBe(false);
-            expect(w.isBoolean()).toBe(false);
-            expect(w.isVector()).toBe(true);
-            expect(w.isColor()).toBe(false);
-            expect(w.isEnumeration()).toBe(false);
-            expect(w.isFile()).toBe(false);
-
-            w.set('value', 'a,b,c');
-            expect(w.value()).toEqual(['a', 'b', 'c']);
-            expect(w.isValid()).toBe(true);
-
-            w.set('value', ['a', 1, '2']);
-            expect(w.value()).toEqual(['a', '1', '2']);
-            expect(w.isValid()).toBe(true);
+                title: 'Title',
+                id: 'string-vector-widget',
+                value: 'one,two,three'
+            })
         });
-        it('number-vector', function () {
-            var w = new itemTasks.models.WidgetModel({
+
+        w.render();
+        checkWidgetCommon(w);
+        expect(w.$('input').val()).toBe('one,two,three');
+
+        w.$('input').val('1,2,3').trigger('change');
+        expect(w.model.value()).toEqual(['1', '2', '3']);
+    });
+
+    it('number-vector', function () {
+        var w = new itemTasks.views.ControlWidget({
+            parentView: parentView,
+            el: $el.get(0),
+            model: new itemTasks.models.WidgetModel({
                 type: 'number-vector',
-                title: 'Number vector widget'
-            });
-            expect(w.isNumeric()).toBe(true);
-            expect(w.isBoolean()).toBe(false);
-            expect(w.isVector()).toBe(true);
-            expect(w.isColor()).toBe(false);
-            expect(w.isEnumeration()).toBe(false);
-            expect(w.isFile()).toBe(false);
-
-            w.set('value', 'a,b,c');
-            expect(w.isValid()).toBe(false);
-
-            w.set('value', ['a', 1, '2']);
-            expect(w.isValid()).toBe(false);
-
-            w.set('value', '1,2,3');
-            expect(w.value()).toEqual([1, 2, 3]);
-            expect(w.isValid()).toBe(true);
-
-            w.set('value', ['0', 1, '2']);
-            expect(w.value()).toEqual([0, 1, 2]);
-            expect(w.isValid()).toBe(true);
+                title: 'Title',
+                id: 'number-vector-widget',
+                value: '1,2,3'
+            })
         });
-        it('string-enumeration', function () {
-            var w = new itemTasks.models.WidgetModel({
+
+        w.render();
+        checkWidgetCommon(w);
+        expect(w.$('input').val()).toBe('1,2,3');
+
+        w.$('input').val('10,20,30').trigger('change');
+        expect(w.model.value()).toEqual([10, 20, 30]);
+    });
+
+    it('string-enumeration', function () {
+        var w = new itemTasks.views.ControlWidget({
+            parentView: parentView,
+            el: $el.get(0),
+            model: new itemTasks.models.WidgetModel({
                 type: 'string-enumeration',
-                title: 'String enumeration widget',
+                title: 'Title',
+                id: 'string-enumeration-widget',
+                value: 'value 2',
                 values: [
                     'value 1',
                     'value 2',
                     'value 3'
                 ]
-            });
-            expect(w.isNumeric()).toBe(false);
-            expect(w.isBoolean()).toBe(false);
-            expect(w.isVector()).toBe(false);
-            expect(w.isColor()).toBe(false);
-            expect(w.isEnumeration()).toBe(true);
-            expect(w.isFile()).toBe(false);
-
-            w.set('value', 'value 1');
-            expect(w.isValid()).toBe(true);
-
-            w.set('value', 'value 4');
-            expect(w.isValid()).toBe(false);
-
-            w.set('value', 'value 3');
-            expect(w.isValid()).toBe(true);
+            })
         });
-        it('number-enumeration', function () {
-            var w = new itemTasks.models.WidgetModel({
+
+        w.render();
+        checkWidgetCommon(w);
+        expect(w.$('select').val()).toBe('value 2');
+
+        w.$('select').val('value 3').trigger('change');
+        expect(w.model.value()).toBe('value 3');
+    });
+
+    it('number-enumeration', function () {
+        var w = new itemTasks.views.ControlWidget({
+            parentView: parentView,
+            el: $el.get(0),
+            model: new itemTasks.models.WidgetModel({
                 type: 'number-enumeration',
-                title: 'Number enumeration widget',
+                title: 'Title',
+                id: 'number-enumeration-widget',
+                value: 200,
                 values: [
-                    11,
-                    12,
-                    '13'
+                    100,
+                    200,
+                    300
                 ]
-            });
-            expect(w.isNumeric()).toBe(true);
-            expect(w.isBoolean()).toBe(false);
-            expect(w.isVector()).toBe(false);
-            expect(w.isColor()).toBe(false);
-            expect(w.isEnumeration()).toBe(true);
-            expect(w.isFile()).toBe(false);
-
-            w.set('value', '11');
-            expect(w.isValid()).toBe(true);
-
-            w.set('value', 0);
-            expect(w.isValid()).toBe(false);
-
-            w.set('value', 13);
-            expect(w.isValid()).toBe(true);
+            })
         });
-        it('file', function () {
-            var w = new itemTasks.models.WidgetModel({
+
+        w.render();
+        checkWidgetCommon(w);
+        expect(w.$('select').val()).toBe('200');
+
+        w.$('select').val('300').trigger('change');
+        expect(w.model.value()).toBe(300);
+    });
+
+    it('file', function () {
+        var item = new girder.models.ItemModel({id: 'model id', name: 'b'}),
+            browser;
+
+        hProto.initialize = function () {
+            browser = this;
+        };
+        hProto.render = function () {};
+
+        var w = new itemTasks.views.ControlWidget({
+            parentView: parentView,
+            el: $el.get(0),
+            model: new itemTasks.models.WidgetModel({
                 type: 'file',
-                title: 'File widget'
-            });
-            expect(w.isNumeric()).toBe(false);
-            expect(w.isBoolean()).toBe(false);
-            expect(w.isVector()).toBe(false);
-            expect(w.isColor()).toBe(false);
-            expect(w.isEnumeration()).toBe(false);
-            expect(w.isFile()).toBe(true);
+                title: 'Title',
+                id: 'file-widget'
+            })
         });
-        it('invalid', function () {
-            var w = new itemTasks.models.WidgetModel({
-                type: 'invalid type',
-                title: 'Invalid widget'
-            });
-            expect(w.isNumeric()).toBe(false);
-            expect(w.isBoolean()).toBe(false);
-            expect(w.isVector()).toBe(false);
-            expect(w.isColor()).toBe(false);
-            expect(w.isEnumeration()).toBe(false);
-            expect(w.isFile()).toBe(false);
 
-            expect(w.isValid()).toBe(false);
-        });
+        w.render();
+        checkWidgetCommon(w);
+
+        w.$('.g-select-file-button').click();
+
+        // make sure the browser widget was initialized
+        expect(!!browser).toBe(true);
+
+        // trigger a response from the mocked widget
+        browser.model = item;
+        browser.trigger('g:saved', item);
+
+        expect(w.model.get('value')).toBe(item);
     });
 
-    describe('widget collection', function () {
-        it('values', function () {
-            var c = new itemTasks.collections.WidgetCollection([
-                {type: 'range', id: 'range', value: 0},
-                {type: 'number', id: 'number', value: '1'},
-                {type: 'boolean', id: 'boolean', value: 'yes'},
-                {type: 'string', id: 'string', value: 0},
-                {type: 'color', id: 'color', value: 'red'},
-                {type: 'string-vector', id: 'string-vector', value: 'a,b,c'},
-                {type: 'number-vector', id: 'number-vector', value: '1,2,3'},
-                {type: 'string-enumeration', id: 'string-enumeration', values: ['a'], value: 'a'},
-                {type: 'number-enumeration', id: 'number-enumeration', values: [1], value: '1'},
-                {type: 'file', id: 'file', value: new Backbone.Model({id: 'a'})},
-                {type: 'new-file', id: 'new-file', value: new Backbone.Model({name: 'a', folderId: 'b'})},
-                {type: 'image', id: 'image', value: new Backbone.Model({id: 'c'})}
-            ]);
+    it('new-file', function () {
+        var browser,
+            folder = new girder.models.FolderModel({id: 'folder id', name: 'c'});
 
-            expect(c.values()).toEqual({
-                range: '0',
-                number: '1',
-                boolean: 'true',
-                string: '"0"',
-                color: '"#ff0000"',
-                'string-vector': '["a","b","c"]',
-                'number-vector': '[1,2,3]',
-                'string-enumeration': '"a"',
-                'number-enumeration': '1',
-                'file_girderItemId': 'a',
-                'new-file_girderFolderId': 'b',
-                'new-file_name': 'a',
-                'image_girderFileId': 'c'
-            });
+        hProto.initialize = function () {
+            browser = this;
+        };
+        hProto.render = function () {};
+        var w = new itemTasks.views.ControlWidget({
+            parentView: parentView,
+            el: $el.get(0),
+            model: new itemTasks.models.WidgetModel({
+                type: 'new-file',
+                title: 'Title',
+                id: 'file-widget'
+            })
         });
+
+        w.render();
+        checkWidgetCommon(w);
+
+        w.$('.g-select-file-button').click();
+
+        // make sure the browser widget was initialized
+        expect(!!browser).toBe(true);
+
+        // trigger a response from the mocked widget
+        browser.model = folder;
+        browser.trigger('g:saved', folder);
+
+        expect(w.model.get('value')).toBe(folder);
     });
 
-    describe('control widget view', function () {
-        var $el, hInit, hRender, hProto, parentView = {
-                registerChildView: function () {}
-            };
-
-        function checkWidgetCommon(widget) {
-            var model = widget.model;
-            expect(widget.$('label[for="' + model.id + '"]').text())
-                .toBe(model.get('title'));
-            if (widget.model.isEnumeration()) {
-                expect(widget.$('select#' + model.id).length).toBe(1);
-            } else {
-                expect(widget.$('input#' + model.id).length).toBe(1);
-            }
-        }
-
-        beforeEach(function () {
-            hProto = girder.views.widgets.BrowserWidget.prototype;
-            hInit = hProto.initialize;
-            hRender = hProto.render;
-
-            $el = $('<div/>').appendTo('body');
+    it('invalid', function () {
+        var w = new itemTasks.views.ControlWidget({
+            parentView: parentView,
+            el: $el.get(0),
+            model: new itemTasks.models.WidgetModel({
+                type: 'invalid',
+                title: 'Title',
+                id: 'invalid-widget'
+            })
         });
+        var _warn = console.warn;
+        var message;
+        console.warn = function (m) { message = m; };
 
-        afterEach(function () {
-            hProto.initialize = hInit;
-            hProto.render = hRender;
-            $el.remove();
-        });
+        w.render();
+        expect(message).toBe('Invalid widget type "invalid"');
+        console.warn = _warn;
+    });
 
-        it('range', function () {
-            var w = new itemTasks.views.ControlWidget({
-                parentView: parentView,
-                el: $el.get(0),
-                model: new itemTasks.models.WidgetModel({
-                    type: 'range',
-                    title: 'Title',
-                    id: 'range-widget',
-                    value: 2,
-                    min: 0,
-                    max: 10,
-                    step: 2
-                })
-            });
-
-            w.render();
-
-            checkWidgetCommon(w);
-            expect(w.$('input').val()).toBe('2');
-            w.$('input').val('4').trigger('change');
-            expect(w.model.value()).toBe(4);
-        });
-
-        it('number', function () {
+    describe('events', function () {
+        it('g:itemTaskWidgetSet', function () {
             var w = new itemTasks.views.ControlWidget({
                 parentView: parentView,
                 el: $el.get(0),
@@ -400,378 +672,106 @@ girderTest.promise.done(function () {
                     type: 'number',
                     title: 'Title',
                     id: 'number-widget',
-                    value: 2,
-                    min: 0,
-                    max: 10,
-                    step: 2
+                    value: 0
                 })
             });
-
             w.render();
 
-            checkWidgetCommon(w);
-            expect(w.$('input').val()).toBe('2');
-            w.$('input').val('4').trigger('change');
-            expect(w.model.value()).toBe(4);
+            girder.events.trigger('g:itemTaskWidgetSet:' + w.model.id, 1);
+            expect(w.$('input').val()).toBe('1');
+        });
 
+        it('g:itemTaskWidgetChanged', function () {
+            var e1, e2;
+
+            var w = new itemTasks.views.ControlWidget({
+                parentView: parentView,
+                el: $el.get(0),
+                model: new itemTasks.models.WidgetModel({
+                    type: 'number',
+                    title: 'Title',
+                    id: 'number-widget',
+                    value: 0
+                })
+            });
+            w.render();
+
+            girder.events.once('g:itemTaskWidgetChanged', function (model) {
+                e1 = true;
+                expect(model).toBe(w.model);
+            });
+
+            girder.events.once('g:itemTaskWidgetChanged:number', function (model) {
+                e2 = true;
+                expect(model).toBe(w.model);
+            });
+
+            // this should trigger both change events
+            w.$('input').val(1).trigger('change');
+            expect(e1).toBe(true);
+            expect(e2).toBe(true);
+        });
+
+        it('g:itemTaskWidgetRemoved', function () {
+            var e1, e2;
+
+            var w = new itemTasks.views.ControlWidget({
+                parentView: parentView,
+                el: $el.get(0),
+                model: new itemTasks.models.WidgetModel({
+                    type: 'number',
+                    title: 'Title',
+                    id: 'number-widget',
+                    value: 0
+                })
+            });
+            w.render();
+
+            girder.events.once('g:itemTaskWidgetRemoved', function (model) {
+                e1 = true;
+                expect(model).toBe(w.model);
+            });
+
+            girder.events.once('g:itemTaskWidgetRemoved:number', function (model) {
+                e2 = true;
+                expect(model).toBe(w.model);
+            });
+
+            // this should trigger both change events
+            w.model.trigger('destroy', w.model);
+            expect(e1).toBe(true);
+            expect(e2).toBe(true);
+        });
+
+        it('g:itemTaskWidgetInvalid', function () {
+            var e1, e2;
+
+            var w = new itemTasks.views.ControlWidget({
+                parentView: parentView,
+                el: $el.get(0),
+                model: new itemTasks.models.WidgetModel({
+                    type: 'number',
+                    title: 'Title',
+                    id: 'number-widget',
+                    value: 0
+                })
+            });
+            w.render();
+
+            girder.events.once('g:itemTaskWidgetInvalid', function (model) {
+                e1 = true;
+                expect(model).toBe(w.model);
+            });
+
+            girder.events.once('g:itemTaskWidgetInvalid:number', function (model) {
+                e2 = true;
+                expect(model).toBe(w.model);
+            });
+
+            // this should trigger both change events
             w.$('input').val('not a number').trigger('change');
-            expect(w.$('.form-group').hasClass('has-error')).toBe(true);
-
-            w.$('input').val('4').trigger('change');
-            expect(w.$('.form-group').hasClass('has-error')).toBe(false);
-        });
-
-        it('boolean', function () {
-            var w = new itemTasks.views.ControlWidget({
-                parentView: parentView,
-                el: $el.get(0),
-                model: new itemTasks.models.WidgetModel({
-                    type: 'boolean',
-                    title: 'Title',
-                    id: 'boolean-widget'
-                })
-            });
-
-            w.render();
-
-            checkWidgetCommon(w);
-            expect(w.$('input').prop('checked')).toBe(false);
-
-            w.$('input').click();
-            expect(w.model.value()).toBe(true);
-        });
-
-        it('string', function () {
-            var w = new itemTasks.views.ControlWidget({
-                parentView: parentView,
-                el: $el.get(0),
-                model: new itemTasks.models.WidgetModel({
-                    type: 'string',
-                    title: 'Title',
-                    id: 'string-widget',
-                    value: 'default'
-                })
-            });
-
-            w.render();
-
-            checkWidgetCommon(w);
-            expect(w.$('input').val()).toBe('default');
-
-            w.$('input').val('new value').trigger('change');
-            expect(w.model.value()).toBe('new value');
-        });
-
-        it('color', function () {
-            var w = new itemTasks.views.ControlWidget({
-                parentView: parentView,
-                el: $el.get(0),
-                model: new itemTasks.models.WidgetModel({
-                    type: 'color',
-                    title: 'Title',
-                    id: 'color-widget',
-                    value: 'red'
-                })
-            });
-
-            w.render();
-
-            checkWidgetCommon(w);
-            expect(w.model.value()).toBe('#ff0000');
-
-            w.$('.input-group-addon').click();
-            expect($('.colorpicker-visible').length).toBe(1);
-
-            w.$('input').val('#ffffff').trigger('change');
-            expect(w.model.value()).toBe('#ffffff');
-        });
-
-        it('string-vector', function () {
-            var w = new itemTasks.views.ControlWidget({
-                parentView: parentView,
-                el: $el.get(0),
-                model: new itemTasks.models.WidgetModel({
-                    type: 'string-vector',
-                    title: 'Title',
-                    id: 'string-vector-widget',
-                    value: 'one,two,three'
-                })
-            });
-
-            w.render();
-            checkWidgetCommon(w);
-            expect(w.$('input').val()).toBe('one,two,three');
-
-            w.$('input').val('1,2,3').trigger('change');
-            expect(w.model.value()).toEqual(['1', '2', '3']);
-        });
-
-        it('number-vector', function () {
-            var w = new itemTasks.views.ControlWidget({
-                parentView: parentView,
-                el: $el.get(0),
-                model: new itemTasks.models.WidgetModel({
-                    type: 'number-vector',
-                    title: 'Title',
-                    id: 'number-vector-widget',
-                    value: '1,2,3'
-                })
-            });
-
-            w.render();
-            checkWidgetCommon(w);
-            expect(w.$('input').val()).toBe('1,2,3');
-
-            w.$('input').val('10,20,30').trigger('change');
-            expect(w.model.value()).toEqual([10, 20, 30]);
-        });
-
-        it('string-enumeration', function () {
-            var w = new itemTasks.views.ControlWidget({
-                parentView: parentView,
-                el: $el.get(0),
-                model: new itemTasks.models.WidgetModel({
-                    type: 'string-enumeration',
-                    title: 'Title',
-                    id: 'string-enumeration-widget',
-                    value: 'value 2',
-                    values: [
-                        'value 1',
-                        'value 2',
-                        'value 3'
-                    ]
-                })
-            });
-
-            w.render();
-            checkWidgetCommon(w);
-            expect(w.$('select').val()).toBe('value 2');
-
-            w.$('select').val('value 3').trigger('change');
-            expect(w.model.value()).toBe('value 3');
-        });
-
-        it('number-enumeration', function () {
-            var w = new itemTasks.views.ControlWidget({
-                parentView: parentView,
-                el: $el.get(0),
-                model: new itemTasks.models.WidgetModel({
-                    type: 'number-enumeration',
-                    title: 'Title',
-                    id: 'number-enumeration-widget',
-                    value: 200,
-                    values: [
-                        100,
-                        200,
-                        300
-                    ]
-                })
-            });
-
-            w.render();
-            checkWidgetCommon(w);
-            expect(w.$('select').val()).toBe('200');
-
-            w.$('select').val('300').trigger('change');
-            expect(w.model.value()).toBe(300);
-        });
-
-        it('file', function () {
-            var item = new girder.models.ItemModel({id: 'model id', name: 'b'}),
-                browser;
-
-            hProto.initialize = function () {
-                browser = this;
-            };
-            hProto.render = function () {};
-
-            var w = new itemTasks.views.ControlWidget({
-                parentView: parentView,
-                el: $el.get(0),
-                model: new itemTasks.models.WidgetModel({
-                    type: 'file',
-                    title: 'Title',
-                    id: 'file-widget'
-                })
-            });
-
-            w.render();
-            checkWidgetCommon(w);
-
-            w.$('.g-select-file-button').click();
-
-            // make sure the browser widget was initialized
-            expect(!!browser).toBe(true);
-
-            // trigger a response from the mocked widget
-            browser.model = item;
-            browser.trigger('g:saved', item);
-
-            expect(w.model.get('value')).toBe(item);
-        });
-
-        it('new-file', function () {
-            var browser,
-                folder = new girder.models.FolderModel({id: 'folder id', name: 'c'});
-
-            hProto.initialize = function () {
-                browser = this;
-            };
-            hProto.render = function () {};
-            var w = new itemTasks.views.ControlWidget({
-                parentView: parentView,
-                el: $el.get(0),
-                model: new itemTasks.models.WidgetModel({
-                    type: 'new-file',
-                    title: 'Title',
-                    id: 'file-widget'
-                })
-            });
-
-            w.render();
-            checkWidgetCommon(w);
-
-            w.$('.g-select-file-button').click();
-
-            // make sure the browser widget was initialized
-            expect(!!browser).toBe(true);
-
-            // trigger a response from the mocked widget
-            browser.model = folder;
-            browser.trigger('g:saved', folder);
-
-            expect(w.model.get('value')).toBe(folder);
-        });
-
-        it('invalid', function () {
-            var w = new itemTasks.views.ControlWidget({
-                parentView: parentView,
-                el: $el.get(0),
-                model: new itemTasks.models.WidgetModel({
-                    type: 'invalid',
-                    title: 'Title',
-                    id: 'invalid-widget'
-                })
-            });
-            var _warn = console.warn;
-            var message;
-            console.warn = function (m) { message = m; };
-
-            w.render();
-            expect(message).toBe('Invalid widget type "invalid"');
-            console.warn = _warn;
-        });
-
-        describe('events', function () {
-            it('g:itemTaskWidgetSet', function () {
-                var w = new itemTasks.views.ControlWidget({
-                    parentView: parentView,
-                    el: $el.get(0),
-                    model: new itemTasks.models.WidgetModel({
-                        type: 'number',
-                        title: 'Title',
-                        id: 'number-widget',
-                        value: 0
-                    })
-                });
-                w.render();
-
-                girder.events.trigger('g:itemTaskWidgetSet:' + w.model.id, 1);
-                expect(w.$('input').val()).toBe('1');
-            });
-
-            it('g:itemTaskWidgetChanged', function () {
-                var e1, e2;
-
-                var w = new itemTasks.views.ControlWidget({
-                    parentView: parentView,
-                    el: $el.get(0),
-                    model: new itemTasks.models.WidgetModel({
-                        type: 'number',
-                        title: 'Title',
-                        id: 'number-widget',
-                        value: 0
-                    })
-                });
-                w.render();
-
-                girder.events.once('g:itemTaskWidgetChanged', function (model) {
-                    e1 = true;
-                    expect(model).toBe(w.model);
-                });
-
-                girder.events.once('g:itemTaskWidgetChanged:number', function (model) {
-                    e2 = true;
-                    expect(model).toBe(w.model);
-                });
-
-                // this should trigger both change events
-                w.$('input').val(1).trigger('change');
-                expect(e1).toBe(true);
-                expect(e2).toBe(true);
-            });
-
-            it('g:itemTaskWidgetRemoved', function () {
-                var e1, e2;
-
-                var w = new itemTasks.views.ControlWidget({
-                    parentView: parentView,
-                    el: $el.get(0),
-                    model: new itemTasks.models.WidgetModel({
-                        type: 'number',
-                        title: 'Title',
-                        id: 'number-widget',
-                        value: 0
-                    })
-                });
-                w.render();
-
-                girder.events.once('g:itemTaskWidgetRemoved', function (model) {
-                    e1 = true;
-                    expect(model).toBe(w.model);
-                });
-
-                girder.events.once('g:itemTaskWidgetRemoved:number', function (model) {
-                    e2 = true;
-                    expect(model).toBe(w.model);
-                });
-
-                // this should trigger both change events
-                w.model.trigger('destroy', w.model);
-                expect(e1).toBe(true);
-                expect(e2).toBe(true);
-            });
-
-            it('g:itemTaskWidgetInvalid', function () {
-                var e1, e2;
-
-                var w = new itemTasks.views.ControlWidget({
-                    parentView: parentView,
-                    el: $el.get(0),
-                    model: new itemTasks.models.WidgetModel({
-                        type: 'number',
-                        title: 'Title',
-                        id: 'number-widget',
-                        value: 0
-                    })
-                });
-                w.render();
-
-                girder.events.once('g:itemTaskWidgetInvalid', function (model) {
-                    e1 = true;
-                    expect(model).toBe(w.model);
-                });
-
-                girder.events.once('g:itemTaskWidgetInvalid:number', function (model) {
-                    e2 = true;
-                    expect(model).toBe(w.model);
-                });
-
-                // this should trigger both change events
-                w.$('input').val('not a number').trigger('change');
-                expect(e1).toBe(true);
-                expect(e2).toBe(true);
-            });
+            expect(e1).toBe(true);
+            expect(e2).toBe(true);
         });
     });
 });

--- a/plugins/item_tasks/plugin_tests/widgetsSpec.js
+++ b/plugins/item_tasks/plugin_tests/widgetsSpec.js
@@ -1,4 +1,6 @@
 girderTest.importPlugin('jobs', 'worker', 'item_tasks');
+// This is a unit test, so do not start the app
+
 
 girderTest.promise.done(function () {
     var itemTasks = girder.plugins.item_tasks;

--- a/plugins/jobs/plugin_tests/jobsSpec.js
+++ b/plugins/jobs/plugin_tests/jobsSpec.js
@@ -1,11 +1,10 @@
 girderTest.importPlugin('jobs');
+var app;
+girderTest.startApp()
+    .done(function (startedApp) {
+        app = startedApp;
+    });
 
-girder.events.trigger('g:appload.before');
-var app = new girder.views.App({
-    el: 'body',
-    parentView: null
-});
-girder.events.trigger('g:appload.after');
 
 $(function () {
     describe('Unit test the job detail widget.', function () {

--- a/plugins/jobs/plugin_tests/jobsSpec.js
+++ b/plugins/jobs/plugin_tests/jobsSpec.js
@@ -5,430 +5,427 @@ girderTest.startApp()
         app = startedApp;
     });
 
+describe('Unit test the job detail widget.', function () {
+    it('Show a job detail widget.', function () {
+        waitsFor('app to render', function () {
+            return $('#g-app-body-container').length > 0;
+        });
 
-$(function () {
-    describe('Unit test the job detail widget.', function () {
-        it('Show a job detail widget.', function () {
-            waitsFor('app to render', function () {
-                return $('#g-app-body-container').length > 0;
+        var jobInfo = {
+            _id: 'foo',
+            title: 'My batch job',
+            status: girder.plugins.jobs.JobStatus.INACTIVE,
+            log: ['Hello world\n', 'goodbye world'],
+            updated: '2015-01-12T12:00:12Z',
+            created: '2015-01-12T12:00:00Z',
+            when: '2015-01-12T12:00:00Z',
+            timestamps: [{
+                status: girder.plugins.jobs.JobStatus.QUEUED,
+                time: '2015-01-12T12:00:02Z'
+            }, {
+                status: girder.plugins.jobs.JobStatus.RUNNING,
+                time: '2015-01-12T12:00:03Z'
+            }, {
+                status: girder.plugins.jobs.JobStatus.SUCCESS,
+                time: '2015-01-12T12:00:12Z'
+            }]
+        };
+
+        runs(function () {
+            // mock fetch to simulate fetching a job
+            spyOn(girder.plugins.jobs.models.JobModel.prototype, 'fetch').andCallFake(function () {
+                this.set(jobInfo);
+                this.trigger('g:fetched');
+                return $.Deferred().resolve(jobInfo).promise();
             });
 
-            var jobInfo = {
-                _id: 'foo',
-                title: 'My batch job',
-                status: girder.plugins.jobs.JobStatus.INACTIVE,
-                log: ['Hello world\n', 'goodbye world'],
-                updated: '2015-01-12T12:00:12Z',
-                created: '2015-01-12T12:00:00Z',
-                when: '2015-01-12T12:00:00Z',
-                timestamps: [{
-                    status: girder.plugins.jobs.JobStatus.QUEUED,
-                    time: '2015-01-12T12:00:02Z'
-                }, {
-                    status: girder.plugins.jobs.JobStatus.RUNNING,
-                    time: '2015-01-12T12:00:03Z'
-                }, {
-                    status: girder.plugins.jobs.JobStatus.SUCCESS,
-                    time: '2015-01-12T12:00:12Z'
-                }]
-            };
+            girder.router.navigate('job/foo', {trigger: true});
+        });
 
-            runs(function () {
-                // mock fetch to simulate fetching a job
-                spyOn(girder.plugins.jobs.models.JobModel.prototype, 'fetch').andCallFake(function () {
-                    this.set(jobInfo);
-                    this.trigger('g:fetched');
-                    return $.Deferred().resolve(jobInfo).promise();
-                });
+        waitsFor(function () {
+            return $('.g-job-info-key').length > 0;
+        }, 'the JobDetailsWidget to finish rendering');
 
-                girder.router.navigate('job/foo', {trigger: true});
+        runs(function () {
+            expect($('.g-monospace-viewer[property="kwargs"]').length).toBe(0);
+            expect($('.g-monospace-viewer[property="log"]').text()).toBe(jobInfo.log.join(''));
+            expect($('.g-job-info-value[property="_id"]').text()).toBe(jobInfo._id);
+            expect($('.g-job-info-value[property="title"]').text()).toBe(jobInfo.title);
+            expect($('.g-job-info-value[property="when"]').text()).toContain('January 12, 2015');
+            expect($('.g-job-status-badge').text()).toContain('Inactive');
+
+            expect($('.g-timeline-segment').length).toBe(3);
+            expect($('.g-timeline-point').length).toBe(4);
+            expect($('.g-timeline-start-label').text()).toBe('0 s');
+            expect($('.g-timeline-end-label').text()).toBe('12 s');
+            expect($('.g-timeline-point')[3].className).toContain('g-job-color-success');
+
+            // Make sure view change happens when notification is sent for this job
+            girder.utilities.eventStream.trigger('g:event.job_status', {
+                data: {
+                    _id: 'foo',
+                    status: girder.plugins.jobs.JobStatus.SUCCESS
+                }
             });
 
-            waitsFor(function () {
-                return $('.g-job-info-key').length > 0;
-            }, 'the JobDetailsWidget to finish rendering');
+            expect($('.g-job-status-badge').text()).toContain('Success');
 
-            runs(function () {
-                expect($('.g-monospace-viewer[property="kwargs"]').length).toBe(0);
-                expect($('.g-monospace-viewer[property="log"]').text()).toBe(jobInfo.log.join(''));
-                expect($('.g-job-info-value[property="_id"]').text()).toBe(jobInfo._id);
-                expect($('.g-job-info-value[property="title"]').text()).toBe(jobInfo.title);
-                expect($('.g-job-info-value[property="when"]').text()).toContain('January 12, 2015');
-                expect($('.g-job-status-badge').text()).toContain('Inactive');
-
-                expect($('.g-timeline-segment').length).toBe(3);
-                expect($('.g-timeline-point').length).toBe(4);
-                expect($('.g-timeline-start-label').text()).toBe('0 s');
-                expect($('.g-timeline-end-label').text()).toBe('12 s');
-                expect($('.g-timeline-point')[3].className).toContain('g-job-color-success');
-
-                // Make sure view change happens when notification is sent for this job
-                girder.utilities.eventStream.trigger('g:event.job_status', {
-                    data: {
-                        _id: 'foo',
-                        status: girder.plugins.jobs.JobStatus.SUCCESS
-                    }
-                });
-
-                expect($('.g-job-status-badge').text()).toContain('Success');
-
-                // Make sure view change only happens for the currently viewed job
-                girder.utilities.eventStream.trigger('g:event.job_status', {
-                    data: {
-                        _id: 'bar',
-                        status: girder.plugins.jobs.JobStatus.QUEUED
-                    }
-                });
-
-                expect($('.g-job-status-badge').text()).toContain('Success');
-
-                // Test log output events
-                girder.utilities.eventStream.trigger('g:event.job_log', {
-                    data: {
-                        _id: 'foo',
-                        overwrite: true,
-                        text: 'overwritten log'
-                    }
-                });
-                expect($('.g-monospace-viewer[property="log"]').text()).toBe('overwritten log');
-
-                girder.utilities.eventStream.trigger('g:event.job_log', {
-                    data: {
-                        _id: 'foo',
-                        overwrite: false,
-                        text: '<script type="text/javascript">xss probe!</script>'
-                    }
-                });
-
-                expect($('.g-monospace-viewer[property="log"]').text()).toBe(
-                    'overwritten log<script type="text/javascript">xss probe!</script>');
+            // Make sure view change only happens for the currently viewed job
+            girder.utilities.eventStream.trigger('g:event.job_status', {
+                data: {
+                    _id: 'bar',
+                    status: girder.plugins.jobs.JobStatus.QUEUED
+                }
             });
 
-            runs(function () {
-                girder.plugins.jobs.models.JobModel.prototype.fetch.andCallThrough();
-                // Return to the main page, since 'job/foo' isn't legal without mocking
-                girder.router.navigate('', {trigger: true});
+            expect($('.g-job-status-badge').text()).toContain('Success');
+
+            // Test log output events
+            girder.utilities.eventStream.trigger('g:event.job_log', {
+                data: {
+                    _id: 'foo',
+                    overwrite: true,
+                    text: 'overwritten log'
+                }
             });
-            girderTest.waitForLoad();
+            expect($('.g-monospace-viewer[property="log"]').text()).toBe('overwritten log');
+
+            girder.utilities.eventStream.trigger('g:event.job_log', {
+                data: {
+                    _id: 'foo',
+                    overwrite: false,
+                    text: '<script type="text/javascript">xss probe!</script>'
+                }
+            });
+
+            expect($('.g-monospace-viewer[property="log"]').text()).toBe(
+                'overwritten log<script type="text/javascript">xss probe!</script>');
+        });
+
+        runs(function () {
+            girder.plugins.jobs.models.JobModel.prototype.fetch.andCallThrough();
+            // Return to the main page, since 'job/foo' isn't legal without mocking
+            girder.router.navigate('', {trigger: true});
+        });
+        girderTest.waitForLoad();
+    });
+});
+
+describe('Unit test the job list widget.', function () {
+    // This spy must be attached to the prototype, since the instantiation of JobListWidget will
+    // bind and make calls to '_renderData' immediately
+    var renderDataSpy;
+    beforeEach(function () {
+        renderDataSpy = spyOn(girder.plugins.jobs.views.JobListWidget.prototype, '_renderData').andCallThrough();
+    });
+
+    it('Show a job list widget.', function () {
+        var jobs, rows, widget;
+
+        girderTest.createUser(
+            'admin', 'admin@email.com', 'Quota', 'Admin', 'testpassword')();
+
+        runs(function () {
+            widget = new girder.plugins.jobs.views.JobListWidget({
+                el: $('#g-app-body-container'),
+                filter: {},
+                parentView: app,
+                showGraphs: true,
+                showFilters: true,
+                showPageSizeSelector: true
+            });
+        });
+        waitsFor(function () {
+            // Wait for the pending fetch (causing the 2nd render) to complete, so it doesn't
+            // overwrite "widget.collection" after the synchronous "widget.collection.add"
+            // is made below
+            return renderDataSpy.callCount >= 2;
+        }, 'job list to finish initial loading');
+
+        runs(function () {
+            expect($('.g-jobs-list-table>tbody>tr').length).toBe(0);
+
+            jobs = _.map([
+                girder.plugins.jobs.JobStatus.QUEUED,
+                girder.plugins.jobs.JobStatus.RUNNING,
+                girder.plugins.jobs.JobStatus.SUCCESS
+            ], function (status, i) {
+                return new girder.plugins.jobs.models.JobModel({
+                    _id: 'foo' + i,
+                    title: 'My batch job ' + i,
+                    status: status,
+                    updated: '2015-01-12T12:00:0' + i,
+                    created: '2015-01-12T12:00:0' + i,
+                    when: '2015-01-12T12:00:0' + i
+                });
+            });
+
+            widget.collection.add(jobs);
+
+            // job list should re-render when collection is updated
+            expect($('.g-jobs-list-table>tbody>tr').length).toBe(3);
+        });
+
+        runs(function () {
+            // Make sure we are in reverse chronological order
+            rows = $('.g-jobs-list-table>tbody>tr');
+            expect($(rows[0]).text()).toContain('My batch job 2');
+            expect($(rows[0]).text()).toContain('Success');
+            expect($(rows[1]).text()).toContain('My batch job 1');
+            expect($(rows[1]).text()).toContain('Running');
+            expect($(rows[2]).text()).toContain('My batch job 0');
+            expect($(rows[2]).text()).toContain('Queued');
+
+            // Simulate an SSE notification that changes a job status
+            girder.utilities.eventStream.trigger('g:event.job_status', {
+                data: _.extend({}, jobs[0].attributes, {
+                    status: girder.plugins.jobs.JobStatus.ERROR
+                })
+            });
+        });
+
+        // Table row should update automatically
+        waitsFor(function () {
+            return $($('.g-jobs-list-table>tbody>tr').get(2)).find('td.g-job-status-cell').text() === 'Error';
+        }, 'Third row status change to Error');
+
+        runs(function () {
+            // The data in this is meaningless, but this will trigger a new API fetch
+            renderDataSpy.reset();
+            girder.utilities.eventStream.trigger('g:event.job_created', {
+                data: {
+                    _id: 'foo' + 4,
+                    title: 'My batch job ' + 4,
+                    status: girder.plugins.jobs.JobStatus.ERROR,
+                    updated: '2015-01-12T12:00:0' + 4,
+                    created: '2015-01-12T12:00:0' + 4,
+                    when: '2015-01-12T12:00:0' + 4
+                }
+            });
+        });
+
+        waitsFor(function () {
+            return renderDataSpy.wasCalled;
+        });
+
+        runs(function () {
+            // Since the server contains no actual jobs, once the API fetch completes, all of
+            // the previously-added local jobs will be blown away, and the local view will
+            // re-render to show no jobs
+            expect($('.g-no-job-record').is(':visible')).toBe(true);
         });
     });
 
-    describe('Unit test the job list widget.', function () {
-        // This spy must be attached to the prototype, since the instantiation of JobListWidget will
-        // bind and make calls to '_renderData' immediately
-        var renderDataSpy;
-        beforeEach(function () {
-            renderDataSpy = spyOn(girder.plugins.jobs.views.JobListWidget.prototype, '_renderData').andCallThrough();
-        });
-
-        it('Show a job list widget.', function () {
-            var jobs, rows, widget;
-
-            girderTest.createUser(
-                'admin', 'admin@email.com', 'Quota', 'Admin', 'testpassword')();
-
-            runs(function () {
-                widget = new girder.plugins.jobs.views.JobListWidget({
-                    el: $('#g-app-body-container'),
-                    filter: {},
-                    parentView: app,
-                    showGraphs: true,
-                    showFilters: true,
-                    showPageSizeSelector: true
-                });
-            });
-            waitsFor(function () {
-                // Wait for the pending fetch (causing the 2nd render) to complete, so it doesn't
-                // overwrite "widget.collection" after the synchronous "widget.collection.add"
-                // is made below
-                return renderDataSpy.callCount >= 2;
-            }, 'job list to finish initial loading');
-
-            runs(function () {
-                expect($('.g-jobs-list-table>tbody>tr').length).toBe(0);
-
-                jobs = _.map([
-                    girder.plugins.jobs.JobStatus.QUEUED,
-                    girder.plugins.jobs.JobStatus.RUNNING,
-                    girder.plugins.jobs.JobStatus.SUCCESS
-                ], function (status, i) {
-                    return new girder.plugins.jobs.models.JobModel({
-                        _id: 'foo' + i,
-                        title: 'My batch job ' + i,
-                        status: status,
-                        updated: '2015-01-12T12:00:0' + i,
-                        created: '2015-01-12T12:00:0' + i,
-                        when: '2015-01-12T12:00:0' + i
-                    });
-                });
-
-                widget.collection.add(jobs);
-
-                // job list should re-render when collection is updated
-                expect($('.g-jobs-list-table>tbody>tr').length).toBe(3);
-            });
-
-            runs(function () {
-                // Make sure we are in reverse chronological order
-                rows = $('.g-jobs-list-table>tbody>tr');
-                expect($(rows[0]).text()).toContain('My batch job 2');
-                expect($(rows[0]).text()).toContain('Success');
-                expect($(rows[1]).text()).toContain('My batch job 1');
-                expect($(rows[1]).text()).toContain('Running');
-                expect($(rows[2]).text()).toContain('My batch job 0');
-                expect($(rows[2]).text()).toContain('Queued');
-
-                // Simulate an SSE notification that changes a job status
-                girder.utilities.eventStream.trigger('g:event.job_status', {
-                    data: _.extend({}, jobs[0].attributes, {
-                        status: girder.plugins.jobs.JobStatus.ERROR
-                    })
-                });
-            });
-
-            // Table row should update automatically
-            waitsFor(function () {
-                return $($('.g-jobs-list-table>tbody>tr').get(2)).find('td.g-job-status-cell').text() === 'Error';
-            }, 'Third row status change to Error');
-
-            runs(function () {
-                // The data in this is meaningless, but this will trigger a new API fetch
-                renderDataSpy.reset();
-                girder.utilities.eventStream.trigger('g:event.job_created', {
-                    data: {
-                        _id: 'foo' + 4,
-                        title: 'My batch job ' + 4,
-                        status: girder.plugins.jobs.JobStatus.ERROR,
-                        updated: '2015-01-12T12:00:0' + 4,
-                        created: '2015-01-12T12:00:0' + 4,
-                        when: '2015-01-12T12:00:0' + 4
-                    }
-                });
-            });
-
-            waitsFor(function () {
-                return renderDataSpy.wasCalled;
-            });
-
-            runs(function () {
-                // Since the server contains no actual jobs, once the API fetch completes, all of
-                // the previously-added local jobs will be blown away, and the local view will
-                // re-render to show no jobs
-                expect($('.g-no-job-record').is(':visible')).toBe(true);
+    it('Job list widget filter by status & type.', function () {
+        var widget;
+        runs(function () {
+            widget = new girder.plugins.jobs.views.JobListWidget({
+                el: $('#g-app-body-container'),
+                filter: {},
+                parentView: app,
+                showGraphs: true,
+                showFilters: true,
+                showPageSizeSelector: true
             });
         });
+        waitsFor(function () {
+            return renderDataSpy.callCount >= 2;
+        }, 'job list to finish initial loading');
 
-        it('Job list widget filter by status & type.', function () {
-            var widget;
-            runs(function () {
-                widget = new girder.plugins.jobs.views.JobListWidget({
-                    el: $('#g-app-body-container'),
-                    filter: {},
-                    parentView: app,
-                    showGraphs: true,
-                    showFilters: true,
-                    showPageSizeSelector: true
-                });
+        runs(function () {
+            expect($('.g-jobs-list-table>tbody>tr').length).toBe(0);
+
+            // programmatically set value
+            widget.typeFilterWidget.setItems({
+                'type A': true,
+                'type B': true,
+                'type C': false
             });
-            waitsFor(function () {
-                return renderDataSpy.callCount >= 2;
-            }, 'job list to finish initial loading');
 
-            runs(function () {
-                expect($('.g-jobs-list-table>tbody>tr').length).toBe(0);
+            // one item should be unchecked
+            expect(widget.$('.g-job-filter-container .type .dropdown ul li input[type="checkbox"]:checked').length).toBe(2);
 
-                // programmatically set value
-                widget.typeFilterWidget.setItems({
-                    'type A': true,
-                    'type B': true,
-                    'type C': false
-                });
+            widget.$('.g-job-filter-container .type .dropdown ul li input').first().click();
 
-                // one item should be unchecked
-                expect(widget.$('.g-job-filter-container .type .dropdown ul li input[type="checkbox"]:checked').length).toBe(2);
+            expect(widget.$('.g-job-filter-container .type .dropdown ul li input[type="checkbox"]:checked').length).toBe(1);
 
-                widget.$('.g-job-filter-container .type .dropdown ul li input').first().click();
+            widget.$('.g-job-filter-container .type .dropdown .g-job-checkall input').click();
 
-                expect(widget.$('.g-job-filter-container .type .dropdown ul li input[type="checkbox"]:checked').length).toBe(1);
+            // all should be checked after clicking Check all
+            expect(widget.$('.g-job-filter-container .type .dropdown ul li input[type="checkbox"]:checked').length).toBe(3);
+            expect($('.g-job-filter-container .type .dropdown .g-job-checkall input').is(':checked')).toBe(true);
 
-                widget.$('.g-job-filter-container .type .dropdown .g-job-checkall input').click();
+            widget.$('.g-job-filter-container .status .dropdown .g-job-checkall input').click();
 
-                // all should be checked after clicking Check all
-                expect(widget.$('.g-job-filter-container .type .dropdown ul li input[type="checkbox"]:checked').length).toBe(3);
-                expect($('.g-job-filter-container .type .dropdown .g-job-checkall input').is(':checked')).toBe(true);
+            expect(widget.$('.g-job-filter-container .status .dropdown ul li input[type="checkbox"]:checked').length).toBe(0);
 
-                widget.$('.g-job-filter-container .status .dropdown .g-job-checkall input').click();
+            widget.$('.g-page-size').val(50).trigger('change');
+            expect(widget.collection.pageLimit).toBe(50);
+        });
+    });
 
-                expect(widget.$('.g-job-filter-container .status .dropdown ul li input[type="checkbox"]:checked').length).toBe(0);
+    it('Trigger click event.', function () {
+        var jobs, widget;
 
-                widget.$('.g-page-size').val(50).trigger('change');
-                expect(widget.collection.pageLimit).toBe(50);
+        runs(function () {
+            widget = new girder.plugins.jobs.views.JobListWidget({
+                el: $('#g-app-body-container'),
+                parentView: app,
+                filter: {},
+                triggerJobClick: true,
+                showGraphs: true,
+                showFilters: true,
+                showPageSizeSelector: true
             });
         });
+        waitsFor(function () {
+            return renderDataSpy.callCount >= 2;
+        }, 'job list to finish initial loading');
 
-        it('Trigger click event.', function () {
-            var jobs, widget;
+        runs(function () {
+            expect($('.g-jobs-list-table>tbody>tr').length).toBe(0);
 
-            runs(function () {
-                widget = new girder.plugins.jobs.views.JobListWidget({
-                    el: $('#g-app-body-container'),
-                    parentView: app,
-                    filter: {},
-                    triggerJobClick: true,
-                    showGraphs: true,
-                    showFilters: true,
-                    showPageSizeSelector: true
+            jobs = _.map([
+                girder.plugins.jobs.JobStatus.QUEUED,
+                girder.plugins.jobs.JobStatus.RUNNING,
+                girder.plugins.jobs.JobStatus.SUCCESS
+            ], function (status, i) {
+                return new girder.plugins.jobs.models.JobModel({
+                    _id: 'foo' + i,
+                    title: 'My batch job ' + i,
+                    status: status,
+                    updated: '2015-01-12T12:00:0' + i,
+                    created: '2015-01-12T12:00:0' + i,
+                    when: '2015-01-12T12:00:0' + i
                 });
             });
-            waitsFor(function () {
-                return renderDataSpy.callCount >= 2;
-            }, 'job list to finish initial loading');
 
-            runs(function () {
-                expect($('.g-jobs-list-table>tbody>tr').length).toBe(0);
-
-                jobs = _.map([
-                    girder.plugins.jobs.JobStatus.QUEUED,
-                    girder.plugins.jobs.JobStatus.RUNNING,
-                    girder.plugins.jobs.JobStatus.SUCCESS
-                ], function (status, i) {
-                    return new girder.plugins.jobs.models.JobModel({
-                        _id: 'foo' + i,
-                        title: 'My batch job ' + i,
-                        status: status,
-                        updated: '2015-01-12T12:00:0' + i,
-                        created: '2015-01-12T12:00:0' + i,
-                        when: '2015-01-12T12:00:0' + i
-                    });
-                });
-
-                widget.collection.add(jobs);
-            });
-
-            waitsFor(function () {
-                return $('.g-jobs-list-table>tbody>tr').length === 3;
-            }, 'job list to auto-reload when collection is updated');
-
-            runs(function () {
-                var fired = false;
-                widget.on('g:jobClicked', function () {
-                    fired = true;
-                });
-                widget.$('.g-job-trigger-link').click();
-                expect(fired).toBe(true);
-            });
+            widget.collection.add(jobs);
         });
 
-        it('job list widget in all jobs mode', function () {
-            var widget;
-            runs(function () {
-                widget = new girder.plugins.jobs.views.JobListWidget({
-                    el: $('#g-app-body-container'),
-                    parentView: app,
-                    filter: {},
-                    allJobsMode: true,
-                    showGraphs: true,
-                    showFilters: true,
-                    showPageSizeSelector: true
-                });
-            });
-            waitsFor(function () {
-                return renderDataSpy.callCount >= 2;
-            }, 'job list to finish initial loading');
+        waitsFor(function () {
+            return $('.g-jobs-list-table>tbody>tr').length === 3;
+        }, 'job list to auto-reload when collection is updated');
 
-            runs(function () {
-                expect(widget.collection.resourceName).toEqual('job/all');
+        runs(function () {
+            var fired = false;
+            widget.on('g:jobClicked', function () {
+                fired = true;
+            });
+            widget.$('.g-job-trigger-link').click();
+            expect(fired).toBe(true);
+        });
+    });
+
+    it('job list widget in all jobs mode', function () {
+        var widget;
+        runs(function () {
+            widget = new girder.plugins.jobs.views.JobListWidget({
+                el: $('#g-app-body-container'),
+                parentView: app,
+                filter: {},
+                allJobsMode: true,
+                showGraphs: true,
+                showFilters: true,
+                showPageSizeSelector: true
             });
         });
+        waitsFor(function () {
+            return renderDataSpy.callCount >= 2;
+        }, 'job list to finish initial loading');
 
-        it('timing history and time chart', function () {
-            var jobs, widget;
-            runs(function () {
-                widget = new girder.plugins.jobs.views.JobListWidget({
-                    el: $('#g-app-body-container'),
-                    filter: {},
-                    parentView: app,
-                    showGraphs: true,
-                    showFilters: true,
-                    showPageSizeSelector: true
-                });
-            });
-            waitsFor(function () {
-                return renderDataSpy.callCount >= 2;
-            }, 'job list to finish initial loading');
-
-            runs(function () {
-                jobs = _.map(['one', 'two', 'three'], function (type, i) {
-                    return new girder.plugins.jobs.models.JobModel({
-                        _id: 'foo' + i,
-                        title: 'My batch job ' + i,
-                        status: girder.plugins.jobs.JobStatus.ERROR,
-                        type: type,
-                        timestamps: [
-                            {
-                                'status': girder.plugins.jobs.JobStatus.QUEUED,
-                                'time': '2017-03-10T18:31:59.008Z'
-                            },
-                            {
-                                'status': girder.plugins.jobs.JobStatus.RUNNING,
-                                'time': '2017-03-10T18:32:06.190Z'
-                            },
-                            {
-                                'status': girder.plugins.jobs.JobStatus.ERROR,
-                                'time': '2017-03-10T18:32:34.760Z'
-                            }
-                        ],
-                        updated: '2017-03-10T18:32:34.760Z',
-                        created: '2017-03-10T18:31:59.008Z',
-                        when: '2017-03-10T18:31:59.008Z'
-                    });
-                });
-
-                widget.collection.add(jobs);
-
-                $('.g-jobs.nav.nav-tabs li a[name="timing-history"]').tab('show');
-            });
-            waitsFor(function () {
-                // Charts will render asynchronously with Vega
-                return widget.$('.g-jobs-graph svg .mark-rect.timing rect').length;
-            }, 'timing history graph to render');
-
-            runs(function () {
-                expect(widget.$('.g-jobs-graph svg .mark-rect.timing rect').length).toBe(6);
-                $('.g-jobs.nav.nav-tabs li a[name="time"]').tab('show');
-            });
-            waitsFor(function () {
-                return widget.$('.g-jobs-graph svg .mark-symbol.circle path').length;
-            }, 'time graph to render');
-
-            runs(function () {
-                expect(widget.$('.g-jobs-graph svg .mark-symbol.circle path').length).toBe(3);
-                $('.g-job-filter-container .timing .dropdown .g-job-checkall input').click();
-            });
-            waitsFor(function () {
-                return !widget.$('.g-jobs-graph svg .mark-symbol.circle path').length;
-            }, 'graph to clear');
+        runs(function () {
+            expect(widget.collection.resourceName).toEqual('job/all');
         });
+    });
 
-        it('Instantiate without graphs, filter, and page size selector.', function () {
-            var widget;
+    it('timing history and time chart', function () {
+        var jobs, widget;
+        runs(function () {
+            widget = new girder.plugins.jobs.views.JobListWidget({
+                el: $('#g-app-body-container'),
+                filter: {},
+                parentView: app,
+                showGraphs: true,
+                showFilters: true,
+                showPageSizeSelector: true
+            });
+        });
+        waitsFor(function () {
+            return renderDataSpy.callCount >= 2;
+        }, 'job list to finish initial loading');
 
-            runs(function () {
-                widget = new girder.plugins.jobs.views.JobListWidget({
-                    el: $('#g-app-body-container'),
-                    parentView: app,
-                    filter: {}
+        runs(function () {
+            jobs = _.map(['one', 'two', 'three'], function (type, i) {
+                return new girder.plugins.jobs.models.JobModel({
+                    _id: 'foo' + i,
+                    title: 'My batch job ' + i,
+                    status: girder.plugins.jobs.JobStatus.ERROR,
+                    type: type,
+                    timestamps: [
+                        {
+                            'status': girder.plugins.jobs.JobStatus.QUEUED,
+                            'time': '2017-03-10T18:31:59.008Z'
+                        },
+                        {
+                            'status': girder.plugins.jobs.JobStatus.RUNNING,
+                            'time': '2017-03-10T18:32:06.190Z'
+                        },
+                        {
+                            'status': girder.plugins.jobs.JobStatus.ERROR,
+                            'time': '2017-03-10T18:32:34.760Z'
+                        }
+                    ],
+                    updated: '2017-03-10T18:32:34.760Z',
+                    created: '2017-03-10T18:31:59.008Z',
+                    when: '2017-03-10T18:31:59.008Z'
                 });
             });
-            waitsFor(function () {
-                return renderDataSpy.callCount >= 2;
-            }, 'job list to finish initial loading');
 
-            runs(function () {
-                expect(widget.$('.g-jobs.nav.nav-tabs').length).toBe(0);
-                expect(widget.$('.g-job-filter-container').length).toBe(0);
-                expect(widget.$('.g-page-size-container').length).toBe(0);
+            widget.collection.add(jobs);
+
+            $('.g-jobs.nav.nav-tabs li a[name="timing-history"]').tab('show');
+        });
+        waitsFor(function () {
+            // Charts will render asynchronously with Vega
+            return widget.$('.g-jobs-graph svg .mark-rect.timing rect').length;
+        }, 'timing history graph to render');
+
+        runs(function () {
+            expect(widget.$('.g-jobs-graph svg .mark-rect.timing rect').length).toBe(6);
+            $('.g-jobs.nav.nav-tabs li a[name="time"]').tab('show');
+        });
+        waitsFor(function () {
+            return widget.$('.g-jobs-graph svg .mark-symbol.circle path').length;
+        }, 'time graph to render');
+
+        runs(function () {
+            expect(widget.$('.g-jobs-graph svg .mark-symbol.circle path').length).toBe(3);
+            $('.g-job-filter-container .timing .dropdown .g-job-checkall input').click();
+        });
+        waitsFor(function () {
+            return !widget.$('.g-jobs-graph svg .mark-symbol.circle path').length;
+        }, 'graph to clear');
+    });
+
+    it('Instantiate without graphs, filter, and page size selector.', function () {
+        var widget;
+
+        runs(function () {
+            widget = new girder.plugins.jobs.views.JobListWidget({
+                el: $('#g-app-body-container'),
+                parentView: app,
+                filter: {}
             });
+        });
+        waitsFor(function () {
+            return renderDataSpy.callCount >= 2;
+        }, 'job list to finish initial loading');
+
+        runs(function () {
+            expect(widget.$('.g-jobs.nav.nav-tabs').length).toBe(0);
+            expect(widget.$('.g-job-filter-container').length).toBe(0);
+            expect(widget.$('.g-page-size-container').length).toBe(0);
         });
     });
 });

--- a/plugins/provenance/plugin_tests/provenanceSpec.js
+++ b/plugins/provenance/plugin_tests/provenanceSpec.js
@@ -1,5 +1,4 @@
 girderTest.importPlugin('provenance');
-
 girderTest.startApp();
 
 $(function () {

--- a/plugins/provenance/plugin_tests/provenanceSpec.js
+++ b/plugins/provenance/plugin_tests/provenanceSpec.js
@@ -1,50 +1,48 @@
 girderTest.importPlugin('provenance');
 girderTest.startApp();
 
-$(function () {
-    describe('test the provenance plugin', function () {
-        it('create the admin user', girderTest.createUser(
-            'provenance', 'provenance@girder.org', 'Provenance', 'Plugin',
-            'testpassword'));
-        it('change the provenance settings', function () {
-            waitsFor(function () {
-                return $('a.g-nav-link[g-target="admin"]').length > 0;
-            }, 'admin console link to load');
-            runs(function () {
-                $('a.g-nav-link[g-target="admin"]').click();
-            });
-            waitsFor(function () {
-                return $('.g-plugins-config').length > 0;
-            }, 'the admin console to load');
-            runs(function () {
-                $('.g-plugins-config').click();
-            });
-            girderTest.waitForLoad();
-            waitsFor(function () {
-                return $('input.g-plugin-switch[key="provenance"]').length > 0;
-            }, 'the plugins page to load');
-            runs(function () {
-                expect($('.g-plugin-config-link[g-route="plugins/provenance/config"]').length > 0);
-                $('.g-plugin-config-link[g-route="plugins/provenance/config"]').click();
-            });
-            girderTest.waitForLoad();
-            waitsFor(function () {
-                return $('input#provenance').length > 0;
-            }, 'resource list setting to be shown');
-            runs(function () {
-                $('input#provenance').val('folder');
-                $('#g-provenance-form input.btn-primary').click();
-            });
-            waitsFor(function () {
-                var resp = girder.rest.restRequest({
-                    path: 'system/setting',
-                    type: 'GET',
-                    data: {key: 'provenance.resources'},
-                    async: false
-                });
-                return resp.responseText === '"folder"';
-            }, 'provenance settings to change');
-            girderTest.waitForLoad();
+describe('test the provenance plugin', function () {
+    it('create the admin user', girderTest.createUser(
+        'provenance', 'provenance@girder.org', 'Provenance', 'Plugin',
+        'testpassword'));
+    it('change the provenance settings', function () {
+        waitsFor(function () {
+            return $('a.g-nav-link[g-target="admin"]').length > 0;
+        }, 'admin console link to load');
+        runs(function () {
+            $('a.g-nav-link[g-target="admin"]').click();
         });
+        waitsFor(function () {
+            return $('.g-plugins-config').length > 0;
+        }, 'the admin console to load');
+        runs(function () {
+            $('.g-plugins-config').click();
+        });
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('input.g-plugin-switch[key="provenance"]').length > 0;
+        }, 'the plugins page to load');
+        runs(function () {
+            expect($('.g-plugin-config-link[g-route="plugins/provenance/config"]').length > 0);
+            $('.g-plugin-config-link[g-route="plugins/provenance/config"]').click();
+        });
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('input#provenance').length > 0;
+        }, 'resource list setting to be shown');
+        runs(function () {
+            $('input#provenance').val('folder');
+            $('#g-provenance-form input.btn-primary').click();
+        });
+        waitsFor(function () {
+            var resp = girder.rest.restRequest({
+                path: 'system/setting',
+                type: 'GET',
+                data: {key: 'provenance.resources'},
+                async: false
+            });
+            return resp.responseText === '"folder"';
+        }, 'provenance settings to change');
+        girderTest.waitForLoad();
     });
 });

--- a/plugins/thumbnails/plugin_tests/thumbnailsSpec.js
+++ b/plugins/thumbnails/plugin_tests/thumbnailsSpec.js
@@ -1,67 +1,65 @@
 girderTest.importPlugin('jobs', 'thumbnails');
 girderTest.startApp();
 
-$(function () {
-    describe('Test the thumbnail creation UI.', function () {
-        it('register a user', girderTest.createUser(
-            'johndoe', 'john.doe@email.com', 'John', 'Doe', 'password!'
-        ));
+describe('Test the thumbnail creation UI.', function () {
+    it('register a user', girderTest.createUser(
+        'johndoe', 'john.doe@email.com', 'John', 'Doe', 'password!'
+    ));
 
-        it('uploads the thumbnail', function () {
-            runs(function () {
-                expect($('#g-user-action-menu.open').length).toBe(0);
-                $('.g-user-text>a:first').click();
-            });
-            girderTest.waitForLoad();
-
-            runs(function () {
-                expect($('#g-user-action-menu.open').length).toBe(1);
-                $('a.g-my-folders').click();
-            });
-            girderTest.waitForLoad();
-            waitsFor(function () {
-                // The page may be loaded, but the folder list still populates asynchronously
-                return $('.g-folder-list>.g-folder-list-entry').length === 2;
-            });
-
-            runs(function () {
-                $('a.g-folder-list-link:last').click();
-            });
-            girderTest.waitForLoad();
-
-            waitsFor(function () {
-                return $('ol.breadcrumb>li.active').text() === 'Public' &&
-                       $('.g-empty-parent-message:visible').length === 1;
-            }, 'descending into Public folder');
-
-            girderTest.binaryUpload('clients/web/static/img/Girder_Mark.png');
-
-            runs(function () {
-                $('.g-item-list-link:first').click();
-            });
-
-            waitsFor(function () {
-                return $('.g-file-actions-container .g-create-thumbnail').length === 1;
-            }, 'the create thumbnail button to appear');
-
-            runs(function () {
-                $('.g-create-thumbnail').click();
-            });
-
-            waitsFor(function () {
-                return $('input#g-thumbnail-width').length === 1;
-            }, 'create thumbnail dialog to appear');
-            girderTest.waitForDialog();
-
-            runs(function () {
-                $('#g-thumbnail-width').val('64');
-                $('.g-submit-create-thumbnail').click();
-            });
-            girderTest.waitForLoad();
-
-            waitsFor(function () {
-                return $('.g-thumbnail-container').length === 1;
-            }, 'thumbnail to appear on the item');
+    it('uploads the thumbnail', function () {
+        runs(function () {
+            expect($('#g-user-action-menu.open').length).toBe(0);
+            $('.g-user-text>a:first').click();
         });
+        girderTest.waitForLoad();
+
+        runs(function () {
+            expect($('#g-user-action-menu.open').length).toBe(1);
+            $('a.g-my-folders').click();
+        });
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            // The page may be loaded, but the folder list still populates asynchronously
+            return $('.g-folder-list>.g-folder-list-entry').length === 2;
+        });
+
+        runs(function () {
+            $('a.g-folder-list-link:last').click();
+        });
+        girderTest.waitForLoad();
+
+        waitsFor(function () {
+            return $('ol.breadcrumb>li.active').text() === 'Public' &&
+                   $('.g-empty-parent-message:visible').length === 1;
+        }, 'descending into Public folder');
+
+        girderTest.binaryUpload('clients/web/static/img/Girder_Mark.png');
+
+        runs(function () {
+            $('.g-item-list-link:first').click();
+        });
+
+        waitsFor(function () {
+            return $('.g-file-actions-container .g-create-thumbnail').length === 1;
+        }, 'the create thumbnail button to appear');
+
+        runs(function () {
+            $('.g-create-thumbnail').click();
+        });
+
+        waitsFor(function () {
+            return $('input#g-thumbnail-width').length === 1;
+        }, 'create thumbnail dialog to appear');
+        girderTest.waitForDialog();
+
+        runs(function () {
+            $('#g-thumbnail-width').val('64');
+            $('.g-submit-create-thumbnail').click();
+        });
+        girderTest.waitForLoad();
+
+        waitsFor(function () {
+            return $('.g-thumbnail-container').length === 1;
+        }, 'thumbnail to appear on the item');
     });
 });

--- a/plugins/thumbnails/plugin_tests/thumbnailsSpec.js
+++ b/plugins/thumbnails/plugin_tests/thumbnailsSpec.js
@@ -1,5 +1,4 @@
 girderTest.importPlugin('jobs', 'thumbnails');
-
 girderTest.startApp();
 
 $(function () {

--- a/plugins/user_quota/plugin_tests/userQuotaSpec.js
+++ b/plugins/user_quota/plugin_tests/userQuotaSpec.js
@@ -1,5 +1,4 @@
 girderTest.importPlugin('user_quota');
-
 girderTest.startApp();
 
 $(function () {

--- a/plugins/user_quota/plugin_tests/userQuotaSpec.js
+++ b/plugins/user_quota/plugin_tests/userQuotaSpec.js
@@ -1,418 +1,416 @@
 girderTest.importPlugin('user_quota');
 girderTest.startApp();
 
-$(function () {
-    /* Go to the collections page.  If a collection is specified, go to that
-     * collection's page.
-     *
-     * @param collection: the name of the collection to go to.
-     */
-    function _goToCollection(collection) {
+/* Go to the collections page.  If a collection is specified, go to that
+ * collection's page.
+ *
+ * @param collection: the name of the collection to go to.
+ */
+function _goToCollection(collection) {
+    runs(function () {
+        $('a.g-nav-link[g-target=\'collections\']').click();
+    });
+    waitsFor(function () {
+        return $('.g-collections-search-container:visible').length > 0;
+    }, 'navigate to collections page');
+    girderTest.waitForLoad();
+    if (collection) {
         runs(function () {
-            $('a.g-nav-link[g-target=\'collections\']').click();
+            $('a.g-collection-link').has('b:contains(' + collection +
+                                         ')').click();
         });
         waitsFor(function () {
-            return $('.g-collections-search-container:visible').length > 0;
-        }, 'navigate to collections page');
+            return $('.g-collection-actions-button:visible').is(':enabled');
+        }, 'collection actions link to appear');
         girderTest.waitForLoad();
-        if (collection) {
-            runs(function () {
-                $('a.g-collection-link').has('b:contains(' + collection +
-                                             ')').click();
-            });
-            waitsFor(function () {
-                return $('.g-collection-actions-button:visible').is(':enabled');
-            }, 'collection actions link to appear');
-            girderTest.waitForLoad();
-        }
     }
+}
 
-    /* Go to the users page.  If a user is specified, go to that user's page.
-     *
-     * @param user: the full name of the user to go to.
-     */
-    function _goToUser(user) {
-        girderTest.goToUsersPage()();
-        if (user) {
-            runs(function () {
-                $('a.g-user-link:contains("' + user + '")').click();
-            });
-            waitsFor(function () {
-                return $('.g-user-name').text() === user;
-            }, 'user page to appear');
-            girderTest.waitForLoad();
-        }
+/* Go to the users page.  If a user is specified, go to that user's page.
+ *
+ * @param user: the full name of the user to go to.
+ */
+function _goToUser(user) {
+    girderTest.goToUsersPage()();
+    if (user) {
+        runs(function () {
+            $('a.g-user-link:contains("' + user + '")').click();
+        });
+        waitsFor(function () {
+            return $('.g-user-name').text() === user;
+        }, 'user page to appear');
+        girderTest.waitForLoad();
     }
+}
 
-    /* Go to a collection, make it public, and give user1 access to it.
-     *
-     * @param collection: the name of the collection to go to.
-     */
-    function _makeCollectionPublic(collection) {
-        _goToCollection(collection);
+/* Go to a collection, make it public, and give user1 access to it.
+ *
+ * @param collection: the name of the collection to go to.
+ */
+function _makeCollectionPublic(collection) {
+    _goToCollection(collection);
+    runs(function () {
+        $('.g-collection-actions-button').click();
+    });
+    waitsFor(function () {
+        return $('.g-collection-access-control[role="menuitem"]:visible').length === 1;
+    }, 'access control menu item to appear');
+    runs(function () {
+        $('.g-collection-access-control').click();
+    });
+    girderTest.waitForDialog();
+    waitsFor(function () {
+        return $('#g-dialog-container').hasClass('in') &&
+               $('#g-access-public:visible').is(':enabled');
+    }, 'dialog and public access radio button to appear');
+    runs(function () {
+        $('#g-access-public').click();
+        $('#g-dialog-container .g-search-field').val('user1');
+        $('#g-dialog-container input.g-search-field').trigger('input');
+    });
+    waitsFor(function () {
+        return $('.g-search-result').length === 1;
+    }, 'user1 to be listed');
+    runs(function () {
+        $('.g-search-result a').click();
+    });
+    waitsFor(function () {
+        return $('.g-user-access-entry').length === 2;
+    }, 'user1 to be in the access list');
+    runs(function () {
+        $('.g-access-col-right select').eq(1).val(2);
+    });
+    waitsFor(function () {
+        return $('.g-save-access-list:visible').is(':enabled') &&
+               $('.radio.g-selected').text().match('Public').length > 0;
+    }, 'access save button to appear');
+    runs(function () {
+        $('.g-save-access-list').click();
+    });
+    girderTest.waitForLoad();
+    waitsFor(function () {
+        return !$('#g-dialog-container').hasClass('in');
+    }, 'access dialog to be hidden');
+}
+
+/* Test the quota dialog, expecting that this is an admin and can set the
+ * quota.
+ * @param: hasChart: if true, we expect a pie chart.  If false, we don't.
+ * @param capacity: the capacity in bytes to set.
+ */
+function _testQuotaDialogAsAdmin(hasChart, capacity) {
+    girderTest.waitForDialog('quota dialog to appear');
+    waitsFor(function () {
+        return $('.g-quota-capacity').length === 1;
+    }, 'capacity to appear');
+    waitsFor(function () {
+        return $('a.btn-default').length === 1;
+    }, 'the cancel button to appear');
+    waitsFor(function () {
+        return $(hasChart ? '.g-has-chart' : '.g-no-chart').length === 1;
+    }, 'the chart to be determined (' + hasChart + ' ' + capacity + ')');
+    runs(function () {
+        expect($('#g-sizeValue').length).toBe(1);
+        /* The change() call should automatically set the custom quota radio
+         * button. */
+        $('#g-sizeValue').val('abc').trigger('input');
+        $('.g-save-policies').click();
+    });
+    waitsFor(function () {
+        return $('.g-validation-failed-message').text().indexOf('Invalid quota') >= 0;
+    }, 'an error message to appear');
+    runs(function () {
+        $('#g-sizeValue').val(capacity || '');
+    });
+    runs(function () {
+        $('.g-save-policies').click();
+    });
+    girderTest.waitForLoad('quota dialog to hide');
+}
+
+/* Test the quota dialog, expecting that this is a user and can not set the
+ * quota.
+ * @param: hasChart: if true, we expect a pie chart.  If false, we don't.
+ */
+function _testQuotaDialogAsUser(hasChart) {
+    girderTest.waitForDialog();
+    waitsFor(function () {
+        return $('.g-quota-capacity').length === 1;
+    }, 'capacity to appear');
+    waitsFor(function () {
+        return $('a.btn-default').length === 1;
+    }, 'the cancel button to appear');
+    waitsFor(function () {
+        return $(hasChart ? '.g-has-chart' : '.g-no-chart').length === 1;
+    }, 'the chart to be determined');
+    runs(function () {
+        expect($('#g-sizeValue').length).toBe(0);
+    });
+    runs(function () {
+        $('a.btn-default').click();
+    });
+    girderTest.waitForLoad();
+}
+
+describe('test the user quota plugin', function () {
+    var collectionDialogRoute, userDialogRoute, userRoute;
+    it('create resources', function () {
+        girderTest.createUser(
+            'admin', 'admin@email.com', 'Quota', 'Admin', 'testpassword')();
+        _goToCollection();
+        girderTest.createCollection('Collection A', 'ColDescription')();
+        _goToCollection();
+        girderTest.createCollection('Collection B', 'ColDescription')();
+        girderTest.logout('logout from admin')();
+        girderTest.createUser(
+            'user1', 'user@email.com', 'Quota', 'User', 'testpassword')();
+        girderTest.logout('logout from user1')();
+        girderTest.createUser(
+            'user2', 'user2@email.com', 'Another', 'User', 'testpassword')();
+        girderTest.logout('logout from user2')();
+        girderTest.createUser(
+            'user3', 'user3@email.com', 'Third', 'User', 'testpassword')();
+    });
+    it('make the collections public', function () {
+        girderTest.logout('logout from user3')();
+        girderTest.login('admin', 'Quota', 'Admin', 'testpassword')();
+        _makeCollectionPublic('Collection A');
+        _makeCollectionPublic('Collection B');
+    });
+    it('check that admin can set the default quotas', function () {
+        waitsFor(function () {
+            return $('a.g-nav-link[g-target="admin"]').length > 0;
+        }, 'admin console link to load');
+        runs(function () {
+            $('a.g-nav-link[g-target="admin"]').click();
+        });
+        waitsFor(function () {
+            return $('.g-plugins-config').length > 0;
+        }, 'the admin console to load');
+        runs(function () {
+            $('.g-plugins-config').click();
+        });
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('input.g-plugin-switch[key="user_quota"]').length > 0;
+        }, 'the plugins page to load');
+        runs(function () {
+            expect($('.g-plugin-config-link[g-route="plugins/user_quota/config"]').length > 0);
+            $('.g-plugin-config-link[g-route="plugins/user_quota/config"]').click();
+        });
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('input.g-sizeValue').length > 0;
+        }, 'quota default settings to be shown');
+        runs(function () {
+            $('input.g-sizeValue[model=user]').val('abc');
+            $('#g-user-quota-form input.btn-primary').click();
+        });
+        waitsFor(function () {
+            return $('#g-user-quota-error-message').text().indexOf('Invalid quota') >= 0;
+        }, 'error message to appear');
+        runs(function () {
+            $('input.g-sizeValue[model=user]').val('512000');
+            $('#g-user-quota-form input.btn-primary').click();
+        });
+        waitsFor(function () {
+            var resp = girder.rest.restRequest({
+                path: 'system/setting',
+                type: 'GET',
+                data: {key: 'user_quota.default_user_quota'},
+                async: false
+            });
+            return resp.responseText === '512000';
+        }, 'default quota settings to change');
+        girderTest.waitForLoad();
+    });
+    it('check that admin can set quota for collections and users', function () {
+        _goToCollection('Collection A');
         runs(function () {
             $('.g-collection-actions-button').click();
         });
         waitsFor(function () {
-            return $('.g-collection-access-control[role="menuitem"]:visible').length === 1;
-        }, 'access control menu item to appear');
+            return $('.g-collection-policies[role="menuitem"]:visible').length === 1;
+        }, 'collection actions menu to appear');
         runs(function () {
-            $('.g-collection-access-control').click();
+            $('.g-collection-policies').click();
         });
         girderTest.waitForDialog();
-        waitsFor(function () {
-            return $('#g-dialog-container').hasClass('in') &&
-                   $('#g-access-public:visible').is(':enabled');
-        }, 'dialog and public access radio button to appear');
         runs(function () {
-            $('#g-access-public').click();
-            $('#g-dialog-container .g-search-field').val('user1');
-            $('#g-dialog-container input.g-search-field').trigger('input');
+            collectionDialogRoute = window.location.hash;
+        });
+        _testQuotaDialogAsAdmin(false, 2048);
+        runs(function () {
+            $('.g-collection-policies').click();
+        });
+        /* We should now have a chart */
+        _testQuotaDialogAsAdmin(true, '32 kB');
+        _goToUser('Quota User');
+        runs(function () {
+            userRoute = window.location.hash;
+            $('.g-user-actions-button').click();
         });
         waitsFor(function () {
-            return $('.g-search-result').length === 1;
-        }, 'user1 to be listed');
+            return $('.g-user-policies[role="menuitem"]:visible').length === 1;
+        }, 'user actions menu to appear');
         runs(function () {
-            $('.g-search-result a').click();
+            $('.g-user-policies').click();
         });
-        waitsFor(function () {
-            return $('.g-user-access-entry').length === 2;
-        }, 'user1 to be in the access list');
+        girderTest.waitForDialog();
         runs(function () {
-            $('.g-access-col-right select').eq(1).val(2);
+            userDialogRoute = window.location.hash;
         });
-        waitsFor(function () {
-            return $('.g-save-access-list:visible').is(':enabled') &&
-                   $('.radio.g-selected').text().match('Public').length > 0;
-        }, 'access save button to appear');
+        _testQuotaDialogAsAdmin(true, 2048);
+    });
+    it('test routes', function () {
+        girderTest.testRoute(collectionDialogRoute, true, function () {
+            return $('.g-quota-capacity').length === 1;
+        });
+        girderTest.testRoute(userRoute, false, function () {
+            return $('.g-user-name').text() === 'Quota User';
+        });
+        girderTest.testRoute(userDialogRoute, true, function () {
+            return $('.g-quota-capacity').length === 1;
+        });
         runs(function () {
-            $('.g-save-access-list').click();
+            $('a[data-dismiss="modal"]').click();
+        });
+        girderTest.waitForLoad();
+    });
+    it('upload', function () {
+        runs(function () {
+            $('a.g-folder-list-link').eq(0).click();
         });
         girderTest.waitForLoad();
         waitsFor(function () {
-            return !$('#g-dialog-container').hasClass('in');
-        }, 'access dialog to be hidden');
-    }
-
-    /* Test the quota dialog, expecting that this is an admin and can set the
-     * quota.
-     * @param: hasChart: if true, we expect a pie chart.  If false, we don't.
-     * @param capacity: the capacity in bytes to set.
-     */
-    function _testQuotaDialogAsAdmin(hasChart, capacity) {
-        girderTest.waitForDialog('quota dialog to appear');
-        waitsFor(function () {
-            return $('.g-quota-capacity').length === 1;
-        }, 'capacity to appear');
-        waitsFor(function () {
-            return $('a.btn-default').length === 1;
-        }, 'the cancel button to appear');
-        waitsFor(function () {
-            return $(hasChart ? '.g-has-chart' : '.g-no-chart').length === 1;
-        }, 'the chart to be determined (' + hasChart + ' ' + capacity + ')');
+            return $('li.g-folder-list-entry').length === 0;
+        }, 'my folders list to display');
+        girderTest.testUpload(2048);
+        girderTest.testUpload(2048, 'abort', 'file storage quota');
         runs(function () {
-            expect($('#g-sizeValue').length).toBe(1);
-            /* The change() call should automatically set the custom quota radio
-             * button. */
-            $('#g-sizeValue').val('abc').trigger('input');
-            $('.g-save-policies').click();
+            window.callPhantom({
+                action: 'uploadCleanup',
+                suffix: girderTest._uploadSuffix
+            });
+        });
+    });
+    it('check that user1 can view but not set quota', function () {
+        girderTest.logout('logout from admin')();
+        girderTest.login('user1', 'Quota', 'User', 'testpassword')();
+        _goToCollection('Collection A');
+        runs(function () {
+            $('.g-collection-actions-button').click();
         });
         waitsFor(function () {
-            return $('.g-validation-failed-message').text().indexOf('Invalid quota') >= 0;
-        }, 'an error message to appear');
+            return $('.g-collection-policies[role="menuitem"]:visible').length === 1;
+        }, 'collection actions menu to appear');
         runs(function () {
-            $('#g-sizeValue').val(capacity || '');
+            $('.g-collection-policies').click();
         });
+        _testQuotaDialogAsUser(true);
+        _goToUser('Quota User');
         runs(function () {
-            $('.g-save-policies').click();
+            $('.g-user-actions-button').click();
         });
-        girderTest.waitForLoad('quota dialog to hide');
-    }
-
-    /* Test the quota dialog, expecting that this is a user and can not set the
-     * quota.
-     * @param: hasChart: if true, we expect a pie chart.  If false, we don't.
-     */
-    function _testQuotaDialogAsUser(hasChart) {
-        girderTest.waitForDialog();
         waitsFor(function () {
-            return $('.g-quota-capacity').length === 1;
-        }, 'capacity to appear');
-        waitsFor(function () {
-            return $('a.btn-default').length === 1;
-        }, 'the cancel button to appear');
-        waitsFor(function () {
-            return $(hasChart ? '.g-has-chart' : '.g-no-chart').length === 1;
-        }, 'the chart to be determined');
+            return $('.g-user-policies[role="menuitem"]:visible').length === 1;
+        }, 'user actions menu to appear');
         runs(function () {
-            expect($('#g-sizeValue').length).toBe(0);
+            $('.g-user-policies').click();
         });
+        _testQuotaDialogAsUser(true);
+    });
+    it('check that a different user does not see quota', function () {
+        girderTest.logout('logout from user1')();
+        girderTest.login('user2', 'Another', 'User', 'testpassword')();
+        _goToCollection('Collection A');
+        waitsFor(function () {
+            return $('.g-collection-actions-button:visible').is(':enabled');
+        }, 'collection actions link to appear');
         runs(function () {
-            $('a.btn-default').click();
+            $('.g-collection-actions-button').click();
+        });
+        waitsFor(function () {
+            return $('.g-download-collection[role="menuitem"]:visible').length === 1;
+        }, 'collection actions menu to appear');
+        runs(function () {
+            expect($('.g-collection-policies').length).toBe(0);
+        });
+        _goToUser('Quota User');
+        runs(function () {
+            expect($('button:contains("Actions")').length).toBe(0);
+        });
+    });
+    it('check that admin can set the default collection quota', function () {
+        girderTest.logout('logout from user2')();
+        girderTest.login('admin', 'Quota', 'Admin', 'testpassword')();
+        waitsFor(function () {
+            return $('a.g-nav-link[g-target="admin"]').length > 0;
+        }, 'admin console link to load');
+        runs(function () {
+            $('a.g-nav-link[g-target="admin"]').click();
+        });
+        waitsFor(function () {
+            return $('.g-plugins-config').length > 0;
+        }, 'the admin console to load');
+        runs(function () {
+            $('.g-plugins-config').click();
         });
         girderTest.waitForLoad();
-    }
-
-    describe('test the user quota plugin', function () {
-        var collectionDialogRoute, userDialogRoute, userRoute;
-        it('create resources', function () {
-            girderTest.createUser(
-                'admin', 'admin@email.com', 'Quota', 'Admin', 'testpassword')();
-            _goToCollection();
-            girderTest.createCollection('Collection A', 'ColDescription')();
-            _goToCollection();
-            girderTest.createCollection('Collection B', 'ColDescription')();
-            girderTest.logout('logout from admin')();
-            girderTest.createUser(
-                'user1', 'user@email.com', 'Quota', 'User', 'testpassword')();
-            girderTest.logout('logout from user1')();
-            girderTest.createUser(
-                'user2', 'user2@email.com', 'Another', 'User', 'testpassword')();
-            girderTest.logout('logout from user2')();
-            girderTest.createUser(
-                'user3', 'user3@email.com', 'Third', 'User', 'testpassword')();
+        waitsFor(function () {
+            return $('input.g-plugin-switch[key="user_quota"]').length > 0;
+        }, 'the plugins page to load');
+        runs(function () {
+            expect($('.g-plugin-config-link[g-route="plugins/user_quota/config"]').length > 0);
+            $('.g-plugin-config-link[g-route="plugins/user_quota/config"]').click();
         });
-        it('make the collections public', function () {
-            girderTest.logout('logout from user3')();
-            girderTest.login('admin', 'Quota', 'Admin', 'testpassword')();
-            _makeCollectionPublic('Collection A');
-            _makeCollectionPublic('Collection B');
+        girderTest.waitForLoad();
+        waitsFor(function () {
+            return $('input.g-sizeValue').length > 0;
+        }, 'quota default settings to be shown');
+        runs(function () {
+            $('input.g-sizeValue[model=collection]').val('256000');
+            $('#g-user-quota-form input.btn-primary').click();
         });
-        it('check that admin can set the default quotas', function () {
-            waitsFor(function () {
-                return $('a.g-nav-link[g-target="admin"]').length > 0;
-            }, 'admin console link to load');
-            runs(function () {
-                $('a.g-nav-link[g-target="admin"]').click();
+        waitsFor(function () {
+            var resp = girder.rest.restRequest({
+                path: 'system/setting',
+                type: 'GET',
+                data: {key: 'user_quota.default_collection_quota'},
+                async: false
             });
-            waitsFor(function () {
-                return $('.g-plugins-config').length > 0;
-            }, 'the admin console to load');
-            runs(function () {
-                $('.g-plugins-config').click();
-            });
-            girderTest.waitForLoad();
-            waitsFor(function () {
-                return $('input.g-plugin-switch[key="user_quota"]').length > 0;
-            }, 'the plugins page to load');
-            runs(function () {
-                expect($('.g-plugin-config-link[g-route="plugins/user_quota/config"]').length > 0);
-                $('.g-plugin-config-link[g-route="plugins/user_quota/config"]').click();
-            });
-            girderTest.waitForLoad();
-            waitsFor(function () {
-                return $('input.g-sizeValue').length > 0;
-            }, 'quota default settings to be shown');
-            runs(function () {
-                $('input.g-sizeValue[model=user]').val('abc');
-                $('#g-user-quota-form input.btn-primary').click();
-            });
-            waitsFor(function () {
-                return $('#g-user-quota-error-message').text().indexOf('Invalid quota') >= 0;
-            }, 'error message to appear');
-            runs(function () {
-                $('input.g-sizeValue[model=user]').val('512000');
-                $('#g-user-quota-form input.btn-primary').click();
-            });
-            waitsFor(function () {
-                var resp = girder.rest.restRequest({
-                    path: 'system/setting',
-                    type: 'GET',
-                    data: {key: 'user_quota.default_user_quota'},
-                    async: false
-                });
-                return resp.responseText === '512000';
-            }, 'default quota settings to change');
-            girderTest.waitForLoad();
+            return resp.responseText === '256000';
+        }, 'default collection quota settings to change');
+        girderTest.waitForLoad();
+    });
+    it('check that a user that has never had their quota altered sees the default', function () {
+        girderTest.logout('logout from admin')();
+        girderTest.login('user3', 'Third', 'User', 'testpassword')();
+        _goToUser('Third User');
+        runs(function () {
+            $('.g-user-actions-button').click();
         });
-        it('check that admin can set quota for collections and users', function () {
-            _goToCollection('Collection A');
-            runs(function () {
-                $('.g-collection-actions-button').click();
-            });
-            waitsFor(function () {
-                return $('.g-collection-policies[role="menuitem"]:visible').length === 1;
-            }, 'collection actions menu to appear');
-            runs(function () {
-                $('.g-collection-policies').click();
-            });
-            girderTest.waitForDialog();
-            runs(function () {
-                collectionDialogRoute = window.location.hash;
-            });
-            _testQuotaDialogAsAdmin(false, 2048);
-            runs(function () {
-                $('.g-collection-policies').click();
-            });
-            /* We should now have a chart */
-            _testQuotaDialogAsAdmin(true, '32 kB');
-            _goToUser('Quota User');
-            runs(function () {
-                userRoute = window.location.hash;
-                $('.g-user-actions-button').click();
-            });
-            waitsFor(function () {
-                return $('.g-user-policies[role="menuitem"]:visible').length === 1;
-            }, 'user actions menu to appear');
-            runs(function () {
-                $('.g-user-policies').click();
-            });
-            girderTest.waitForDialog();
-            runs(function () {
-                userDialogRoute = window.location.hash;
-            });
-            _testQuotaDialogAsAdmin(true, 2048);
+        waitsFor(function () {
+            return $('.g-user-policies[role="menuitem"]:visible').length === 1;
+        }, 'user actions menu to appear');
+        runs(function () {
+            $('.g-user-policies').click();
         });
-        it('test routes', function () {
-            girderTest.testRoute(collectionDialogRoute, true, function () {
-                return $('.g-quota-capacity').length === 1;
-            });
-            girderTest.testRoute(userRoute, false, function () {
-                return $('.g-user-name').text() === 'Quota User';
-            });
-            girderTest.testRoute(userDialogRoute, true, function () {
-                return $('.g-quota-capacity').length === 1;
-            });
-            runs(function () {
-                $('a[data-dismiss="modal"]').click();
-            });
-            girderTest.waitForLoad();
+        _testQuotaDialogAsUser(true);
+    });
+    it('check that a collection that has never had their quota altered sees the default', function () {
+        girderTest.logout('logout from user3')();
+        girderTest.login('user1', 'Quota', 'User', 'testpassword')();
+        _goToCollection('Collection B');
+        runs(function () {
+            $('.g-collection-actions-button').click();
         });
-        it('upload', function () {
-            runs(function () {
-                $('a.g-folder-list-link').eq(0).click();
-            });
-            girderTest.waitForLoad();
-            waitsFor(function () {
-                return $('li.g-folder-list-entry').length === 0;
-            }, 'my folders list to display');
-            girderTest.testUpload(2048);
-            girderTest.testUpload(2048, 'abort', 'file storage quota');
-            runs(function () {
-                window.callPhantom({
-                    action: 'uploadCleanup',
-                    suffix: girderTest._uploadSuffix
-                });
-            });
+        waitsFor(function () {
+            return $('.g-collection-policies[role="menuitem"]:visible').length === 1;
+        }, 'collection actions menu to appear');
+        runs(function () {
+            $('.g-collection-policies').click();
         });
-        it('check that user1 can view but not set quota', function () {
-            girderTest.logout('logout from admin')();
-            girderTest.login('user1', 'Quota', 'User', 'testpassword')();
-            _goToCollection('Collection A');
-            runs(function () {
-                $('.g-collection-actions-button').click();
-            });
-            waitsFor(function () {
-                return $('.g-collection-policies[role="menuitem"]:visible').length === 1;
-            }, 'collection actions menu to appear');
-            runs(function () {
-                $('.g-collection-policies').click();
-            });
-            _testQuotaDialogAsUser(true);
-            _goToUser('Quota User');
-            runs(function () {
-                $('.g-user-actions-button').click();
-            });
-            waitsFor(function () {
-                return $('.g-user-policies[role="menuitem"]:visible').length === 1;
-            }, 'user actions menu to appear');
-            runs(function () {
-                $('.g-user-policies').click();
-            });
-            _testQuotaDialogAsUser(true);
-        });
-        it('check that a different user does not see quota', function () {
-            girderTest.logout('logout from user1')();
-            girderTest.login('user2', 'Another', 'User', 'testpassword')();
-            _goToCollection('Collection A');
-            waitsFor(function () {
-                return $('.g-collection-actions-button:visible').is(':enabled');
-            }, 'collection actions link to appear');
-            runs(function () {
-                $('.g-collection-actions-button').click();
-            });
-            waitsFor(function () {
-                return $('.g-download-collection[role="menuitem"]:visible').length === 1;
-            }, 'collection actions menu to appear');
-            runs(function () {
-                expect($('.g-collection-policies').length).toBe(0);
-            });
-            _goToUser('Quota User');
-            runs(function () {
-                expect($('button:contains("Actions")').length).toBe(0);
-            });
-        });
-        it('check that admin can set the default collection quota', function () {
-            girderTest.logout('logout from user2')();
-            girderTest.login('admin', 'Quota', 'Admin', 'testpassword')();
-            waitsFor(function () {
-                return $('a.g-nav-link[g-target="admin"]').length > 0;
-            }, 'admin console link to load');
-            runs(function () {
-                $('a.g-nav-link[g-target="admin"]').click();
-            });
-            waitsFor(function () {
-                return $('.g-plugins-config').length > 0;
-            }, 'the admin console to load');
-            runs(function () {
-                $('.g-plugins-config').click();
-            });
-            girderTest.waitForLoad();
-            waitsFor(function () {
-                return $('input.g-plugin-switch[key="user_quota"]').length > 0;
-            }, 'the plugins page to load');
-            runs(function () {
-                expect($('.g-plugin-config-link[g-route="plugins/user_quota/config"]').length > 0);
-                $('.g-plugin-config-link[g-route="plugins/user_quota/config"]').click();
-            });
-            girderTest.waitForLoad();
-            waitsFor(function () {
-                return $('input.g-sizeValue').length > 0;
-            }, 'quota default settings to be shown');
-            runs(function () {
-                $('input.g-sizeValue[model=collection]').val('256000');
-                $('#g-user-quota-form input.btn-primary').click();
-            });
-            waitsFor(function () {
-                var resp = girder.rest.restRequest({
-                    path: 'system/setting',
-                    type: 'GET',
-                    data: {key: 'user_quota.default_collection_quota'},
-                    async: false
-                });
-                return resp.responseText === '256000';
-            }, 'default collection quota settings to change');
-            girderTest.waitForLoad();
-        });
-        it('check that a user that has never had their quota altered sees the default', function () {
-            girderTest.logout('logout from admin')();
-            girderTest.login('user3', 'Third', 'User', 'testpassword')();
-            _goToUser('Third User');
-            runs(function () {
-                $('.g-user-actions-button').click();
-            });
-            waitsFor(function () {
-                return $('.g-user-policies[role="menuitem"]:visible').length === 1;
-            }, 'user actions menu to appear');
-            runs(function () {
-                $('.g-user-policies').click();
-            });
-            _testQuotaDialogAsUser(true);
-        });
-        it('check that a collection that has never had their quota altered sees the default', function () {
-            girderTest.logout('logout from user3')();
-            girderTest.login('user1', 'Quota', 'User', 'testpassword')();
-            _goToCollection('Collection B');
-            runs(function () {
-                $('.g-collection-actions-button').click();
-            });
-            waitsFor(function () {
-                return $('.g-collection-policies[role="menuitem"]:visible').length === 1;
-            }, 'collection actions menu to appear');
-            runs(function () {
-                $('.g-collection-policies').click();
-            });
-            _testQuotaDialogAsUser(true);
-        });
+        _testQuotaDialogAsUser(true);
     });
 });


### PR DESCRIPTION
* Make girderTest.startApp chain onto girderTest.promise more robustly
* Use girderTest.startApp to start the app in testing
* Don't wrap test specs in "$(function..."
  * The test runner will only load and execute specs once the page is ready.
* Add additional documentation on plugin tests