### PR TITLE
Fix SEEK_END in the FileHandle class.

### DIFF
--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -111,7 +111,7 @@ class FileHandle(object):
         elif whence == os.SEEK_CUR:
             self._pos += offset
         elif whence == os.SEEK_END:
-            self._pos = max(self._file['size'] - offset, 0)
+            self._pos = max(self._file['size'] + offset, 0)
 
         if self._pos != oldPos:
             self._prev = []

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -341,16 +341,20 @@ class FileTestCase(base.TestCase):
             buf = _readFile(handle)
             self.assertEqual(buf, contents[4:])
 
-            handle.seek(2, os.SEEK_END)
+            handle.seek(-2, os.SEEK_END)
             buf = _readFile(handle)
             self.assertEqual(buf, contents[-2:])
+
+            handle.seek(2, os.SEEK_END)
+            buf = _readFile(handle)
+            self.assertEqual(buf, b'')
 
             # Read without a length parameter
             handle.seek(0, os.SEEK_SET)
             buf = handle.read()
             self.assertEqual(buf, contents)
 
-            handle.seek(2, os.SEEK_END)
+            handle.seek(-2, os.SEEK_END)
             buf = handle.read()
             self.assertEqual(buf, contents[-2:])
 
@@ -359,7 +363,7 @@ class FileTestCase(base.TestCase):
             buf = handle.read(-1)
             self.assertEqual(buf, contents)
 
-            handle.seek(2, os.SEEK_END)
+            handle.seek(-2, os.SEEK_END)
             buf = handle.read(-5)
             self.assertEqual(buf, contents[-2:])
 
@@ -370,7 +374,7 @@ class FileTestCase(base.TestCase):
                 self.assertRaises(GirderException, handle.read, 7)
                 handle.seek(0, os.SEEK_SET)
                 self.assertRaises(GirderException, handle.read)
-                handle.seek(2, os.SEEK_END)
+                handle.seek(-2, os.SEEK_END)
                 buf = handle.read()
                 self.assertEqual(buf, contents[-2:])
 


### PR DESCRIPTION
The FileHandle class inverted the offset when using SEEK_END.  To get to
100 bytes before the end of the file, seek should use `file.seek(-100,
os.SEEK_END)`, not `file.seek(100, os.SEEK_END)`.