### PR TITLE
Fix missing userId key in anonymous jobs

### DIFF
--- a/plugins/jobs/server/models/job.py
+++ b/plugins/jobs/server/models/job.py
@@ -240,6 +240,8 @@ class Job(AccessControlledModel):
         if user:
             job['userId'] = user['_id']
             self.setUserAccess(job, user=user, level=AccessType.ADMIN)
+        else:
+            job['userId'] = None
 
         if save:
             job = self.save(job)


### PR DESCRIPTION
This fixes an issue for Flow, see https://github.com/Kitware/flow/issues/214. Since Flow is on 1.x, the fix would needed to be back-ported, or Flow would need to upgrade to latest Girder to resolve the issue.

The problem is that there are several places with logic like `if job['userId']` which throw a `KeyError` if there was no user specified on job creation. Another fix would have been to change those other accesses to something like `if job.get('userId')`, but this fix is smaller.