### PR TITLE
Allow S3 credentials to be inferred by Boto

### DIFF
--- a/clients/web/src/templates/widgets/editAssetstoreWidget.pug
+++ b/clients/web/src/templates/widgets/editAssetstoreWidget.pug
@@ -54,6 +54,10 @@
               input#g-edit-s3-region.input-sm.form-control(type="text", placeholder="Region")
             .checkbox
               label
+                input#g-edit-s3-infercredentials(type="checkbox")
+                | Infer Credentials
+            .checkbox
+              label
                 input#g-edit-s3-readonly(type="checkbox")
                 | Read only
         if assetstore.get('hasFiles')

--- a/clients/web/src/templates/widgets/newAssetstore.pug
+++ b/clients/web/src/templates/widgets/newAssetstore.pug
@@ -109,5 +109,10 @@
             label
               input#g-new-s3-readonly(type="checkbox")
               | Read only
+          .checkbox
+            label
+              input#g-new-s3-infercredentials(type="checkbox")
+              | Infer Credentials
+
           p#g-new-s3-error.g-validation-failed-message
           input.g-new-assetstore-submit.btn.btn-sm.btn-primary(type="submit", value="Create")

--- a/clients/web/src/views/widgets/EditAssetstoreWidget.js
+++ b/clients/web/src/views/widgets/EditAssetstoreWidget.js
@@ -127,7 +127,8 @@ fieldsMap[AssetstoreType.S3] = {
             secret: this.$('#g-edit-s3-secret').val(),
             service: this.$('#g-edit-s3-service').val(),
             region: this.$('#g-edit-s3-region').val(),
-            readOnly: this.$('#g-edit-s3-readonly').is(':checked')
+            readOnly: this.$('#g-edit-s3-readonly').is(':checked'),
+            inferCredentials: this.$('#g-edit-s3-infercredentials').is(':checked')
         };
     },
     set: function () {
@@ -138,6 +139,8 @@ fieldsMap[AssetstoreType.S3] = {
         this.$('#g-edit-s3-service').val(this.model.get('service'));
         this.$('#g-edit-s3-region').val(this.model.get('region'));
         this.$('#g-edit-s3-readonly').attr('checked', this.model.get('readOnly') ? 'checked' : undefined);
+        this.$('#g-edit-s3-infercredentials').attr('checked', (this.model.get('inferCredentials')
+                                                               ? 'checked' : undefined));
     }
 };
 

--- a/clients/web/src/views/widgets/NewAssetstoreWidget.js
+++ b/clients/web/src/views/widgets/NewAssetstoreWidget.js
@@ -44,7 +44,8 @@ var NewAssetstoreWidget = View.extend({
                 secret: this.$('#g-new-s3-secret').val(),
                 service: this.$('#g-new-s3-service').val(),
                 region: this.$('#g-new-s3-region').val(),
-                readOnly: this.$('#g-new-s3-readonly').is(':checked')
+                readOnly: this.$('#g-new-s3-readonly').is(':checked'),
+                inferCredentials: this.$('#g-new-s3-infercredentials').is(':checked')
             });
         }
     },

--- a/girder/api/v1/assetstore.py
+++ b/girder/api/v1/assetstore.py
@@ -95,11 +95,14 @@ class Assetstore(Resource):
                required=False, dataType='boolean', default=False)
         .param('region', 'The AWS region to which the S3 bucket belongs.', required=False,
                default=DEFAULT_REGION)
+        .param('inferCredentials', 'The credentials for connecting to S3 will be inferred '
+               'by Boto rather than explicitly passed. Inferring credentials will '
+               'ignore accessKeyId and secret.', dataType='boolean', required=False)
         .errorResponse()
         .errorResponse('You are not an administrator.', 403)
     )
     def createAssetstore(self, name, type, root, perms, db, mongohost, replicaset, shard, bucket,
-                         prefix, accessKeyId, secret, service, readOnly, region):
+                         prefix, accessKeyId, secret, service, readOnly, region, inferCredentials):
         if type == AssetstoreType.FILESYSTEM:
             self.requireParams({'root': root})
             return self.model('assetstore').createFilesystemAssetstore(
@@ -112,7 +115,8 @@ class Assetstore(Resource):
             self.requireParams({'bucket': bucket})
             return self.model('assetstore').createS3Assetstore(
                 name=name, bucket=bucket, prefix=prefix, secret=secret,
-                accessKeyId=accessKeyId, service=service, readOnly=readOnly, region=region)
+                accessKeyId=accessKeyId, service=service, readOnly=readOnly, region=region,
+                inferCredentials=inferCredentials)
         else:
             raise RestException('Invalid type parameter')
 
@@ -185,12 +189,15 @@ class Assetstore(Resource):
         .param('region', 'The AWS region to which the S3 bucket belongs.', required=False,
                default=DEFAULT_REGION)
         .param('current', 'Whether this is the current assetstore', dataType='boolean')
+        .param('inferCredentials', 'The credentials for connecting to S3 will be inferred '
+               'by Boto rather than explicitly passed. Inferring credentials will '
+               'ignore accessKeyId and secret.', dataType='boolean', required=False)
         .errorResponse()
         .errorResponse('You are not an administrator.', 403)
     )
     def updateAssetstore(self, assetstore, name, root, perms, db, mongohost, replicaset, shard,
                          bucket, prefix, accessKeyId, secret, service, readOnly, region, current,
-                         params):
+                         inferCredentials, params):
         assetstore['name'] = name
         assetstore['current'] = current
 
@@ -220,6 +227,7 @@ class Assetstore(Resource):
             assetstore['secret'] = secret
             assetstore['service'] = service
             assetstore['region'] = region
+            assetstore['inferCredentials'] = inferCredentials
             if readOnly is not None:
                 assetstore['readOnly'] = readOnly
         else:

--- a/girder/models/assetstore.py
+++ b/girder/models/assetstore.py
@@ -141,7 +141,7 @@ class Assetstore(Model):
         })
 
     def createS3Assetstore(self, name, bucket, accessKeyId, secret, prefix='',
-                           service='', readOnly=False, region=None):
+                           service='', readOnly=False, region=None, inferCredentials=False):
         return self.save({
             'type': AssetstoreType.S3,
             'created': datetime.datetime.utcnow(),
@@ -152,7 +152,8 @@ class Assetstore(Model):
             'prefix': prefix,
             'bucket': bucket,
             'service': service,
-            'region': region
+            'region': region,
+            'inferCredentials': inferCredentials
         })
 
     def getCurrent(self):


### PR DESCRIPTION
Fixes #2054 

> This commit adds an option to S3 assetstores named inferCredentials
> which will allow boto clients to connect without being explicitly
> given credentials but instead by using Boto's fallback mechanisms
> documented here:
> http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials.

The easiest way to test this is to test creating an assetstore without credentials and without inferring, and then without credentials and with inferring, while tailing these logs:
```
from botocore.credentials import logger as botoCredentialsLogger
botoCredentialsLogger.setLevel(logging.DEBUG)
botoCredentialsLogger.addHandler(logging.FileHandler('boto.log'))
```

When inferring you should see it doing the lookups in the log file:
```
Looking for credentials via: env
Looking for credentials via: assume-role
Looking for credentials via: shared-credentials-file
Found credentials in shared credentials file: ~/.aws/credentials
```

I'm unsure of how exactly I should programmatically test this, seeing as how moto more or less ignores credentials entirely.

Sidenote: The Girder ansible-client has since gone out of date with the recent changes to S3 assetstores, I'll open a PR soon-ish bringing all of the arguments there up to date.