### PR TITLE
Add an optionalArgumentDecorator utility, fixing @boundHandler

### DIFF
--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -115,7 +115,7 @@ route for ``GET /item/:id/cat`` to the system,
     from girder.api.rest import boundHandler
 
     @access.public
-    @boundHandler()
+    @boundHandler
     def myHandler(self, id, params):
         self.requireParams('cat', params)
 

--- a/girder/api/access.py
+++ b/girder/api/access.py
@@ -21,119 +21,94 @@ import six
 
 from girder.api import rest
 from girder.models.model_base import AccessException
+from girder.utility import optionalArgumentDecorator
 from girder.utility.model_importer import ModelImporter
 
 
-def admin(*args, **kwargs):
+@optionalArgumentDecorator
+def admin(fun, scope=None):
     """
-    Functions that require administrator access should be wrapped in this
-    decorator.
+    REST endpoints that require administrator access should be wrapped in this decorator.
 
+    :param fun: A REST endpoint.
+    :type fun: callable
     :param scope: To also expose this endpoint for certain token scopes,
         pass those scopes here. If multiple are passed, all will be required.
-    :type scope: str or list of str
+    :type scope: str or list of str or None
     """
-    if len(args) == 1 and callable(args[0]):  # Raw decorator
-        @six.wraps(args[0])
-        def wrapped(*iargs, **ikwargs):
-            rest.requireAdmin(rest.getCurrentUser())
-            return args[0](*iargs, **ikwargs)
-        wrapped.accessLevel = 'admin'
-        return wrapped
-    else:  # We should return a decorator
-        def dec(fun):
-            @six.wraps(fun)
-            def wrapped(*iargs, **ikwargs):
-                rest.requireAdmin(rest.getCurrentUser())
-                return fun(*iargs, **ikwargs)
-            wrapped.accessLevel = 'admin'
-            wrapped.requiredScopes = kwargs.get('scope')
-            return wrapped
-        return dec
+    @six.wraps(fun)
+    def wrapped(*args, **kwargs):
+        rest.requireAdmin(rest.getCurrentUser())
+        return fun(*args, **kwargs)
+    wrapped.accessLevel = 'admin'
+    wrapped.requiredScopes = scope
+    return wrapped
 
 
-def user(*args, **kwargs):
+@optionalArgumentDecorator
+def user(fun, scope=None):
     """
-    Functions that require a logged-in user should be wrapped with this access
-    decorator.
+    REST endpoints that require a logged-in user should be wrapped with this access decorator.
 
+    :param fun: A REST endpoint.
+    :type fun: callable
     :param scope: To also expose this endpoint for certain token scopes,
         pass those scopes here. If multiple are passed, all will be required.
-    :type scope: str or list of str
+    :type scope: str or list of str or None
     """
-    if len(args) == 1 and callable(args[0]):  # Raw decorator
-        @six.wraps(args[0])
-        def wrapped(*iargs, **ikwargs):
-            if not rest.getCurrentUser():
-                raise AccessException('You must be logged in.')
-            return args[0](*iargs, **ikwargs)
-        wrapped.accessLevel = 'user'
-        return wrapped
-    else:  # We should return a decorator
-        def dec(fun):
-            @six.wraps(fun)
-            def wrapped(*iargs, **ikwargs):
-                if not rest.getCurrentUser():
-                    raise AccessException('You must be logged in.')
-                return fun(*iargs, **ikwargs)
-            wrapped.accessLevel = 'user'
-            wrapped.requiredScopes = kwargs.get('scope')
-            return wrapped
-        return dec
+    @six.wraps(fun)
+    def wrapped(*args, **kwargs):
+        if not rest.getCurrentUser():
+            raise AccessException('You must be logged in.')
+        return fun(*args, **kwargs)
+    wrapped.accessLevel = 'user'
+    wrapped.requiredScopes = scope
+    return wrapped
 
 
-def token(*args, **kwargs):
+@optionalArgumentDecorator
+def token(fun, scope=None, required=False):
     """
-    Functions that require a token, but not necessarily a user authentication
-    token, should use this access decorator.
+    REST endpoints that require a token, but not necessarily a user authentication token, should use
+    this access decorator.
 
+    :param fun: A REST endpoint.
+    :type fun: callable
     :param scope: The scope or list of scopes required for this token.
-    :type scope: str or list of str
+    :type scope: str or list of str or None
+    :param required: Whether all of the passed ``scope`` are required to access the endpoint at all.
+    :type required: bool
     """
