### PR TITLE
Add Terraform assetstore module

### DIFF
--- a/devops/terraform/README.rst
+++ b/devops/terraform/README.rst
@@ -1,0 +1,7 @@
+Terraform
+-----------
+
+This directory contains modules for managing infrastructure using `Terraform <https://www.terraform.io>`_. Modules are organized by
+provider name.
+
+For information on how to include Terraform modules in configuration, see `Module Sources <https://www.terraform.io/docs/modules/sources.html>`_.

--- a/devops/terraform/aws/assetstore/README.rst
+++ b/devops/terraform/aws/assetstore/README.rst
@@ -1,0 +1,31 @@
+Assetstore Module
+-------------------
+
+A Terraform module to create a Girder-compliant S3 bucket for use as an assetstore.
+
+In addition to creating an S3 bucket, this module also creates an IAM role policy granting access to the
+s3:\* actions on the bucket and all objects within it.
+
+Inputs
+~~~~~~~~~~
+
++------------------------------------------------------+----------+---------+--------------------------------------------------------------+
+| parameter                                            | required | default | comments                                                     |
++======================================================+==========+=========+==============================================================+
+| role_id                                              | yes      |         | The id of the IAM role to attach the assetstore policy to.   |
++------------------------------------------------------+----------+---------+--------------------------------------------------------------+
+| s3_cors_allowed_origins                              | no       | ["\*"]  | The allowed origins for CORS.                                |
++------------------------------------------------------+----------+---------+--------------------------------------------------------------+
+| s3_force_destroy                                     | no       | false   | Whether to forcibly destroy the bucket (regardless of data). |
++------------------------------------------------------+----------+---------+--------------------------------------------------------------+
+
+Outputs
+~~~~~~~~~~~
+
++----------------------------------+--------------------------------------------------+
+| name                             | comments                                         |
++==================================+==================================================+
+| s3_bucket                        | The id attribute of the created S3 bucket.       |
++----------------------------------+--------------------------------------------------+
+| iam_role_policy_id               | The id attribute of the created IAM role policy. |
++----------------------------------+--------------------------------------------------+

--- a/devops/terraform/aws/assetstore/main.tf
+++ b/devops/terraform/aws/assetstore/main.tf
@@ -1,0 +1,32 @@
+resource "aws_iam_role_policy" "s3_iam_role_policy" {
+  name_prefix = "assetstore-"
+  role = "${var.role_id}"
+
+  # TODO this allows all actions, ideally this would only be limited to what Girder
+  # actually needs. This means removing things such as create/delete bucket permissions.
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:*"],
+      "Resource": ["${aws_s3_bucket.assetstore.arn}", "${aws_s3_bucket.assetstore.arn}/*"]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_s3_bucket" "assetstore" {
+  bucket_prefix = "assetstore-"
+  force_destroy = "${var.s3_force_destroy}"
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["PUT", "POST", "GET", "DELETE"]
+    allowed_origins = "${var.s3_cors_allowed_origins}"
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3000
+  }
+}

--- a/devops/terraform/aws/assetstore/outputs.tf
+++ b/devops/terraform/aws/assetstore/outputs.tf
@@ -1,0 +1,7 @@
+output "s3_bucket" {
+  value = "${aws_s3_bucket.assetstore.id}"
+}
+
+output "iam_role_policy_id" {
+  value = "${aws_iam_role_policy.s3_iam_role_policy.id}"
+}

--- a/devops/terraform/aws/assetstore/variables.tf
+++ b/devops/terraform/aws/assetstore/variables.tf
@@ -1,0 +1,13 @@
+variable "role_id" {
+  description = "The id of the IAM role to attach the assetstore policy to."
+}
+
+variable "s3_cors_allowed_origins" {
+  default = ["*"]  # TODO only allow from deployed url
+  description = "List of allowed origins for CORs rule on S3 bucket."
+}
+
+variable "s3_force_destroy" {
+  default = false
+  description = "Whether or not to forcibly destroy S3 buckets (whether they have data in them or not)."
+}


### PR DESCRIPTION
This is a reusable Terraform component for creating an S3 bucket
which is compliant as a Girder assetstore.