### PR TITLE
Move babel coverage config to .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,10 @@
+{
+  "env": {
+    "cover": {
+      "plugins": [[
+        "babel-plugin-istanbul",
+        {"include": ["**/clients/web/src/**/*.js", "**/plugins/*/web_client/**/*.js"]}
+      ]],
+    }
+  }
+}

--- a/grunt_tasks/webpack.config.js
+++ b/grunt_tasks/webpack.config.js
@@ -36,22 +36,6 @@ function fileLoader() {
     };
 }
 
-function _coverageConfig() {
-    try {
-        var istanbulPlugin = require.resolve('babel-plugin-istanbul');
-        return {
-            plugins: [[
-                istanbulPlugin, {
-                    exclude: ['**/*.pug', '**/*.jade', 'node_modules/**/*']
-                }
-            ]]
-        };
-    } catch (e) {
-        // We won't have the istanbul plugin installed in a prod env.
-        return {};
-    }
-}
-
 var loaderPaths = [path.resolve('clients', 'web', 'src')];
 var loaderPathsNodeModules = loaderPaths.concat([path.resolve('node_modules')]);
 
@@ -84,10 +68,7 @@ module.exports = {
                     {
                         loader: 'babel-loader',
                         options: {
-                            presets: [es2015Preset],
-                            env: {
-                                cover: _coverageConfig()
-                            }
+                            presets: [es2015Preset]
                         }
                     }
                 ]


### PR DESCRIPTION
I was able to track down the problems with our javascript coverage reporting to the webpack helper in the dicom_viewer plugin.  For some reason, adding the babel loader there without including the coverage config breaks it's use elsewhere.  It probably shouldn't be doing that because the include/exclude rules are correct.  Maybe there is some caching going on.

I think we were originally using a `.babelrc` file, which we removed to fix problems with symlinking plugins into place.  This will probably break that use case again, but I can't think of a good way around it.  If anyone has any ideas, let me know.

See the difference: [before](https://2272-11854950-gh.circle-artifacts.com/2/tmp/circle-artifacts.UjI6cEz/coverage/js/plugins/item_tasks/web_client/models/WidgetModel.js.html) and [after](https://2289-11854950-gh.circle-artifacts.com/2/tmp/circle-artifacts.1grdGeC/coverage/js/plugins/item_tasks/web_client/models/WidgetModel.js.html)