### PR TITLE
Ensure that all enumerators in copyFolder[public] are strings. Fixes #2194

### DIFF
--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -725,6 +725,6 @@ class autoDescribeRoute(describeRoute):  # noqa: class name
         # Enum validation (should be afer type coercion)
         if 'enum' in descParam and value not in descParam['enum']:
             raise RestException('Invalid value for %s: "%s". Allowed values: %s.' % (
-                name, value, ', '.join(descParam['enum'])))
+                name, value, ', '.join(str(v) for v in descParam['enum'])))
 
         return value

--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -309,7 +309,7 @@ class Folder(Resource):
                "default, inherits the value from parent folder, or in the case "
                "of user or collection parentType, defaults to False. If "
                "'original', use the value of the original folder.",
-               required=False, enum=[True, False, 'original'])
+               required=False, enum=['true', 'false', 'original'])
         .param('progress', 'Whether to record progress on this task.',
                required=False, dataType='boolean', default=False)
         .errorResponse(('A parameter was invalid.',

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -735,8 +735,13 @@ class Folder(AccessControlledModel):
             name = srcFolder['name']
         if description is None:
             description = srcFolder['description']
-        if public == 'original':
-            public = srcFolder.get('public', None)
+        if public is not None and isinstance(public, six.string_types):
+            if public == 'original':
+                public = srcFolder.get('public', None)
+            elif public.lower() == 'true':
+                public = True
+            elif public.lower() == 'false':
+                public = False
         newFolder = self.createFolder(
             parentType=parentType, parent=parent, name=name,
             description=description, public=public, creator=creator,

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -738,10 +738,8 @@ class Folder(AccessControlledModel):
         if public is not None and isinstance(public, six.string_types):
             if public == 'original':
                 public = srcFolder.get('public', None)
-            elif public.lower() == 'true':
-                public = True
-            elif public.lower() == 'false':
-                public = False
+            else:
+                public = self.boolParam('public', params)
         newFolder = self.createFolder(
             parentType=parentType, parent=parent, name=name,
             description=description, public=public, creator=creator,

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -739,7 +739,7 @@ class Folder(AccessControlledModel):
             if public == 'original':
                 public = srcFolder.get('public', None)
             else:
-                public = self.boolParam('public', params)
+                public = public == 'true'
         newFolder = self.createFolder(
             parentType=parentType, parent=parent, name=name,
             description=description, public=public, creator=creator,

--- a/tests/cases/folder_test.py
+++ b/tests/cases/folder_test.py
@@ -695,3 +695,9 @@ class FolderTestCase(base.TestCase):
                 'parentType': 'folder',
                 'parentId': str(subFolder['_id'])})
         self.assertStatusOk(resp)
+
+        # Test copying with public set to False
+        resp = self.request(
+            path='/folder/%s/copy' % subFolder['_id'], method='POST',
+            user=self.admin, params={'public': 'false', 'progress': True})
+        self.assertStatusOk(resp)


### PR DESCRIPTION
This fixes the issue, but IMO it's mighty confusing that `public` accepts strings, whereas everywhere else it's a boolean parameter.