### PR TITLE
Refactor "Resource._matchRoute" to cleanly return a route handler

### DIFF
--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -795,6 +795,22 @@ class Resource(ModelImporter):
                 resource=resource, route=route, method=method,
                 info=handler.description.asDict(), handler=handler)
 
+    def getRouteHandler(self, method, route):
+        """
+        Get the handler method for a given method and route.
+
+        :param method: The HTTP method, e.g. 'GET', 'POST', 'PUT'
+        :type method: str
+        :param route: The route, as a list of path params relative to the
+                      resource root, exactly as it was passed to the ``route`` method.
+        :type route: tuple[str]
+        :returns: The handler method for the route.
+        :rtype: Function
+        """
+        for registeredRoute, registeredHandler in self._routes[method.lower()][len(route)]:
+            if registeredRoute == route:
+                return registeredHandler
+
     def _shouldInsertRoute(self, a, b):
         """
         Return bool representing whether route a should go before b. Checks by

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -776,21 +776,25 @@ class Resource(ModelImporter):
         :type route: tuple[str]
         :param handler: The method called for the route; this is necessary to
                         remove the documentation.
-        :type handler: function
+        .. deprecated :: 2.3.0
+        :type handler: Function
         :param resource: the name of the resource at the root of this route.
         """
         self._ensureInit()
+
         nLengthRoutes = self._routes[method.lower()][len(route)]
-        for i in range(len(nLengthRoutes)):
-            if nLengthRoutes[i][0] == route:
+        for i, (registeredRoute, registeredHandler) in enumerate(nLengthRoutes):
+            if registeredRoute == route:
+                handler = registeredHandler
                 del nLengthRoutes[i]
                 break
+
         # Remove the api doc
-        if resource is None and hasattr(self, 'resourceName'):
-            resource = self.resourceName
-        elif resource is None:
-            resource = handler.__module__.rsplit('.', 1)[-1]
-        if handler and getattr(handler, 'description', None) is not None:
+        if resource is None:
+            resource = self.resourceName \
+                if hasattr(self, 'resourceName') \
+                else handler.__module__.rsplit('.', 1)[-1]
+        if getattr(handler, 'description', None) is not None:
             docs.removeRouteDocs(
                 resource=resource, route=route, method=method,
                 info=handler.description.asDict(), handler=handler)

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -838,91 +838,92 @@ class Resource(ModelImporter):
         :param method: The HTTP method of the current request.
         :type method: str
         :param path: The path params of the request.
-        :type path: `list`
+        :type path: tuple[str]
         """
-        if not self._routes:
-            raise Exception('No routes defined for resource')
-
         method = method.lower()
 
-        for route, handler in self._routes[method][len(path)]:
-            kwargs = self._matchRoute(path, route)
-            if kwargs is False:
-                continue
+        route, handler, kwargs = self._matchRoute(method, path)
 
-            cherrypy.request.requiredScopes = getattr(
-                handler, 'requiredScopes', None) or TokenScope.USER_AUTH
+        cherrypy.request.requiredScopes = getattr(
+            handler, 'requiredScopes', None) or TokenScope.USER_AUTH
 
-            if hasattr(handler, 'cookieAuth'):
-                if isinstance(handler.cookieAuth, tuple):
-                    cookieAuth, forceCookie = handler.cookieAuth
-                else:
-                    # previously, cookieAuth was not set by a decorator, so the
-                    # legacy way must be supported too
-                    cookieAuth = handler.cookieAuth
-                    forceCookie = False
-                if cookieAuth:
-                    if forceCookie or method in ('head', 'get'):
-                        # getCurrentToken will cache its output, so calling it
-                        # once with allowCookie will make the parameter
-                        # effectively permanent (for the request)
-                        getCurrentToken(allowCookie=True)
-
-            kwargs['params'] = params
-            # Add before call for the API method. Listeners can return
-            # their own responses by calling preventDefault() and
-            # adding a response on the event.
-
-            if hasattr(self, 'resourceName'):
-                resource = self.resourceName
+        if hasattr(handler, 'cookieAuth'):
+            if isinstance(handler.cookieAuth, tuple):
+                cookieAuth, forceCookie = handler.cookieAuth
             else:
-                resource = handler.__module__.rsplit('.', 1)[-1]
+                # previously, cookieAuth was not set by a decorator, so the
+                # legacy way must be supported too
+                cookieAuth = handler.cookieAuth
+                forceCookie = False
+            if cookieAuth:
+                if forceCookie or method in ('head', 'get'):
+                    # getCurrentToken will cache its output, so calling it
+                    # once with allowCookie will make the parameter
+                    # effectively permanent (for the request)
+                    getCurrentToken(allowCookie=True)
 
-            routeStr = '/'.join((resource, '/'.join(route))).rstrip('/')
-            eventPrefix = '.'.join(('rest', method, routeStr))
+        kwargs['params'] = params
+        # Add before call for the API method. Listeners can return
+        # their own responses by calling preventDefault() and
+        # adding a response on the event.
 
-            event = events.trigger('.'.join((eventPrefix, 'before')),
-                                   kwargs, pre=self._defaultAccess)
-            if event.defaultPrevented and len(event.responses) > 0:
-                val = event.responses[0]
-            else:
-                self._defaultAccess(handler)
-                val = handler(**kwargs)
+        if hasattr(self, 'resourceName'):
+            resource = self.resourceName
+        else:
+            resource = handler.__module__.rsplit('.', 1)[-1]
 
-            # Fire the after-call event that has a chance to augment the
-            # return value of the API method that was called. You can
-            # reassign the return value completely by adding a response to
-            # the event and calling preventDefault() on it.
-            kwargs['returnVal'] = val
-            event = events.trigger('.'.join((eventPrefix, 'after')), kwargs)
-            if event.defaultPrevented and len(event.responses) > 0:
-                val = event.responses[0]
+        routeStr = '/'.join((resource, '/'.join(route))).rstrip('/')
+        eventPrefix = '.'.join(('rest', method, routeStr))
 
-            return val
+        event = events.trigger('.'.join((eventPrefix, 'before')),
+                               kwargs, pre=self._defaultAccess)
+        if event.defaultPrevented and len(event.responses) > 0:
+            val = event.responses[0]
+        else:
+            self._defaultAccess(handler)
+            val = handler(**kwargs)
 
-        raise RestException('No matching route for "%s %s"' % (
-            method.upper(), '/'.join(path)))
+        # Fire the after-call event that has a chance to augment the
+        # return value of the API method that was called. You can
+        # reassign the return value completely by adding a response to
+        # the event and calling preventDefault() on it.
+        kwargs['returnVal'] = val
+        event = events.trigger('.'.join((eventPrefix, 'after')), kwargs)
+        if event.defaultPrevented and len(event.responses) > 0:
+            val = event.responses[0]
 
-    def _matchRoute(self, path, route):
+        return val
+
+    def _matchRoute(self, method, path):
         """
