### PR TITLE
Various ansible improvements

### DIFF
--- a/devops/ansible/examples/girder-custom-python/requirements.yml
+++ b/devops/ansible/examples/girder-custom-python/requirements.yml
@@ -1,0 +1,2 @@
+- src: Stouts.mongodb
+- src: torian.python

--- a/devops/ansible/examples/girder-custom-python/site.yml
+++ b/devops/ansible/examples/girder-custom-python/site.yml
@@ -1,0 +1,56 @@
+---
+
+- hosts: all
+  vars:
+    girder_update: no
+    girder_force: no
+    girder_web: yes
+    girder_user: girder
+    girder_path: "/home/{{ girder_user }}/girder"
+    girder_always_build_assets: yes
+
+  pre_tasks:
+    - name: Update package cache
+      apt:
+        update_cache: yes
+      become: yes
+      become_user: root
+      when: ansible_os_family == "Debian"
+
+    - name: Install EPEL
+      yum:
+        name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+        state: present
+      become: yes
+      become_user: root
+      when: ansible_os_family == "RedHat"
+
+    - name: Create Girder user
+      user:
+        name: "{{ girder_user }}"
+      become: yes
+      become_user: root
+
+  roles:
+    - role: torian.python
+      python_version: 3.6.2
+      python_bin: /usr/local/bin/python3.6
+      python_setuptools_bin: /usr/local/bin/easy_install-3.6
+      become: yes
+      become_user: root
+
+    - role: Stouts.mongodb
+      become: yes
+      become_user: root
+      when: ansible_os_family == "Debian"
+
+    - role: redhat-mongodb
+      become: yes
+      become_user: root
+      when: ansible_os_family == "RedHat"
+
+    - role: girder
+      girder_python: /usr/local/bin/python3.6
+      girder_pip: /usr/local/bin/pip3.6
+      become: yes
+      become_user: "{{ girder_user }}"

--- a/devops/ansible/roles/girder/README.md
+++ b/devops/ansible/roles/girder/README.md
@@ -15,21 +15,23 @@ Ubuntu 14.04/16.04 or CentOS 7.
 Role Variables
 --------------
 
-| parameter                  | required | default      | comments                                                                                                                                                            |
-| -------------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| girder_path                | no       | $HOME/girder | Path to download and build Girder in.                                                                                                                               |
-| girder_version             | no       | master       | Git commit-ish for fetching Girder.                                                                                                                                 |
-| girder_virtualenv          | no       | none         | Path to a Python virtual environment to install Girder in.                                                                                                          |
-| girder_clone               | no       | yes          | Whether provisioning should clone Girder into `girder_path`.                                                                                                        |
-| girder_update              | no       | yes          | Whether provisioning should fetch new versions via git.                                                                                                             |
-| girder_force               | no       | yes          | Whether provisioning should discard modified files in the working directory.                                                                                        |
-| girder_web                 | no       | yes          | Whether to build the Girder web client.                                                                                                                             |
-| girder_always_build_assets | no       | no           | Whether to always rebuild client side assets (has no effect if girder_web is disabled).                                                                             |
-| girder_daemonize           | no       | yes          | Whether to install the relevant service files (systemd or upstart). Disabling this can be useful inside of containers which might not have an init system.          |
-| girder_enabled             | no       | yes          | Whether to enable the installed service (requires `girder_daemonize`).                                                                                              |
-| girder_plugins             | no       | []           | List of paths to external plugins to install.                                                                                                                       |
-| girder_web_extra_args      | no       | none         | Any additional arguments to pass to `girder-install web`. Passing `--all-plugins` can be useful if your environment doesn't have access to Mongo at provision time. |
-| girder_user                | no       | $SSH_USER    | The (already existing) user to run Girder under, this defaults to `ansible_user_id` which is typically the user Ansible is running under.                           |
+| parameter                  | required | default        | comments                                                                                                                                                            |
+| -------------------------- | -------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| girder_path                | no       | $HOME/girder   | Path to download and build Girder in.                                                                                                                               |
+| girder_version             | no       | master         | Git commit-ish for fetching Girder.                                                                                                                                 |
+| girder_python              | no       | ansible_python | Path to a specific Python to install and run Girder against. Requires `girder_pip` be specified.                                                                    |
+| girder_pip                 | no       | pip2           | Path to a specific pip executable to install against, can't be specified with `girder_virtualenv`.                                                                  |
+| girder_virtualenv          | no       | none           | Path to a Python virtual environment to install Girder in.                                                                                                          |
+| girder_clone               | no       | yes            | Whether provisioning should clone Girder into `girder_path`.                                                                                                        |
+| girder_update              | no       | yes            | Whether provisioning should fetch new versions via git.                                                                                                             |
+| girder_force               | no       | yes            | Whether provisioning should discard modified files in the working directory.                                                                                        |
+| girder_web                 | no       | yes            | Whether to build the Girder web client.                                                                                                                             |
+| girder_always_build_assets | no       | no             | Whether to always rebuild client side assets (has no effect if girder_web is disabled).                                                                             |
+| girder_daemonize           | no       | yes            | Whether to install the relevant service files (systemd or upstart). Disabling this can be useful inside of containers which might not have an init system.          |
+| girder_enabled             | no       | yes            | Whether to enable the installed service (requires `girder_daemonize`).                                                                                              |
+| girder_plugins             | no       | []             | List of paths to external plugins to install.                                                                                                                       |
+| girder_web_extra_args      | no       | none           | Any additional arguments to pass to `girder-install web`. Passing `--all-plugins` can be useful if your environment doesn't have access to Mongo at provision time. |
+| girder_user                | no       | $SSH_USER      | The (already existing) user to run Girder under, this defaults to `ansible_user_id` which is typically the user Ansible is running under.                           |
 
 Generated Facts
 ---------------

