### PR TITLE
Make the babel-loader test more explicit in dicom_viewer

### DIFF
--- a/plugins/dicom_viewer/webpack.helper.js
+++ b/plugins/dicom_viewer/webpack.helper.js
@@ -1,7 +1,7 @@
 module.exports = function (config) {
     config.module.rules.push({
         resource: {
-            test: /\.glsl$/,
+            test: /node_modules(\/|\\)vtk\.js(\/|\\).*.glsl$/,
             include: [/node_modules(\/|\\)vtk\.js(\/|\\)/]
         },
         use: [
@@ -10,7 +10,7 @@ module.exports = function (config) {
     });
     config.module.rules.push({
         resource: {
-            test: /\.js$/,
+            test: /node_modules(\/|\\)vtk\.js(\/|\\).*.js$/,
             include: [/node_modules(\/|\\)vtk\.js(\/|\\)/]
         },
         use: [


### PR DESCRIPTION
We append all the plugin paths to the `include` array.  Perhaps we should not do that, but in any case this prevents the babel-loader from running twice on other plugins' sources.