### PR TITLE
Ignore packaging_install test files

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,2 +1,4 @@
 assetstore
 cases/py_client/_testDownload
+packaging/entry_point_json_plugin/*/
+packaging/entry_point_plugin/*/


### PR DESCRIPTION
The `packaging_install` test creates several folders that are not tracked or ignored. This PR ignores folders in `tests/packaging/entry_point_json_plugin/` and `tests/packaging/entry_point_plugin/` directories. 