--- a/devops/ansible/roles/girder/README.md
+++ b/devops/ansible/roles/girder/README.md
@@ -29,6 +29,7 @@ Role Variables
 | girder_enabled             | no       | yes          | Whether to enable the installed service (requires `girder_daemonize`).                                                                                              |
 | girder_plugins             | no       | []           | List of paths to external plugins to install.                                                                                                                       |
 | girder_web_extra_args      | no       | none         | Any additional arguments to pass to `girder-install web`. Passing `--all-plugins` can be useful if your environment doesn't have access to Mongo at provision time. |
+| girder_user                | no       | $SSH_USER    | The (already existing) user to run Girder under, this defaults to `ansible_user_id` which is typically the user Ansible is running under.                           |
 
 Generated Facts
 ---------------

--- a/devops/ansible/roles/girder/tasks/daemon.yml
+++ b/devops/ansible/roles/girder/tasks/daemon.yml
@@ -7,33 +7,47 @@
     girder_use_systemd: '{{ (ansible_os_family == "RedHat" and ansible_distribution_major_version == "7") or
                             (ansible_os_family == "Debian" and ansible_distribution_release != "trusty") }}'
 
-- name: Install service
-  template:
-    src: "daemon/upstart.girder.conf.j2"
-    dest: "/etc/init/girder.conf"
+
+# Setup upstart service
+- block:
+    - name: Install service
+      template:
+        src: "daemon/upstart.girder.conf.j2"
+        dest: "/etc/init/girder.conf"
+
+    - name: (Re)start service
+      service:
+        name: girder
+        state: restarted
+      when: girder_start
+
+    - name: Enable/Disable Girder service on boot
+      service:
+        name: girder
+        enabled: "{{ girder_enabled }}"
   become: yes
   become_user: root
   when: girder_use_upstart
 
-- name: Install service
-  template:
-    src: "daemon/girder.service.j2"
-    dest: "/etc/systemd/system/girder.service"
+# Setup systemd service
+- block:
+    - name: Install service
+      template:
+        src: "daemon/girder.service.j2"
+        dest: "/etc/systemd/system/girder.service"
+
+    - name: (Re)start service
+      systemd:
+        name: girder
+        daemon_reload: yes
+        state: restarted
+      when: girder_start
+
+    - name: Enable/Disable Girder service on boot
+      systemd:
+        name: girder
+        daemon_reload: yes
+        enabled: "{{ girder_enabled }}"
   become: yes
   become_user: root
   when: girder_use_systemd
-
-- name: (Re)start service
-  service:
-    name: girder
-    state: restarted
-  become: yes
-  become_user: root
-  when: girder_start
-
-- name: Enable/Disable Girder service on boot
-  service:
-    name: girder
-    enabled: "{{ girder_enabled }}"
-  become: yes
-  become_user: root

--- a/devops/ansible/roles/girder/tasks/girder.yml
+++ b/devops/ansible/roles/girder/tasks/girder.yml
@@ -1,42 +1,65 @@
 ---
 
