### PR TITLE
Adjust display of restart warning message and rebuild button

### DIFF
--- a/clients/web/src/templates/body/plugins.pug
+++ b/clients/web/src/templates/body/plugins.pug
@@ -1,14 +1,10 @@
 .g-body-title Plugins
-  .g-rebuild-container
+  .g-rebuild-container(class=cherrypyServer ? '' : 'hide')
     button.g-rebuild-and-restart.btn.btn-primary(title="Rebuild web code and restart the server",
         disabled=!cherrypyServer)
       i.icon-arrows-cw
       | Rebuild and restart
     .g-clear
-if !cherrypyServer
-  p
-    | Note that restarting the Girder server is disabled. As a result, plugins enabled or disabled here
-    | might not take effect until the system administrator has restarted Girder.
 .g-plugin-rebuild-restart-text
   | The selected plugins have changed.
   br

--- a/clients/web/src/views/body/PluginsView.js
+++ b/clients/web/src/views/body/PluginsView.js
@@ -127,10 +127,10 @@ var PluginsView = View.extend({
                         this.enabled.splice(idx, 1);
                     }
                 }
-                $('button.g-rebuild-and-restart').addClass('btn-danger');
+                this.$('button.g-rebuild-and-restart').addClass('btn-danger');
 
                 if (this.cherrypyServer) {
-                    $('.g-plugin-rebuild-restart-text').addClass('show');
+                    this.$('.g-plugin-rebuild-restart-text').addClass('show');
                 }
 
                 if (!this.cherrypyServer && !_.has(this, 'displayedCherrypyNotification')) {

--- a/clients/web/src/views/body/PluginsView.js
+++ b/clients/web/src/views/body/PluginsView.js
@@ -115,27 +115,26 @@ var PluginsView = View.extend({
             allPlugins: this._sortPlugins(this.allPlugins)
         }));
 
-        var view = this;
         this.$('.g-plugin-switch').bootstrapSwitch()
             .off('switchChange.bootstrapSwitch')
