### PR TITLE
Add public flag to the initialized view after upload

### DIFF
--- a/clients/web/src/views/widgets/HierarchyWidget.js
+++ b/clients/web/src/views/widgets/HierarchyWidget.js
@@ -527,7 +527,8 @@ var HierarchyWidget = View.extend({
                     downloadLinks: this._downloadLinks,
                     viewLinks: this._viewLinks,
                     itemFilter: this._itemFilter,
-                    showSizes: this._showSizes
+                    showSizes: this._showSizes,
+                    public: this.parentModel.get('public')
                 });
             } else {
                 this._initFolderViewSubwidgets();


### PR DESCRIPTION
After a file upload, the view was rendered without the public flag which was causing highlighting to be wrong with public items. This commit fixes that issue.