### PR TITLE
Allow read() on file-like objects.

### DIFF
--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -56,17 +56,19 @@ class FileHandle(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
-    def read(self, size):
+    def read(self, size=None):
         """
         Read *size* bytes from the file data.
 
         :param size: The number of bytes to read from the current position. The
             actual number returned could be less than this if the end of the
             file is reached. An empty response indicates that the file has been
-            completely consumed.
+            completely consumed.  If None, read to the end of the file.
         :type size: int
         :rtype: bytes
         """
+        if size is None:
+            size = self._file['size'] - self._pos
         data = six.BytesIO()
         length = 0
         for chunk in itertools.chain(self._prev, self._stream):

--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -63,11 +63,12 @@ class FileHandle(object):
         :param size: The number of bytes to read from the current position. The
             actual number returned could be less than this if the end of the
             file is reached. An empty response indicates that the file has been
-            completely consumed.  If None, read to the end of the file.
+            completely consumed.  If None or negative, read to the end of the
+            file.
         :type size: int
         :rtype: bytes
         """
-        if size is None:
+        if size is None or size < 0:
             size = self._file['size'] - self._pos
         data = six.BytesIO()
         length = 0

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -345,6 +345,15 @@ class FileTestCase(base.TestCase):
             buf = _readFile(handle)
             self.assertEqual(buf, contents[-2:])
 
+            # Read without a length parameter
+            handle.seek(0, os.SEEK_SET)
+            buf = handle.read()
+            self.assertEqual(buf, contents)
+
+            handle.seek(2, os.SEEK_END)
+            buf = handle.read()
+            self.assertEqual(buf, contents[-2:])
+
     def _testDownloadFolder(self):
         """
         Test downloading an entire folder as a zip file.

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -33,7 +33,7 @@ from .. import base, mock_s3
 from girder import events
 from girder.constants import SettingKey
 from girder.models import getDbConnection
-from girder.models.model_base import AccessException
+from girder.models.model_base import AccessException, GirderException
 from girder.utility import gridfs_assetstore_adapter
 from girder.utility.filesystem_assetstore_adapter import DEFAULT_PERMS
 from girder.utility.s3_assetstore_adapter import makeBotoConnectParams, S3AssetstoreAdapter
@@ -354,7 +354,7 @@ class FileTestCase(base.TestCase):
             buf = handle.read()
             self.assertEqual(buf, contents[-2:])
 
-            # Read without a negative length parametera
+            # Read with a negative length parameter
             handle.seek(0, os.SEEK_SET)
             buf = handle.read(-1)
             self.assertEqual(buf, contents)
@@ -362,6 +362,17 @@ class FileTestCase(base.TestCase):
             handle.seek(2, os.SEEK_END)
             buf = handle.read(-5)
             self.assertEqual(buf, contents[-2:])
+
+            # Read too many bytes on files long enough to test
+            if len(contents) > 6:
+                handle._maximumReadSize = 6
+                handle.seek(0, os.SEEK_SET)
+                self.assertRaises(GirderException, handle.read, 7)
+                handle.seek(0, os.SEEK_SET)
+                self.assertRaises(GirderException, handle.read)
+                handle.seek(2, os.SEEK_END)
+                buf = handle.read()
+                self.assertEqual(buf, contents[-2:])
 
     def _testDownloadFolder(self):
         """

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -354,6 +354,15 @@ class FileTestCase(base.TestCase):
             buf = handle.read()
             self.assertEqual(buf, contents[-2:])
 
+            # Read without a negative length parametera
+            handle.seek(0, os.SEEK_SET)
+            buf = handle.read(-1)
+            self.assertEqual(buf, contents)
+
+            handle.seek(2, os.SEEK_END)
+            buf = handle.read(-5)
+            self.assertEqual(buf, contents[-2:])
+
     def _testDownloadFolder(self):
         """
         Test downloading an entire folder as a zip file.


### PR DESCRIPTION
We expose Girder files as python file-like objects.  For the default
python file, the size of a read is optional.  We were requiring it,
which broke sending the file-like object to certain functions
(json.load, for instance).