### PR TITLE
Add back the webroot variable for packaging tests

### DIFF
--- a/tests/packaging/pip_install_girder.sh
+++ b/tests/packaging/pip_install_girder.sh
@@ -87,6 +87,7 @@ fi
 
 # Use the already downloaded fontello archive.
 export GIRDER_LOCAL_FONTELLO_ARCHIVE=${PROJECT_SOURCE_DIR}/clients/web/static/built/fontello.zip
+webroot=$(girder-install web-root)
 
 # Build the web client code
 girder-install web || exit 1


### PR DESCRIPTION
Everything worked correctly from #2175, we just need the `webroot` variable to be defined for the checks a couple of lines below this.