-- name: Install Girder system dependencies
-  apt:
-    name: "{{ item }}"
+- block:
+    - name: Install Girder system dependencies
+      apt:
+        name: "{{ item }}"
+      with_items:
+        - curl
+        - git
+        - libffi-dev
+        - build-essential
+        - libjpeg-dev
+        - libssl-dev
+        - zlib1g-dev
+        # Needed for LDAP plugin
+        - libsasl2-dev
+        - libldap2-dev
+
+    # Python dev headers are only installed if the user hasn't specified a python executable
+    - name: Install Python development headers
+      apt:
+        name: python2.7-dev
+      when: girder_python is not defined
+
+    # Pip is only installed via the package manager if an existing pip wasn't defined
+    # *and* a custom python wasn't defined. If a custom Python is defined the user
+    # is expected to have installed their own development headers and pip.
+    - name: Install pip
+      apt:
+        name: python-pip
+      when: girder_python is not defined and girder_pip is not defined
   become: yes
   become_user: root
-  with_items:
-    - curl
-    - git
-    - libffi-dev
-    - build-essential
-    - python2.7-dev
-    - python-pip
-    - libjpeg-dev
-    - libssl-dev
-    - zlib1g-dev
-    # Needed for LDAP plugin
-    - libsasl2-dev
-    - libldap2-dev
   when: ansible_os_family == "Debian"
 
-- name: Install Girder system dependencies
-  yum:
-    name: "{{ item }}"
+- block:
+    - name: Install Girder system dependencies
+      yum:
+        name: "{{ item }}"
+      with_items:
+        - curl
+        - gcc-c++
+        - git
+        - libffi-devel
+        - make
+        - openssl-devel
+        - libjpeg-turbo-devel
+        - zlib-devel
+        - openldap-devel
+
+    - name: Install Python development headers
+      yum:
+        name: python-devel
+      when: girder_python is not defined
+
+    - name: Install pip
+      yum:
+        name: python2-pip
+      when: girder_python is not defined and girder_pip is not defined
+
   become: yes
   become_user: root
-  with_items:
-    - curl
-    - gcc-c++
-    - git
-    - libffi-devel
-    - make
-    - openssl-devel
-    - libjpeg-turbo-devel
-    - zlib-devel
-    - python2-pip
-    - python-devel
-    - openldap-devel
   when: ansible_os_family == "RedHat"
 
 - name: Download Girder

--- a/devops/ansible/roles/girder/tasks/main.yml
+++ b/devops/ansible/roles/girder/tasks/main.yml
@@ -10,8 +10,8 @@
   file:
     path: "{{ girder_path }}"
     state: directory
-    group: "{{ ansible_user_id }}"
-    owner: "{{ ansible_user_id }}"
+    group: "{{ girder_user|default(ansible_user_id) }}"
+    owner: "{{ girder_user|default(ansible_user_id) }}"
     mode: 0755
   become: yes
   become_user: root

--- a/devops/ansible/roles/girder/tasks/main.yml
+++ b/devops/ansible/roles/girder/tasks/main.yml
@@ -61,7 +61,7 @@
   with_items: "{{ girder_plugins }}"
 
 - name: Build Girder (web)
-  command: "{{ girder_install_executable|default('girder-install') }} web {{ girder_web_extra_args }}"
+  command: "{{ girder_install_executable }} web {{ girder_web_extra_args }}"
   args:
     chdir: "{{ girder_path }}"
   # ensure that the install is one that uses web assets and

--- a/devops/ansible/roles/girder/tasks/main.yml
+++ b/devops/ansible/roles/girder/tasks/main.yml
@@ -6,6 +6,14 @@
         (ansible_distribution_release != "xenial") and
         (ansible_os_family == "RedHat" and ansible_distribution_major_version != "7")
 
+- fail:
+    msg="girder_pip and girder_virtualenv are mututally exclusive variables."
+  when: girder_pip is defined and girder_virtualenv is defined
+
+- fail:
+    msg="Setting girder_python requires setting girder_pip."
+  when: girder_python is defined and girder_pip is not defined
+
 - name: Ensure girder base directory exists
   file:
     path: "{{ girder_path }}"
@@ -26,27 +34,16 @@
     - girder_web
     - ansible_os_family == "Debian"
 
