### PR TITLE
Add an ESLint style rule to require single quoted strings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-    "extends": "girder"
+    "extends": "girder",
+    "rules": {
+        "quotes": ["error", "single", {"avoidEscape": true, "allowTemplateLiterals": true}]
+    }
 }

--- a/clients/web/test/spec/adminSpec.js
+++ b/clients/web/test/spec/adminSpec.js
@@ -53,7 +53,7 @@ describe('Test the settings page', function () {
     it('Login as admin', girderTest.login('admin', 'Admin', 'Admin', 'adminpassword!'));
     it('Go to settings page', function () {
         runs(function () {
-            $("a.g-nav-link[g-target='admin']").click();
+            $('a.g-nav-link[g-target="admin"]').click();
         });
 
         waitsFor(function () {
@@ -190,7 +190,7 @@ describe('Test the assetstore page', function () {
         it('Create, switch to, and delete a ' + assetstore + ' assetstore', function () {
             /* create the assetstore */
             runs(function () {
-                $("[data-target='#" + tab + "']").click();
+                $('[data-target="#' + tab + '"]').click();
             });
             waitsFor(function () {
                 return $('#' + tab + ' .g-new-assetstore-submit:visible').length > 0;
@@ -288,7 +288,7 @@ describe('Test the assetstore page', function () {
 
             /* navigate away and back */
             runs(function () {
-                $("a.g-nav-link[g-target='admin']").click();
+                $('a.g-nav-link[g-target="admin"]').click();
             });
             waitsFor(function () {
                 return $('.g-assetstore-config').length > 0;
@@ -477,11 +477,11 @@ describe('Test the assetstore page', function () {
         girderTest.login('admin', 'Admin', 'Admin', 'adminpassword!')();
 
         runs(function () {
-            $("a.g-nav-link[g-target='admin']").click();
+            $('a.g-nav-link[g-target="admin"]').click();
         });
 
         runs(function () {
-            $("a.g-nav-link[g-target='admin']").click();
+            $('a.g-nav-link[g-target="admin"]').click();
         });
 
         waitsFor(function () {
@@ -570,7 +570,7 @@ describe('Test the plugins page', function () {
     it('Login as admin', girderTest.login('admin', 'Admin', 'Admin', 'adminpassword!'));
     it('Go to plugins page', function () {
         runs(function () {
-            $("a.g-nav-link[g-target='admin']").click();
+            $('a.g-nav-link[g-target="admin"]').click();
         });
         waitsFor(function () {
             return $('.g-plugins-config').length > 0;
@@ -637,7 +637,7 @@ describe('Test the plugins page', function () {
     });
     it('Go away and back to plugins page', function () {
         runs(function () {
-            $("a.g-nav-link[g-target='admin']").click();
+            $('a.g-nav-link[g-target="admin"]').click();
         });
         waitsFor(function () {
             return $('.g-plugins-config').length > 0;

--- a/clients/web/test/spec/collectionSpec.js
+++ b/clients/web/test/spec/collectionSpec.js
@@ -12,7 +12,7 @@ describe('Test collection actions', function () {
 
     it('go to collections page', function () {
         runs(function () {
-            $("a.g-nav-link[g-target='collections']").click();
+            $('a.g-nav-link[g-target="collections"]').click();
         });
 
         waitsFor(function () {
@@ -29,7 +29,7 @@ describe('Test collection actions', function () {
 
     it('go back to collections page', function () {
         runs(function () {
-            $("a.g-nav-link[g-target='collections']").click();
+            $('a.g-nav-link[g-target="collections"]').click();
         });
 
         waitsFor(function () {
@@ -144,7 +144,7 @@ describe('Test collection actions', function () {
         girderTest.login('admin', 'Admin', 'Admin', 'adminpassword!')();
 
         runs(function () {
-            $("a.g-nav-link[g-target='collections']").click();
+            $('a.g-nav-link[g-target="collections"]').click();
         });
 
         waitsFor(function () {
@@ -168,7 +168,7 @@ describe('Test collection actions', function () {
         });
 
         waitsFor(function () {
-            return $(".g-collection-access-control[role='menuitem']:visible").length === 1;
+            return $('.g-collection-access-control[role="menuitem"]:visible').length === 1;
         }, 'access control menu item to appear');
 
         runs(function () {
@@ -222,7 +222,7 @@ describe('Test collection actions', function () {
         girderTest.login('admin', 'Admin', 'Admin', 'adminpassword!')();
 
         runs(function () {
-            $("a.g-nav-link[g-target='collections']").click();
+            $('a.g-nav-link[g-target="collections"]').click();
         });
 
         waitsFor(function () {
@@ -244,7 +244,7 @@ describe('Test collection actions', function () {
 
     it('check if public collection is viewable (and ensure private is not)', function () {
         runs(function () {
-            $("a.g-nav-link[g-target='collections']").click();
+            $('a.g-nav-link[g-target="collections"]').click();
         });
 
         waitsFor(function () {
@@ -265,7 +265,7 @@ describe('Test collection actions', function () {
 
     it('delete the collection', function () {
         runs(function () {
-            $("a.g-nav-link[g-target='collections']").click();
+            $('a.g-nav-link[g-target="collections"]').click();
         });
 
         waitsFor(function () {

--- a/clients/web/test/spec/itemSpec.js
+++ b/clients/web/test/spec/itemSpec.js
@@ -144,7 +144,7 @@ describe('Test item creation, editing, and deletion', function () {
         });
 
         runs(function () {
-            $("a.g-user-link:contains('Not Admin')").click();
+            $('a.g-user-link:contains("Not Admin")').click();
         });
 
         waitsFor(function () {
@@ -153,7 +153,7 @@ describe('Test item creation, editing, and deletion', function () {
 
         // check for actions menu
         runs(function () {
-            expect($("button:contains('Actions')").length).toBe(1);
+            expect($('button:contains("Actions")').length).toBe(1);
         });
     });
 
@@ -165,7 +165,7 @@ describe('Test item creation, editing, and deletion', function () {
 
     it('view the users on the user page and click on one', function () {
         runs(function () {
-            $("a.g-user-link:contains('Not Admin')").click();
+            $('a.g-user-link:contains("Not Admin")').click();
         });
 
         waitsFor(function () {

--- a/clients/web/test/spec/userSpec.js
+++ b/clients/web/test/spec/userSpec.js
@@ -59,7 +59,7 @@ describe('Create an admin and non-admin user', function () {
         });
 
         runs(function () {
-            $("a.g-user-link:contains('Admin Admin')").click();
+            $('a.g-user-link:contains("Admin Admin")').click();
         });
 
         waitsFor(function () {
@@ -69,7 +69,7 @@ describe('Create an admin and non-admin user', function () {
         girderTest.waitForLoad();
         // check for actions menu
         runs(function () {
-            expect($("button:contains('Actions')").length).toBe(0);
+            expect($('button:contains("Actions")').length).toBe(0);
         });
     });
 
@@ -118,7 +118,7 @@ describe('Create an admin and non-admin user', function () {
         }, 'error to vanish');
     });
 
-    it("test changing other user's password", function () {
+    it('test changing other user\'s password', function () {
         runs(function () {
             girder.router.navigate('useraccount/' + registeredUsers[1].id + '/password',
                                    {trigger: true});
@@ -361,7 +361,7 @@ describe('test email verification', function () {
         girderTest.logout()();
         girderTest.login('admin', 'Admin', 'Admin', 'adminpassword!')();
         runs(function () {
-            $("a.g-nav-link[g-target='admin']").click();
+            $('a.g-nav-link[g-target="admin"]').click();
         });
         waitsFor(function () {
             return $('.g-server-config').length > 0;
@@ -414,7 +414,7 @@ describe('test email verification', function () {
         }, 'email verification message to appear');
 
         runs(function () {
-            $("a[data-dismiss='modal']").click();
+            $('a[data-dismiss="modal"]').click();
         });
     });
 });
@@ -423,7 +423,7 @@ describe('test account approval', function () {
     it('Turn on approval policy', function () {
         girderTest.login('admin', 'Admin', 'Admin', 'adminpassword!')();
         runs(function () {
-            $("a.g-nav-link[g-target='admin']").click();
+            $('a.g-nav-link[g-target="admin"]').click();
         });
         waitsFor(function () {
             return $('.g-server-config').length > 0;
@@ -490,7 +490,7 @@ describe('test account approval', function () {
         }, 'approval message to appear');
 
         runs(function () {
-            $("a[data-dismiss='modal']").click();
+            $('a[data-dismiss="modal"]').click();
         });
     });
 });

--- a/plugins/curation/plugin_tests/curationSpec.js
+++ b/plugins/curation/plugin_tests/curationSpec.js
@@ -51,7 +51,7 @@ describe('test the curation ui', function () {
         });
         runs(function () {
             $('#g-curation-enable:visible').click();
-            $("a[data-dismiss='modal']:visible").click();
+            $('a[data-dismiss="modal"]:visible').click();
         });
         waitsFor(function () {
             return $('.g-curation-summary:visible').length === 0;
@@ -71,7 +71,7 @@ describe('test the curation ui', function () {
 
         runs(function () {
             $('#g-curation-request:visible').click();
-            $("a[data-dismiss='modal']:visible").click();
+            $('a[data-dismiss="modal"]:visible').click();
         });
         waitsFor(function () {
             return $('.g-curation-summary:visible').length === 0;
@@ -91,7 +91,7 @@ describe('test the curation ui', function () {
 
         runs(function () {
             $('#g-curation-approve:visible').click();
-            $("a[data-dismiss='modal']:visible").click();
+            $('a[data-dismiss="modal"]:visible').click();
         });
         waitsFor(function () {
             return $('.g-curation-summary:visible').length === 0;


### PR DESCRIPTION
This was already the de facto standard in Girder, this just enforces the rule and tweaks some very old test files to comply.