-            .on('switchChange.bootstrapSwitch', function (event, state) {
+            .on('switchChange.bootstrapSwitch', (event, state) => {
                 var plugin = $(event.currentTarget).attr('key');
                 if (state === true) {
-                    view.enabled.push(plugin);
+                    this.enabled.push(plugin);
                 } else {
                     var idx;
-                    while ((idx = view.enabled.indexOf(plugin)) >= 0) {
-                        view.enabled.splice(idx, 1);
+                    while ((idx = this.enabled.indexOf(plugin)) >= 0) {
+                        this.enabled.splice(idx, 1);
                     }
                 }
                 $('button.g-rebuild-and-restart').addClass('btn-danger');
 
-                if (view.cherrypyServer) {
+                if (this.cherrypyServer) {
                     $('.g-plugin-rebuild-restart-text').addClass('show');
                 }
 
-                if (!view.cherrypyServer && !_.has(view, 'displayedCherrypyNotification')) {
-                    view.displayedCherrypyNotification = true;
+                if (!this.cherrypyServer && !_.has(this, 'displayedCherrypyNotification')) {
+                    this.displayedCherrypyNotification = true;
 
                     events.trigger('g:alert', {
                         text: `Enabling and disabling plugins might not take effect until the system administrator has restarted Girder.`,
@@ -145,7 +144,7 @@ var PluginsView = View.extend({
                     });
                 }
 
-                view._updatePlugins();
+                this._updatePlugins();
             });
         this.$('.g-plugin-config-link').tooltip({
             container: this.$el,

--- a/clients/web/src/views/body/PluginsView.js
+++ b/clients/web/src/views/body/PluginsView.js
@@ -57,6 +57,8 @@ var PluginsView = View.extend({
     initialize: function (settings) {
         cancelRestRequests('fetch');
         if (settings.all && settings.enabled) {
+            this.cherrypyServer = (_.has(settings, 'cherrypyServer')
+                                   ? settings.cherrypyServer : true);
             this.enabled = settings.enabled;
             this.allPlugins = settings.all;
             this.failed = _.has(settings, 'failed') ? settings.failed : null;
@@ -127,7 +129,22 @@ var PluginsView = View.extend({
                   }
               }
               $('button.g-rebuild-and-restart').addClass('btn-danger');
-              $('.g-plugin-rebuild-restart-text').addClass('show');
+
+              if (view.cherrypyServer) {
+                  $('.g-plugin-rebuild-restart-text').addClass('show');
+              }
+
+              if (!view.cherrypyServer && !_.has(view, 'displayedCherrypyNotification')) {
+                  view.displayedCherrypyNotification = true;
+
+                  events.trigger('g:alert', {
+                      text: `Enabling and disabling plugins might not take effect until the system administrator has restarted Girder.`,
+                      type: 'info',
+                      timeout: 5000,
+                      icon: 'info'
+                  });
+              }
+
               view._updatePlugins();
           });
         this.$('.g-plugin-config-link').tooltip({

--- a/clients/web/src/views/body/PluginsView.js
+++ b/clients/web/src/views/body/PluginsView.js
@@ -117,36 +117,36 @@ var PluginsView = View.extend({
 
         var view = this;
         this.$('.g-plugin-switch').bootstrapSwitch()
-          .off('switchChange.bootstrapSwitch')
-          .on('switchChange.bootstrapSwitch', function (event, state) {
-              var plugin = $(event.currentTarget).attr('key');
-              if (state === true) {
-                  view.enabled.push(plugin);
-              } else {
-                  var idx;
-                  while ((idx = view.enabled.indexOf(plugin)) >= 0) {
-                      view.enabled.splice(idx, 1);
-                  }
-              }
-              $('button.g-rebuild-and-restart').addClass('btn-danger');
+            .off('switchChange.bootstrapSwitch')
+            .on('switchChange.bootstrapSwitch', function (event, state) {
+                var plugin = $(event.currentTarget).attr('key');
+                if (state === true) {
+                    view.enabled.push(plugin);
+                } else {
+                    var idx;
+                    while ((idx = view.enabled.indexOf(plugin)) >= 0) {
+                        view.enabled.splice(idx, 1);
+                    }
+                }
+                $('button.g-rebuild-and-restart').addClass('btn-danger');
 
-              if (view.cherrypyServer) {
-                  $('.g-plugin-rebuild-restart-text').addClass('show');
-              }
+                if (view.cherrypyServer) {
+                    $('.g-plugin-rebuild-restart-text').addClass('show');
+                }
 
-              if (!view.cherrypyServer && !_.has(view, 'displayedCherrypyNotification')) {
-                  view.displayedCherrypyNotification = true;
+                if (!view.cherrypyServer && !_.has(view, 'displayedCherrypyNotification')) {
+                    view.displayedCherrypyNotification = true;
 
-                  events.trigger('g:alert', {
-                      text: `Enabling and disabling plugins might not take effect until the system administrator has restarted Girder.`,
-                      type: 'info',
-                      timeout: 5000,
-                      icon: 'info'
-                  });
-              }
+                    events.trigger('g:alert', {
+                        text: `Enabling and disabling plugins might not take effect until the system administrator has restarted Girder.`,
+                        type: 'info',
+                        timeout: 5000,
+                        icon: 'info'
+                    });
+                }
 
-              view._updatePlugins();
-          });
+                view._updatePlugins();
+            });
         this.$('.g-plugin-config-link').tooltip({
             container: this.$el,
             animation: false,


### PR DESCRIPTION
The following now holds for enabling and disabling plugins on a
non-restartable server:
- The first time a plugin is enabled or disabled an informational
alert is displayed warning the user that plugins may not take effect
until a restart of Girder
- No additional messages are shown
- The rebuild/restart button is completely hidden

Supersedes #2152, cc @jeffbaumes @brianhelba 