### PR TITLE
Update the accessLevel in the HierarchyWidget.

### DIFF
--- a/clients/web/src/views/widgets/HierarchyWidget.js
+++ b/clients/web/src/views/widgets/HierarchyWidget.js
@@ -287,6 +287,7 @@ var HierarchyWidget = View.extend({
             this._initFolderViewSubwidgets();
             this.itemListView.setElement(this.$('.g-item-list-container')).render();
             this.metadataWidget.setItem(this.parentModel);
+            this.metadataWidget.accessLevel = this.parentModel.getAccessLevel();
             if (this._showMetadata) {
                 this.metadataWidget.setElement(this.$('.g-folder-metadata')).render();
             }
@@ -528,7 +529,8 @@ var HierarchyWidget = View.extend({
                     viewLinks: this._viewLinks,
                     itemFilter: this._itemFilter,
                     showSizes: this._showSizes,
-                    public: this.parentModel.get('public')
+                    public: this.parentModel.get('public'),
+                    accessLevel: this.parentModel.getAccessLevel()
                 });
             } else {
                 this._initFolderViewSubwidgets();


### PR DESCRIPTION
When changing the parent model in the HierarchyWidget, update the `accessLevel`.  This allows children to avoid asking for the parent's access level.

Prior to this, the metadata widget, if it was reused, could have the wrong accessLevel value (since it would have the value from when it was initialized not when it was last set to a particular parent).  I don't this was causing any problems, but I could be wrong.