### PR TITLE
Remove some usages of Model.attributes

### DIFF
--- a/plugins/item_tasks/web_client/views/ControlWidget.js
+++ b/plugins/item_tasks/web_client/views/ControlWidget.js
@@ -44,7 +44,7 @@ var ControlWidget = View.extend({
         if (options && options.norender) {
             return this;
         }
-        this.$el.html(this.template()(this.model.attributes));  // eslint-disable-line backbone/no-view-model-attributes
+        this.$el.html(this.template()(this.model.toJSON()));
         this.$('.g-control-item[data-type="range"] input').slider();
         this.$('.g-control-item[data-type="color"] .input-group').colorpicker({});
 

--- a/plugins/user_quota/web_client/views/QuotaPoliciesWidget.js
+++ b/plugins/user_quota/web_client/views/QuotaPoliciesWidget.js
@@ -130,16 +130,11 @@ var QuotaPoliciesWidget = View.extend({
     },
 
     render: function () {
-        var view = this;
         var sizeInfo, defaultQuota, defaultQuotaString, modal;
-        var name = view.model.attributes.name;
+        var name = this.model.name();
         var currentUser = getCurrentUser();
-        if (view.modelType === 'user') {
-            name = view.model.attributes.firstName + ' ' +
-                   view.model.attributes.lastName;
-        }
         sizeInfo = sizeToValueAndUnits(
-            view.model.get('quotaPolicy').fileSizeQuota);
+            this.model.get('quotaPolicy').fileSizeQuota);
         defaultQuota = this.model.get('defaultQuota');
         if (!defaultQuota) {
             defaultQuotaString = 'Unlimited';
@@ -149,33 +144,32 @@ var QuotaPoliciesWidget = View.extend({
         this._destroyPlots();
         modal = this.$el.html(QuotaPoliciesWidgetTemplate({
             currentUser: currentUser,
-            model: view.model,
-            modelType: view.modelType,
+            model: this.model,
+            modelType: this.modelType,
             name: name,
-            quotaPolicy: view.model.get('quotaPolicy'),
+            quotaPolicy: this.model.get('quotaPolicy'),
             sizeValue: sizeInfo.sizeValue,
             sizeUnits: sizeInfo.sizeUnits,
             assetstoreList: (currentUser.get('admin')
-                ? view.model.get('assetstoreList').models : undefined),
+                ? this.model.get('assetstoreList').models : undefined),
             capacityString: ' ' + this.capacityString(),
             defaultQuotaString: defaultQuotaString
-        })).girderModal(this).on('shown.bs.modal', function () {
-            view.$('#g-fileSizeQuota').focus();
-            view.capacityChart(view, '.g-quota-capacity-chart');
-        }).on('hidden.bs.modal', function () {
+        })).girderModal(this).on('shown.bs.modal', () => {
+            this.$('#g-fileSizeQuota').focus();
+            this.capacityChart(this, '.g-quota-capacity-chart');
+        }).on('hidden.bs.modal', () => {
             handleClose('quota');
-            view.trigger('g:hidden');
+            this.trigger('g:hidden');
         });
         modal.trigger($.Event('ready.girder.modal', {relatedTarget: modal}));
-        view.$('#g-fileSizeQuota').focus();
+        this.$('#g-fileSizeQuota').focus();
         handleOpen('quota');
         return this;
     },
 
     updateQuotaPolicies: function (fields) {
-        var view = this;
-        _.each(fields, function (value, key) {
-            view.model.get('quotaPolicy')[key] = value;
+        _.each(fields, (value, key) => {
+            this.model.get('quotaPolicy')[key] = value;
         });
         this.model.on('g:quotaPolicySaved', function () {
             this.$el.modal('hide');


### PR DESCRIPTION
Backbone provides a `Model.toJSON` method to get a copy of the attributes. Girder provides a `Model.name` method to robustly get the display name of any Model type.