### PR TITLE
Improve test database setup config

### DIFF
--- a/tests/cases/setup_database_test.py
+++ b/tests/cases/setup_database_test.py
@@ -233,3 +233,13 @@ class SetupDatabaseTestCase(base.TestCase):
         }, item, 'item.txt')
 
         self.assertImported(folder)
+
+    def testYAMLAliases(self):
+        folderModel = self.model('folder')
+        aliasedFolders = list(folderModel.find({'name': 'Common'}, force=True))
+        self.assertTrue(len(aliasedFolders) == 2)
+
+        for folder in aliasedFolders:
+            self.assertTrue(
+                len(list(folderModel.childItems(folder, force=True))) == 2
+            )

--- a/tests/cases/setup_database_test.yml
+++ b/tests/cases/setup_database_test.yml
@@ -4,12 +4,12 @@ _common: &common
   folders:
     - name: 'Common'
       items:
-      - name: 'Item 1'
-      - name: 'Item 2'
+        - name: 'Item 1'
+        - name: 'Item 2'
       folders:
-      - name: 'Common subfolder'
-        items:
-        - name: 'Item 3'
+        - name: 'Common subfolder'
+          items:
+            - name: 'Item 3'
 
 users:
   # a typical admin user

--- a/tests/cases/setup_database_test.yml
+++ b/tests/cases/setup_database_test.yml
@@ -1,4 +1,16 @@
 ---
+# create a list of common folders that can be inserted in multiple places
+_common: &common
+  folders:
+    - name: 'Common'
+      items:
+      - name: 'Item 1'
+      - name: 'Item 2'
+      folders:
+      - name: 'Common subfolder'
+        items:
+        - name: 'Item 3'
+
 users:
   # a typical admin user
   - login: 'admin'
@@ -96,3 +108,6 @@ collections:
     folders:
       - name: 'Imported folder'
         import: 'setup_database_test/importedCollection'
+
+  - name: 'Common folders'
+    <<: *common

--- a/tests/cases/setup_database_test.yml
+++ b/tests/cases/setup_database_test.yml
@@ -44,11 +44,18 @@ users:
         public: true
         creator: 'admin'
 
+  # a user with common folders using a yaml alias
+  - login: 'aliasTest'
+    password: 'aliasTest'
+    firstName: 'User'
+    lastName: 'Four'
+    email: 'user4@email.com'
+    admin: false
+    <<: *common
 
 collections:
   # create a collection with nested folders described manually
   - name: 'Public Collection'
-    creator: 'admin'
     description: 'This is an example collection'
     public: true
     folders:

--- a/tests/setup_database.py
+++ b/tests/setup_database.py
@@ -265,8 +265,9 @@ def createDocument(type, node):
 
     # inject this document as the parent for all child specs
     for childType in children:
-        for childNode in children[childType]:
-            childNode['parent'] = doc
+        children[childType] = [
+            dict(parent=doc, **child) for child in children[childType]
+        ]
 
     return children
 

--- a/tests/setup_database.py
+++ b/tests/setup_database.py
@@ -110,6 +110,12 @@ def addCreator(spec, parent=None):
         # if all else fails, just use any user for the creator
         spec['creator'] = userModel.findOne({}, force=True)
 
+        if spec['creator'] is None:
+            raise Exception('At least one user must be provided in the spec')
+
+    if spec.get('creator') is None:
+        raise Exception('Could not find the requested creator')
+
 
 def createUser(defaultFolders=False, **args):
     """Create a user document from a user spec.


### PR DESCRIPTION
This contains two changes to make the `setup_database` spec more robust:
1. `creator` is now optional for toplevel collections.  If the creator is not specified, then it will use the first user returned by a database lookup.
2. Support YAML aliases for using a common config object in multiple places in the spec.