### PR TITLE
Allow the HierarchyWidget to self-render after instantiation

### DIFF
--- a/clients/web/src/views/body/CollectionView.js
+++ b/clients/web/src/views/body/CollectionView.js
@@ -69,15 +69,12 @@ var CollectionView = View.extend({
                 this.folder.set({
                     _id: settings.folderId
                 }).on('g:fetched', function () {
-                    this._createHierarchyWidget();
                     this.render();
                 }, this).on('g:error', function () {
                     this.folder = null;
-                    this._createHierarchyWidget();
                     this.render();
                 }, this).fetch();
             } else {
-                this._createHierarchyWidget();
                 this.render();
             }
         } else if (settings.id) {
@@ -85,26 +82,9 @@ var CollectionView = View.extend({
             this.model.set('_id', settings.id);
 
             this.model.on('g:fetched', function () {
-                this._createHierarchyWidget();
                 this.render();
             }, this).fetch();
         }
-    },
-
-    _createHierarchyWidget: function () {
-        this.hierarchyWidget = new HierarchyWidget({
-            parentModel: this.folder || this.model,
-            upload: this.upload,
-            folderAccess: this.folderAccess,
-            folderEdit: this.folderEdit,
-            folderCreate: this.folderCreate,
-            itemCreate: this.itemCreate,
-            parentView: this
-        }).on('g:setCurrentModel', function () {
-            // When a user descends into the hierarchy, hide the collection
-            // actions list to avoid confusion.
-            this.$('.g-collection-header .g-collection-actions-button').hide();
-        }, this);
     },
 
     editCollection: function () {
@@ -129,8 +109,27 @@ var CollectionView = View.extend({
             renderMarkdown: renderMarkdown
         }));
 
-        this.hierarchyWidget.setElement(
-            this.$('.g-collection-hierarchy-container')).render();
+        if (!this.hierarchyWidget) {
+            // The HierarchyWidget will self-render when instantiated
+            this.hierarchyWidget = new HierarchyWidget({
+                el: this.$('.g-collection-hierarchy-container'),
+                parentModel: this.folder || this.model,
+                upload: this.upload,
+                folderAccess: this.folderAccess,
+                folderEdit: this.folderEdit,
+                folderCreate: this.folderCreate,
+                itemCreate: this.itemCreate,
+                parentView: this
+            }).on('g:setCurrentModel', () => {
+                // When a user descends into the hierarchy, hide the collection
+                // actions list to avoid confusion.
+                this.$('.g-collection-header .g-collection-actions-button').hide();
+            });
+        } else {
+            this.hierarchyWidget
+                .setElement(this.$('.g-collection-hierarchy-container'))
+                .render();
+        }
 
         this.upload = false;
         this.folderAccess = false;

--- a/clients/web/src/views/body/FolderView.js
+++ b/clients/web/src/views/body/FolderView.js
@@ -19,7 +19,12 @@ var FolderView = View.extend({
         this.folderEdit = settings.folderEdit || false;
         this.itemCreate = settings.itemCreate || false;
 
+        this.render();
+    },
+
+    render: function () {
         this.hierarchyWidget = new HierarchyWidget({
+            el: this.$el,
             parentModel: this.folder,
             upload: this.upload,
             folderAccess: this.folderAccess,
@@ -29,11 +34,6 @@ var FolderView = View.extend({
             parentView: this
         });
 
-        this.render();
-    },
-
-    render: function () {
-        this.hierarchyWidget.setElement(this.$el).render();
         return this;
     }
 }, {

--- a/clients/web/src/views/body/UserView.js
+++ b/clients/web/src/views/body/UserView.js
@@ -74,16 +74,12 @@ var UserView = View.extend({
                 this.folder.set({
                     _id: settings.folderId
                 }).on('g:fetched', function () {
-                    this._createHierarchyWidget();
                     this.render();
                 }, this).on('g:error', function () {
                     this.folder = null;
-                    this._createHierarchyWidget();
-
                     this.render();
                 }, this).fetch();
             } else {
-                this._createHierarchyWidget();
                 this.render();
             }
         } else if (settings.id) {
@@ -91,22 +87,9 @@ var UserView = View.extend({
             this.model.set('_id', settings.id);
 
             this.model.on('g:fetched', function () {
-                this._createHierarchyWidget();
                 this.render();
             }, this).fetch();
         }
-    },
-
-    _createHierarchyWidget: function () {
-        this.hierarchyWidget = new HierarchyWidget({
-            parentModel: this.folder || this.model,
-            upload: this.upload,
-            folderAccess: this.folderAccess,
-            folderEdit: this.folderEdit,
-            folderCreate: this.folderCreate,
-            itemCreate: this.itemCreate,
-            parentView: this
-        });
     },
 
     render: function () {
@@ -115,7 +98,23 @@ var UserView = View.extend({
             AccessType: AccessType
         }));
 
-        this.hierarchyWidget.setElement(this.$('.g-user-hierarchy-container')).render();
+        if (!this.hierarchyWidget) {
+            // The HierarchyWidget will self-render when instantiated
+            this.hierarchyWidget = new HierarchyWidget({
+                el: this.$('.g-user-hierarchy-container'),
+                parentModel: this.folder || this.model,
+                upload: this.upload,
+                folderAccess: this.folderAccess,
+                folderEdit: this.folderEdit,
+                folderCreate: this.folderCreate,
+                itemCreate: this.itemCreate,
+                parentView: this
+            });
+        } else {
+            this.hierarchyWidget
+                .setElement(this.$('.g-user-hierarchy-container'))
+                .render();
+        }
 
         this.upload = false;
         this.folderAccess = false;

--- a/clients/web/src/views/widgets/BrowserWidget.js
+++ b/clients/web/src/views/widgets/BrowserWidget.js
@@ -108,6 +108,7 @@ var BrowserWidget = View.extend({
         }
         this.$('.g-wait-for-root').removeClass('hidden');
         this._hierarchyView = new HierarchyWidget({
+            el: this.$('.g-hierarchy-widget-container'),
             parentView: this,
             parentModel: this.root,
             checkboxes: false,
@@ -118,7 +119,6 @@ var BrowserWidget = View.extend({
             showMetadata: this.showMetadata
         });
         this.listenTo(this._hierarchyView, 'g:setCurrentModel', this._selectModel);
-        this._hierarchyView.setElement(this.$('.g-hierarchy-widget-container')).render();
         this._selectModel();
     },
 


### PR DESCRIPTION
The `HierarchyWidget` already self-renders after being instantiated, so there's no need for the creator to call the `.render()` method externally.

Additionally, in all places where a `HierarchyWidget` was being created, it was being instantiated within the same synchronous sequence as the rendering of its container template. Accordingly, there is minimal benefit to first instantiating a `HierarchyWidget` without an element, rendering the container template, then calling `setElement` to attach the `HierarchyWidget` within the container template. Instead, container templates are rendered, then the `HierarchyWidget` is instantiated with its element preset, which is significantly simpler.

This fixes #2178 , as the `HierarchyWidget` is no longer being rendered twice, which is particularly helpful in cases where the `HierarchyWidget` also displays a modal (and has to animate its show / hide behavior twice).