-        Helper function that attempts to match the requested path with a
-        given route specification. Returns False if the requested path does
-        not match the route. If it does match, this will return the dict of
-        kwargs that should be passed to the underlying handler, based on the
-        wildcard tokens of the route.
+        Helper function that attempts to match the requested ``method`` and ``path`` with a
+        registered route specification.
 
+        :param method: The requested HTTP method, in lowercase.
+        :type method: str
         :param path: The requested path.
-        :type path: `list`
-        :param route: The route specification to match against.
-        :type route: `list`
+        :type path: tuple[str]
+        :returns: A tuple of ``(route, handler, wildcards)``, where ``route`` is the registered
+                  `list` of route components, ``handler`` is the route handler `function`, and
+                  ``wildcards`` is a `dict` of kwargs that should be passed to the underlying
+                  handler, based on the wildcard tokens of the route.
+        :raises: `GirderException`, when no routes are defined on this resource.
+        :raises: `RestException`, when no route can be matched.
         """
-        wildcards = {}
-        for i in range(0, len(route)):
-            if route[i][0] == ':':  # Wildcard token
-                wildcards[route[i][1:]] = path[i]
-            elif route[i] != path[i]:  # Exact match token
-                return False
-        return wildcards
+        if not self._routes:
+            raise GirderException('No routes defined for resource')
+
+        for route, handler in self._routes[method][len(path)]:
+            wildcards = {}
+            for routeComponent, pathComponent in six.moves.zip(route, path):
+                if routeComponent[0] == ':':  # Wildcard token
+                    wildcards[routeComponent[1:]] = pathComponent
+                elif routeComponent != pathComponent:  # Exact match token
+                    break
+            else:
+                return route, handler, wildcards
+
+        raise RestException('No matching route for "%s %s"' % (method.upper(), '/'.join(path)))
 
     def requireParams(self, required, provided=None):
         """

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -808,13 +808,13 @@ class Resource(ModelImporter):
         :type route: tuple[str]
         :returns: The handler method for the route.
         :rtype: Function
-        :raises: `RestException`, when no route can be matched.
+        :raises: `Exception`, when no route can be found.
         """
         for registeredRoute, registeredHandler in self._routes[method.lower()][len(route)]:
             if registeredRoute == route:
                 return registeredHandler
         else:
-            raise RestException('Could not find route "%s %s"' % (method.upper(), '/'.join(route)))
+            raise Exception('Could not find route "%s %s"' % (method.upper(), '/'.join(route)))
 
     def _shouldInsertRoute(self, a, b):
         """

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -808,10 +808,13 @@ class Resource(ModelImporter):
         :type route: tuple[str]
         :returns: The handler method for the route.
         :rtype: Function
