### PR TITLE
Add curl to Ansible system dependencies

### DIFF
--- a/devops/ansible/roles/girder/tasks/girder.yml
+++ b/devops/ansible/roles/girder/tasks/girder.yml
@@ -6,6 +6,7 @@
   become: yes
   become_user: root
   with_items:
+    - curl
     - git
     - libffi-dev
     - build-essential


### PR DESCRIPTION
This already existed for the RedHat version, but not Debian. This is
particularly noticeable when using this role to install on the default
Ubuntu Docker image which doesn't come preinstalled with curl.