-    if len(args) == 1 and callable(args[0]):  # Raw decorator
-        @six.wraps(args[0])
-        def wrapped(*iargs, **ikwargs):
-            if not rest.getCurrentToken():
-                raise AccessException(
-                    'You must be logged in or have a valid auth token.')
-            return args[0](*iargs, **ikwargs)
-        wrapped.accessLevel = 'token'
-        return wrapped
-    else:  # We should return a decorator
-        def dec(fun):
-            @six.wraps(fun)
-            def wrapped(*iargs, **ikwargs):
-                if not rest.getCurrentToken():
-                    raise AccessException(
-                        'You must be logged in or have a valid auth token.')
-                required = kwargs.get('required', False)
-                if required:
-                    ModelImporter.model('token').requireScope(rest.getCurrentToken(),
-                                                              kwargs['scope'])
-                return fun(*iargs, **ikwargs)
-            wrapped.accessLevel = 'token'
-            wrapped.requiredScopes = kwargs.get('scope')
-            return wrapped
-        return dec
+    @six.wraps(fun)
+    def wrapped(*args, **kwargs):
+        if not rest.getCurrentToken():
+            raise AccessException('You must be logged in or have a valid auth token.')
+        if required:
+            ModelImporter.model('token').requireScope(rest.getCurrentToken(), scope)
+        return fun(*args, **kwargs)
+    wrapped.accessLevel = 'token'
+    wrapped.requiredScopes = scope
+    return wrapped
 
 
-def public(*args, **kwargs):
+@optionalArgumentDecorator
+def public(fun, scope=None):
     """
     Functions that allow any client access, including those that haven't logged
     in should be wrapped in this decorator.
+
+    :param fun: A REST endpoint.
+    :type fun: callable
+    :param scope: The scope or list of scopes required for this token.
+    :type scope: str or list of str or None
     """
-    if len(args) == 1 and callable(args[0]):  # Raw decorator
-        args[0].accessLevel = 'public'
-        return args[0]
-    else:  # We should return a decorator
-        def dec(fun):
-            fun.accessLevel = 'public'
-            fun.requiredScopes = kwargs.get('scope')
-            return fun
-        return dec
+    fun.accessLevel = 'public'
+    fun.requiredScopes = scope
+    return fun
 
 
-def cookie(*args, **kwargs):
+@optionalArgumentDecorator
+def cookie(fun, force=False):
     """
     REST endpoints that allow the use of a cookie for authentication should be
     wrapped in this decorator.
@@ -145,14 +120,11 @@ def cookie(*args, **kwargs):
     application to Cross-Site Request Forgery (CSRF) attacks, an optional
     ``force=True`` kwarg may be passed to the decorator to make it effective
     on any type of route.
-    """
-    if len(args) == 1 and callable(args[0]):  # Used as a raw decorator
-        force = False
-        args[0].cookieAuth = (True, force)
-        return args[0]
-    else:  # Used with arguments
-        def decorator(fun):
-            fun.cookieAuth = (True, kwargs.get('force', False))
-            return fun
 
-        return decorator
+    :param fun: A REST endpoint.
+    :type fun: callable
+    :param force: Allow this to apply to non-GET and non-HEAD endpoints.
+    :type force: bool
+    """
+    fun.cookieAuth = (True, force)
+    return fun

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -31,8 +31,8 @@ from . import docs
 from girder import events, logger, logprint
 from girder.constants import SettingKey, TokenScope, SortDir
 from girder.models.model_base import AccessException, GirderException, ValidationException
+from girder.utility import toBool, config, JsonEncoder, optionalArgumentDecorator
 from girder.utility.model_importer import ModelImporter
-from girder.utility import toBool, config, JsonEncoder
 from six.moves import range, urllib
 
 # Arbitrary buffer length for stream-reading request bodies
@@ -1161,7 +1161,8 @@ class Resource(ModelImporter):
 _sharedContext = Resource()
 
 
-class boundHandler(object):  # noqa: class name
+@optionalArgumentDecorator
+def boundHandler(fun, ctx=None):
     """
     This decorator allows unbound functions to be conveniently added as route
     handlers to existing :py:class:`girder.api.rest.Resource` instances.