-- name: Install virtualenv
-  apt:
-    name: python-virtualenv
-    state: latest
-  become: yes
-  become_user: root
-  when:
-    - girder_virtualenv is defined
-    - ansible_os_family == "Debian"
-
-- name: Install virtualenv
-  yum:
-    name: python-virtualenv
-    state: latest
-  become: yes
-  become_user: root
-  when:
-    - girder_virtualenv is defined
-    - ansible_os_family == "RedHat"
-
 - include: girder.yml
+
+- name: Install virtualenv
+  pip:
+    name: virtualenv
+    executable: "{{ girder_pip | default(omit) }}"
+    state: latest
+  become: yes
+  become_user: root
+  when: girder_virtualenv is defined
 
 - include: pip.yml
   when: girder_virtualenv is not defined

--- a/devops/ansible/roles/girder/tasks/pip.yml
+++ b/devops/ansible/roles/girder/tasks/pip.yml
@@ -1,16 +1,34 @@
-- name: Update Pip
-  pip:
-    name: pip
-    state: latest
-    virtualenv: "{{ girder_virtualenv | default(omit) }}"
+- block:
+    - name: Update Pip
+      pip:
+        name: pip
+        state: latest
+        virtualenv: "{{ girder_virtualenv }}"
+        virtualenv_python: "{{ girder_python | default(ansible_python.executable) }}"
 
-- name: Install Girder and plugin requirements
-  pip:
-    name: ".[plugins]"
-    extra_args: "-e"
-    chdir: "{{ girder_path }}"
-    virtualenv: "{{ girder_virtualenv | default(omit) }}"
+    - name: Install Girder and plugin requirements
+      pip:
+        name: ".[plugins]"
+        extra_args: "-e"
+        chdir: "{{ girder_path }}"
+        virtualenv: "{{ girder_virtualenv }}"
+        virtualenv_python: "{{ girder_python | default(ansible_python.executable) }}"
 
-- set_fact:
-    girder_install_executable: "{{ girder_virtualenv }}/bin/girder-install"
+    - set_fact:
+        girder_install_executable: "{{ girder_virtualenv }}/bin/girder-install"
   when: girder_virtualenv is defined
+
+- block:
+    - name: Update Pip
+      pip:
+        name: pip
+        state: latest
+        executable: "{{ girder_pip | default(omit) }}"
+
+    - name: Install Girder and plugin requirements
+      pip:
+        name: ".[plugins]"
+        extra_args: "-e"
+        chdir: "{{ girder_path }}"
+        executable: "{{ girder_pip | default(omit) }}"
+  when: girder_virtualenv is not defined

--- a/devops/ansible/roles/girder/tasks/pip.yml
+++ b/devops/ansible/roles/girder/tasks/pip.yml
@@ -31,4 +31,13 @@
         extra_args: "-e"
         chdir: "{{ girder_path }}"
         executable: "{{ girder_pip | default(omit) }}"
+
+    - name: Find girder-install executable
+      shell: "which girder-install"
+      register: executable
+      environment:
+        PATH: "{{ ansible_env.PATH }}:/usr/local/bin"
+
+    - set_fact:
+        girder_install_executable: "{{ executable.stdout_lines[0] }}"
   when: girder_virtualenv is not defined

--- a/devops/ansible/roles/girder/templates/daemon/girder.service.j2
+++ b/devops/ansible/roles/girder/templates/daemon/girder.service.j2
@@ -3,8 +3,8 @@ Description=Girder
 After=network.target
 
 [Service]
-User={{ ansible_user_id }}
-Group={{ ansible_user_id }}
+User={{ girder_user | default(ansible_user_id) }}
+Group={{ girder_user | default(ansible_user_id) }}
 WorkingDirectory={{ girder_path }}
 Restart=always
 {% if girder_virtualenv is defined %}

--- a/devops/ansible/roles/girder/templates/daemon/girder.service.j2
+++ b/devops/ansible/roles/girder/templates/daemon/girder.service.j2
@@ -10,7 +10,7 @@ Restart=always
 {% if girder_virtualenv is defined %}
 ExecStart={{ girder_virtualenv }}/bin/python -m girder
 {% else %}
-ExecStart={{ ansible_python.executable }} -m girder
+ExecStart={{ girder_python | default(ansible_python.executable) }} -m girder
 {% endif %}
 
 {% if girder_hardened %}

