### PR TITLE
Clean up and fix minor bugs in Grunt code

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,9 +61,7 @@ module.exports = function (grunt) {
         pluginDir: 'plugins',
         staticDir: 'clients/web/static',
         isSourceBuild: isSourceBuild,
-        default: {
-            setup: {}
-        }
+        default: {}
     });
 
     if (isSourceBuild) {
@@ -96,19 +94,6 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-zip');
     grunt.loadNpmTasks('grunt-file-creator');
     grunt.loadNpmTasks('grunt-webpack');
-
-    // This task should be run once manually at install time.
-    grunt.registerTask('setup', 'Initial install/setup tasks', function () {
-        // If the local config file doesn't exist, we make it
-        var confDir = grunt.config.get('girderDir') + '/conf';
-        if (!fs.existsSync(confDir + '/girder.local.cfg')) {
-            fs.writeFileSync(
-                confDir + '/girder.local.cfg',
-                fs.readFileSync(confDir + '/girder.dist.cfg')
-            );
-            console.log('Created local config file.');
-        }
-    });
 
     /**
      * Load `default` target by topologically sorting the tasks given by keys the config object.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,13 +14,17 @@
  * limitations under the License.
  */
 
+const fs = require('fs');
+
+require('colors');
+const toposort = require('toposort');
+const _ = require('underscore');
+
 /**
  * This function takes an object like `grunt.config.get('default')` and
  * returns a topologically sorted array of tasks.
  */
 function sortTasks(obj) {
-    var toposort = require('toposort');
-    var _ = require('underscore');
     var nodes = _.keys(obj);
     var edges = _(obj).chain()
         .pairs()
@@ -45,10 +49,8 @@ function sortTasks(obj) {
 }
 
 module.exports = function (grunt) {
-    var fs = require('fs');
     var isSourceBuild = fs.existsSync('girder/__init__.py');
     var environment = grunt.option('env') || 'dev';
-    require('colors');
 
     if (['dev', 'prod'].indexOf(environment) === -1) {
         grunt.fatal('The "env" argument must be either "dev" or "prod".');
@@ -94,6 +96,16 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-zip');
     grunt.loadNpmTasks('grunt-file-creator');
     grunt.loadNpmTasks('grunt-webpack');
+
+    /**
+     * This task is noop that exists for backwards compatibility in case any plugins rely
+     * on its existence.
+     * @deprecated: remove in v3
+     */
+    grunt.registerTask('init', 'This task is deprecated, in favor of "default".', _.constant(true));
+    grunt.config.merge({
+        default: grunt.config.get('init')
+    });
 
     /**
      * Load `default` target by topologically sorting the tasks given by keys the config object.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,7 @@
  */
 
 /**
- * This function takes an object like `grunt.config.get('init')` and
+ * This function takes an object like `grunt.config.get('default')` and
  * returns a topologically sorted array of tasks.
  */
 function sortTasks(obj) {
@@ -61,10 +61,9 @@ module.exports = function (grunt) {
         pluginDir: 'plugins',
         staticDir: 'clients/web/static',
         isSourceBuild: isSourceBuild,
-        init: {
+        default: {
             setup: {}
-        },
-        default: {}
+        }
     });
 
     if (isSourceBuild) {
@@ -112,10 +111,10 @@ module.exports = function (grunt) {
     });
 
     /**
-     * Load `default` and `init` targets by topologically sorting the
-     * tasks given by keys the config object.  As in:
+     * Load `default` target by topologically sorting the tasks given by keys the config object.
+     * As in:
      * {
-     *   'init': {
+     *   'default': {
      *     'copy:a': {}
      *     'uglify:a': {
      *       'dependencies': ['copy:a']
@@ -123,8 +122,7 @@ module.exports = function (grunt) {
      *   }
      * }
      *
-     * The init task will run `copy:a` followed by `uglify:a`.
+     * The 'default' task will run `copy:a` followed by `uglify:a`.
      */
-    grunt.registerTask('init', sortTasks(grunt.config.get('init')));
     grunt.registerTask('default', sortTasks(grunt.config.get('default')));
 };

--- a/grunt_tasks/fontello.js
+++ b/grunt_tasks/fontello.js
@@ -1,9 +1,57 @@
-module.exports = function (grunt) {
-    var fs = require('fs');
-    var path = require('path');
+/**
+ * Copyright Kitware Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-    var archivePath = 'clients/web/static/built/fontello.zip';
-    var srcUrl = 'https://data.kitware.com/api/v1/file/57c5d1fc8d777f10f269dece/download';
+const fs = require('fs');
+const path = require('path');
+const process = require('process');
+
+const archivePath = 'clients/web/static/built/fontello.zip';
+const srcUrl = 'https://data.kitware.com/api/v1/file/57c5d1fc8d777f10f269dece/download';
+
+module.exports = function (grunt) {
+    const localArchive = process.env.GIRDER_LOCAL_FONTELLO_ARCHIVE;
+    let fetchTask;
+    if (localArchive) {
+        // Use an already existing local fontello zip file
+        if (!fs.existsSync(localArchive)) {
+            grunt.fail.warn(`Fontello local archive does not exist: ${localArchive}`);
+        }
+        grunt.log.writeln(`Using local Fontello archive: ${localArchive}`.blue);
+        grunt.config.merge({
+            copy: {
+                fontello: {
+                    files: [{
+                        src: localArchive,
+                        dest: archivePath
+                    }]
+                }
+            }
+        });
+        fetchTask = 'copy:fontello';
+    } else {
+        // Download font archive from data.kitware.com
+        grunt.config.merge({
+            shell: {
+                fontello: {
+                    command: `curl "${srcUrl}" -o "${archivePath}"`
+                }
+            }
+        });
+        fetchTask = 'shell:fontello';
+    }
 
     grunt.config.merge({
         unzip: {
@@ -18,44 +66,13 @@ module.exports = function (grunt) {
         }
     });
 
-    var localArchive = process.env.GIRDER_LOCAL_FONTELLO_ARCHIVE;
-    if (localArchive) {
-        // Use an already existing local fontello zip file
-        if (!fs.existsSync(localArchive)) {
-            grunt.fail.warn('fontello local archive does not exist: ' + localArchive);
+    grunt.registerTask('fontello', [
+        fetchTask,
+        'unzip:fontello'
+    ]);
+    grunt.config.merge({
+        default: {
+            fontello: {}
         }
-        grunt.log.writeln(('Using local fontello archive: ' + localArchive).blue);
-        grunt.config.merge({
-            copy: {
-                fontello: {
-                    files: [{
-                        src: localArchive,
-                        dest: archivePath
-                    }]
-                }
-            },
-
-            init: {
-                'copy:fontello': {},
-                'unzip:fontello': {
-                    dependencies: ['copy:fontello']
-                }
-            }
-        });
-    } else {
-        // Download font archive from data.kitware.com
-        grunt.config.merge({
-            shell: {
-                fontello: {
-                    command: 'curl "' + srcUrl + '" -o "' + archivePath + '"'
-                }
-            },
-            init: {
-                'shell:fontello': {},
-                'unzip:fontello': {
-                    dependencies: ['curl:fontello']
-                }
-            }
-        });
-    }
+    });
 };

--- a/grunt_tasks/localConfig.js
+++ b/grunt_tasks/localConfig.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright Kitware Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require('fs');
+
+module.exports = function (grunt) {
+    const confDir = `${grunt.config.get('girderDir')}/conf`;
+    const localConfigPath = `${confDir}/girder.local.cfg`;
+
+    grunt.config.merge({
+        copy: {
+            'local-config': {
+                src: `${confDir}/girder.dist.cfg`,
+                dest: localConfigPath
+            }
+        }
+    });
+
+    // This task should be run once manually at install time.
+    grunt.registerTask('local-config', 'Ensure the girder.local.cfg file exists', function () {
+        // If the local config file doesn't exist, we make it
+        if (!fs.existsSync(localConfigPath)) {
+            grunt.task.run('copy:local-config');
+            grunt.log.writeln('Created local config file.');
+        }
+    });
+    grunt.config.merge({
+        default: {
+            'local-config': {}
+        }
+    });
+};

--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -495,7 +495,6 @@ module.exports = function (grunt) {
                     path.resolve(dir, config.grunt.file || 'Gruntfile.js')
                 )(grunt);
             } catch (e) {
-                // the error can be safely ignored when doing `grunt init`
                 // otherwise a default task will most likely fail later on
                 // write out a warning to help the developers debug errors
                 grunt.log.writeln((

--- a/grunt_tasks/sphinx.js
+++ b/grunt_tasks/sphinx.js
@@ -21,35 +21,18 @@ module.exports = function (grunt) {
     grunt.config.merge({
         shell: {
             sphinx: {
-                command: [
-                    'cd docs',
-                    'make html'
-                ].join('&&'),
-                options: {
-                    stdout: true
-                }
+                command: 'make html',
+                cwd: 'docs'
             },
             sphinx_clean: {
-                command: [
-                    'cd docs',
-                    'make clean'
-                ].join('&&'),
-                options: {
-                    stdout: true
-                }
-            }
-        },
-
-        watch: {
-            sphinx: {
-                files: ['docs/*.rst'],
-                tasks: ['docs']
+                command: 'make clean',
+                cwd: 'docs'
             }
         }
     });
 
     grunt.registerTask('docs', function (target) {
-        var tasks = ['shell:sphinx'];
+        let tasks = ['shell:sphinx'];
         if (target === 'clean') {
             tasks.unshift('shell:sphinx_clean');
         }

--- a/grunt_tasks/swagger.js
+++ b/grunt_tasks/swagger.js
@@ -40,11 +40,8 @@ module.exports = function (grunt) {
             }
         },
 
-        init: {
-            'copy:swagger': {}
-        },
-
         default: {
+            'copy:swagger': {},
             'stylus:swagger': {}
         }
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -4072,13 +4072,27 @@
             "integrity": "sha1-8mqEj2pHl6X/foUOYCIMDea+jnI="
         },
         "grunt-shell": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/grunt-shell/-/grunt-shell-1.3.1.tgz",
-            "integrity": "sha1-XivuzQXV03h/pAECjVcz1dQ7m9E=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/grunt-shell/-/grunt-shell-2.1.0.tgz",
+            "integrity": "sha1-Q595FZ7RHmSmUaacyKPQK+v17MI=",
             "requires": {
                 "chalk": "1.1.3",
-                "npm-run-path": "1.0.0",
-                "object-assign": "4.1.1"
+                "npm-run-path": "2.0.2"
+            },
+            "dependencies": {
+                "npm-run-path": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+                    "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+                    "requires": {
+                        "path-key": "2.0.1"
+                    }
+                },
+                "path-key": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+                    "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+                }
             }
         },
         "grunt-webpack": {
@@ -5652,14 +5666,6 @@
                 "sort-keys": "1.1.2"
             }
         },
-        "npm-run-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
-            "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
-            "requires": {
-                "path-key": "1.0.0"
-            }
-        },
         "nth-check": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
@@ -5871,11 +5877,6 @@
             "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
             "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
             "dev": true
-        },
-        "path-key": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
-            "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68="
         },
         "path-parse": {
             "version": "1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1700,15 +1700,6 @@
                 "clone": "1.0.2"
             }
         },
-        "define-properties": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-            "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-            "requires": {
-                "foreach": "2.0.5",
-                "object-keys": "1.0.11"
-            }
-        },
         "defined": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
@@ -2835,11 +2826,6 @@
                 "for-in": "1.0.2"
             }
         },
-        "foreach": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-            "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-        },
         "forever-agent": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -3928,15 +3914,30 @@
             "integrity": "sha1-yDYWwDVxGmwAYqKBDPHHf/xr7Ss="
         },
         "grunt-contrib-uglify": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-2.3.0.tgz",
-            "integrity": "sha1-s9AmDr3WzvoS/y+Onh4ln33kIW8=",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-3.0.1.tgz",
+            "integrity": "sha1-/etfk4pMgEL46Grkb2NVTo6VEcs=",
             "requires": {
                 "chalk": "1.1.3",
                 "maxmin": "1.1.0",
-                "object.assign": "4.0.4",
-                "uglify-js": "2.8.29",
+                "uglify-js": "3.0.27",
                 "uri-path": "1.0.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.11.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+                    "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+                },
+                "uglify-js": {
+                    "version": "3.0.27",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.27.tgz",
+                    "integrity": "sha512-HD8CmxPXUI62v5tweiulMcP/apAtx1DXGcNZkhKQZyC+MTrTsoCBb8yPAwVrbvpgw3EpRU76bRe6axjIiCYcQg==",
+                    "requires": {
+                        "commander": "2.11.0",
+                        "source-map": "0.5.6"
+                    }
+                }
             }
         },
         "grunt-file-creator": {
@@ -5702,21 +5703,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        },
-        "object-keys": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-            "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
-        },
-        "object.assign": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
-            "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
-            "requires": {
-                "define-properties": "1.1.2",
-                "function-bind": "1.1.0",
-                "object-keys": "1.0.11"
-            }
         },
         "object.omit": {
             "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "grunt-contrib-copy": "^1.0.0",
         "grunt-contrib-stylus": "^1.2.0",
         "grunt-contrib-symlink": "^1.0.0",
-        "grunt-contrib-uglify": "^2.3.0",
+        "grunt-contrib-uglify": "^3.0.1",
         "grunt-file-creator": "^0.1.3",
         "grunt-fontello": "^0.3.4",
         "grunt-gitinfo": "^0.1.8",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "stylint": "^1.5.9"
     },
     "scripts": {
-        "build": "grunt init && NODE_PATH=$PWD/node_modules grunt",
+        "build": "NODE_PATH=$PWD/node_modules grunt",
         "watch": "NODE_PATH=$PWD/node_modules grunt --watch",
         "lint": "eslint --cache clients/web Gruntfile.js grunt_tasks scripts clients/web/test && pug-lint clients/web/src/templates",
         "docs": "grunt docs",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "grunt-file-creator": "^0.1.3",
         "grunt-fontello": "^0.3.4",
         "grunt-gitinfo": "^0.1.8",
-        "grunt-shell": "^1.3.1",
+        "grunt-shell": "^2.1.0",
         "grunt-webpack": "^3.0.2",
         "grunt-zip": "^0.17.1",
         "nib": "^1.1.2",


### PR DESCRIPTION
* Upgrade grunt-shell and cleanup its usage for building docs
* Reorganize the Grunt Fontello building, ensuring correct task ordering
* Roll the "init" Grunt task into the "default" Grunt task
* Rename the "setup" task to "local-config", and clean it up
* Upgrade grunt-contrib-uglify