### PR TITLE
Add static analysis tests for Stylus files

### DIFF
--- a/.stylintrc
+++ b/.stylintrc
@@ -1,0 +1,109 @@
+{
+    "blocks": false,
+    "brackets": {
+        "expect": "never",
+        "error": true
+    },
+    "colons": {
+        "expect": "never",
+        "error": true
+    },
+    "colors": false,
+    "commaSpace": {
+        "expect": "always",
+        "error": true
+    },
+    "commentSpace": {
+        "expect": "always",
+        "error": true
+    },
+    "cssLiteral": {
+        "expect": "never",
+        "error": true
+    },
+    "depthLimit": false,
+    "duplicates": {
+        "expect": true,
+        "error": true
+    },
+    "efficient": {
+        "expect": "always",
+        "error": true
+    },
+    "exclude": [
+        "node_modules/**/*"
+    ],
+    "extendPref": "@extend",
+    "globalDupe": false,
+    "groupOutputByFile": {
+        "expect": true,
+        "error": true
+    },
+    "indentPref": {
+        "expect": 2,
+        "error": true
+    },
+    "leadingZero": {
+        "expect": "always",
+        "error": true
+    },
+    "maxErrors": false,
+    "maxWarnings": false,
+    "mixed": false,
+    "mixins": [],
+    "namingConvention": false,
+    "namingConventionStrict": false,
+    "none": {
+        "expect": "always",
+        "error": true
+    },
+    "noImportant": false,
+    "parenSpace": {
+        "expect": "never",
+        "error": true
+    },
+    "placeholders": false,
+    "prefixVarsWithDollar": {
+        "expect": "always",
+        "error": true
+    },
+    "quotePref": {
+        "expect": "double",
+        "error": true
+    },
+    "reporterOptions": {
+          "columns": ["lineData", "severity", "description", "rule"],
+          "columnSplitter": "  ",
+          "showHeaders": false,
+          "truncate": true
+      },
+    "semicolons": {
+        "expect": "never",
+        "error": true
+    },
+    "sortOrder": false,
+    "stackedProperties": {
+        "expect": "never",
+        "error": true
+    },
+    "trailingWhitespace": {
+        "expect": "never",
+        "error": true
+    },
+    "universal": {
+        "expect": "never",
+        "error": true
+    },
+    "valid": {
+        "expect": true,
+        "error": true
+    },
+    "zeroUnits": {
+        "expect": "never",
+        "error": true
+    },
+    "zIndexNormalize": {
+        "expect": 5,
+        "error": true
+    }
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ if(JAVASCRIPT_STYLE_TESTS)
   endif()
   find_program(ESLINT_EXECUTABLE eslint ${PROJECT_SOURCE_DIR}/node_modules/.bin NO_DEFAULT_PATH)
   find_program(PUGLINT_EXECUTABLE pug-lint ${PROJECT_SOURCE_DIR}/node_modules/.bin NO_DEFAULT_PATH)
+  find_program(STYLINT_EXECUTABLE stylint ${PROJECT_SOURCE_DIR}/node_modules/.bin NO_DEFAULT_PATH)
 endif()
 
 if(BUILD_JAVASCRIPT_TESTS)

--- a/clients/web/src/stylesheets/apidocs/apidocs.styl
+++ b/clients/web/src/stylesheets/apidocs/apidocs.styl
@@ -1,10 +1,10 @@
-@import 'nib'
+@import "nib"
 
 $radius = 6px
 $border = 1px solid #d7d7d7
 
 body
-  font-family 'Droid Sans', sans-serif
+  font-family "Droid Sans", sans-serif
   background-color #adada1
 
 .right
@@ -36,7 +36,7 @@ body
     max-width 960px
     margin-left auto
     margin-right auto
-    box-shadow 0 5px 12px 0px rgba(0, 0, 0, 0.2)
+    box-shadow 0 5px 12px 0 rgba(0, 0, 0, 0.2)
 
   body
     padding-bottom 25px

--- a/clients/web/src/stylesheets/body/frontPage.styl
+++ b/clients/web/src/stylesheets/body/frontPage.styl
@@ -21,7 +21,7 @@
     vertical-align top
 
 .g-frontpage-body
-  padding 12px 12px 0 12px
+  padding 12px 12px 0
   margin-top 10px
 
   border-radius 2px

--- a/clients/web/src/stylesheets/body/groupPage.styl
+++ b/clients/web/src/stylesheets/body/groupPage.styl
@@ -34,10 +34,10 @@
   > a
     font-weight bold
 
-.g-group-members-container,.g-group-requests-container,.g-group-admins-container,.g-group-mods-container
+.g-group-members-container, .g-group-requests-container, .g-group-admins-container, .g-group-mods-container
   margin-top 15px
 
-.g-group-members,.g-group-mods,.g-group-admins,.g-group-requests,.g-group-invites
+.g-group-members, .g-group-mods, .g-group-admins, .g-group-requests, .g-group-invites
   list-style-type none
   padding 0
   margin-bottom 20px
@@ -57,7 +57,7 @@
   margin 5px 0
 
 .g-group-member-controls
-  >a,span>a
+  >a, span>a
     font-size 15px
     margin-left 4px
     border 1px solid #d5d5d5

--- a/clients/web/src/stylesheets/body/plugins.styl
+++ b/clients/web/src/stylesheets/body/plugins.styl
@@ -1,5 +1,3 @@
-@import '~nib/index.styl'
-
 $warnColor = #f0ad4e
 $failColor = red
 $failBackgroundColor = #f2dede
@@ -19,7 +17,7 @@ $failBackgroundColor = #f2dede
   text-align right
   overflow hidden
   visibility hidden
-  max-height 0px
+  max-height 0
   transition max-height 0.35s ease-in-out
 
   &.show

--- a/clients/web/src/stylesheets/body/userAccount.styl
+++ b/clients/web/src/stylesheets/body/userAccount.styl
@@ -45,7 +45,7 @@
     float right
 
     .pagination
-      margin 12px 0 0 0
+      margin 12px 0 0
 
   .g-api-key-list-bottom-buttons
     margin-top 10px

--- a/clients/web/src/stylesheets/body/userList.styl
+++ b/clients/web/src/stylesheets/body/userList.styl
@@ -30,7 +30,7 @@
     float right
     color #909090
 
-  .g-user-joined-date,.g-user-space-used
+  .g-user-joined-date, .g-user-space-used
     color #444
 
 .g-user-list-header

--- a/clients/web/src/stylesheets/layout/footer.styl
+++ b/clients/web/src/stylesheets/layout/footer.styl
@@ -1,7 +1,7 @@
 #g-app-footer-container
   border-top 1px solid #eee
   text-align center
-  background-image linear-gradient(to bottom, #f6f6f6 0%, #fff 5px)
+  background-image linear-gradient(to bottom, #f6f6f6 0, #fff 5px)
 
 .g-quick-search-form
   >.form-group
@@ -14,6 +14,6 @@
   margin-bottom 10px
 
 .g-footer-links
-  margin 15px auto 10px auto
+  margin 15px auto 10px
   a
     margin 0 10px

--- a/clients/web/src/stylesheets/layout/global.styl
+++ b/clients/web/src/stylesheets/layout/global.styl
@@ -1,17 +1,15 @@
 /**
  * Place global styles in this file.
  */
-@import '~nib/index.styl'
 
-*:not(i)
-  font-family 'Droid Sans',sans-serif
+body
+  // Override the default font from Bootstrap
+  font-family "Droid Sans", sans-serif !important
+  padding 0
+  word-wrap break-word
 
 i
   font-smoothing antialiased
-
-body
-  padding 0
-  word-wrap break-word
 
 a
   cursor pointer
@@ -39,7 +37,7 @@ ul.dropdown-menu
       margin-right 3px
 
 .panel-heading
-  padding 10px 10px
+  padding 10px
 
 .panel-title
   font-size 15px
@@ -76,7 +74,7 @@ ul.dropdown-menu
   border-radius 0
 
 .modal-backdrop.in
-  opacity .35
+  opacity 0.35
 
 /* By default bootstrap only applies form-inline rules at >=768px width */
 .form-inline .form-group

--- a/clients/web/src/stylesheets/layout/globalNav.styl
+++ b/clients/web/src/stylesheets/layout/globalNav.styl
@@ -4,14 +4,14 @@ $minHeight=500px
 
 .g-global-nav-main
   box-shadow inset -1px 0 0 #eee
-  background-image linear-gradient(to left, #f4f4f4 0%, #fff 7px)
+  background-image linear-gradient(to left, #f4f4f4 0, #fff 7px)
   min-height $minHeight - 12px
   padding 15px 0 20px 6px
 
 .g-global-nav-fade
   height 12px
   box-shadow inset -1px 0 0 #f5f5f5
-  background-image linear-gradient(to left, #f4f4f4 0%, #fff 4px)
+  background-image linear-gradient(to left, #f4f4f4 0, #fff 4px)
 
 .g-nav-link
   display block
@@ -46,7 +46,7 @@ ul.g-global-nav
     border-top $navLinkBorder
     border-bottom $navLinkBorder
     border-left $navLinkBorder
-    box-shadow -1px 1px 3px rgba(0,0,0,0.05)
+    box-shadow -1px 1px 3px rgba(0, 0, 0, 0.05)
     .g-nav-link
       color black
     i

--- a/clients/web/src/stylesheets/layout/loading.styl
+++ b/clients/web/src/stylesheets/layout/loading.styl
@@ -1,5 +1,4 @@
 /* CSS for the loading animation */
-@import '~nib/index.styl'
 
 #g-loading-animation
   margin 4px

--- a/clients/web/src/stylesheets/layout/progressArea.styl
+++ b/clients/web/src/stylesheets/layout/progressArea.styl
@@ -1,5 +1,3 @@
-@import '~nib/index.styl'
-
 $containerBorder = 1px solid #d7d7d7
 
 .g-progress-list-container

--- a/clients/web/src/stylesheets/widgets/accessWidget.styl
+++ b/clients/web/src/stylesheets/widgets/accessWidget.styl
@@ -1,5 +1,3 @@
-@import '~nib/index.styl'
-
 .g-access-modal-body
   padding-top 10px
   padding-bottom 0
@@ -49,7 +47,7 @@ i.g-flag-icon
   background linear-gradient(top, #d3d3d3 0, #f0f0f0 6px)
   padding 1px 4px
 
-  .g-group-access-entry,.g-user-access-entry
+  .g-group-access-entry, .g-user-access-entry
     margin 9px 0
 
   .g-access-icon

--- a/clients/web/src/stylesheets/widgets/hierarchyWidget.styl
+++ b/clients/web/src/stylesheets/widgets/hierarchyWidget.styl
@@ -1,10 +1,8 @@
-@import '~nib/index.styl'
-
 .g-hierarchy-widget
   border 1px solid #eaeaea
 
   .g-hierarchy-actions-header
-    background linear-gradient(top, #e6e6e6 0%, #f7f7f7 8px)
+    background linear-gradient(top, #e6e6e6 0, #f7f7f7 8px)
     padding 4px 5px 3px
     background-color #f6f6f6
     border-top 1px solid #ddd
@@ -54,23 +52,23 @@
       user-select none
       cursor default
 
-      .g-subfolder-count-container,.g-item-count-container
+      .g-subfolder-count-container, .g-item-count-container
         display inline-block
         position relative
         margin-left 8px
 
-      .g-subfolder-count,.g-item-count
+      .g-subfolder-count, .g-item-count
         display inline-block
         border-radius 3px
         color black
-        background-color rgba(255,255,255,0.75)
+        background-color rgba(255, 255, 255, 0.75)
         position absolute
         font-size 9px
         bottom -2px
         right -3px
         padding 0 0.3em
 
-  .g-folder-list,.g-item-list,.g-file-list
+  .g-folder-list, .g-item-list, .g-file-list
     margin 0
     padding 0
     list-style-type none
@@ -80,7 +78,7 @@
       box-sizing border-box
       padding 4px 5px 3px
 
-    >.g-folder-list-entry,>.g-item-list-entry
+    >.g-folder-list-entry, >.g-item-list-entry
       font-size 15px
 
       &:hover
@@ -93,7 +91,7 @@
           background-color #f4eedf
 
     >.g-show-more
-      background-image linear-gradient(top, #f6f6f6 0%, #fff 10px)
+      background-image linear-gradient(top, #f6f6f6 0, #fff 10px)
 
     .g-list-checkbox
       font-size 16px
@@ -118,7 +116,7 @@
         border 1px solid #aaa
         background-color #dadada
 
-  .g-item-size,.g-folder-privacy
+  .g-item-size, .g-folder-privacy
     display inline-block
     padding 1px 5px
     margin-left 10px
@@ -135,7 +133,7 @@
 .g-folder-metadata
   margin-top 20px
 
-.g-folder-info-line,.g-collection-info-line,.g-file-info-line
+.g-folder-info-line, .g-collection-info-line, .g-file-info-line
   color #808080
   margin-bottom 2px
   padding 2px 4px
@@ -147,5 +145,5 @@
     font-weight bold
 
 .g-info-dialog-description
-  margin 0 0 10px 0
+  margin 0 0 10px
   border-bottom 1px solid #eee

--- a/clients/web/src/stylesheets/widgets/markdownWidget.styl
+++ b/clients/web/src/stylesheets/widgets/markdownWidget.styl
@@ -1,5 +1,3 @@
-@import '~nib/index.styl'
-
 $hoverBorderColor = #aaa
 $hoverBg = #fbfac0
 
@@ -27,7 +25,7 @@ $hoverBg = #fbfac0
     padding 5px 9px
     background-color #fafafa
     border 1px solid #ccc
-    box-shadow inset 0 1px 2px rgba(0,0,0,0.075)
+    box-shadow inset 0 1px 2px rgba(0, 0, 0, 0.075)
 
     &:focus
       background-color #fff
@@ -88,7 +86,7 @@ $hoverBg = #fbfac0
     bottom 0
     left 0
     padding 15px
-    background-color rgba(75,75,75,0.77)
+    background-color rgba(75, 75, 75, 0.77)
     border-radius 3px
-    z-index 2
+    z-index 10
     color white

--- a/clients/web/src/stylesheets/widgets/metadataWidget.styl
+++ b/clients/web/src/stylesheets/widgets/metadataWidget.styl
@@ -48,6 +48,12 @@
   margin-left 5px
   margin-right 5px
 
+  .ace_editor, textarea
+    height 400px !important
+
+  .ace_content * // @stylint ignore
+    font-family monospace !important
+
 .jsoneditor
   border 2px solid #e3e3e3
 

--- a/clients/web/src/stylesheets/widgets/metadataWidget.styl
+++ b/clients/web/src/stylesheets/widgets/metadataWidget.styl
@@ -23,21 +23,21 @@
   font-weight bold
   width 30%
 
-.g-widget-metadata-key span.small
-  float right
+  span.small
+    float right
 
 .g-widget-metadata-value
   width 60%
 
-.g-widget-metadata-value pre
-  padding 0px
-  font-size 14px
-  color #777
-  background-color transparent
-  border none
-  max-height 320px
-  overflow auto
-  margin-bottom 0
+  pre
+    padding 0
+    font-size 14px
+    color #777
+    background-color transparent
+    border none
+    max-height 320px
+    overflow auto
+    margin-bottom 0
 
 .g-json-editor
   width 54%
@@ -51,36 +51,32 @@
 .jsoneditor
   border 2px solid #e3e3e3
 
-.jsoneditor .menu
-  background-color #fbfbfb
-  border-bottom 1px solid #f0f0f0
+  .menu
+    background-color #fbfbfb
+    border-bottom 1px solid #f0f0f0
 
-.jsoneditor .menu button
-  background #fbfbfb url("~jsoneditor/dist/img/jsoneditor-icons.png")
-  border 1px solid #f0f0f0
+    button
+      background #fbfbfb url("~jsoneditor/dist/img/jsoneditor-icons.png")
+      border 1px solid #f0f0f0
 
-.jsoneditor .menu button:disabled
-  background #fbfbfb url("~jsoneditor/dist/img/jsoneditor-icons.png")
-  border 1px solid #f0f0f0
+      :disabled
+        background #fbfbfb url("~jsoneditor/dist/img/jsoneditor-icons.png")
+        border 1px solid #f0f0f0
 
-.jsoneditor .search .frame
-  border 1px solid #f0f0f0
+    button:hover, button:focus
+      background-color #f0f0f0
 
-.g-json-editor .ace_editor, .g-json-editor textarea
-  height 400px !important
+    .search
+      button
+        border none
+        background-color transparent
 
-.g-json-editor .ace_content *
-  font-family monospace !important
-
-.jsoneditor .menu button:hover, .jsoneditor .menu button:focus
-  background-color #f0f0f0
+  .search
+    .frame
+      border 1px solid #f0f0f0
 
 .jsoneditor-contextmenu ul li .selected
   background-color #eaebea
-
-.jsoneditor .menu .search button
-  border none
-  background-color transparent
 
 button.g-widget-metadata-add-button
   float right

--- a/clients/web/src/stylesheets/widgets/searchFieldWidget.styl
+++ b/clients/web/src/stylesheets/widgets/searchFieldWidget.styl
@@ -1,6 +1,6 @@
 $buttonBg = #eee
 $buttonBorder = 1px solid #ccc
-$buttonHoverBg = linear-gradient(to bottom, #e2e2e2 0%, #eee 80%)
+$buttonHoverBg = linear-gradient(to bottom, #e2e2e2 0, #eee 80%)
 $borderRadius = 3px
 
 .g-search-wrapper
@@ -61,7 +61,7 @@ $borderRadius = 3px
   line-height 1.25
 
 .g-search-examples-list
-  margin-left 0px
+  margin-left 0
   list-style-position inside
   padding-left 2px
 

--- a/clients/web/src/stylesheets/widgets/taskProgress.styl
+++ b/clients/web/src/stylesheets/widgets/taskProgress.styl
@@ -1,5 +1,3 @@
-@import '~nib/index.styl'
-
 .g-task-progress-bar
   width 140px
   display inline-block

--- a/clients/web/src/stylesheets/widgets/timelineWidget.styl
+++ b/clients/web/src/stylesheets/widgets/timelineWidget.styl
@@ -1,5 +1,3 @@
-@import '~nib/index.styl'
-
 $height = 14px
 
 .g-timeline-container
@@ -8,24 +6,24 @@ $height = 14px
   margin-left 10px
   background-color #e4e4e4
   position relative
-  box-shadow inset 0 3px 3px rgba(0,0,0,0.08)
+  box-shadow inset 0 3px 3px rgba(0, 0, 0, 0.08)
 
   .g-timeline-segment
     position absolute
-    z-index 1
+    z-index 5
     height $height
-    box-shadow 0 2px 4px rgba(0,0,0,0.15)
+    box-shadow 0 2px 4px rgba(0, 0, 0, 0.15)
 
   .g-timeline-point
     position absolute
     height $height + 6px
     width $height + 6px
     border-radius 50%
-    z-index 2
+    z-index 10
     top -3px
-    box-shadow 0 2px 4px rgba(0,0,0,0.15)
+    box-shadow 0 2px 4px rgba(0, 0, 0, 0.15)
 
-  .g-point-default,.g-segment-default
+  .g-point-default, .g-segment-default
     background-color #4c4
 
 .g-timeline-labels-container

--- a/clients/web/src/stylesheets/widgets/uploadWidget.styl
+++ b/clients/web/src/stylesheets/widgets/uploadWidget.styl
@@ -1,9 +1,9 @@
-.g-current-progress-message,.g-overall-progress-message
+.g-current-progress-message, .g-overall-progress-message
   color #737373
   margin-top 5px
   margin-bottom 5px
 
-.g-progress-current,.g-progress-overall
+.g-progress-current, .g-progress-overall
   >.progress-bar
     transition none
 
@@ -22,7 +22,7 @@
   cursor pointer
   border 1px solid #484
   background-color #4ca84c
-  background-image linear-gradient(to bottom, #4ca84c 0%, #5cb85c 100%)
+  background-image linear-gradient(to bottom, #4ca84c 0, #5cb85c 100%)
 
 .g-dropzone-show
   border-radius 5px

--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -976,7 +976,7 @@ However, plugin developers can also choose to extend or even entirely override t
 To do this, you only need to provide a path to a custom ESLint configuration file, using the
 ``ESLINT_CONFIG_FILE`` option to ``add_eslint_test``. Of course, since ``add_standard_plugin_tests``
 should be prevented from adding these tests, static analysis should also be manually added to PugJS
-template files with ``add_puglint_test``. For example:
+template files with ``add_puglint_test`` and ``add_stylint_test``. For example:
 
 .. code-block:: cmake
 
@@ -984,6 +984,7 @@ template files with ``add_puglint_test``. For example:
     add_eslint_test(js_static_analysis_cats "${PROJECT_SOURCE_DIR}/plugins/cats/web_client"
         ESLINT_CONFIG_FILE "${PROJECT_SOURCE_DIR}/plugins/cats/.eslintrc.json")
     add_puglint_test(cats "${PROJECT_SOURCE_DIR}/plugins/cats/web_client/templates")
+    add_stylint_test(cats "${PROJECT_SOURCE_DIR}/plugins/cats/web_client/stylesheets")
 
 You can `configure ESLint <http://eslint.org/docs/user-guide/configuring.html>`_ inside your
 ``.eslintrc.json`` file however you choose.  For example, to extend Girder's own configuration to

--- a/grunt_tasks/version.js
+++ b/grunt_tasks/version.js
@@ -44,7 +44,7 @@ module.exports = function (grunt) {
             'python-version': {
                 'girder/girder-version.json': function (fs, fd, done) {
                     var girderVersion = versionInfoObject();
-                    fs.writeSync(fd, girderVersion);
+                    fs.writeSync(fd, girderVersion + '\n');
                     done();
                 }
             },

--- a/grunt_tasks/webpack.config.js
+++ b/grunt_tasks/webpack.config.js
@@ -106,7 +106,10 @@ module.exports = {
                             options: {
                                 // The 'resolve url' option is not well-documented, but was
                                 // added at https://github.com/shama/stylus-loader/pull/6
-                                'resolve url': true
+                                'resolve url': true,
+                                import: [
+                                    '~nib/index.styl'
+                                ]
                             }
                         }
                     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -470,7 +470,7 @@
             "dev": true,
             "requires": {
                 "find-up": "2.1.0",
-                "istanbul-lib-instrument": "1.7.3",
+                "istanbul-lib-instrument": "1.7.4",
                 "test-exclude": "4.1.1"
             },
             "dependencies": {
@@ -1342,7 +1342,7 @@
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
             "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
             "requires": {
-                "color-name": "1.1.2"
+                "color-name": "1.1.3"
             }
         },
         "color-logger": {
@@ -1352,16 +1352,16 @@
             "dev": true
         },
         "color-name": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz",
-            "integrity": "sha1-XIq3K2S9IhXWF66VWeuxSEdc+Y0="
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "color-string": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
             "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
             "requires": {
-                "color-name": "1.1.2"
+                "color-name": "1.1.3"
             }
         },
         "colormin": {
@@ -1378,6 +1378,16 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
             "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+        },
+        "columnify": {
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+            "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
+            "dev": true,
+            "requires": {
+                "strip-ansi": "3.0.1",
+                "wcwidth": "1.0.1"
+            }
         },
         "combined-stream": {
             "version": "1.0.5",
@@ -1814,6 +1824,15 @@
             "dev": true,
             "requires": {
                 "strip-bom": "2.0.0"
+            }
+        },
+        "defaults": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+            "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+            "dev": true,
+            "requires": {
+                "clone": "1.0.2"
             }
         },
         "define-properties": {
@@ -4297,7 +4316,7 @@
             "requires": {
                 "abbrev": "1.0.9",
                 "async": "1.5.2",
-                "istanbul-api": "1.1.10",
+                "istanbul-api": "1.1.11",
                 "js-yaml": "3.7.0",
                 "mkdirp": "0.5.1",
                 "nopt": "3.0.6",
@@ -4326,16 +4345,16 @@
             }
         },
         "istanbul-api": {
-            "version": "1.1.10",
-            "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.1.10.tgz",
-            "integrity": "sha1-8n5ecSXI3hP2qAZhr3j1EuVDmys=",
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.1.11.tgz",
+            "integrity": "sha1-/MC0YeKzvaceMFFVE4I4doJX2d4=",
             "dev": true,
             "requires": {
                 "async": "2.5.0",
                 "fileset": "2.0.3",
                 "istanbul-lib-coverage": "1.1.1",
                 "istanbul-lib-hook": "1.0.7",
-                "istanbul-lib-instrument": "1.7.3",
+                "istanbul-lib-instrument": "1.7.4",
                 "istanbul-lib-report": "1.1.1",
                 "istanbul-lib-source-maps": "1.2.1",
                 "istanbul-reports": "1.1.1",
@@ -4360,9 +4379,9 @@
             }
         },
         "istanbul-lib-instrument": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.3.tgz",
-            "integrity": "sha1-klsjkWPqvdaMxASPUsL6T4mez6c=",
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.4.tgz",
+            "integrity": "sha1-6f2SDkdn89Ge3HZeLWs/XMvQ7qg=",
             "dev": true,
             "requires": {
                 "babel-generator": "6.25.0",
@@ -4736,10 +4755,22 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
             "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
         },
+        "lodash.assign": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+            "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+            "dev": true
+        },
         "lodash.assignin": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
             "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI=",
+            "dev": true
+        },
+        "lodash.assigninwith": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.assigninwith/-/lodash.assigninwith-4.2.0.tgz",
+            "integrity": "sha1-rwLJhDKshtk9ppW0voAUAZcXNq8=",
             "dev": true
         },
         "lodash.bind": {
@@ -4821,6 +4852,12 @@
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
             "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU=",
+            "dev": true
+        },
+        "lodash.rest": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.5.tgz",
+            "integrity": "sha1-lU73UEkmIDjJbR/Jiyj9r58Hcqo=",
             "dev": true
         },
         "lodash.some": {
@@ -5060,6 +5097,12 @@
             "requires": {
                 "moment": "2.18.1"
             }
+        },
+        "mout": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/mout/-/mout-0.5.0.tgz",
+            "integrity": "sha1-/5Z1ZqkPKVlenLi254AKW1ZjVYM=",
+            "dev": true
         },
         "ms": {
             "version": "2.0.0",
@@ -5692,6 +5735,18 @@
                 "pinkie": "2.0.4"
             }
         },
+        "pkg-conf": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz",
+            "integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
+            "dev": true,
+            "requires": {
+                "find-up": "1.1.2",
+                "load-json-file": "1.1.0",
+                "object-assign": "4.1.1",
+                "symbol": "0.2.3"
+            }
+        },
         "pkg-dir": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
@@ -5906,7 +5961,7 @@
             "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
             "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
             "requires": {
-                "postcss": "6.0.6"
+                "postcss": "6.0.7"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -5933,9 +5988,9 @@
                     "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                 },
                 "postcss": {
-                    "version": "6.0.6",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.6.tgz",
-                    "integrity": "sha1-u6TVjohPx4yEDRU54Q7dqruPc70=",
+                    "version": "6.0.7",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.7.tgz",
+                    "integrity": "sha512-8h/GrGLLyxM5ZvzpCH2XTYPysaSL3Ku5kWD7tKXeKRj8NVg1tyldHFCQGF4NTvRUDvjQfmcCRuowHHFFlAURUg==",
                     "requires": {
                         "chalk": "2.0.1",
                         "source-map": "0.5.6",
@@ -5958,7 +6013,7 @@
             "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
             "requires": {
                 "css-selector-tokenizer": "0.7.0",
-                "postcss": "6.0.6"
+                "postcss": "6.0.7"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -5985,9 +6040,9 @@
                     "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                 },
                 "postcss": {
-                    "version": "6.0.6",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.6.tgz",
-                    "integrity": "sha1-u6TVjohPx4yEDRU54Q7dqruPc70=",
+                    "version": "6.0.7",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.7.tgz",
+                    "integrity": "sha512-8h/GrGLLyxM5ZvzpCH2XTYPysaSL3Ku5kWD7tKXeKRj8NVg1tyldHFCQGF4NTvRUDvjQfmcCRuowHHFFlAURUg==",
                     "requires": {
                         "chalk": "2.0.1",
                         "source-map": "0.5.6",
@@ -6010,7 +6065,7 @@
             "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
             "requires": {
                 "css-selector-tokenizer": "0.7.0",
-                "postcss": "6.0.6"
+                "postcss": "6.0.7"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -6037,9 +6092,9 @@
                     "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                 },
                 "postcss": {
-                    "version": "6.0.6",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.6.tgz",
-                    "integrity": "sha1-u6TVjohPx4yEDRU54Q7dqruPc70=",
+                    "version": "6.0.7",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.7.tgz",
+                    "integrity": "sha512-8h/GrGLLyxM5ZvzpCH2XTYPysaSL3Ku5kWD7tKXeKRj8NVg1tyldHFCQGF4NTvRUDvjQfmcCRuowHHFFlAURUg==",
                     "requires": {
                         "chalk": "2.0.1",
                         "source-map": "0.5.6",
@@ -6062,7 +6117,7 @@
             "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
             "requires": {
                 "icss-replace-symbols": "1.1.0",
-                "postcss": "6.0.6"
+                "postcss": "6.0.7"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -6089,9 +6144,9 @@
                     "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                 },
                 "postcss": {
-                    "version": "6.0.6",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.6.tgz",
-                    "integrity": "sha1-u6TVjohPx4yEDRU54Q7dqruPc70=",
+                    "version": "6.0.7",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.7.tgz",
+                    "integrity": "sha512-8h/GrGLLyxM5ZvzpCH2XTYPysaSL3Ku5kWD7tKXeKRj8NVg1tyldHFCQGF4NTvRUDvjQfmcCRuowHHFFlAURUg==",
                     "requires": {
                         "chalk": "2.0.1",
                         "source-map": "0.5.6",
@@ -7353,6 +7408,15 @@
                 }
             }
         },
+        "stampit": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/stampit/-/stampit-1.2.0.tgz",
+            "integrity": "sha1-UfnGoIwUZHP80CGvVRyfMu1ce50=",
+            "dev": true,
+            "requires": {
+                "mout": "0.5.0"
+            }
+        },
         "statuses": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
@@ -7458,6 +7522,139 @@
                 }
             }
         },
+        "stylint": {
+            "version": "1.5.9",
+            "resolved": "https://registry.npmjs.org/stylint/-/stylint-1.5.9.tgz",
+            "integrity": "sha1-KfTcEp+hyiIVDNhnIjzuK+1f9qI=",
+            "dev": true,
+            "requires": {
+                "async": "1.5.2",
+                "chalk": "1.1.3",
+                "chokidar": "1.5.2",
+                "columnify": "1.5.4",
+                "glob": "7.0.4",
+                "lodash.defaults": "4.0.1",
+                "path-is-absolute": "1.0.0",
+                "stampit": "1.2.0",
+                "strip-json-comments": "2.0.1",
+                "user-home": "2.0.0",
+                "yargs": "4.7.1"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.5.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                    "dev": true
+                },
+                "camelcase": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+                    "dev": true
+                },
+                "chokidar": {
+                    "version": "1.5.2",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.5.2.tgz",
+                    "integrity": "sha1-KT5yhkDMk92Cd0JDNLPG1K06NIo=",
+                    "dev": true,
+                    "requires": {
+                        "anymatch": "1.3.0",
+                        "async-each": "1.0.1",
+                        "glob-parent": "2.0.0",
+                        "inherits": "2.0.3",
+                        "is-binary-path": "1.0.1",
+                        "is-glob": "2.0.1",
+                        "path-is-absolute": "1.0.0",
+                        "readdirp": "2.1.0"
+                    }
+                },
+                "cliui": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                    "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wrap-ansi": "2.1.0"
+                    }
+                },
+                "glob": {
+                    "version": "7.0.4",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.4.tgz",
+                    "integrity": "sha1-O0SvoJQ73DGyA3uTR5Hi4IS8t/Y=",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.0"
+                    }
+                },
+                "lodash.defaults": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.0.1.tgz",
+                    "integrity": "sha1-BWeOYSqXFsZLW/LOzwRRMco9NAI=",
+                    "dev": true,
+                    "requires": {
+                        "lodash.assigninwith": "4.2.0",
+                        "lodash.rest": "4.0.5"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                    "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+                    "dev": true
+                },
+                "set-blocking": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-1.0.0.tgz",
+                    "integrity": "sha1-zV5dk4BI3xrJLf6S4fFq3WVvXsU=",
+                    "dev": true
+                },
+                "window-size": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+                    "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "4.7.1",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.7.1.tgz",
+                    "integrity": "sha1-5gQyZYozh/8mnAKOrN5KUS5Djf8=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "3.0.0",
+                        "cliui": "3.2.0",
+                        "decamelize": "1.2.0",
+                        "lodash.assign": "4.2.0",
+                        "os-locale": "1.4.0",
+                        "pkg-conf": "1.1.3",
+                        "read-pkg-up": "1.0.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "1.0.0",
+                        "string-width": "1.0.2",
+                        "window-size": "0.2.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "2.4.1"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+                    "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "3.0.0",
+                        "lodash.assign": "4.2.0"
+                    }
+                }
+            }
+        },
         "stylus": {
             "version": "0.54.5",
             "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.54.5.tgz",
@@ -7531,6 +7728,12 @@
             "version": "2.2.10",
             "resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-2.2.10.tgz",
             "integrity": "sha1-sl56IWZOXZC/OR2zDbCN5B6FLXs="
+        },
+        "symbol": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.3.tgz",
+            "integrity": "sha1-O5hzuKkB5Hxu/iFSajrDcu8ou8c=",
+            "dev": true
         },
         "symbol-tree": {
             "version": "3.2.2",
@@ -8016,9 +8219,9 @@
             "integrity": "sha1-sM01KhpQ9RVWNCD/1YYflQ8dhbg="
         },
         "watchpack": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.3.1.tgz",
-            "integrity": "sha1-fYaTkHsozmAT5/NhCqKhrPB9rYc=",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
+            "integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
             "requires": {
                 "async": "2.5.0",
                 "chokidar": "1.7.0",
@@ -8032,6 +8235,15 @@
             "dev": true,
             "requires": {
                 "minimalistic-assert": "1.0.0"
+            }
+        },
+        "wcwidth": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+            "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+            "dev": true,
+            "requires": {
+                "defaults": "1.0.3"
             }
         },
         "webidl-conversions": {
@@ -8063,7 +8275,7 @@
                 "supports-color": "3.2.3",
                 "tapable": "0.2.6",
                 "uglify-js": "2.8.29",
-                "watchpack": "1.3.1",
+                "watchpack": "1.4.0",
                 "webpack-sources": "0.1.5",
                 "yargs": "6.6.0"
             },

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
         "istanbul": "1.1.0-alpha.1",
         "phantomjs-prebuilt": "^2.1.13",
         "pug-lint": "^2.4.0",
+        "stylint": "^1.5.9",
         "webpack-dev-server": "^2.1.0-beta.0"
     },
     "scripts": {

--- a/plugins/authorized_upload/web_client/stylesheets/authorizedUpload.styl
+++ b/plugins/authorized_upload/web_client/stylesheets/authorizedUpload.styl
@@ -1,8 +1,6 @@
-@import '~nib/index.styl'
-
 .g-authorized-upload-page-wrapper
   max-width 770px
-  margin 100px auto 0 auto
+  margin 100px auto 0
 
   p
     font-size 16px
@@ -21,18 +19,18 @@
       text-align center
       line-height 60px
       height 60px
-      box-shadow 0 2px 5px rgba(0,0,0,0.2)
+      box-shadow 0 2px 5px rgba(0, 0, 0, 0.2)
       background-color #5cb897
       border 1px solid #4a8
       padding 0
 
       &:hover
         background-color #6cc8a7
-        background linear-gradient(top,#6cc8a7 50%,#5cb897 100%)
+        background linear-gradient(top, #6cc8a7 50%, #5cb897 100%)
 
       &:active
         background #6cc8a7
-        box-shadow inset 0 3px 5px rgba(0,0,0,0.125)
+        box-shadow inset 0 3px 5px rgba(0, 0, 0, 0.125)
 
       &.g-dropzone-show
         background white

--- a/plugins/curation/web_client/stylesheets/curationDialog.styl
+++ b/plugins/curation/web_client/stylesheets/curationDialog.styl
@@ -1,8 +1,8 @@
 .g-curation-action-container
   float left
 
-.g-curation-action-container button
-  margin-right 5px
+  button
+    margin-right 5px
 
 .g-curation-timeline-container
   margin-top 10px

--- a/plugins/dicom_viewer/web_client/stylesheets/dicom_viewer.styl
+++ b/plugins/dicom_viewer/web_client/stylesheets/dicom_viewer.styl
@@ -19,19 +19,18 @@
 
 .dicom-filename
   text-align center
-
-.dicom-filename
-  margin: 5px 0
-
-.g-dicom-controls .right
-  float right
-
-.g-dicom-controls button
-  margin-right 5px
-
-.g-dicom-controls .right button
-  margin-right 0
-  margin-left 5px
-
-.g-dicom-controls input
   margin 5px 0
+
+.g-dicom-controls
+  .right
+    float right
+
+    button
+      margin-right 0
+      margin-left 5px
+
+  button
+    margin-right 5px
+
+  input
+    margin 5px 0

--- a/plugins/google_analytics/web_client/stylesheets/configView.styl
+++ b/plugins/google_analytics/web_client/stylesheets/configView.styl
@@ -1,5 +1,5 @@
 .g-google-analytics-value-container
-  margin 10px 0 10px 0
+  margin 10px 0
   padding 3px 9px
   border 1px solid #ddd
   background-color #f6f6f6

--- a/plugins/item_previews/web_client/stylesheets/itemPreviewWidget.styl
+++ b/plugins/item_previews/web_client/stylesheets/itemPreviewWidget.styl
@@ -22,27 +22,27 @@ $maxPreviewHeight = 400px
   &.g-wrap
     white-space normal
 
+  img
+    max-height $maxPreviewHeight
+    border-radius 5px
+    width auto
+
+  .panel
+    display inline-block
+    vertical-align top
+    width 30% !important
+
+    .panel-body
+      padding 5px
+
+  .json
+    background-color #f5f5f5
+    border-radius 4px
+    border 1px solid #ccc
+    color #333
+    height 300px
+    white-space pre-wrap
+
 .g-widget-item-preview
   display inline
   margin-right 10px
-
-.g-widget-item-previews-container img
-  max-height $maxPreviewHeight
-  border-radius 5px
-  width auto
-
-.g-widget-item-previews-container .panel
-  display inline-block
-  vertical-align top
-  width 30% !important
-
-.g-widget-item-previews-container .panel .panel-body
-  padding 5px
-
-.g-widget-item-previews-container .json
-  background-color #f5f5f5
-  border-radius 4px
-  border 1px solid #ccc
-  color #333
-  height 300px
-  white-space pre-wrap

--- a/plugins/item_tasks/web_client/stylesheets/controlWidget.styl
+++ b/plugins/item_tasks/web_client/stylesheets/controlWidget.styl
@@ -1,5 +1,3 @@
-@import '~nib/index.styl'
-
 .g-control-widget-label
   margin-bottom 2px
 

--- a/plugins/item_tasks/web_client/stylesheets/panel.styl
+++ b/plugins/item_tasks/web_client/stylesheets/panel.styl
@@ -2,7 +2,7 @@
 
   .g-panel
     background-color #ffffff
-    opacity .95
+    opacity 0.95
     margin-top 5px
     border-radius 3px
     height auto
@@ -20,7 +20,7 @@
     text-align left
     background-color #f0f0f0
     cursor pointer
-    padding 5px 5px
+    padding 5px
 
     .g-panel-title
       display inline-block

--- a/plugins/item_tasks/web_client/stylesheets/taskList.styl
+++ b/plugins/item_tasks/web_client/stylesheets/taskList.styl
@@ -3,4 +3,4 @@
 
   .g-task-pagination
     ul
-      margin 0px
+      margin 0

--- a/plugins/jobs/web_client/stylesheets/jobListWidget.styl
+++ b/plugins/jobs/web_client/stylesheets/jobListWidget.styl
@@ -1,5 +1,3 @@
-@import '~nib/index.styl'
-
 .g-jobs-list-table
   width 100%
 
@@ -40,7 +38,7 @@ a.g-job-checkbox-menu-link
   overflow hidden
   text-overflow ellipsis
   white-space nowrap
-  color: #333
+  color #333
 
 
 .g-job-filter-container
@@ -58,7 +56,7 @@ a.g-job-checkbox-menu-link
         padding 0
         margin 0
     .checkbox
-      margin 8px 8px
+      margin 8px
     .checkbox.g-job-checkall
       padding-bottom 8px
       border-bottom 1px solid #ddd
@@ -70,8 +68,8 @@ a.g-job-checkbox-menu-link
     margin-right 10px
 
 
-ul.g-jobs.nav.nav-tabs
-  margin 10px 0 10px 0
+ul.g-jobs
+  margin 10px 0
 
 .g-jobs-graph
   height calc(100vh - 230px)

--- a/plugins/oauth/web_client/stylesheets/configView.styl
+++ b/plugins/oauth/web_client/stylesheets/configView.styl
@@ -5,7 +5,7 @@
   border-bottom 1px solid #eee
 
 .g-oauth-value-container
-  margin 10px 0 10px 0
+  margin 10px 0
   padding 3px 9px
   border 1px solid #ddd
   background-color #f6f6f6

--- a/plugins/thumbnails/web_client/stylesheets/flowView.styl
+++ b/plugins/thumbnails/web_client/stylesheets/flowView.styl
@@ -1,5 +1,3 @@
-@import '~nib/index.styl'
-
 .g-thumbnail-container
   display inline-block
   margin 0 10px 10px 0

--- a/plugins/user_quota/web_client/stylesheets/userQuota.styl
+++ b/plugins/user_quota/web_client/stylesheets/userQuota.styl
@@ -1,7 +1,7 @@
-#g-policies-edit-form,#g-user-quota-form
+#g-policies-edit-form, #g-user-quota-form
   .g-quota-description
     font-size 12px
-    margin 0 0 2px 0
+    margin 0 0 2px
   .g-quota-capacity-chart
     height 15px
     width 280px

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -147,6 +147,9 @@ macro(add_standard_plugin_tests)
     if(IS_DIRECTORY "${_pluginDir}/web_client/templates")
       add_puglint_test(${_pluginName} "${_pluginDir}/web_client/templates")
     endif()
+    if(IS_DIRECTORY "${_pluginDir}/web_client/stylesheets")
+      add_stylint_test(${_pluginName} "${_pluginDir}/web_client/stylesheets")
+    endif()
   endif()
 
   # Server plugin_tests

--- a/tests/JavascriptTests.cmake
+++ b/tests/JavascriptTests.cmake
@@ -73,6 +73,23 @@ function(add_puglint_test name path)
   set_property(TEST "puglint_${name}" PROPERTY LABELS girder_static_analysis)
 endfunction()
 
+function(add_stylint_test name path)
+  if (NOT JAVASCRIPT_STYLE_TESTS)
+    return()
+  endif()
+
+  if (NOT STYLINT_EXECUTABLE)
+    message(FATAL_ERROR "CMake variable STYLINT_EXECUTABLE is not set. Run 'npm install' or disable JAVASCRIPT_STYLE_TESTS.")
+  endif()
+
+  add_test(
+    NAME "stylint_${name}"
+    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+    COMMAND "${STYLINT_EXECUTABLE}" --config "${PROJECT_SOURCE_DIR}/.stylintrc" "${path}"
+  )
+  set_property(TEST "stylint_${name}" PROPERTY LABELS girder_static_analysis)
+endfunction()
+
 function(add_web_client_test case specFile)
   # test a web client using a spec file and the specRunner
   # :param case: the name of this test case

--- a/tests/clients/web/CMakeLists.txt
+++ b/tests/clients/web/CMakeLists.txt
@@ -1,3 +1,4 @@
 # All of our core javascript will be checked with a single test
 add_eslint_test(core "${PROJECT_SOURCE_DIR}/clients/web/src")
 add_puglint_test(core "${PROJECT_SOURCE_DIR}/clients/web/src/templates")
+add_stylint_test(core "${PROJECT_SOURCE_DIR}/clients/web/src/stylesheets")


### PR DESCRIPTION
* Add static analysis tests for Stylus files
* Always import Nib when loading Stylus files
* Fix Stylus style issues
* Ensure `girder-version.json` ends with a newline


Fixes #2173