### PR TITLE
Deprecate girder_client.HttpError in favor of requests.HTTPError

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -336,12 +336,12 @@ class GirderClient(object):
             url = self.urlBase + 'user/authentication'
             authResponse = self._requestFunc('get')(url, auth=(username, password))
 
-            if authResponse.status_code == 404:
-                raise HttpError(404, authResponse.text, url, 'GET')
+            if authResponse.status_code in (401, 403):
+                raise AuthenticationError()
+            elif not authResponse.ok:
+                raise HttpError(authResponse.status_code, authResponse.text, url, 'GET')
 
             resp = authResponse.json()
-            if 'authToken' not in resp:
-                raise AuthenticationError()
 
             self.setToken(resp['authToken']['token'])
 
@@ -484,7 +484,6 @@ class GirderClient(object):
                 return result.json()
             else:
                 return result
-        # TODO handle 300-level status (follow redirect?)
         else:
             raise HttpError(
                 status=result.status_code, url=result.url, method=method, text=result.text)

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -76,12 +76,16 @@ class IncorrectUploadLengthError(RuntimeError):
         self.upload = upload
 
 
-class HttpError(Exception):
+class HttpError(requests.HTTPError):
     """
     Raised if the server returns an error status code from a request.
+    @deprecated This will be removed in a future release of Girder. Raisers of this
+    exception should instead raise requests.HTTPError manually or through another mechanism
+    such as requests.Response.raise_for_status.
     """
-    def __init__(self, status, text, url, method):
-        super(HttpError, self).__init__('HTTP error %s: %s %s' % (status, method, url))
+    def __init__(self, status, text, url, method, response=None):
+        super(HttpError, self).__init__('HTTP error %s: %s %s' % (status, method, url),
+                                        response=response)
         self.status = status
         self.responseText = text
         self.url = url

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -343,7 +343,8 @@ class GirderClient(object):
             if authResponse.status_code in (401, 403):
                 raise AuthenticationError()
             elif not authResponse.ok:
-                raise HttpError(authResponse.status_code, authResponse.text, url, 'GET')
+                raise HttpError(authResponse.status_code, authResponse.text, url, 'GET',
+                                response=authResponse)
 
             resp = authResponse.json()
 
