### PR TITLE
Accept metadata object during creation of item or folder

### DIFF
--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -151,10 +151,12 @@ class Folder(Resource):
         .param('parentType', "Type of the folder's parent", required=False,
                enum=['folder', 'user', 'collection'], strip=True)
         .param('parentId', 'Parent ID for the new parent of this folder.', required=False)
+        .jsonParam('metadata', 'A JSON object containing the metadata keys to add',
+                   paramType='form', requireObject=True, required=False)
         .errorResponse('ID was invalid.')
         .errorResponse('Write access was denied for the folder or its new parent object.', 403)
     )
-    def updateFolder(self, folder, name, description, parentType, parentId):
+    def updateFolder(self, folder, name, description, parentType, parentId, metadata):
         user = self.getCurrentUser()
         if name is not None:
             folder['name'] = name
@@ -162,6 +164,8 @@ class Folder(Resource):
             folder['description'] = description
 
         folder = self.model('folder').updateFolder(folder)
+        if metadata:
+            folder = self.model('folder').setMetadata(folder, metadata)
 
         if parentType and parentId:
             parent = self.model(parentType).load(

--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -221,17 +221,23 @@ class Folder(Resource):
                'default, inherits the value from parent folder, or in the '
                'case of user or collection parentType, defaults to False.',
                required=False, dataType='boolean')
+        .jsonParam('metadata', 'A JSON object containing the metadata keys to add',
+                   paramType='form', requireObject=True, required=False)
         .errorResponse()
         .errorResponse('Write access was denied on the parent', 403)
     )
-    def createFolder(self, public, parentType, parentId, name, description, reuseExisting):
+    def createFolder(self, public, parentType, parentId, name, description,
+                     reuseExisting, metadata):
         user = self.getCurrentUser()
         parent = self.model(parentType).load(
             id=parentId, user=user, level=AccessType.WRITE, exc=True)
 
-        return self.model('folder').createFolder(
+        newFolder = self.model('folder').createFolder(
             parent=parent, name=name, parentType=parentType, creator=user,
             description=description, public=public, reuseExisting=reuseExisting)
+        if metadata:
+            newFolder = self.model('folder').setMetadata(newFolder, metadata)
+        return newFolder
 
     @access.public(scope=TokenScope.DATA_READ)
     @filtermodel(model='folder')

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -136,10 +136,12 @@ class Item(Resource):
         .param('description', 'Description for the item.', required=False)
         .modelParam('folderId', 'Pass this to move the item to a new folder.',
                     required=False, paramType='query', level=AccessType.WRITE)
+        .jsonParam('metadata', 'A JSON object containing the metadata keys to add',
+                   paramType='form', requireObject=True, required=False)
         .errorResponse('ID was invalid.')
         .errorResponse('Write access was denied for the item or folder.', 403)
     )
-    def updateItem(self, item, name, description, folder):
+    def updateItem(self, item, name, description, folder, metadata):
         if name is not None:
             item['name'] = name
         if description is not None:
@@ -149,6 +151,9 @@ class Item(Resource):
 
         if folder and folder['_id'] != item['folderId']:
             self.model('item').move(item, folder)
+
+        if metadata:
+            item = self.model('item').setMetadata(item, metadata)
 
         return item
 

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -113,13 +113,18 @@ class Item(Resource):
                default='', strip=True)
         .param('reuseExisting', 'Return existing item (by name) if it exists.',
                required=False, dataType='boolean', default=False)
+        .jsonParam('metadata', 'A JSON object containing the metadata keys to add',
+                   paramType='form', requireObject=True, required=False)
         .errorResponse()
         .errorResponse('Write access was denied on the parent folder.', 403)
     )
