### PR TITLE
Fix broken packaging resulting from #2120

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,7 +5,6 @@ include girder/girder-version.json
 include package.json
 include README.rst
 include girder/conf/girder.dist.cfg
-include scripts/postNpmInstall.js
 recursive-exclude tests *
 recursive-include clients/web *
 recursive-include girder/mail_templates *

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ class InstallWithOptions(install):
                     os.path.join(dest, 'clients', 'web', 'src', 'assets'))
         self.mergeDir('grunt_tasks', dest)
         self.mergeDir('plugins', dest)
-        self.mergeDir('scripts', dest)
 
 with open('README.rst') as f:
     readme = f.read()


### PR DESCRIPTION
The scripts directory no longer exists in the sdist since the
postInstall script was removed.