### PR TITLE
Expose the instantiated girder application as girder.app

### DIFF
--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -1247,7 +1247,6 @@ $(function () {
  * application object.
  */
 girderTest.startApp = function () {
-    var app;
     girderTest.promise = girderTest.promise
         .then(function () {
             /* Track bootstrap transitions.  This is largely a duplicate of the
@@ -1273,17 +1272,16 @@ girderTest.startApp = function () {
             };
 
             girder.events.trigger('g:appload.before');
-            app = new girder.views.App({
+            girder.app = new girder.views.App({
                 el: 'body',
                 parentView: null,
                 start: false
             });
-            girder.app = app;
-            return app.start();
+            return girder.app.start();
         })
         .then(function () {
-            girder.events.trigger('g:appload.after', app);
-            return app;
+            girder.events.trigger('g:appload.after', girder.app);
+            return girder.app;
         });
     return girderTest.promise;
 };

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -1278,10 +1278,11 @@ girderTest.startApp = function () {
                 parentView: null,
                 start: false
             });
+            girder.app = app;
             return app.start();
         })
         .then(function () {
-            girder.events.trigger('g:appload.after');
+            girder.events.trigger('g:appload.after', app);
             return app;
         });
     return girderTest.promise;

--- a/girder/utility/webroot.mako
+++ b/girder/utility/webroot.mako
@@ -20,11 +20,11 @@
     <script type="text/javascript">
         $(function () {
             girder.events.trigger('g:appload.before');
-            new girder.views.App({
+            girder.app = new girder.views.App({
                 el: 'body',
                 parentView: null
             }).render();
-            girder.events.trigger('g:appload.after');
+            girder.events.trigger('g:appload.after', girder.app);
         });
     </script>
     % for plugin in pluginJs:


### PR DESCRIPTION
This is mostly useful for testing where we want to be able to access the view tree (`girder.bodyView`) inside the test without monkey patching.  It is also nice to have for interactive debugging of a running instance.