@@ -1173,28 +1174,19 @@ class boundHandler(object):  # noqa: class name
     Plugins that add new routes to existing API resources are encouraged to use
     this to gain access to bound convenience methods like ``self.model``,
     ``self.boolParam``, ``self.requireParams``, etc.
+
+    :param fun: A REST endpoint.
+    :type fun: callable
+    :param ctx: A Resource instance, to be bound to ``fun``.
+    :type ctx: Resource or None
     """
-    def __init__(self, ctx=None):
+    if ctx is None:
+        ctx = _sharedContext
+    elif not isinstance(ctx, Resource):
+        raise Exception('ctx in boundhandler must be an instance of Resource.')
 
-        if ctx is None or isinstance(ctx, Resource):  # Used with arguments
-            self.ctx = ctx or _sharedContext
-            self.func = None
+    @six.wraps(fun)
+    def wrapped(*args, **kwargs):
+        return fun(ctx, *args, **kwargs)
 
-        elif callable(ctx):  # Used as a raw decorator
-            self.ctx = _sharedContext
-            self.func = ctx
-        else:
-            raise Exception('ctx in boundhandler must be an instance of '
-                            'Resource or a function to be wrapped')
-
-    def __call__(self, *args, **kwargs):
-        if self.func is not None:  # Used as a raw decorator
-            return self.func(self.ctx, *args, **kwargs)
-
-        else:  # Used with arguments
-            fn = args[0]
-
-            @six.wraps(fn)
-            def wrapped(*fargs, **fkwargs):
-                return fn(self.ctx, *fargs, **fkwargs)
-            return wrapped
+    return wrapped

--- a/girder/utility/__init__.py
+++ b/girder/utility/__init__.py
@@ -26,6 +26,7 @@ import os
 import pytz
 import re
 import string
+import six
 
 import girder
 import girder.events
@@ -186,3 +187,57 @@ class RequestBodyStream(object):
             return self.size
 
         return int(cherrypy.request.headers['Content-Length'])
+
+
+def optionalArgumentDecorator(baseDecorator):
+    """
+    This decorator can be applied to other decorators, allowing the target decorator to be used
+    either with or without arguments.
+
+    The target decorator is expected to take at least 1 argument: the function to be wrapped. If
+    additional arguments are provided by the final implementer of the target decorator, they will
+    be passed to the target decorator as additional arguments.
+
+    For example, this may be used as:
+
+        @optionalArgumentDecorator
+        def myDec(fun, someArg=None):
+            ...
+
+        @myDec
+        def a(...):
+            ...
+
+        @myDec()
+        def a(...):
+            ...
+
+        @myDec(5)
+        def a(...):
+            ...
+
+        @myDec(someArg=5)
+        def a(...):
+            ...
+
+    :param baseDecorator: The target decorator.
+    :type baseDecorator: callable
+    """
+    @six.wraps(baseDecorator)
+    def normalizedArgumentDecorator(*args, **kwargs):
+        if len(args) == 1 and callable(args[0]):  # Applied as a raw decorator
+            decoratedFunction = args[0]
+            # baseDecorator must wrap and return decoratedFunction
+            return baseDecorator(decoratedFunction)
+        else:   # Applied as a argument-containing decorator
+            # Decoration will occur in two passes:
+            #   * Now, the decorator arguments are passed, and a new decorator should be returned
+            #   * Afterwards, the new decorator will be called to decorate the decorated function
+            decoratorArgs = args
+            decoratorKwargs = kwargs
+
+            def partiallyAppliedDecorator(decoratedFunction):
+                return baseDecorator(decoratedFunction, *decoratorArgs, **decoratorKwargs)
+            return partiallyAppliedDecorator
+
+    return normalizedArgumentDecorator

--- a/plugins/item_licenses/server/rest.py
+++ b/plugins/item_licenses/server/rest.py
@@ -26,7 +26,7 @@ from .constants import PluginSettings
 
 
 @access.user
-@boundHandler()
+@boundHandler
 @autoDescribeRoute(
     Description('Get list of item licenses.')
     .param('default', 'Whether to return the default list of item licenses.',

--- a/plugins/item_tasks/server/json_tasks.py
+++ b/plugins/item_tasks/server/json_tasks.py
@@ -8,7 +8,7 @@ from . import constants
 
 @access.admin(scope=constants.TOKEN_SCOPE_AUTO_CREATE_CLI)
 @filtermodel(model='job', plugin='jobs')
-@boundHandler()
+@boundHandler
 @autoDescribeRoute(
     Description('Create item task spec based on a task in a docker image.')
     .notes('This operates on an existing item, turning it into an item task '
@@ -90,7 +90,7 @@ def runJsonTasksDescriptionForItem(self, item, image, taskName, setName, setDesc
 
 
 @access.token
-@boundHandler()
+@boundHandler
 @autoDescribeRoute(
     Description('Set a task spec on an item from a JSON specification.')
     .modelParam('id', model='item', force=True)
@@ -137,7 +137,7 @@ def configureItemTaskFromJson(self, item, json, image, taskName, setName, setDes
 
 @access.admin(scope=constants.TOKEN_SCOPE_AUTO_CREATE_CLI)
 @filtermodel(model='job', plugin='jobs')
-@boundHandler()
+@boundHandler
 @autoDescribeRoute(
     Description('Create item task specs based on a docker image.')
     .notes('This operates on an existing folder, adding item tasks '
@@ -199,7 +199,7 @@ def runJsonTasksDescriptionForFolder(self, folder, image, pullImage, params):
 
 
 @access.token
-@boundHandler()
+@boundHandler
 @autoDescribeRoute(
     Description('Create item tasks under a folder using a list of JSON specifications.')
     .modelParam('id', model='folder', force=True)

--- a/plugins/item_tasks/server/slicer_cli_tasks.py
+++ b/plugins/item_tasks/server/slicer_cli_tasks.py
@@ -10,7 +10,7 @@ from . import cli_parser, constants
 
 @access.admin(scope=constants.TOKEN_SCOPE_AUTO_CREATE_CLI)
 @filtermodel(model='job', plugin='jobs')
-@boundHandler()
+@boundHandler
 @autoDescribeRoute(
     Description('Create an item task spec based on a docker image.')
     .notes('This operates on an existing item, turning it into an item task '
@@ -103,7 +103,7 @@ def runSlicerCliTasksDescriptionForItem(
 
 
 @access.token
-@boundHandler()
+@boundHandler
 @autoDescribeRoute(
     Description('Set a task spec on an item from a Slicer CLI XML spec.')
     .modelParam('id', model='item', force=True)
@@ -142,7 +142,7 @@ def configureItemTaskFromSlicerCliXml(self, item, xml, setName, setDescription, 
 
 @access.admin(scope=constants.TOKEN_SCOPE_AUTO_CREATE_CLI)
 @filtermodel(model='job', plugin='jobs')
-@boundHandler()
+@boundHandler
 @autoDescribeRoute(
     Description('Create item task specs based on a docker image.')
     .notes('This operates on an existing folder, adding item tasks '
@@ -209,7 +209,7 @@ def runSlicerCliTasksDescriptionForFolder(self, folder, image, args, pullImage, 
 
 
 @access.token
-@boundHandler()
+@boundHandler
 @autoDescribeRoute(
     Description('Create item tasks under a folder using a list of Slicer CLI XML specs.')
     .modelParam('id', model='folder', force=True)

--- a/plugins/ldap/server/__init__.py
+++ b/plugins/ldap/server/__init__.py
@@ -169,7 +169,7 @@ def _ldapAuth(event):
 
 
 @access.admin
-@boundHandler()
+@boundHandler
 @autoDescribeRoute(
     Description('Test connection status to a LDAP server.')
     .notes('You must be an administrator to call this.')

--- a/tests/cases/rest_decorator_test.py
+++ b/tests/cases/rest_decorator_test.py
@@ -70,24 +70,25 @@ class TestEndpointDecoratorException(base.TestCase):
         self.assertEqual(obj['type'], 'internal')
 
     def testBoundHandlerDecorator(self):
+        user = self.model('user').createUser('tester', 'password', 'Test', 'User', 'test@test.com')
 
-        resp = self.request('/collection/unbound/default/noargs', params={
+        resp = self.request('/collection/unbound/default/noargs', user=user, params={
             'val': False
         })
         self.assertStatusOk(resp)
         self.assertEqual(resp.json, True)
 
-        resp = self.request('/collection/unbound/default', params={
+        resp = self.request('/collection/unbound/default', user=user, params={
             'val': False
         })
         self.assertStatusOk(resp)
         self.assertEqual(resp.json, True)
 
-        resp = self.request('/collection/unbound/explicit')
+        resp = self.request('/collection/unbound/explicit', user=user)
         self.assertStatusOk(resp)
         self.assertEqual(resp.json, {
             'name': 'collection',
-            'user': None
+            'userLogin': 'tester'
         })
 
     def testRawResponse(self):

--- a/tests/test_plugins/test_plugin/server.py
+++ b/tests/test_plugins/test_plugin/server.py
@@ -22,10 +22,11 @@ from girder.api import access
 from girder.api.describe import Description, describeRoute
 from girder.api.rest import boundHandler, rawResponse, Resource, setResponseHeader
 from girder.api.v1.collection import Collection
+from girder.constants import TokenScope
 from girder.utility.server import staticFile
 
 
-@access.public
+@access.user(scope=TokenScope.ANONYMOUS_SESSION)
 @boundHandler
 @describeRoute(None)
 def unboundHandlerDefaultNoArgs(self, params):
@@ -33,7 +34,7 @@ def unboundHandlerDefaultNoArgs(self, params):
     return not self.boolParam('val', params)
 
 
-@access.public
+@access.user(scope=TokenScope.ANONYMOUS_SESSION)
 @boundHandler()
 @describeRoute(None)
 def unboundHandlerDefault(self, params):
@@ -41,12 +42,13 @@ def unboundHandlerDefault(self, params):
     return not self.boolParam('val', params)
 
 
-@access.public
+@access.user(scope=TokenScope.ANONYMOUS_SESSION)
 @boundHandler(Collection())
 @describeRoute(None)
 def unboundHandlerExplicit(self, params):
+    currentUser = self.getCurrentUser()
     return {
-        'user': self.getCurrentUser(),
+        'userLogin': currentUser['login'] if currentUser else None,
         'name': self.resourceName
     }
 


### PR DESCRIPTION
* Remove unnecessary arguments from use of the `@boundHandler` decorator
* Update the `rest_decorator_test` to use more sophisticated decorators
* Add an `optionalArgumentDecorator` utility
* Use the `optionalArgumentDecorator` where appropriate

With only the first two commits in this PR, usage of `@boundhandler` with other decorators and the `rest_decorator_test` will fail with:
```
ERROR: Failed to load plugin "test_plugin":
Traceback (most recent call last):
  File "girder/utility/plugin_utilities.py", line 103, in loadPlugins
    root, appconf, apiRoot = loadPlugin(plugin, root, appconf, apiRoot)
  File "girder/utility/plugin_utilities.py", line 228, in loadPlugin
    module = imp.load_module(moduleName, fp, pathname, description)
  File "tests/test_plugins/test_plugin/server.py", line 31, in <module>
    @describeRoute(None)
  File "girder/api/access.py", line 74, in dec
    @six.wraps(fun)
  File "/home/vagrant/.virtualenvs/girder/local/lib/python2.7/site-packages/six.py", line 792, in wrapper
    f = functools.wraps(wrapped, assigned, updated)(f)
  File "/usr/lib/python2.7/functools.py", line 33, in update_wrapper
    setattr(wrapper, attr, getattr(wrapped, attr))
AttributeError: 'boundHandler' object has no attribute '__name__'
```
due to the buggy implementation of the `@boundhandler` decorator as a class.

This PR corrects the issue more broadly, adding a new `optionalArgumentDecorator` utility, and simplifying the logic of decorators that can now use it.