--- a/devops/ansible/roles/girder/templates/daemon/upstart.girder.conf.j2
+++ b/devops/ansible/roles/girder/templates/daemon/upstart.girder.conf.j2
@@ -15,6 +15,6 @@ script
     {% if girder_virtualenv is defined %}
     . "{{ girder_virtualenv }}/bin/activate" && python -m girder
     {% else %}
-    exec python -m girder
+    exec "{{ girder_python | default(ansible_python.executable) }}" -m girder
     {% endif %}
 end script

--- a/devops/ansible/roles/girder/templates/daemon/upstart.girder.conf.j2
+++ b/devops/ansible/roles/girder/templates/daemon/upstart.girder.conf.j2
@@ -7,8 +7,8 @@ stop on shutdown
 respawn
 respawn limit 20 5
 
-setuid "{{ ansible_user_id }}"
-setgid "{{ ansible_user_id }}"
+setuid "{{ girder_user | default(ansible_user_id) }}"
+setgid "{{ girder_user | default(ansible_user_id) }}"
 
 script
     cd "{{ girder_path }}"

--- a/devops/ansible/roles/redhat-mongodb/files/mongodb.repo
+++ b/devops/ansible/roles/redhat-mongodb/files/mongodb.repo
@@ -1,5 +1,5 @@
-[mongodb]
+[mongodb-org-3.0]
 name=MongoDB Repository
-baseurl=http://downloads-distro.mongodb.org/repo/redhat/os/x86_64/
+baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.0/x86_64/
 gpgcheck=0
 enabled=1

--- a/devops/ansible/roles/redhat-mongodb/tasks/main.yml
+++ b/devops/ansible/roles/redhat-mongodb/tasks/main.yml
@@ -8,6 +8,12 @@
     name: mongodb-org-server
     state: present
 
+- name: Add mongodb configuration
+  template:
+    src: "mongod.conf.j2"
+    dest: "/etc/mongod.conf"
+    backup: yes
+
 - name: Start mongodb
   service:
     name: mongod

--- a/devops/ansible/roles/redhat-mongodb/templates/mongod.conf.j2
+++ b/devops/ansible/roles/redhat-mongodb/templates/mongod.conf.j2
@@ -1,0 +1,44 @@
+# mongod.conf
+
+# for documentation of all options, see:
+#   http://docs.mongodb.org/manual/reference/configuration-options/
+
+# where to write logging data.
+systemLog:
+  destination: file
+  logAppend: true
+  path: /var/log/mongodb/mongod.log
+
+# Where and how to store data.
+storage:
+  dbPath: /var/lib/mongo
+  journal:
+    enabled: true
+#  engine:
+#  mmapv1:
+#  wiredTiger:
+
+# how the process runs
+processManagement:
+  fork: true  # fork and run in background
+  pidFilePath: /var/run/mongodb/mongod.pid  # location of pidfile
+
+# network interfaces
+net:
+  port: 27017
+  bindIp: {{ bindIp|default('127.0.0.1') }}  # Listen to local interface only, comment to listen on all interfaces.
+
+
+#security:
+
+#operationProfiling:
+
+#replication:
+
+#sharding:
+
+## Enterprise-Only Options
+
+#auditLog:
+
+#snmp:


### PR DESCRIPTION
Fixes #1794

These changes should be broken up in commits well enough to review.

- Adds support for specifying a separate user to run Girder under
- Adds support for specifying a custom python/pip to install Girder under
- Updates redhat-mongodb role to use Mongo 3

For testing custom Python, using the upstream `torian.python` role is useful:
```
    - role: torian.python
      python_version: 2.7.13
      python_bin: /usr/local/bin/python2.7
      python_setuptools_bin: /usr/local/bin/easy_install-2.7
      become: yes
      become_user: root
```
There's some complexity associated with supporting various versions of Python that required some decisions to be made, particularly:
- Previously we installed python2.7-dev and python-pip. If the user specifies their own version of python then we don't install either of those. In other words, if the user brings python it's expected they have the development headers and pip from somewhere. This is why `girder_pip` was added.
- In all cases, if a python executable isn't specified then the executable ansible is using is what's assumed.
- When providing a virtualenv the user can't provide a pip executable (`girder_pip`) since the ansible [pip  module](http://docs.ansible.com/ansible/latest/pip_module.html) prevents this.

I still need to test this a bit more (especially with Python3) but one good avenue is using the above snippet in each of the Girder ansible examples and ensuring things still function correctly (with and without virtualenvs, with custom python versions, etc).