-    def createItem(self, folder, name, description, reuseExisting):
-        return self.model('item').createItem(
+    def createItem(self, folder, name, description, reuseExisting, metadata):
+        newItem = self.model('item').createItem(
             folder=folder, name=name, creator=self.getCurrentUser(), description=description,
             reuseExisting=reuseExisting)
+        if metadata:
+            newItem = self.model('item').setMetadata(newItem, metadata)
+        return newItem
 
     @access.user(scope=TokenScope.DATA_WRITE)
     @filtermodel(model='item')

--- a/tests/cases/folder_test.py
+++ b/tests/cases/folder_test.py
@@ -274,6 +274,43 @@ class FolderTestCase(base.TestCase):
         self.assertStatusOk(reuseFolder)
         self.assertEqual(newFolder.json['_id'], reuseFolder.json['_id'])
 
+    def testFolderMetadataWithPost(self):
+        resp = self.request(
+            path='/folder', method='GET', user=self.admin, params={
+                'parentType': 'user',
+                'parentId': self.admin['_id'],
+                'sort': 'name',
+                'sortdir': 1
+            })
+        self.assertStatusOk(resp)
+        publicFolder = resp.json[1]
+
+        # Actually create subfolder under Public
+        resp = self.request(
+            path='/folder', method='POST', user=self.admin, params={
+                'name': ' My public subfolder  ',
+                'parentId': publicFolder['_id'],
+                'metadata': 'invalid json'
+            })
+        self.assertStatus(resp, 400)
+        self.assertEqual(
+            resp.json['message'],
+            'Parameter metadata must be valid JSON.')
+
+        metadata = {
+            'foo': 'bar',
+            'test': 2
+        }
+        resp = self.request(
+            path='/folder', method='POST', user=self.admin, params={
+                'name': ' My public subfolder with meta',
+                'parentId': publicFolder['_id'],
+                'metadata': json.dumps(metadata)}
+        )
+        folder = resp.json
+        self.assertEqual(folder['meta']['foo'], metadata['foo'])
+        self.assertEqual(folder['meta']['test'], metadata['test'])
+
     def testFolderMetadataCrud(self):
         """
         Test CRUD of metadata on folders

--- a/tests/cases/folder_test.py
+++ b/tests/cases/folder_test.py
@@ -274,7 +274,7 @@ class FolderTestCase(base.TestCase):
         self.assertStatusOk(reuseFolder)
         self.assertEqual(newFolder.json['_id'], reuseFolder.json['_id'])
 
-    def testFolderMetadataWithPost(self):
+    def testFolderMetadataDirect(self):
         resp = self.request(
             path='/folder', method='GET', user=self.admin, params={
                 'parentType': 'user',
@@ -307,9 +307,25 @@ class FolderTestCase(base.TestCase):
                 'parentId': publicFolder['_id'],
                 'metadata': json.dumps(metadata)}
         )
+        self.assertStatusOk(resp)
         folder = resp.json
         self.assertEqual(folder['meta']['foo'], metadata['foo'])
         self.assertEqual(folder['meta']['test'], metadata['test'])
+
+        metadata = {
+            'foo': None,
+            'test': 3,
+            'bar': 'baz'
+        }
+        resp = self.request(
+            path='/folder/{_id}'.format(**folder), method='PUT',
+            user=self.admin, params={'metadata': json.dumps(metadata)}
+        )
+        self.assertStatusOk(resp)
+        folder = resp.json
+        self.assertNotHasKeys(folder['meta'], ['foo'])
+        self.assertEqual(folder['meta']['test'], metadata['test'])
+        self.assertEqual(folder['meta']['bar'], metadata['bar'])
 
     def testFolderMetadataCrud(self):
         """

--- a/tests/cases/item_test.py
+++ b/tests/cases/item_test.py
@@ -336,7 +336,7 @@ class ItemTestCase(base.TestCase):
         item = self.model('item').load(item['_id'])
         self.assertEqual(item, None)
 
-    def testItemMetadataPost(self):
+    def testItemMetadataDirect(self):
         params = {
             'name': 'item with metadata via POST',
             'description': ' a description ',
@@ -358,8 +358,24 @@ class ItemTestCase(base.TestCase):
         resp = self.request(
             path='/item', method='POST', params=params, user=self.users[0])
         self.assertStatusOk(resp)
-        self.assertEqual(resp.json['meta']['foo'], metadata['foo'])
-        self.assertEqual(resp.json['meta']['test'], metadata['test'])
+        item = resp.json
+        self.assertEqual(item['meta']['foo'], metadata['foo'])
+        self.assertEqual(item['meta']['test'], metadata['test'])
+
+        metadata = {
+            'foo': None,
+            'test': 3,
+            'bar': 'baz'
+        }
+        resp = self.request(
+            path='/item/{_id}'.format(**item), method='PUT',
+            user=self.users[0], params={'metadata': json.dumps(metadata)}
+        )
+        self.assertStatusOk(resp)
+        item = resp.json
+        self.assertNotHasKeys(item['meta'], ['foo'])
+        self.assertEqual(item['meta']['test'], metadata['test'])
+        self.assertEqual(item['meta']['bar'], metadata['bar'])
 
     def testItemMetadataCrud(self):
         """

--- a/tests/cases/item_test.py
+++ b/tests/cases/item_test.py
@@ -336,6 +336,31 @@ class ItemTestCase(base.TestCase):
         item = self.model('item').load(item['_id'])
         self.assertEqual(item, None)
 
+    def testItemMetadataPost(self):
+        params = {
+            'name': 'item with metadata via POST',
+            'description': ' a description ',
+            'folderId': self.privateFolder['_id'],
+            'metadata': 'not JSON'
+        }
+        resp = self.request(
+            path='/item', method='POST', params=params, user=self.users[0])
+        self.assertStatus(resp, 400)
+        self.assertEqual(
+            resp.json['message'], 'Parameter metadata must be valid JSON.')
+
+        # Add some metadata
+        metadata = {
+            'foo': 'bar',
+            'test': 2
+        }
+        params['metadata'] = json.dumps(metadata)
+        resp = self.request(
+            path='/item', method='POST', params=params, user=self.users[0])
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json['meta']['foo'], metadata['foo'])
+        self.assertEqual(resp.json['meta']['test'], metadata['test'])
+
     def testItemMetadataCrud(self):
         """
         Test CRUD of metadata.


### PR DESCRIPTION
This allows to create item/folder with metadata with just one call. Right now, for reasons I don't understand all tests using *POST /item* and *POST /folder* fail with `Invalid JSON passed in request body.` even though metadata parameter is not required (and given default in one case)