@@ -490,7 +491,8 @@ class GirderClient(object):
                 return result
         else:
             raise HttpError(
-                status=result.status_code, url=result.url, method=method, text=result.text)
+                status=result.status_code, url=result.url, method=method, text=result.text,
+                response=result)
 
     def get(self, path, parameters=None, jsonResp=True):
         """
@@ -1192,7 +1194,7 @@ class GirderClient(object):
         url = '%sfile/%s/download' % (self.urlBase, fileId)
         req = self._requestFunc('get')(url, stream=True, headers={'Girder-Token': self.token})
         if not req.ok:
-            raise HttpError(req.status_code, req.text, url, 'GET')
+            raise HttpError(req.status_code, req.text, url, 'GET', response=req)
         with tempfile.NamedTemporaryFile(delete=False) as tmp:
             with self.progressReporterCls(
                     label=progressFileName,

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -17,9 +17,10 @@
 #  limitations under the License.
 ###############################################################################
 import click
+import requests
 import sys
 import types
-from girder_client import GirderClient, HttpError, __version__
+from girder_client import GirderClient, __version__
 
 
 class GirderCli(GirderClient):
@@ -184,8 +185,8 @@ def _lookup_parent_type(client, object_id):
         try:
             client.get('resource/%s/path' % object_id, parameters={'type': parent_type})
             return parent_type
-        except HttpError as exc_info:
-            if exc_info.status == 400:
+        except requests.HTTPError as exc_info:
+            if exc_info.response.status_code == 400:
                 continue
             raise
 

--- a/devops/ansible/roles/girder/library/girder.py
+++ b/devops/ansible/roles/girder/library/girder.py
@@ -19,6 +19,7 @@
 
 import json
 import os
+import requests
 from inspect import getmembers, ismethod, getargspec
 
 # Ansible's module magic requires this to be
@@ -28,7 +29,7 @@ from inspect import getmembers, ismethod, getargspec
 from ansible.module_utils.basic import *  # noqa
 
 try:
-    from girder_client import GirderClient, AuthenticationError, HttpError
+    from girder_client import GirderClient, AuthenticationError
     HAS_GIRDER_CLIENT = True
 except ImportError:
     HAS_GIRDER_CLIENT = False
@@ -943,7 +944,7 @@ class Resource(object):
         try:
             ret = self.client.post(self.resource_type, body, **kwargs)
             self.client.changed = True
-        except HttpError as htErr:
+        except requests.HTTPError as htErr:
             try:
                 # If we can't create the item,  try and return
                 # The item with the same name
@@ -1210,7 +1211,7 @@ class GirderClientModule(GirderClient):
         try:
             user = self.get("/resource/lookup",
                             {"path": "/user/{}".format(login)})
-        except HttpError:
+        except requests.HTTPError:
             user = None
         return user
 
@@ -1218,7 +1219,7 @@ class GirderClientModule(GirderClient):
         try:
             # Could potentially fail if we have more 50 groups
             group = {g['name']: g for g in self.get("group")}['name']
-        except (KeyError, HttpError):
+        except (KeyError, requests.HTTPError):
             group = None
         return group
 
@@ -1816,8 +1817,8 @@ class GirderClientModule(GirderClient):
 
             try:
                 response = self.put('system/setting', parameters=params)
-            except HttpError as e:
-                self.fail(json.loads(e.responseText)['message'])
+            except requests.HTTPError as e:
+                self.fail(e.response.json()['message'])
 
             if response and isinstance(value, list):
                 self.changed = set(existing_value) != set(value)
@@ -1844,8 +1845,8 @@ class GirderClientModule(GirderClient):
 
                     ret['previous_value'] = existing_value
                     ret['current_value'] = default
-                except HttpError as e:
-                    self.fail(json.loads(e.responseText)['message'])
+                except requests.HTTPError as e:
+                    self.fail(e.response.json()['message'])
 
         return ret
 
@@ -1898,10 +1899,10 @@ def main():
     try:
         gcm(module)
 
-    except HttpError as e:
+    except requests.HTTPError as e:
         import traceback
         module.fail_json(msg="%s:%s\n%s\n%s" % (e.__class__, str(e),
-                                                e.responseText,
+                                                e.response.text,
                                                 traceback.format_exc()))
     except Exception as e:
         import traceback

--- a/scripts/midas/migrate.py
+++ b/scripts/midas/migrate.py
@@ -29,6 +29,7 @@ import logging
 import os
 import pydas
 import random
+import requests
 import sqlite3
 import string
 import tempfile
@@ -188,7 +189,7 @@ def get_or_create(type, id, timestamp, bc, func, args):
         return newObj
     try:
         newObj = func(*args)
-    except girder_client.HttpError as e:
+    except requests.HTTPError as e:
         newObj = lookup_resource(bc)
         if not newObj:
             raise
@@ -212,8 +213,8 @@ def handle_file(item, newItem, bc):
                         newItem['_id'], f, filename, length)
             set_migrated('file', item['item_id'])
             return
-        except girder_client.HttpError as e:
-            logger.exception(e.responseText)
+        except requests.HTTPError as e:
+            logger.exception(e.response.text)
             if i == n - 1:
                 raise
             breadcrumb('RETRY', bc)

--- a/tests/cases/py_client/cli_test.py
+++ b/tests/cases/py_client/cli_test.py
@@ -21,6 +21,7 @@ import contextlib
 import girder_client.cli
 import mock
 import os
+import requests
 import shutil
 import sys
 import six
@@ -210,10 +211,10 @@ class PythonCliTestCase(base.TestCase):
     def testUploadDownload(self):
         localDir = os.path.join(os.path.dirname(__file__), 'testdata')
         args = ['upload', str(self.publicFolder['_id']), localDir, '--parent-type=folder']
-        with self.assertRaises(girder_client.HttpError):
+        with self.assertRaises(requests.HTTPError):
             invokeCli(args)
 
-        with self.assertRaises(girder_client.HttpError):
+        with self.assertRaises(requests.HTTPError):
             invokeCli(['--api-key', '1234'] + args)
 
         # Test dry-run and blacklist options

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -22,6 +22,7 @@ import girder_client
 import json
 import mock
 import os
+import requests
 import shutil
 import six
 from six import StringIO
@@ -110,14 +111,14 @@ class PythonClientTestCase(base.TestCase):
 
             return folders[0]
 
-    def testAuthenticateRaisesHttpError(self):
-        # Test non "OK" responses throw HttpError
+    def testAuthenticateRaisesHTTPError(self):
+        # Test non "OK" responses throw HTTPError
         @httmock.urlmatch(path=r'.*/user/authentication$')
         def mock(url, request):
             return httmock.response(500, None, request=request)
 
         with httmock.HTTMock(mock):
-            with self.assertRaises(girder_client.HttpError):
+            with self.assertRaises(requests.HTTPError):
                 self.client.authenticate(self.user['login'], self.password)
 
     def testAuthenticateRaisesAuthenticationError(self):
@@ -172,10 +173,10 @@ class PythonClientTestCase(base.TestCase):
         flag = False
         try:
             self.client.getResource('user/badId')
-        except girder_client.HttpError as e:
-            self.assertEqual(e.status, 400)
-            self.assertEqual(e.method, 'GET')
-            resp = json.loads(e.responseText)
+        except requests.HTTPError as e:
+            self.assertEqual(e.response.status_code, 400)
+            self.assertEqual(e.request.method, 'GET')
+            resp = e.response.json()
             self.assertEqual(resp['type'], 'validation')
             self.assertEqual(resp['field'], 'id')
             self.assertEqual(resp['message'], 'Invalid ObjectId: badId')
@@ -627,9 +628,9 @@ class PythonClientTestCase(base.TestCase):
         def mock(url, request):
             return httmock.response(500, 'error', request=request)
 
-        # Attempt to download file to object stream, should raise HttpError
+        # Attempt to download file to object stream, should raise HTTPError
         with httmock.HTTMock(mock):
-            with self.assertRaises(girder_client.HttpError):
+            with self.assertRaises(requests.HTTPError):
                 self.client.downloadFile(file['_id'], obj)
 
     def testAddMetadataToItem(self):
@@ -715,7 +716,7 @@ class PythonClientTestCase(base.TestCase):
                          item['_id'])
 
         # Test invalid path, default
-        with self.assertRaises(girder_client.HttpError) as cm:
+        with self.assertRaises(requests.HTTPError) as cm:
             self.client.resourceLookup(testInvalidPath)
 
         self.assertEqual(cm.exception.status, 400)
@@ -741,12 +742,12 @@ class PythonClientTestCase(base.TestCase):
             item['_id'])
 
         # Test invalid path, test = False
-        with self.assertRaises(girder_client.HttpError) as cm:
+        with self.assertRaises(requests.HTTPError) as cm:
             self.client.resourceLookup(testInvalidPath, test=False)
 
-        self.assertEqual(cm.exception.status, 400)
-        self.assertEqual(cm.exception.method, 'GET')
-        resp = json.loads(cm.exception.responseText)
+        self.assertEqual(cm.exception.response.status_code, 400)
+        self.assertEqual(cm.exception.request.method, 'GET')
+        resp = cm.exception.response.json()
         self.assertEqual(resp['type'], 'validation')
         self.assertEqual(resp['message'], 'Path not found: %s' % (testInvalidPath))
 

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -110,6 +110,34 @@ class PythonClientTestCase(base.TestCase):
 
             return folders[0]
 
+    def testAuthenticateRaisesHttpError(self):
+        # Test non "OK" responses throw HttpError
+        @httmock.urlmatch(path=r'.*/user/authentication$')
+        def mock(url, request):
+            return httmock.response(500, None, request=request)
+
+        with httmock.HTTMock(mock):
+            with self.assertRaises(girder_client.HttpError):
+                self.client.authenticate(self.user['login'], self.password)
+
+    def testAuthenticateRaisesAuthenticationError(self):
+        # Test 401/403 raise AuthenticationError
+        @httmock.urlmatch(path=r'.*/user/authentication$')
+        def mock(url, request):
+            return httmock.response(401, None, request=request)
+
+        with httmock.HTTMock(mock):
+            with self.assertRaises(girder_client.AuthenticationError):
+                self.client.authenticate(self.user['login'], self.password)
+
+        @httmock.urlmatch(path=r'.*/user/authentication$')
+        def mock(url, request):
+            return httmock.response(403, None, request=request)
+
+        with httmock.HTTMock(mock):
+            with self.assertRaises(girder_client.AuthenticationError):
+                self.client.authenticate(self.user['login'], self.password)
+
     def testRestCore(self):
         self.assertTrue(self.user['admin'])
 


### PR DESCRIPTION
~~This change does break backwards compatibility in the sense that the exception thrown now is actually different. I'm not sure what the policy is for backwards compat in regards to Girder Client (and its library functions).~~

This PR has been updated to perform a much more scaled back version of what was originally proposed (maintaining backwards compatibility).