### PR TITLE
Update babel-plugin-istanbul

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -308,10 +308,24 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o="
     },
     "babel-plugin-istanbul": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-2.0.3.tgz",
-      "integrity": "sha1-JmswS5EJYH1gdIR0OUZ2mC9mDfQ=",
-      "dev": true
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.4.tgz",
+      "integrity": "sha1-GN3oS/POMp/d8/QQP66SFFbY5Yc=",
+      "dev": true,
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true
+        },
+        "test-exclude": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
+          "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
+          "dev": true
+        }
+      }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
@@ -5542,12 +5556,6 @@
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.6.tgz",
       "integrity": "sha1-IGvo4YiGC1FEJTdebxrom/sB/Y0="
-    },
-    "test-exclude": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-2.1.3.tgz",
-      "integrity": "sha1-qNiWjh2oMmb5hk8oUsVeIg8GQ0o=",
-      "dev": true
     },
     "text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "webpack": "2.2.1"
     },
     "devDependencies": {
-        "babel-plugin-istanbul": "^2.0.1",
+        "babel-plugin-istanbul": "^4.1.4",
         "core-js": "^2.4.1",
         "esdoc": "^0.5.2",
         "eslint": "^3.19.0",


### PR DESCRIPTION
This makes some minor improvements in our js coverage reports for transpiled code (arrow functions in particular).  Unfortunately, t doesn't fix a lot of the problems I'm seeing. :(