### PR TITLE
Don't fail if there is no token.

### DIFF
--- a/plugins/authorized_upload/server/__init__.py
+++ b/plugins/authorized_upload/server/__init__.py
@@ -90,7 +90,7 @@ def _uploadComplete(event):
     more than a single upload at a time, and just decrement it here.
     """
     token = getCurrentToken()
-    if 'authorizedUploadId' in token:
+    if token and 'authorizedUploadId' in token:
         user = ModelImporter.model('user').load(token['userId'], force=True)
         item = ModelImporter.model('item').load(event.info['file']['itemId'], force=True)
 


### PR DESCRIPTION
When a server-side plugin uploads a file outside of a rest request, we might not have an access token.  The authorized upload plugin would throw an exception, preventing this upload.