### PR TITLE
Add region/inferCredentials assetstore parameters to ansible-client

### DIFF
--- a/devops/ansible/roles/girder/library/girder.py
+++ b/devops/ansible/roles/girder/library/girder.py
@@ -33,6 +33,10 @@ try:
 except ImportError:
     HAS_GIRDER_CLIENT = False
 
+try:
+    from girder.utility.s3_assetstore_adapter import DEFAULT_REGION
+except ImportError:
+    DEFAULT_REGION = 'us-east-1'
 
 __version__ = "0.3.0"
 
@@ -233,18 +237,18 @@ options:
                            - The S3 bucket to store data in
 
                    prefix:
-                       required: true
+                       required: false
                        description:
                            - Optional path prefix within the bucket under which
                              files will be stored
 
                    accessKeyId:
-                       required: true
+                       required: false
                        description:
                            - the AWS access key ID to use for authentication
 
                    secret:
-                       required: true
+                       required: false
                        description:
                            - the AWS secret key to use for authentication
 
@@ -256,6 +260,14 @@ options:
                            - This can be used to specify a protocol and port
                              -  use the form [http[s]://](host domain)[:(port)]
                            - Do not include the bucket name here
+
+                   region:
+                       required: false
+                       default: us-east
+
+                   inferCredentials:
+                       required: false
+                       default: false
 
               options (hdfs) (EXPERIMENTAL):
                    host:
@@ -1666,10 +1678,10 @@ class GirderClientModule(GirderClient):
                    replicaset='', bucket=None, prefix='', accessKeyId=None,
                    secret=None, service='s3.amazonaws.com', host=None,
                    port=None, path=None, user=None, webHdfsPort=None,
-                   dbtype=None, dburi=None,
-                   readOnly=False, current=False):
+                   dbtype=None, dburi=None, readOnly=False, current=False,
+                   region=DEFAULT_REGION, inferCredentials=False):
 
-            # Fail if somehow we have an asset type not in assetstore_types
+        # Fail if somehow we have an asset type not in assetstore_types
         if type not in self.assetstore_types.keys():
             self.fail("assetstore type %s is not implemented!" % type)
 
@@ -1684,11 +1696,7 @@ class GirderClientModule(GirderClient):
                        'replicaset': replicaset},
             "s3": {'name': name,
                    'type': self.assetstore_types[type],
-                   'bucket': bucket,
-                   'prefix': prefix,
-                   'accessKeyId': accessKeyId,
-                   'secret': secret,
-                   'service': service},
+                   'bucket': bucket},
             'hdfs': {'name': name,
                      'type': self.assetstore_types[type],
                      'host': host,
@@ -1712,6 +1720,12 @@ class GirderClientModule(GirderClient):
         # Set optional arguments in the hash
         argument_hash[type]['readOnly'] = readOnly
         argument_hash[type]['current'] = current
+        argument_hash[type]['prefix'] = prefix
+        argument_hash[type]['accessKeyId'] = accessKeyId
+        argument_hash[type]['secret'] = secret
+        argument_hash[type]['service'] = service
+        argument_hash[type]['region'] = region
+        argument_hash[type]['inferCredentials'] = inferCredentials
 
         ret = []
         # Get the current assetstores
@@ -1739,7 +1753,8 @@ class GirderClientModule(GirderClient):
                 updateable = ["root", "mongohost", "replicaset", "bucket",
                               "prefix", "db", "accessKeyId", "secret",
                               "service", "host", "port", "path", "user",
-                              "webHdfsPort", "current", "dbtype", "dburi"]
+                              "webHdfsPort", "current", "dbtype", "dburi",
+                              "region", "inferCredentials"]
 
                 # tuples of (key,  value) for fields that can be updated
                 # in the assetstore

--- a/devops/ansible/roles/girder/library/test/test_assetstore.yml
+++ b/devops/ansible/roles/girder/library/test/test_assetstore.yml
@@ -191,8 +191,20 @@
     ############
     # S3 Assetstore tests
     #
-
-    # Untested!
+    # Storing credentials in ~/.aws/credentials using 'aws config' should
+    # allow credentials to be inferred.
+    # - name: Create S3 assetstore
+    #   girder:
+    #     port: 8080
+    #     username: "admin"
+    #     password: "letmein"
+    #     assetstore:
+    #       name: "Temp S3 Assetstore"
+    #       type: "s3"
+    #       bucket: "bucket-name"
+    #       inferCredentials: true
+    #     state: present
+    #   register: ret
 
     ############
     # HDFS Assetstore tests

--- a/girder/api/v1/assetstore.py
+++ b/girder/api/v1/assetstore.py
@@ -217,9 +217,7 @@ class Assetstore(Resource):
                 assetstore['shard'] = shard
         elif assetstore['type'] == AssetstoreType.S3:
             self.requireParams({
-                'bucket': bucket,
-                'accessKeyId': accessKeyId,
-                'secret': secret
+                'bucket': bucket
             })
             assetstore['bucket'] = bucket
             assetstore['prefix'] = prefix


### PR DESCRIPTION
This ports the parameters added in #2153 and #2229 to the ansible client. There is a commented out test that should be run against a real bucket, let me know if you need credentials.