### PR TITLE
Fix local jobs when remote worker plugin is enabled.

### DIFF
--- a/plugins/worker/server/__init__.py
+++ b/plugins/worker/server/__init__.py
@@ -193,12 +193,13 @@ def validateJobStatus(event):
 
 def validTransitions(event):
     """Allow our custom job transitions."""
+    states = None
     if event.info['job']['handler'] == 'worker_handler':
         states = CustomJobStatus.validTransitionsWorker(event.info['status'])
     elif event.info['job']['handler'] == 'celery_handler':
         states = CustomJobStatus.validTransitionsCelery(event.info['status'])
-
-    event.preventDefault().addResponse(states)
+    if states is not None:
+        event.preventDefault().addResponse(states)
 
 
 def load(info):


### PR DESCRIPTION
If we don't have an appropriate transition states list, don't add it to the response.  Otherwise, we were accessing a variable that had not been set.