### PR TITLE
Don't symlink node_modules for packaging tests

### DIFF
--- a/tests/packaging/pip_install_girder.sh
+++ b/tests/packaging/pip_install_girder.sh
@@ -87,9 +87,7 @@ fi
 
 # Use the already downloaded fontello archive.
 export GIRDER_LOCAL_FONTELLO_ARCHIVE=${PROJECT_SOURCE_DIR}/clients/web/static/built/fontello.zip
-# Use node_modules from outer process to make this go quicker
-webroot=$(girder-install web-root)
-ln -s "${PROJECT_SOURCE_DIR}/node_modules" "${webroot}/../../node_modules" || exit 1
+
 # Build the web client code
 girder-install web || exit 1
 


### PR DESCRIPTION
Using a symlink causes the following error:

```
npm ERR! /home/ubuntu/girder/node_modules/webpack/node_modules/fsevents
  is not a child of /home/ubuntu/build/env/lib/python3.4/site-packages/girder
```

This error is thrown by a postinstall script of some dependency.  We might get away with copying the directory instead, but with the new caching in npm 5, there isn't much of a speed up.  I think this will fix the recent build failures on master.