### PR TITLE
Access list widget failed to render new entries

### DIFF
--- a/clients/web/src/templates/widgets/accessEntry.pug
+++ b/clients/web/src/templates/widgets/accessEntry.pug
@@ -16,7 +16,7 @@ div(class=`g-${type}-access-entry`, resourceid=entry.id)
       if !noAccessFlag && _.keys(flagList).length
         a.g-action-manage-flags(title="Access flags")
           i.g-flag-icon.icon-flag
-            .g-flag-count-indicator(class=(entry.flags && entry.flags.length ? null : "hide"))= entry.flags.length
+            .g-flag-count-indicator(class=(entry.flags && entry.flags.length ? null : "hide"))= (entry.flags || []).length
         .g-flags-popover-container.hide(resourcetype=type, resourceid=entry.id, title="Access flags")
           each flag, key in flagList
             - var checked = _.contains(entry.flags, key) ? 'checked' : null;


### PR DESCRIPTION
1. Select a folder, open its access control dialog
2. Type the name of a user or group that does not have access, click a search result.

Expected behavior is that the user or group is appended to the list, but actually nothing appeared and an error message occurred:

```
girder_lib.min.js:4797 Uncaught TypeError: /Users/zach/dev/girder/clients/web/src/templates/widgets/accessEntry.pug:19
    17|         a.g-action-manage-flags(title="Access flags")
    18|           i.g-flag-icon.icon-flag
  > 19|             .g-flag-count-indicator(class=(entry.flags && entry.flags.length ? null : "hide"))= entry.flags.length
    20|         .g-flags-popover-container.hide(resourcetype=type, resourceid=entry.id, title="Access flags")
    21|           each flag, key in flagList
    22|             - var checked = _.contains(entry.flags, key) ? 'checked' : null;

Cannot read property 'length' of undefined
    at girder_lib.min.js:71403
    at template (girder_lib.min.js:71460)
    at child.<anonymous> (girder_lib.min.js:24152)
    at triggerEvents (girder_lib.min.js:18942)
    at triggerApi (girder_lib.min.js:18930)
    at eventsApi (girder_lib.min.js:18729)
    at child.Events.trigger (girder_lib.min.js:18920)
    at Object.<anonymous> (girder_lib.min.js:21135)
    at fire (girder_lib.min.js:8223)
    at Object.fireWith [as resolveWith] (girder_lib.min.js:8353)
```
This bug was introduced in 48a7ca8e448c554dddb9ea4f790c86588204deac