+        :raises: `RestException`, when no route can be matched.
         """
         for registeredRoute, registeredHandler in self._routes[method.lower()][len(route)]:
             if registeredRoute == route:
                 return registeredHandler
+        else:
+            raise RestException('Could not find route "%s %s"' % (method.upper(), '/'.join(route)))
 
     def _shouldInsertRoute(self, a, b):
         """

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -791,9 +791,7 @@ class Resource(ModelImporter):
 
         # Remove the api doc
         if resource is None:
-            resource = self.resourceName \
-                if hasattr(self, 'resourceName') \
-                else handler.__module__.rsplit('.', 1)[-1]
+            resource = getattr(self, 'resourceName', handler.__module__.rsplit('.', 1)[-1])
         if getattr(handler, 'description', None) is not None:
             docs.removeRouteDocs(
                 resource=resource, route=route, method=method,

--- a/plugins/provenance/server/resource.py
+++ b/plugins/provenance/server/resource.py
@@ -104,8 +104,7 @@ class ResourceExt(Resource):
                               'provenance')
                 if hasattr(self.loadInfo['apiRoot'], oldresource):
                     getattr(self.loadInfo['apiRoot'], oldresource).removeRoute(
-                        'GET', (':id', 'provenance'),
-                        self.getGetHandler(oldresource))
+                        'GET', (':id', 'provenance'))
                 del self.boundResources[oldresource]
 
     def getGetHandler(self, resource):

--- a/tests/cases/routes_test.py
+++ b/tests/cases/routes_test.py
@@ -21,6 +21,7 @@ from .. import base
 from girder.api import access
 from girder.api.describe import Description, describeRoute
 from girder.api.rest import Resource, RestException
+from girder.models.model_base import GirderException
 from girder.constants import SettingKey, SettingDefault
 
 testServer = None
@@ -66,6 +67,10 @@ class RoutesTestCase(base.TestCase):
     Unit tests of the routing system of REST Resources.
     """
     def testRouteSystem(self):
+        # Test an empty route handler
+        emptyResource = Resource()
+        self.assertRaises(GirderException, emptyResource.handleRoute, 'GET', (), {})
+
         dummy = DummyResource()
 
         # Bad route should give a useful exception.
@@ -91,6 +96,9 @@ class RoutesTestCase(base.TestCase):
         r = dummy.handleRoute('DUMMY', ('guid', 'dummy'), {})
         self.assertEqual(r, {'id': 'guid', 'params': {}})
 
+        # Test getting the route handler
+        self.assertRaises(Exception, dummy.getRouteHandler, 'FOO', (':id', 'dummy'))
+        self.assertRaises(Exception, dummy.getRouteHandler, 'DUMMY', (':id', 'foo'))
         registeredHandler = dummy.getRouteHandler('DUMMY', (':id', 'dummy'))
         # The handler method cannot be compared directly with `is`, but its name and behavior can be
         # examined

--- a/tests/cases/routes_test.py
+++ b/tests/cases/routes_test.py
@@ -90,6 +90,13 @@ class RoutesTestCase(base.TestCase):
         dummy.route('DUMMY', (':id', 'dummy'), dummy.handler)
         r = dummy.handleRoute('DUMMY', ('guid', 'dummy'), {})
         self.assertEqual(r, {'id': 'guid', 'params': {}})
+
+        registeredHandler = dummy.getRouteHandler('DUMMY', (':id', 'dummy'))
+        # The handler method cannot be compared directly with `is`, but its name and behavior can be
+        # examined
+        self.assertEqual(registeredHandler.__name__, dummy.handler.__name__)
+        self.assertEqual(registeredHandler(foo=42), {'foo': 42})
+
         # Now remove the route
         dummy.removeRoute('DUMMY', (':id', 'dummy'), dummy.handler)
         self.assertRaises(RestException, dummy.handleRoute, 'DUMMY',

--- a/tests/cases/routes_test.py
+++ b/tests/cases/routes_test.py
@@ -98,9 +98,8 @@ class RoutesTestCase(base.TestCase):
         self.assertEqual(registeredHandler(foo=42), {'foo': 42})
 
         # Now remove the route
-        dummy.removeRoute('DUMMY', (':id', 'dummy'), dummy.handler)
-        self.assertRaises(RestException, dummy.handleRoute, 'DUMMY',
-                          ('guid', 'dummy'), {})
+        dummy.removeRoute('DUMMY', (':id', 'dummy'))
+        self.assertRaises(RestException, dummy.handleRoute, 'DUMMY', ('guid', 'dummy'), {})
 
     def testCORS(self):
         testServer.root.api.v1.dummy = DummyResource()


### PR DESCRIPTION
This makes the following changes:
* Refactor `Resource._matchRoute` to cleanly return a route handler
  * Since this method is private, we can safely change its function signature.
* Add a `Resource.getRouteHandler` method
* Deprecate the `handler` keyword argument of `Resource.removeRoute`