### PR TITLE
Unify restRequest with Backbone.ajax and $.ajax

### DIFF
--- a/clients/web/src/auth.js
+++ b/clients/web/src/auth.js
@@ -64,7 +64,7 @@ function setCurrentToken(token) {
 function fetchCurrentUser() {
     return restRequest({
         method: 'GET',
-        path: '/user/me'
+        url: '/user/me'
     });
 }
 
@@ -87,7 +87,7 @@ function login(username, password, cors) {
 
     return restRequest({
         method: 'GET',
-        path: '/user/authentication',
+        url: '/user/authentication',
         headers: {
             'Girder-Authorization': auth
         },
@@ -116,7 +116,7 @@ function login(username, password, cors) {
 function logout() {
     return restRequest({
         method: 'DELETE',
-        path: '/user/authentication'
+        url: '/user/authentication'
     }).done(function () {
         setCurrentUser(null);
         setCurrentToken(null);

--- a/clients/web/src/collections/Collection.js
+++ b/clients/web/src/collections/Collection.js
@@ -155,7 +155,7 @@ var Collection = Backbone.Collection.extend({
 
         function fetchListFragment() {
             var xhr = restRequest({
-                path: this.altUrl || this.resourceName,
+                url: this.altUrl || this.resourceName,
                 data: _.extend({
                     limit: limit,
                     offset: this.offset,

--- a/clients/web/src/models/AccessControlledModel.js
+++ b/clients/web/src/models/AccessControlledModel.js
@@ -26,7 +26,7 @@ var AccessControlledModel = Model.extend({
 
         return restRequest({
             url: `${this.altUrl || this.resourceName}/${this.id}/access`,
-            type: 'PUT',
+            method: 'PUT',
             data: _.extend({
                 access: JSON.stringify(this.get('access')),
                 public: this.get('public'),
@@ -54,7 +54,7 @@ var AccessControlledModel = Model.extend({
         if (!this.get('access') || force) {
             return restRequest({
                 url: `${this.altUrl || this.resourceName}/${this.id}/access`,
-                type: 'GET'
+                method: 'GET'
             }).done(_.bind(function (resp) {
                 if (resp.access) {
                     this.set(resp);

--- a/clients/web/src/models/AccessControlledModel.js
+++ b/clients/web/src/models/AccessControlledModel.js
@@ -25,7 +25,7 @@ var AccessControlledModel = Model.extend({
         }
 
         return restRequest({
-            url: (this.altUrl || this.resourceName) + '/' + this.get('_id') + '/access',
+            url: `${this.altUrl || this.resourceName}/${this.id}/access`,
             type: 'PUT',
             data: _.extend({
                 access: JSON.stringify(this.get('access')),
@@ -53,7 +53,7 @@ var AccessControlledModel = Model.extend({
 
         if (!this.get('access') || force) {
             return restRequest({
-                url: (this.altUrl || this.resourceName) + '/' + this.get('_id') + '/access',
+                url: `${this.altUrl || this.resourceName}/${this.id}/access`,
                 type: 'GET'
             }).done(_.bind(function (resp) {
                 if (resp.access) {

--- a/clients/web/src/models/AccessControlledModel.js
+++ b/clients/web/src/models/AccessControlledModel.js
@@ -25,7 +25,7 @@ var AccessControlledModel = Model.extend({
         }
 
         return restRequest({
-            path: (this.altUrl || this.resourceName) + '/' + this.get('_id') + '/access',
+            url: (this.altUrl || this.resourceName) + '/' + this.get('_id') + '/access',
             type: 'PUT',
             data: _.extend({
                 access: JSON.stringify(this.get('access')),
@@ -53,7 +53,7 @@ var AccessControlledModel = Model.extend({
 
         if (!this.get('access') || force) {
             return restRequest({
-                path: (this.altUrl || this.resourceName) + '/' + this.get('_id') + '/access',
+                url: (this.altUrl || this.resourceName) + '/' + this.get('_id') + '/access',
                 type: 'GET'
             }).done(_.bind(function (resp) {
                 if (resp.access) {

--- a/clients/web/src/models/ApiKeyModel.js
+++ b/clients/web/src/models/ApiKeyModel.js
@@ -8,7 +8,7 @@ var ApiKeyModel = AccessControlledModel.extend({
 
     setActive: function (active) {
         return restRequest({
-            path: 'api_key/' + this.id,
+            url: 'api_key/' + this.id,
             method: 'PUT',
             data: {
                 active: active

--- a/clients/web/src/models/ApiKeyModel.js
+++ b/clients/web/src/models/ApiKeyModel.js
@@ -8,7 +8,7 @@ var ApiKeyModel = AccessControlledModel.extend({
 
     setActive: function (active) {
         return restRequest({
-            url: 'api_key/' + this.id,
+            url: `api_key/${this.id}`,
             method: 'PUT',
             data: {
                 active: active

--- a/clients/web/src/models/AssetstoreModel.js
+++ b/clients/web/src/models/AssetstoreModel.js
@@ -20,7 +20,7 @@ var AssetstoreModel = Model.extend({
 
     import: function (params) {
         return restRequest({
-            url: 'assetstore/' + this.get('_id') + '/import',
+            url: `assetstore/${this.id}/import`,
             type: 'POST',
             data: params,
             error: null

--- a/clients/web/src/models/AssetstoreModel.js
+++ b/clients/web/src/models/AssetstoreModel.js
@@ -21,7 +21,7 @@ var AssetstoreModel = Model.extend({
     import: function (params) {
         return restRequest({
             url: `assetstore/${this.id}/import`,
-            type: 'POST',
+            method: 'POST',
             data: params,
             error: null
         }).done(_.bind(function (resp) {

--- a/clients/web/src/models/AssetstoreModel.js
+++ b/clients/web/src/models/AssetstoreModel.js
@@ -20,7 +20,7 @@ var AssetstoreModel = Model.extend({
 
     import: function (params) {
         return restRequest({
-            path: 'assetstore/' + this.get('_id') + '/import',
+            url: 'assetstore/' + this.get('_id') + '/import',
             type: 'POST',
             data: params,
             error: null

--- a/clients/web/src/models/CollectionCreationPolicyModel.js
+++ b/clients/web/src/models/CollectionCreationPolicyModel.js
@@ -6,7 +6,7 @@ var CollectionCreationPolicyModel = AccessControlledModel.extend({
     fetchAccess: function () {
         return restRequest({
             url: `${this.resourceName}/access`,
-            type: 'GET'
+            method: 'GET'
         }).done((resp) => {
             this.set('access', resp);
             this.trigger('g:accessFetched');

--- a/clients/web/src/models/CollectionCreationPolicyModel.js
+++ b/clients/web/src/models/CollectionCreationPolicyModel.js
@@ -5,7 +5,7 @@ var CollectionCreationPolicyModel = AccessControlledModel.extend({
     resourceName: 'system/setting/collection_creation_policy',
     fetchAccess: function () {
         return restRequest({
-            path: this.resourceName + '/access',
+            url: this.resourceName + '/access',
             type: 'GET'
         }).done((resp) => {
             this.set('access', resp);

--- a/clients/web/src/models/CollectionCreationPolicyModel.js
+++ b/clients/web/src/models/CollectionCreationPolicyModel.js
@@ -5,7 +5,7 @@ var CollectionCreationPolicyModel = AccessControlledModel.extend({
     resourceName: 'system/setting/collection_creation_policy',
     fetchAccess: function () {
         return restRequest({
-            url: this.resourceName + '/access',
+            url: `${this.resourceName}/access`,
             type: 'GET'
         }).done((resp) => {
             this.set('access', resp);

--- a/clients/web/src/models/FileModel.js
+++ b/clients/web/src/models/FileModel.js
@@ -35,7 +35,7 @@ var FileModel = Model.extend({
         data = this._wrapData(data);
 
         this.upload(null, data, {
-            url: 'file/' + this.get('_id') + '/contents',
+            url: `file/${this.id}/contents`,
             type: 'PUT',
             data: {
                 size: data.size

--- a/clients/web/src/models/FileModel.js
+++ b/clients/web/src/models/FileModel.js
@@ -35,7 +35,7 @@ var FileModel = Model.extend({
         data = this._wrapData(data);
 
         this.upload(null, data, {
-            path: 'file/' + this.get('_id') + '/contents',
+            url: 'file/' + this.get('_id') + '/contents',
             type: 'PUT',
             data: {
                 size: data.size
@@ -100,7 +100,7 @@ var FileModel = Model.extend({
         this.resumeInfo = null;
         this.uploadHandler = null;
         _restParams = _restParams || {
-            path: 'file',
+            url: 'file',
             type: 'POST',
             data: _.extend({
                 parentType: parentModel.resourceName,
@@ -183,7 +183,7 @@ var FileModel = Model.extend({
 
         // Request the actual offset we need to resume at
         restRequest({
-            path: 'file/offset',
+            url: 'file/offset',
             type: 'GET',
             data: {
                 uploadId: this.resumeInfo.uploadId
@@ -212,7 +212,7 @@ var FileModel = Model.extend({
             return;
         }
         restRequest({
-            path: 'system/uploads',
+            url: 'system/uploads',
             type: 'DELETE',
             data: {
                 uploadId: this.resumeInfo.uploadId
@@ -230,7 +230,7 @@ var FileModel = Model.extend({
         var blob = file[sliceFn](this.startByte, endByte);
 
         restRequest({
-            path: `file/chunk?offset=${this.startByte}&uploadId=${uploadId}`,
+            url: `file/chunk?offset=${this.startByte}&uploadId=${uploadId}`,
             type: 'POST',
             dataType: 'json',
             data: blob,

--- a/clients/web/src/models/FileModel.js
+++ b/clients/web/src/models/FileModel.js
@@ -232,7 +232,6 @@ var FileModel = Model.extend({
         restRequest({
             url: `file/chunk?offset=${this.startByte}&uploadId=${uploadId}`,
             method: 'POST',
-            dataType: 'json',
             data: blob,
             contentType: false,
             processData: false,

--- a/clients/web/src/models/FileModel.js
+++ b/clients/web/src/models/FileModel.js
@@ -36,7 +36,7 @@ var FileModel = Model.extend({
 
         this.upload(null, data, {
             url: `file/${this.id}/contents`,
-            type: 'PUT',
+            method: 'PUT',
             data: {
                 size: data.size
             }
@@ -101,7 +101,7 @@ var FileModel = Model.extend({
         this.uploadHandler = null;
         _restParams = _restParams || {
             url: 'file',
-            type: 'POST',
+            method: 'POST',
             data: _.extend({
                 parentType: parentModel.resourceName,
                 parentId: parentModel.get('_id'),
@@ -184,7 +184,7 @@ var FileModel = Model.extend({
         // Request the actual offset we need to resume at
         restRequest({
             url: 'file/offset',
-            type: 'GET',
+            method: 'GET',
             data: {
                 uploadId: this.resumeInfo.uploadId
             },
@@ -213,7 +213,7 @@ var FileModel = Model.extend({
         }
         restRequest({
             url: 'system/uploads',
-            type: 'DELETE',
+            method: 'DELETE',
             data: {
                 uploadId: this.resumeInfo.uploadId
             },
@@ -231,7 +231,7 @@ var FileModel = Model.extend({
 
         restRequest({
             url: `file/chunk?offset=${this.startByte}&uploadId=${uploadId}`,
-            type: 'POST',
+            method: 'POST',
             dataType: 'json',
             data: blob,
             contentType: false,

--- a/clients/web/src/models/FolderModel.js
+++ b/clients/web/src/models/FolderModel.js
@@ -9,7 +9,7 @@ var FolderModel = AccessControlledModel.extend({
 
     getRootPath: function () {
         return restRequest({
-            path: `${this.resourceName}/${this.id}/rootpath`
+            url: `${this.resourceName}/${this.id}/rootpath`
         });
     }
 });

--- a/clients/web/src/models/GroupModel.js
+++ b/clients/web/src/models/GroupModel.js
@@ -19,7 +19,7 @@ var GroupModel = AccessControlledModel.extend({
     sendInvitation: function (userId, accessType, request, params) {
         params = params || {};
         return restRequest({
-            url: this.resourceName + '/' + this.get('_id') + '/invitation',
+            url: `${this.resourceName}/${this.id}/invitation`,
             data: _.extend({
                 userId: userId,
                 level: accessType
@@ -48,7 +48,7 @@ var GroupModel = AccessControlledModel.extend({
      */
     joinGroup: function () {
         return restRequest({
-            url: this.resourceName + '/' + this.get('_id') + '/member',
+            url: `${this.resourceName}/${this.id}/member`,
             type: 'POST'
         }).done(_.bind(function (resp) {
             getCurrentUser().addToGroup(this.get('_id'));
@@ -69,7 +69,7 @@ var GroupModel = AccessControlledModel.extend({
      */
     requestInvitation: function () {
         return restRequest({
-            url: this.resourceName + '/' + this.get('_id') + '/member',
+            url: `${this.resourceName}/${this.id}/member`,
             type: 'POST'
         }).done(_.bind(function (resp) {
             this.set(resp);
@@ -94,7 +94,7 @@ var GroupModel = AccessControlledModel.extend({
             role = 'admin';
         }
         return restRequest({
-            url: this.resourceName + '/' + this.get('_id') + '/' + role,
+            url: `${this.resourceName}/${this.id}/${role}`,
             data: {
                 userId: user.get('_id')
             },
@@ -122,8 +122,7 @@ var GroupModel = AccessControlledModel.extend({
             role = 'admin';
         }
         return restRequest({
-            url: this.resourceName + '/' + this.get('_id') + '/' + role +
-                '?userId=' + userId,
+            url: `${this.resourceName}/${this.id}/${role}?userId=${userId}`,
             type: 'DELETE'
         }).done(_.bind(function (resp) {
             this.set(resp);
@@ -142,8 +141,7 @@ var GroupModel = AccessControlledModel.extend({
      */
     removeMember: function (userId) {
         return restRequest({
-            url: this.resourceName + '/' + this.get('_id') +
-                  '/member?userId=' + userId,
+            url: `${this.resourceName}/${this.id}/member?userId=${userId}`,
             type: 'DELETE'
         }).done(_.bind(function (resp) {
             if (userId === getCurrentUser().get('_id')) {

--- a/clients/web/src/models/GroupModel.js
+++ b/clients/web/src/models/GroupModel.js
@@ -19,7 +19,7 @@ var GroupModel = AccessControlledModel.extend({
     sendInvitation: function (userId, accessType, request, params) {
         params = params || {};
         return restRequest({
-            path: this.resourceName + '/' + this.get('_id') + '/invitation',
+            url: this.resourceName + '/' + this.get('_id') + '/invitation',
             data: _.extend({
                 userId: userId,
                 level: accessType
@@ -48,7 +48,7 @@ var GroupModel = AccessControlledModel.extend({
      */
     joinGroup: function () {
         return restRequest({
-            path: this.resourceName + '/' + this.get('_id') + '/member',
+            url: this.resourceName + '/' + this.get('_id') + '/member',
             type: 'POST'
         }).done(_.bind(function (resp) {
             getCurrentUser().addToGroup(this.get('_id'));
@@ -69,7 +69,7 @@ var GroupModel = AccessControlledModel.extend({
      */
     requestInvitation: function () {
         return restRequest({
-            path: this.resourceName + '/' + this.get('_id') + '/member',
+            url: this.resourceName + '/' + this.get('_id') + '/member',
             type: 'POST'
         }).done(_.bind(function (resp) {
             this.set(resp);
@@ -94,7 +94,7 @@ var GroupModel = AccessControlledModel.extend({
             role = 'admin';
         }
         return restRequest({
-            path: this.resourceName + '/' + this.get('_id') + '/' + role,
+            url: this.resourceName + '/' + this.get('_id') + '/' + role,
             data: {
                 userId: user.get('_id')
             },
@@ -122,7 +122,7 @@ var GroupModel = AccessControlledModel.extend({
             role = 'admin';
         }
         return restRequest({
-            path: this.resourceName + '/' + this.get('_id') + '/' + role +
+            url: this.resourceName + '/' + this.get('_id') + '/' + role +
                 '?userId=' + userId,
             type: 'DELETE'
         }).done(_.bind(function (resp) {
@@ -142,7 +142,7 @@ var GroupModel = AccessControlledModel.extend({
      */
     removeMember: function (userId) {
         return restRequest({
-            path: this.resourceName + '/' + this.get('_id') +
+            url: this.resourceName + '/' + this.get('_id') +
                   '/member?userId=' + userId,
             type: 'DELETE'
         }).done(_.bind(function (resp) {

--- a/clients/web/src/models/GroupModel.js
+++ b/clients/web/src/models/GroupModel.js
@@ -24,7 +24,7 @@ var GroupModel = AccessControlledModel.extend({
                 userId: userId,
                 level: accessType
             }, params),
-            type: 'POST',
+            method: 'POST',
             error: null
         }).done(_.bind(function (resp) {
             this.set(resp);
@@ -49,7 +49,7 @@ var GroupModel = AccessControlledModel.extend({
     joinGroup: function () {
         return restRequest({
             url: `${this.resourceName}/${this.id}/member`,
-            type: 'POST'
+            method: 'POST'
         }).done(_.bind(function (resp) {
             getCurrentUser().addToGroup(this.get('_id'));
             getCurrentUser().removeInvitation(this.get('_id'));
@@ -70,7 +70,7 @@ var GroupModel = AccessControlledModel.extend({
     requestInvitation: function () {
         return restRequest({
             url: `${this.resourceName}/${this.id}/member`,
-            type: 'POST'
+            method: 'POST'
         }).done(_.bind(function (resp) {
             this.set(resp);
 
@@ -98,7 +98,7 @@ var GroupModel = AccessControlledModel.extend({
             data: {
                 userId: user.get('_id')
             },
-            type: 'POST'
+            method: 'POST'
         }).done(_.bind(function (resp) {
             this.set(resp);
 
@@ -123,7 +123,7 @@ var GroupModel = AccessControlledModel.extend({
         }
         return restRequest({
             url: `${this.resourceName}/${this.id}/${role}?userId=${userId}`,
-            type: 'DELETE'
+            method: 'DELETE'
         }).done(_.bind(function (resp) {
             this.set(resp);
 
@@ -142,7 +142,7 @@ var GroupModel = AccessControlledModel.extend({
     removeMember: function (userId) {
         return restRequest({
             url: `${this.resourceName}/${this.id}/member?userId=${userId}`,
-            type: 'DELETE'
+            method: 'DELETE'
         }).done(_.bind(function (resp) {
             if (userId === getCurrentUser().get('_id')) {
                 getCurrentUser().removeFromGroup(this.get('_id'));

--- a/clients/web/src/models/ItemModel.js
+++ b/clients/web/src/models/ItemModel.js
@@ -42,7 +42,7 @@ var ItemModel = Model.extend({
      */
     getRootPath: function (callback) {
         return restRequest({
-            path: this.resourceName + '/' + this.get('_id') + '/rootpath'
+            url: this.resourceName + '/' + this.get('_id') + '/rootpath'
         }).done(_.bind(function (resp) {
             callback(resp);
         }, this)).fail(_.bind(function (err) {

--- a/clients/web/src/models/ItemModel.js
+++ b/clients/web/src/models/ItemModel.js
@@ -42,7 +42,7 @@ var ItemModel = Model.extend({
      */
     getRootPath: function (callback) {
         return restRequest({
-            url: this.resourceName + '/' + this.get('_id') + '/rootpath'
+            url: `${this.resourceName}/${this.id}/rootpath`
         }).done(_.bind(function (resp) {
             callback(resp);
         }, this)).fail(_.bind(function (err) {

--- a/clients/web/src/models/MetadataMixin.js
+++ b/clients/web/src/models/MetadataMixin.js
@@ -10,7 +10,7 @@ var MetadataMixin = {
                 ((this.altUrl || this.resourceName) + `/${this.id}/metadata?allowNull=true`),
             contentType: 'application/json',
             data: JSON.stringify(metadata),
-            type: 'PUT',
+            method: 'PUT',
             error: null
         }).done(_.bind(function (resp) {
             this.set(opts.field || 'meta', resp.meta);
@@ -48,7 +48,7 @@ var MetadataMixin = {
                 ((this.altUrl || this.resourceName) + `/${this.id}/metadata`),
             contentType: 'application/json',
             data: JSON.stringify(key),
-            type: 'DELETE',
+            method: 'DELETE',
             error: null
         }).done((resp) => {
             this.set(opts.field || 'meta', resp.meta);

--- a/clients/web/src/models/MetadataMixin.js
+++ b/clients/web/src/models/MetadataMixin.js
@@ -6,7 +6,7 @@ var MetadataMixin = {
     _sendMetadata: function (metadata, successCallback, errorCallback, opts) {
         opts = opts || {};
         restRequest({
-            path: opts.path ||
+            url: opts.path ||
                 ((this.altUrl || this.resourceName) + `/${this.id}/metadata?allowNull=true`),
             contentType: 'application/json',
             data: JSON.stringify(metadata),
@@ -44,7 +44,7 @@ var MetadataMixin = {
             key = [key];
         }
         restRequest({
-            path: opts.path ||
+            url: opts.path ||
                 ((this.altUrl || this.resourceName) + `/${this.id}/metadata`),
             contentType: 'application/json',
             data: JSON.stringify(key),

--- a/clients/web/src/models/Model.js
+++ b/clients/web/src/models/Model.js
@@ -66,7 +66,7 @@ var Model = Backbone.Model.extend({
 
         return restRequest({
             url: path,
-            type: type,
+            method: type,
             data: data,
             error: null // don't do default error behavior (validation may fail)
         }).done(_.bind(function (resp) {
@@ -153,7 +153,7 @@ var Model = Backbone.Model.extend({
 
         var args = {
             url: `${this.altUrl || this.resourceName}/${this.id}`,
-            type: 'DELETE'
+            method: 'DELETE'
         };
 
         opts = opts || {};

--- a/clients/web/src/models/Model.js
+++ b/clients/web/src/models/Model.js
@@ -65,7 +65,7 @@ var Model = Backbone.Model.extend({
         }, this);
 
         return restRequest({
-            path: path,
+            url: path,
             type: type,
             data: data,
             error: null // don't do default error behavior (validation may fail)
@@ -83,7 +83,7 @@ var Model = Backbone.Model.extend({
      *
      * @param {object|undefined} opts: additional options, which can include:
      *     ignoreError: true - ignore the default error handler
-     *     extraPath - a string to append to the end of the resource path
+     *     extraPath - a string to append to the end of the resource URL
      *     data - a dictionary of parameters to pass to the endpoint.
      */
     fetch: function (opts) {
@@ -93,10 +93,10 @@ var Model = Backbone.Model.extend({
 
         opts = opts || {};
         var restOpts = {
-            path: (this.altUrl || this.resourceName) + '/' + this.get('_id')
+            url: (this.altUrl || this.resourceName) + '/' + this.get('_id')
         };
         if (opts.extraPath) {
-            restOpts.path += '/' + opts.extraPath;
+            restOpts.url += '/' + opts.extraPath;
         }
         if (opts.ignoreError) {
             restOpts.error = null;
@@ -152,13 +152,13 @@ var Model = Backbone.Model.extend({
         }
 
         var args = {
-            path: (this.altUrl || this.resourceName) + '/' + this.get('_id'),
+            url: (this.altUrl || this.resourceName) + '/' + this.get('_id'),
             type: 'DELETE'
         };
 
         opts = opts || {};
         if (opts.progress === true) {
-            args.path += '?progress=true';
+            args.url += '?progress=true';
         }
 
         if (opts.throwError !== false) {

--- a/clients/web/src/models/Model.js
+++ b/clients/web/src/models/Model.js
@@ -93,7 +93,7 @@ var Model = Backbone.Model.extend({
 
         opts = opts || {};
         var restOpts = {
-            url: (this.altUrl || this.resourceName) + '/' + this.get('_id')
+            url: `${this.altUrl || this.resourceName}/${this.id}`
         };
         if (opts.extraPath) {
             restOpts.url += '/' + opts.extraPath;
@@ -152,7 +152,7 @@ var Model = Backbone.Model.extend({
         }
 
         var args = {
-            url: (this.altUrl || this.resourceName) + '/' + this.get('_id'),
+            url: `${this.altUrl || this.resourceName}/${this.id}`,
             type: 'DELETE'
         };
 

--- a/clients/web/src/models/UserModel.js
+++ b/clients/web/src/models/UserModel.js
@@ -88,7 +88,7 @@ var UserModel = Model.extend({
      */
     changePassword: function (oldPassword, newPassword) {
         return restRequest({
-            path: this.resourceName + '/password',
+            url: this.resourceName + '/password',
             data: {
                 old: oldPassword,
                 new: newPassword
@@ -107,7 +107,7 @@ var UserModel = Model.extend({
      */
     adminChangePassword: function (newPassword) {
         return restRequest({
-            path: this.resourceName + '/' + this.id + '/password',
+            url: this.resourceName + '/' + this.id + '/password',
             data: {
                 password: newPassword
             },

--- a/clients/web/src/models/UserModel.js
+++ b/clients/web/src/models/UserModel.js
@@ -88,7 +88,7 @@ var UserModel = Model.extend({
      */
     changePassword: function (oldPassword, newPassword) {
         return restRequest({
-            url: this.resourceName + '/password',
+            url: `${this.resourceName}/password`,
             data: {
                 old: oldPassword,
                 new: newPassword
@@ -107,7 +107,7 @@ var UserModel = Model.extend({
      */
     adminChangePassword: function (newPassword) {
         return restRequest({
-            url: this.resourceName + '/' + this.id + '/password',
+            url: `${this.resourceName}/${this.id}/password`,
             data: {
                 password: newPassword
             },

--- a/clients/web/src/models/UserModel.js
+++ b/clients/web/src/models/UserModel.js
@@ -93,7 +93,7 @@ var UserModel = Model.extend({
                 old: oldPassword,
                 new: newPassword
             },
-            type: 'PUT',
+            method: 'PUT',
             error: null
         }).done(_.bind(function () {
             this.trigger('g:passwordChanged');
@@ -111,7 +111,7 @@ var UserModel = Model.extend({
             data: {
                 password: newPassword
             },
-            type: 'PUT',
+            method: 'PUT',
             error: null
         }).done(_.bind(function () {
             this.trigger('g:passwordChanged');

--- a/clients/web/src/rest.js
+++ b/clients/web/src/rest.js
@@ -75,25 +75,31 @@ setStaticRoot(
 );
 
 /**
- * Make a request to the REST API. Bind a "done" handler to the return
- * value that will be called when the response is successful. To bind a
- * custom error handler, bind a "fail" handler to the return promise,
- * which will be executed in addition to the normal behavior of logging
- * the error to the console. To override the default error handling
- * behavior, pass an "error" key in your opts object; this should be done
- * any time the server might throw an exception from validating user input,
- * e.g. logging in, registering, or generally filling out forms.
+ * Make a request to the REST API.
  *
- * @param {Object} opts Options for the request, most of which will be passed through to `$.ajax`.
- * @param {string} opts.url The resource path, e.g. "user/login"
+ * This is a wrapper around {@link http://api.jquery.com/jQuery.ajax/ $.ajax}, which also handles
+ * authentication and routing to the Girder API, and provides a default for error notification.
+ *
+ * Most users of this method should attach a "done" handler to the return value. In cases where the
+ * server is ordinarily expected to return a non-200 status (e.g. validating user input), the
+ * "error: null" argument should probably be provided, and errors should be processed via an
+ * attached "fail" handler.
+ *
+ * Before this function is called, the API root must be set (which typically happens automatically).
+ *
+ * @param {Object} opts Options for the request, most of which will be passed through to $.ajax.
+ * @param {string} opts.url The resource path, relative to the API root, without leading or trailing
+ *        slashes. e.g. "user/login"
  * @param {string} [opts.method='GET'] The HTTP method to invoke.
- * @param [opts.data] The query string or form parameter object.
+ * @param {string|Object} [opts.data] The query string or form parameter object.
  * @param {?Function} [opts.error] An error callback, as documented in
- *        `$.ajax <http://api.jquery.com/jQuery.ajax/>`_, or null. If not provided, this will have a
- *        default behavior of triggering a `'g:alert'` global event, with details of the error.
+ *        {@link http://api.jquery.com/jQuery.ajax/ $.ajax}, or null. If not provided, this will
+ *        have a default behavior of triggering a 'g:alert' global event, with details of the
+ *        error, and logging the error to the console. It is recommended that you do not ever pass
+ *        a non-null callback function, and handle errors via promise rejection handlers instead.
  * @param {string} [opts.girderToken] An alternative auth token to use for this request.
  * @returns {$.Promise} A jqXHR promise, which resolves and rejects
- *          `as documented by $.ajax<http://api.jquery.com/jQuery.ajax/#jqXHR>`_.
+ *          {@link http://api.jquery.com/jQuery.ajax/#jqXHR as documented by $.ajax}.
  */
 let restRequest = function (opts) {
     opts = opts || {};

--- a/clients/web/src/rest.js
+++ b/clients/web/src/rest.js
@@ -91,7 +91,6 @@ setStaticRoot(
  * @param {?Function} [opts.error] An error callback, as documented in
  *        `$.ajax <http://api.jquery.com/jQuery.ajax/>`_, or null. If not provided, this will have a
  *        default behavior of triggering a `'g:alert'` global event, with details of the error.
- * @param {string} [opts.dataType='json'] The type of data expected back from the server.
  * @param {string} [opts.girderToken] An alternative auth token to use for this request.
  * @returns {$.Promise} A jqXHR promise, which resolves and rejects
  *          `as documented by $.ajax<http://api.jquery.com/jQuery.ajax/#jqXHR>`_.
@@ -100,7 +99,6 @@ function __restRequest(opts) {
     opts = opts || {};
     const defaults = {
         method: 'GET',
-        dataType: 'json',
         girderToken: getCurrentToken() || cookie.find('girderToken'),
 
         error: (error, status) => {

--- a/clients/web/src/rest.js
+++ b/clients/web/src/rest.js
@@ -95,7 +95,7 @@ setStaticRoot(
  * @returns {$.Promise} A jqXHR promise, which resolves and rejects
  *          `as documented by $.ajax<http://api.jquery.com/jQuery.ajax/#jqXHR>`_.
  */
-function __restRequest(opts) {
+let restRequest = function (opts) {
     opts = opts || {};
     const defaults = {
         method: 'GET',
@@ -178,28 +178,20 @@ function __restRequest(opts) {
         return jqXHR.fail.apply(jqXHR, arguments);
     };
     return jqXHR;
-}
+};
 
+const _originalRestRequest = restRequest;
 /**
- * Make a request to the REST API.
- *
- * Provide an API to mock this single conduit connecting the client to the server.
- * While this can be done with various testing framework, choosing the right one depends on the
- * way our code is bundled (spyOn() vs. rewire(), for example). Let's provide a specific API
- * to mock restRequest nonetheless, since it is likely to be mocked the most.
+ * @deprecated: will be removed in v3
  */
-var restRequestMock = null;
-function restRequest() {
-    if (restRequestMock) {
-        return restRequestMock.apply(this, arguments);
-    }
-    return __restRequest.apply(this, arguments);
-}
 function mockRestRequest(mock) {
-    restRequestMock = mock;
+    restRequest = mock;
 }
-function unmockRestRequest(mock) {
-    restRequestMock = null;
+/**
+ * @deprecated: will be removed in v3
+ */
+function unmockRestRequest() {
+    restRequest = _originalRestRequest;
 }
 
 // All requests from Backbone should go through restRequest, adding authentication and the API root.

--- a/clients/web/src/routes.js
+++ b/clients/web/src/routes.js
@@ -149,7 +149,7 @@ router.route('useraccount/:id/:tab', 'accountTab', function (id, tab) {
 });
 router.route('useraccount/:id/token/:token', 'accountToken', function (id, token) {
     restRequest({
-        path: 'user/password/temporary/' + id,
+        url: 'user/password/temporary/' + id,
         type: 'GET',
         data: {token: token},
         error: null
@@ -171,7 +171,7 @@ router.route('useraccount/:id/token/:token', 'accountToken', function (id, token
 
 router.route('useraccount/:id/verification/:token', 'accountVerify', function (id, token) {
     restRequest({
-        path: 'user/' + id + '/verification',
+        url: 'user/' + id + '/verification',
         type: 'PUT',
         data: {token: token},
         error: null

--- a/clients/web/src/routes.js
+++ b/clients/web/src/routes.js
@@ -150,7 +150,7 @@ router.route('useraccount/:id/:tab', 'accountTab', function (id, tab) {
 router.route('useraccount/:id/token/:token', 'accountToken', function (id, token) {
     restRequest({
         url: `user/password/temporary/${id}`,
-        type: 'GET',
+        method: 'GET',
         data: {token: token},
         error: null
     }).done(_.bind(function (resp) {
@@ -172,7 +172,7 @@ router.route('useraccount/:id/token/:token', 'accountToken', function (id, token
 router.route('useraccount/:id/verification/:token', 'accountVerify', function (id, token) {
     restRequest({
         url: `user/${id}/verification`,
-        type: 'PUT',
+        method: 'PUT',
         data: {token: token},
         error: null
     }).done(_.bind(function (resp) {

--- a/clients/web/src/routes.js
+++ b/clients/web/src/routes.js
@@ -149,7 +149,7 @@ router.route('useraccount/:id/:tab', 'accountTab', function (id, tab) {
 });
 router.route('useraccount/:id/token/:token', 'accountToken', function (id, token) {
     restRequest({
-        url: 'user/password/temporary/' + id,
+        url: `user/password/temporary/${id}`,
         type: 'GET',
         data: {token: token},
         error: null
@@ -171,7 +171,7 @@ router.route('useraccount/:id/token/:token', 'accountToken', function (id, token
 
 router.route('useraccount/:id/verification/:token', 'accountVerify', function (id, token) {
     restRequest({
-        url: 'user/' + id + '/verification',
+        url: `user/${id}/verification`,
         type: 'PUT',
         data: {token: token},
         error: null

--- a/clients/web/src/server.js
+++ b/clients/web/src/server.js
@@ -35,7 +35,7 @@ function _retryUntilFulfilled(func, delay) {
 function restartServer() {
     // Query the server first
     return restRequest({
-        type: 'GET',
+        method: 'GET',
         url: 'system/version'
     })
         // Restart the server
@@ -68,7 +68,7 @@ function restartServer() {
  */
 restartServer._checkServer = function (lastStartDate) {
     return restRequest({
-        type: 'GET',
+        method: 'GET',
         url: 'system/version',
         error: null
     })
@@ -84,7 +84,7 @@ restartServer._checkServer = function (lastStartDate) {
 /* Having these as object properties facilitates testing */
 restartServer._callSystemRestart = function () {
     return restRequest({
-        type: 'PUT',
+        method: 'PUT',
         url: 'system/restart'
     });
 };
@@ -109,7 +109,7 @@ function rebuildWebClient() {
 rebuildWebClient._rebuildWebClient = function () {
     return restRequest({
         url: 'system/web_build',
-        type: 'POST',
+        method: 'POST',
         data: { progress: true }
     });
 };

--- a/clients/web/src/server.js
+++ b/clients/web/src/server.js
@@ -36,7 +36,7 @@ function restartServer() {
     // Query the server first
     return restRequest({
         type: 'GET',
-        path: 'system/version'
+        url: 'system/version'
     })
         // Restart the server
         .then((resp) => {
@@ -69,7 +69,7 @@ function restartServer() {
 restartServer._checkServer = function (lastStartDate) {
     return restRequest({
         type: 'GET',
-        path: 'system/version',
+        url: 'system/version',
         error: null
     })
     .then((resp) => {
@@ -85,7 +85,7 @@ restartServer._checkServer = function (lastStartDate) {
 restartServer._callSystemRestart = function () {
     return restRequest({
         type: 'PUT',
-        path: 'system/restart'
+        url: 'system/restart'
     });
 };
 
@@ -108,7 +108,7 @@ function rebuildWebClient() {
 
 rebuildWebClient._rebuildWebClient = function () {
     return restRequest({
-        path: 'system/web_build',
+        url: 'system/web_build',
         type: 'POST',
         data: { progress: true }
     });

--- a/clients/web/src/utilities/S3UploadHandler.js
+++ b/clients/web/src/utilities/S3UploadHandler.js
@@ -65,7 +65,7 @@ prototype.execute = function () {
 
                 restRequest({
                     url: 'file/completion',
-                    type: 'POST',
+                    method: 'POST',
                     data: {
                         uploadId: this.params.upload._id
                     },
@@ -115,7 +115,7 @@ prototype.resume = function () {
     // to re-generate the initial request with a new timestamp.
     restRequest({
         url: 'file/offset',
-        type: 'GET',
+        method: 'GET',
         data: {
             uploadId: this.params.upload._id
         },
@@ -182,7 +182,7 @@ prototype._sendNextChunk = function () {
     // Get the authorized request from Girder
     restRequest({
         url: 'file/chunk',
-        type: 'POST',
+        method: 'POST',
         data: {
             offset: 0,
             chunk: JSON.stringify({
@@ -245,7 +245,7 @@ prototype._sendNextChunk = function () {
 prototype._finalizeMultiChunkUpload = function () {
     restRequest({
         url: 'file/completion',
-        type: 'POST',
+        method: 'POST',
         data: {
             uploadId: this.params.upload._id
         },

--- a/clients/web/src/utilities/S3UploadHandler.js
+++ b/clients/web/src/utilities/S3UploadHandler.js
@@ -64,7 +64,7 @@ prototype.execute = function () {
                 });
 
                 restRequest({
-                    path: 'file/completion',
+                    url: 'file/completion',
                     type: 'POST',
                     data: {
                         uploadId: this.params.upload._id
@@ -114,7 +114,7 @@ prototype.resume = function () {
     // If this is a single-chunk upload, we have to use the offset method
     // to re-generate the initial request with a new timestamp.
     restRequest({
-        path: 'file/offset',
+        url: 'file/offset',
         type: 'GET',
         data: {
             uploadId: this.params.upload._id
@@ -181,7 +181,7 @@ prototype._sendNextChunk = function () {
 
     // Get the authorized request from Girder
     restRequest({
-        path: 'file/chunk',
+        url: 'file/chunk',
         type: 'POST',
         data: {
             offset: 0,
@@ -244,7 +244,7 @@ prototype._sendNextChunk = function () {
  */
 prototype._finalizeMultiChunkUpload = function () {
     restRequest({
-        path: 'file/completion',
+        url: 'file/completion',
         type: 'POST',
         data: {
             uploadId: this.params.upload._id

--- a/clients/web/src/views/body/PluginsView.js
+++ b/clients/web/src/views/body/PluginsView.js
@@ -66,11 +66,11 @@ var PluginsView = View.extend({
         } else {
             const promises = [
                 restRequest({
-                    path: 'system/plugins',
+                    url: 'system/plugins',
                     type: 'GET'
                 }).then((resp) => resp),
                 restRequest({
-                    path: 'system/configuration',
+                    url: 'system/configuration',
                     type: 'GET',
                     data: {
                         section: 'server',
@@ -208,7 +208,7 @@ var PluginsView = View.extend({
         this.enabled = _.intersection(this.enabled, _.keys(this.allPlugins));
 
         restRequest({
-            path: 'system/plugins',
+            url: 'system/plugins',
             type: 'PUT',
             data: {
                 plugins: JSON.stringify(this.enabled)

--- a/clients/web/src/views/body/PluginsView.js
+++ b/clients/web/src/views/body/PluginsView.js
@@ -67,11 +67,11 @@ var PluginsView = View.extend({
             const promises = [
                 restRequest({
                     url: 'system/plugins',
-                    type: 'GET'
+                    method: 'GET'
                 }).then((resp) => resp),
                 restRequest({
                     url: 'system/configuration',
-                    type: 'GET',
+                    method: 'GET',
                     data: {
                         section: 'server',
                         key: 'cherrypy_server'
@@ -209,7 +209,7 @@ var PluginsView = View.extend({
 
         restRequest({
             url: 'system/plugins',
-            type: 'PUT',
+            method: 'PUT',
             data: {
                 plugins: JSON.stringify(this.enabled)
             }

--- a/clients/web/src/views/body/SystemConfigurationView.js
+++ b/clients/web/src/views/body/SystemConfigurationView.js
@@ -46,7 +46,7 @@ var SystemConfigurationView = View.extend({
             }, this);
 
             restRequest({
-                type: 'PUT',
+                method: 'PUT',
                 url: 'system/setting',
                 data: {
                     list: JSON.stringify(settings)
@@ -95,7 +95,7 @@ var SystemConfigurationView = View.extend({
         this.settingsKeys = keys;
         restRequest({
             url: 'system/setting',
-            type: 'GET',
+            method: 'GET',
             data: {
                 list: JSON.stringify(keys),
                 default: 'none'
@@ -104,7 +104,7 @@ var SystemConfigurationView = View.extend({
             this.settings = resp;
             restRequest({
                 url: 'system/setting',
-                type: 'GET',
+                method: 'GET',
                 data: {
                     list: JSON.stringify(keys),
                     default: 'default'

--- a/clients/web/src/views/body/SystemConfigurationView.js
+++ b/clients/web/src/views/body/SystemConfigurationView.js
@@ -47,7 +47,7 @@ var SystemConfigurationView = View.extend({
 
             restRequest({
                 type: 'PUT',
-                path: 'system/setting',
+                url: 'system/setting',
                 data: {
                     list: JSON.stringify(settings)
                 },
@@ -94,7 +94,7 @@ var SystemConfigurationView = View.extend({
         ];
         this.settingsKeys = keys;
         restRequest({
-            path: 'system/setting',
+            url: 'system/setting',
             type: 'GET',
             data: {
                 list: JSON.stringify(keys),
@@ -103,7 +103,7 @@ var SystemConfigurationView = View.extend({
         }).done(_.bind(function (resp) {
             this.settings = resp;
             restRequest({
-                path: 'system/setting',
+                url: 'system/setting',
                 type: 'GET',
                 data: {
                     list: JSON.stringify(keys),

--- a/clients/web/src/views/body/UserAccountView.js
+++ b/clients/web/src/views/body/UserAccountView.js
@@ -168,7 +168,7 @@ var UserAccountView = View.extend({
 
     temporaryPassword: function (id, token) {
         restRequest({
-            url: 'user/password/temporary/' + id,
+            url: `user/password/temporary/${id}`,
             type: 'GET',
             data: {token: token},
             error: null

--- a/clients/web/src/views/body/UserAccountView.js
+++ b/clients/web/src/views/body/UserAccountView.js
@@ -169,7 +169,7 @@ var UserAccountView = View.extend({
     temporaryPassword: function (id, token) {
         restRequest({
             url: `user/password/temporary/${id}`,
-            type: 'GET',
+            method: 'GET',
             data: {token: token},
             error: null
         }).done(_.bind(function (resp) {

--- a/clients/web/src/views/body/UserAccountView.js
+++ b/clients/web/src/views/body/UserAccountView.js
@@ -168,7 +168,7 @@ var UserAccountView = View.extend({
 
     temporaryPassword: function (id, token) {
         restRequest({
-            path: 'user/password/temporary/' + id,
+            url: 'user/password/temporary/' + id,
             type: 'GET',
             data: {token: token},
             error: null

--- a/clients/web/src/views/layout/LoginView.js
+++ b/clients/web/src/views/layout/LoginView.js
@@ -44,7 +44,7 @@ var LoginView = View.extend({
             this.$('.g-validation-failed-message').html('');
             restRequest({
                 url: 'user/verification',
-                type: 'POST',
+                method: 'POST',
                 data: {login: this.$('#g-login').val()},
                 error: null
             }).done(_.bind(function (resp) {

--- a/clients/web/src/views/layout/LoginView.js
+++ b/clients/web/src/views/layout/LoginView.js
@@ -43,7 +43,7 @@ var LoginView = View.extend({
         'click .g-send-verification-email': function () {
             this.$('.g-validation-failed-message').html('');
             restRequest({
-                path: 'user/verification',
+                url: 'user/verification',
                 type: 'POST',
                 data: {login: this.$('#g-login').val()},
                 error: null

--- a/clients/web/src/views/layout/ResetPasswordView.js
+++ b/clients/web/src/views/layout/ResetPasswordView.js
@@ -22,7 +22,7 @@ var ResetPasswordView = View.extend({
                 data: {
                     email: this.$('#g-email').val().trim()
                 },
-                type: 'PUT',
+                method: 'PUT',
                 error: null // don't do default error behavior
             }).done(_.bind(function () {
                 this.$el.modal('hide');

--- a/clients/web/src/views/layout/ResetPasswordView.js
+++ b/clients/web/src/views/layout/ResetPasswordView.js
@@ -18,7 +18,7 @@ var ResetPasswordView = View.extend({
         'submit #g-reset-password-form': function (e) {
             e.preventDefault();
             restRequest({
-                path: 'user/password/temporary',
+                url: 'user/password/temporary',
                 data: {
                     email: this.$('#g-email').val().trim()
                 },

--- a/clients/web/src/views/widgets/AccessWidget.js
+++ b/clients/web/src/views/widgets/AccessWidget.js
@@ -75,7 +75,7 @@ var AccessWidget = View.extend({
         var flagListPromise = null;
         if (!this.noAccessFlag) {
             flagListPromise = restRequest({
-                path: 'system/access_flag'
+                url: 'system/access_flag'
             }).done((resp) => {
                 this.flagList = resp;
             });

--- a/clients/web/src/views/widgets/EditApiKeyWidget.js
+++ b/clients/web/src/views/widgets/EditApiKeyWidget.js
@@ -55,7 +55,7 @@ var EditApiKeyWidget = View.extend({
         this._shouldRender = false;
 
         restRequest({
-            path: 'token/scopes'
+            url: 'token/scopes'
         }).done(_.bind(function (resp) {
             this.scopeInfo = resp;
             if (this._shouldRender) {

--- a/clients/web/src/views/widgets/HierarchyWidget.js
+++ b/clients/web/src/views/widgets/HierarchyWidget.js
@@ -603,7 +603,7 @@ var HierarchyWidget = View.extend({
                  * method. */
                 restRequest({
                     url: 'resource',
-                    type: 'POST',
+                    method: 'POST',
                     data: {resources: resources, progress: true},
                     headers: {'X-HTTP-Method-Override': 'DELETE'}
                 }).done(() => {
@@ -848,7 +848,7 @@ var HierarchyWidget = View.extend({
         var nItems = (pickedResources.resources.item || []).length;
         restRequest({
             url: 'resource/move',
-            type: 'PUT',
+            method: 'PUT',
             data: {
                 resources: resources,
                 parentType: this.parentModel.resourceName,
@@ -871,7 +871,7 @@ var HierarchyWidget = View.extend({
         var nItems = (pickedResources.resources.item || []).length;
         restRequest({
             url: 'resource/copy',
-            type: 'POST',
+            method: 'POST',
             data: {
                 resources: resources,
                 parentType: this.parentModel.resourceName,

--- a/clients/web/src/views/widgets/HierarchyWidget.js
+++ b/clients/web/src/views/widgets/HierarchyWidget.js
@@ -602,7 +602,7 @@ var HierarchyWidget = View.extend({
                  * can't get it to work under jasmine/phantom), so override the
                  * method. */
                 restRequest({
-                    path: 'resource',
+                    url: 'resource',
                     type: 'POST',
                     data: {resources: resources, progress: true},
                     headers: {'X-HTTP-Method-Override': 'DELETE'}
@@ -847,7 +847,7 @@ var HierarchyWidget = View.extend({
         var nFolders = (pickedResources.resources.folder || []).length;
         var nItems = (pickedResources.resources.item || []).length;
         restRequest({
-            path: 'resource/move',
+            url: 'resource/move',
             type: 'PUT',
             data: {
                 resources: resources,
@@ -870,7 +870,7 @@ var HierarchyWidget = View.extend({
         var nFolders = (pickedResources.resources.folder || []).length;
         var nItems = (pickedResources.resources.item || []).length;
         restRequest({
-            path: 'resource/copy',
+            url: 'resource/copy',
             type: 'POST',
             data: {
                 resources: resources,

--- a/clients/web/src/views/widgets/SearchFieldWidget.js
+++ b/clients/web/src/views/widgets/SearchFieldWidget.js
@@ -195,7 +195,7 @@ var SearchFieldWidget = View.extend({
         this.pending = null;
 
         restRequest({
-            path: 'resource/search',
+            url: 'resource/search',
             data: {
                 q: q,
                 mode: this.currentMode,

--- a/clients/web/test/spec/adminSpec.js
+++ b/clients/web/test/spec/adminSpec.js
@@ -662,7 +662,7 @@ describe('Test the plugins page', function () {
         });
         waitsFor(function () {
             var resp = girder.rest.restRequest({
-                path: 'system/plugins',
+                url: 'system/plugins',
                 type: 'GET',
                 async: false
             });

--- a/clients/web/test/spec/adminSpec.js
+++ b/clients/web/test/spec/adminSpec.js
@@ -663,7 +663,7 @@ describe('Test the plugins page', function () {
         waitsFor(function () {
             var resp = girder.rest.restRequest({
                 url: 'system/plugins',
-                type: 'GET',
+                method: 'GET',
                 async: false
             });
             return (resp && resp.responseJSON && resp.responseJSON.enabled &&

--- a/clients/web/test/spec/browserSpec.js
+++ b/clients/web/test/spec/browserSpec.js
@@ -1,21 +1,13 @@
 describe('Test the hierarchy browser modal', function () {
     var testEl;
-    var requestArgs = [];
-    var requestContext = [];
     var returnVal;
-    var onRestRequest;
     var transition;
 
     beforeEach(function () {
         testEl = $('<div/>').appendTo('body');
         returnVal = null;
-        onRestRequest = null;
-        girder.rest.mockRestRequest(function () {
-            requestContext.push(this);
-            requestArgs.push(_.toArray(arguments));
-            if (onRestRequest) {
-                return onRestRequest.apply(this, arguments);
-            }
+
+        spyOn(girder.rest, 'restRequest').andCallFake(function () {
             return $.Deferred().resolve(returnVal).promise();
         });
         transition = $.support.transition;
@@ -24,7 +16,6 @@ describe('Test the hierarchy browser modal', function () {
     afterEach(function () {
         testEl.remove();
         girder.auth.logout();
-        girder.rest.unmockRestRequest();
         $.support.transition = transition;
     });
 
@@ -131,8 +122,8 @@ describe('Test the hierarchy browser modal', function () {
                     token: ''
                 }
             };
-            onRestRequest = function (params) {
-                if (params.path === '/user/authentication') {
+            girder.rest.restRequest.andCallFake(function (params) {
+                if (params.url === '/user/authentication') {
                     // The return value for the initial login call
                     return $.Deferred().resolve(user).promise();
                 }
@@ -140,7 +131,7 @@ describe('Test the hierarchy browser modal', function () {
                 // After login return an empty array for collection fetches
                 // on the RootSelector
                 return $.Deferred().resolve([]).promise();
-            };
+            });
 
             var view;
             runs(function () {

--- a/clients/web/test/spec/customWidgetsSpec.js
+++ b/clients/web/test/spec/customWidgetsSpec.js
@@ -430,7 +430,7 @@ describe('Test access widget with non-standard options', function () {
         runs(function () {
             // Register a couple access flags in the system
             xhr = girder.rest.restRequest({
-                path: 'webclienttest/access_flag',
+                url: 'webclienttest/access_flag',
                 type: 'POST',
                 contentType: 'application/json',
                 data: JSON.stringify({

--- a/clients/web/test/spec/customWidgetsSpec.js
+++ b/clients/web/test/spec/customWidgetsSpec.js
@@ -431,7 +431,7 @@ describe('Test access widget with non-standard options', function () {
             // Register a couple access flags in the system
             xhr = girder.rest.restRequest({
                 url: 'webclienttest/access_flag',
-                type: 'POST',
+                method: 'POST',
                 contentType: 'application/json',
                 data: JSON.stringify({
                     openFlag: {

--- a/clients/web/test/spec/dataSpec.js
+++ b/clients/web/test/spec/dataSpec.js
@@ -950,7 +950,7 @@ describe('Test FileModel static upload functions', function () {
 
         runs(function () {
             file = girder.rest.restRequest({
-                url: '/item/' + item.get('_id') + '/files',
+                url: '/item/' + item.id + '/files',
                 type: 'GET',
                 async: false
             });

--- a/clients/web/test/spec/dataSpec.js
+++ b/clients/web/test/spec/dataSpec.js
@@ -20,7 +20,7 @@ function _setMinimumChunkSize(minSize) {
     if (!minUploadSize) {
         minUploadSize = {UPLOAD_CHUNK_SIZE: girder.rest.getUploadChunkSize()};
         var resp = girder.rest.restRequest({
-            path: 'system/setting',
+            url: 'system/setting',
             type: 'GET',
             data: {key: 'core.upload_minimum_chunk_size'},
             async: false
@@ -36,7 +36,7 @@ function _setMinimumChunkSize(minSize) {
     }
     girder.rest.setUploadChunkSize(uploadChunkSize);
     girder.rest.restRequest({
-        path: 'system/setting',
+        url: 'system/setting',
         type: 'PUT',
         data: {key: 'core.upload_minimum_chunk_size', value: settingSize},
         async: false
@@ -889,7 +889,7 @@ describe('Test FileModel static upload functions', function () {
             var item;
 
             item = girder.rest.restRequest({
-                path: '/item',
+                url: '/item',
                 type: 'GET',
                 data: {
                     folderId: folder.get('_id'),
@@ -901,7 +901,7 @@ describe('Test FileModel static upload functions', function () {
             item = item && item.responseJSON && item.responseJSON[0];
 
             file = girder.rest.restRequest({
-                path: '/item/' + item._id + '/files',
+                url: '/item/' + item._id + '/files',
                 type: 'GET',
                 async: false
             });
@@ -910,7 +910,7 @@ describe('Test FileModel static upload functions', function () {
 
             if (file) {
                 var resp = girder.rest.restRequest({
-                    path: '/file/' + file._id + '/download',
+                    url: '/file/' + file._id + '/download',
                     type: 'GET',
                     dataType: 'text'
                 }).done(function () {
@@ -950,7 +950,7 @@ describe('Test FileModel static upload functions', function () {
 
         runs(function () {
             file = girder.rest.restRequest({
-                path: '/item/' + item.get('_id') + '/files',
+                url: '/item/' + item.get('_id') + '/files',
                 type: 'GET',
                 async: false
             });
@@ -959,7 +959,7 @@ describe('Test FileModel static upload functions', function () {
 
             if (file) {
                 var resp = girder.rest.restRequest({
-                    path: '/file/' + file._id + '/download',
+                    url: '/file/' + file._id + '/download',
                     type: 'GET',
                     dataType: 'text'
                 }).done(function () {

--- a/clients/web/test/spec/dataSpec.js
+++ b/clients/web/test/spec/dataSpec.js
@@ -21,7 +21,7 @@ function _setMinimumChunkSize(minSize) {
         minUploadSize = {UPLOAD_CHUNK_SIZE: girder.rest.getUploadChunkSize()};
         var resp = girder.rest.restRequest({
             url: 'system/setting',
-            type: 'GET',
+            method: 'GET',
             data: {key: 'core.upload_minimum_chunk_size'},
             async: false
         });
@@ -37,7 +37,7 @@ function _setMinimumChunkSize(minSize) {
     girder.rest.setUploadChunkSize(uploadChunkSize);
     girder.rest.restRequest({
         url: 'system/setting',
-        type: 'PUT',
+        method: 'PUT',
         data: {key: 'core.upload_minimum_chunk_size', value: settingSize},
         async: false
     });
@@ -890,7 +890,7 @@ describe('Test FileModel static upload functions', function () {
 
             item = girder.rest.restRequest({
                 url: '/item',
-                type: 'GET',
+                method: 'GET',
                 data: {
                     folderId: folder.get('_id'),
                     text: filename
@@ -902,7 +902,7 @@ describe('Test FileModel static upload functions', function () {
 
             file = girder.rest.restRequest({
                 url: '/item/' + item._id + '/files',
-                type: 'GET',
+                method: 'GET',
                 async: false
             });
 
@@ -911,7 +911,7 @@ describe('Test FileModel static upload functions', function () {
             if (file) {
                 var resp = girder.rest.restRequest({
                     url: '/file/' + file._id + '/download',
-                    type: 'GET',
+                    method: 'GET',
                     dataType: 'text'
                 }).done(function () {
                     text = resp.responseText;
@@ -951,7 +951,7 @@ describe('Test FileModel static upload functions', function () {
         runs(function () {
             file = girder.rest.restRequest({
                 url: '/item/' + item.id + '/files',
-                type: 'GET',
+                method: 'GET',
                 async: false
             });
 
@@ -960,7 +960,7 @@ describe('Test FileModel static upload functions', function () {
             if (file) {
                 var resp = girder.rest.restRequest({
                     url: '/file/' + file._id + '/download',
-                    type: 'GET',
+                    method: 'GET',
                     dataType: 'text'
                 }).done(function () {
                     text = resp.responseText;

--- a/clients/web/test/spec/groupSpec.js
+++ b/clients/web/test/spec/groupSpec.js
@@ -80,7 +80,7 @@ function _testDirectAdd(policy, curUser, curSetting) {
         runs(function () {
             girder.rest.restRequest({
                 url: 'system/setting',
-                type: 'PUT',
+                method: 'PUT',
                 data: {
                     key: 'core.add_to_group_policy',
                     value: policy.setting

--- a/clients/web/test/spec/groupSpec.js
+++ b/clients/web/test/spec/groupSpec.js
@@ -79,7 +79,7 @@ function _testDirectAdd(policy, curUser, curSetting) {
         }
         runs(function () {
             girder.rest.restRequest({
-                path: 'system/setting',
+                url: 'system/setting',
                 type: 'PUT',
                 data: {
                     key: 'core.add_to_group_policy',

--- a/clients/web/test/spec/itemSpec.js
+++ b/clients/web/test/spec/itemSpec.js
@@ -192,7 +192,7 @@ describe('Test item creation, editing, and deletion', function () {
             var id = window.location.hash.split('/')[1].split('?')[0];
             /* Create a link file */
             girder.rest.restRequest({
-                path: 'file',
+                url: 'file',
                 type: 'POST',
                 data: {
                     parentType: 'item',

--- a/clients/web/test/spec/itemSpec.js
+++ b/clients/web/test/spec/itemSpec.js
@@ -193,7 +193,7 @@ describe('Test item creation, editing, and deletion', function () {
             /* Create a link file */
             girder.rest.restRequest({
                 url: 'file',
-                type: 'POST',
+                method: 'POST',
                 data: {
                     parentType: 'item',
                     parentId: id,

--- a/clients/web/test/spec/widgetsSpec.js
+++ b/clients/web/test/spec/widgetsSpec.js
@@ -12,7 +12,7 @@ function _setProgress(test, duration, resourceId, resourceName) {
      *     is associated with.
      */
     girder.rest.restRequest({
-        path: 'webclienttest/progress',
+        url: 'webclienttest/progress',
         type: 'GET',
         data: {
             test: test,
@@ -131,7 +131,7 @@ describe('Test widgets that are not covered elsewhere', function () {
         runs(function () {
             girder.utilities.eventStream.settings._heartbeatTimeout = 5000;
             girder.rest.restRequest({
-                path: 'webclienttest/progress/stop',
+                url: 'webclienttest/progress/stop',
                 type: 'PUT',
                 async: false
             });

--- a/clients/web/test/spec/widgetsSpec.js
+++ b/clients/web/test/spec/widgetsSpec.js
@@ -13,7 +13,7 @@ function _setProgress(test, duration, resourceId, resourceName) {
      */
     girder.rest.restRequest({
         url: 'webclienttest/progress',
-        type: 'GET',
+        method: 'GET',
         data: {
             test: test,
             duration: duration,
@@ -132,7 +132,7 @@ describe('Test widgets that are not covered elsewhere', function () {
             girder.utilities.eventStream.settings._heartbeatTimeout = 5000;
             girder.rest.restRequest({
                 url: 'webclienttest/progress/stop',
-                type: 'PUT',
+                method: 'PUT',
                 async: false
             });
         });

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -1170,9 +1170,9 @@ girderTest.anonymousLoadPage = function (logoutFirst, fragment, hasLoginDialog, 
     var MAX_AJAX_LOG_SIZE = 20;
     var logIndex = 0;
     var ajaxCalls = [];
-    var backboneAjax = Backbone.ajax;
+    var backboneAjax = Backbone.$.ajax;
 
-    Backbone.ajax = function () {
+    Backbone.$.ajax = function () {
         var opts = {}, record;
 
         if (arguments.length === 1) {
@@ -1192,7 +1192,7 @@ girderTest.anonymousLoadPage = function (logoutFirst, fragment, hasLoginDialog, 
         ajaxCalls[logIndex] = record;
         logIndex = (logIndex + 1) % MAX_AJAX_LOG_SIZE;
 
-        return backboneAjax(opts).done(
+        return backboneAjax.call(Backbone.$, opts).done(
             function (data, textStatus) {
                 record.status = textStatus;
                 // this data structure has circular references that cannot be serialized.

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -762,7 +762,7 @@ girderTest.binaryUpload = function (path) {
         oldLen = $('.g-item-list-entry').length;
 
         girder.rest.restRequest({
-            path: 'webclienttest/file',
+            url: 'webclienttest/file',
             type: 'POST',
             data: {
                 path: path,

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -763,7 +763,7 @@ girderTest.binaryUpload = function (path) {
 
         girder.rest.restRequest({
             url: 'webclienttest/file',
-            type: 'POST',
+            method: 'POST',
             data: {
                 path: path,
                 folderId: folderId

--- a/docs/external-web-clients.rst
+++ b/docs/external-web-clients.rst
@@ -158,7 +158,7 @@ In your JavaScript, perform callbacks such as the following:
 
     $('#logout').click(function () {
         restRequest({
-            path: 'user/authentication',
+            url: 'user/authentication',
             type: 'DELETE'
         }).done(function () {
             setCurrentUser(null);
@@ -189,7 +189,7 @@ In your JavaScript, perform callbacks such as the following:
 
     // Check for who is logged in initially
     restRequest({
-        path: 'user/authentication',
+        url: 'user/authentication',
         error: null
     }).done(function (resp) {
         setCurrentUser(UserModel(resp.user));

--- a/plugins/authorized_upload/web_client/views/AuthorizeUploadView.js
+++ b/plugins/authorized_upload/web_client/views/AuthorizeUploadView.js
@@ -9,7 +9,7 @@ var AuthorizeUploadView = View.extend({
         'click .g-create-authorized-upload': function () {
             restRequest({
                 url: 'authorized_upload',
-                type: 'POST',
+                method: 'POST',
                 data: {
                     folderId: this.folder.id,
                     duration: this.$('.g-num-days').val() || 30

--- a/plugins/authorized_upload/web_client/views/AuthorizeUploadView.js
+++ b/plugins/authorized_upload/web_client/views/AuthorizeUploadView.js
@@ -8,7 +8,7 @@ var AuthorizeUploadView = View.extend({
     events: {
         'click .g-create-authorized-upload': function () {
             restRequest({
-                path: 'authorized_upload',
+                url: 'authorized_upload',
                 type: 'POST',
                 data: {
                     folderId: this.folder.id,

--- a/plugins/autojoin/web_client/views/ConfigView.js
+++ b/plugins/autojoin/web_client/views/ConfigView.js
@@ -60,7 +60,7 @@ var ConfigView = View.extend({
 
         restRequest({
             type: 'GET',
-            path: 'system/setting',
+            url: 'system/setting',
             data: {
                 list: JSON.stringify(['autojoin'])
             }
@@ -110,7 +110,7 @@ var ConfigView = View.extend({
     _saveSettings: function (settings) {
         restRequest({
             type: 'PUT',
-            path: 'system/setting',
+            url: 'system/setting',
             data: {
                 list: JSON.stringify(settings)
             },

--- a/plugins/autojoin/web_client/views/ConfigView.js
+++ b/plugins/autojoin/web_client/views/ConfigView.js
@@ -59,7 +59,7 @@ var ConfigView = View.extend({
         }, this).fetch();
 
         restRequest({
-            type: 'GET',
+            method: 'GET',
             url: 'system/setting',
             data: {
                 list: JSON.stringify(['autojoin'])
@@ -109,7 +109,7 @@ var ConfigView = View.extend({
 
     _saveSettings: function (settings) {
         restRequest({
-            type: 'PUT',
+            method: 'PUT',
             url: 'system/setting',
             data: {
                 list: JSON.stringify(settings)

--- a/plugins/celery_jobs/web_client/views/ConfigView.js
+++ b/plugins/celery_jobs/web_client/views/ConfigView.js
@@ -30,7 +30,7 @@ var ConfigView = View.extend({
     initialize: function () {
         restRequest({
             type: 'GET',
-            path: 'system/setting',
+            url: 'system/setting',
             data: {
                 list: JSON.stringify([
                     'celery_jobs.broker_url',
@@ -75,7 +75,7 @@ var ConfigView = View.extend({
     _saveSettings: function (settings) {
         restRequest({
             type: 'PUT',
-            path: 'system/setting',
+            url: 'system/setting',
             data: {
                 list: JSON.stringify(settings)
             },

--- a/plugins/celery_jobs/web_client/views/ConfigView.js
+++ b/plugins/celery_jobs/web_client/views/ConfigView.js
@@ -29,7 +29,7 @@ var ConfigView = View.extend({
     },
     initialize: function () {
         restRequest({
-            type: 'GET',
+            method: 'GET',
             url: 'system/setting',
             data: {
                 list: JSON.stringify([
@@ -74,7 +74,7 @@ var ConfigView = View.extend({
 
     _saveSettings: function (settings) {
         restRequest({
-            type: 'PUT',
+            method: 'PUT',
             url: 'system/setting',
             data: {
                 list: JSON.stringify(settings)

--- a/plugins/curation/web_client/views/CurationDialog.js
+++ b/plugins/curation/web_client/views/CurationDialog.js
@@ -62,7 +62,7 @@ var CurationDialog = View.extend({
         this.folder = this.parentView.parentModel;
         this.curation = {timeline: []};
         restRequest({
-            path: 'folder/' + this.folder.get('_id') + '/curation'
+            url: 'folder/' + this.folder.get('_id') + '/curation'
         }).done(_.bind(function (resp) {
             this.curation = resp;
             this.render();
@@ -108,7 +108,7 @@ var CurationDialog = View.extend({
     _save: function (successText, data) {
         restRequest({
             type: 'PUT',
-            path: 'folder/' + this.folder.get('_id') + '/curation',
+            url: 'folder/' + this.folder.get('_id') + '/curation',
             data: data
         }).done(_.bind(function (resp) {
             this.curation = resp;

--- a/plugins/curation/web_client/views/CurationDialog.js
+++ b/plugins/curation/web_client/views/CurationDialog.js
@@ -107,7 +107,7 @@ var CurationDialog = View.extend({
 
     _save: function (successText, data) {
         restRequest({
-            type: 'PUT',
+            method: 'PUT',
             url: `folder/${this.folder.id}/curation`,
             data: data
         }).done(_.bind(function (resp) {

--- a/plugins/curation/web_client/views/CurationDialog.js
+++ b/plugins/curation/web_client/views/CurationDialog.js
@@ -62,7 +62,7 @@ var CurationDialog = View.extend({
         this.folder = this.parentView.parentModel;
         this.curation = {timeline: []};
         restRequest({
-            url: 'folder/' + this.folder.get('_id') + '/curation'
+            url: `folder/${this.folder.id}/curation`
         }).done(_.bind(function (resp) {
             this.curation = resp;
             this.render();
@@ -108,7 +108,7 @@ var CurationDialog = View.extend({
     _save: function (successText, data) {
         restRequest({
             type: 'PUT',
-            url: 'folder/' + this.folder.get('_id') + '/curation',
+            url: `folder/${this.folder.id}/curation`,
             data: data
         }).done(_.bind(function (resp) {
             this.curation = resp;

--- a/plugins/curation/web_client/views/HierarchyWidget.js
+++ b/plugins/curation/web_client/views/HierarchyWidget.js
@@ -24,7 +24,7 @@ wrap(HierarchyWidget, 'render', function (render) {
             _addCurationButton();
         } else {
             restRequest({
-                path: 'folder/' + this.parentModel.get('_id') + '/curation'
+                url: 'folder/' + this.parentModel.get('_id') + '/curation'
             }).done(_.bind(function (resp) {
                 if (resp.enabled) {
                     _addCurationButton();

--- a/plugins/curation/web_client/views/HierarchyWidget.js
+++ b/plugins/curation/web_client/views/HierarchyWidget.js
@@ -24,7 +24,7 @@ wrap(HierarchyWidget, 'render', function (render) {
             _addCurationButton();
         } else {
             restRequest({
-                url: 'folder/' + this.parentModel.get('_id') + '/curation'
+                url: `folder/${this.parentModel.id}/curation`
             }).done(_.bind(function (resp) {
                 if (resp.enabled) {
                     _addCurationButton();

--- a/plugins/dicom_viewer/web_client/views/DicomView.js
+++ b/plugins/dicom_viewer/web_client/views/DicomView.js
@@ -132,7 +132,7 @@ var DicomView = View.extend({
 
     loadFileList: function () {
         restRequest({
-            path: '/item/' + this.item.get('_id') + '/dicom',
+            url: '/item/' + this.item.get('_id') + '/dicom',
             data: {
                 // don't need the dicom tags, just want the sorted results
                 filters: 'dummy'

--- a/plugins/dicom_viewer/web_client/views/DicomView.js
+++ b/plugins/dicom_viewer/web_client/views/DicomView.js
@@ -132,7 +132,7 @@ var DicomView = View.extend({
 
     loadFileList: function () {
         restRequest({
-            url: '/item/' + this.item.get('_id') + '/dicom',
+            url: `item/${this.item.id}/dicom`,
             data: {
                 // don't need the dicom tags, just want the sorted results
                 filters: 'dummy'

--- a/plugins/geospatial/web_client/models/ItemModel.js
+++ b/plugins/geospatial/web_client/models/ItemModel.js
@@ -7,7 +7,7 @@ import { wrap } from 'girder/utilities/PluginUtils';
 wrap(ItemModel, 'fetch', function (fetch) {
     fetch.call(this);
     restRequest({
-        path: this.resourceName + '/' + this.get('_id') + '/geospatial',
+        url: this.resourceName + '/' + this.get('_id') + '/geospatial',
         error: null
     }).done(_.bind(function (resp) {
         this.set(resp);

--- a/plugins/geospatial/web_client/models/ItemModel.js
+++ b/plugins/geospatial/web_client/models/ItemModel.js
@@ -7,7 +7,7 @@ import { wrap } from 'girder/utilities/PluginUtils';
 wrap(ItemModel, 'fetch', function (fetch) {
     fetch.call(this);
     restRequest({
-        url: this.resourceName + '/' + this.get('_id') + '/geospatial',
+        url: `${this.resourceName}/${this.id}/geospatial`,
         error: null
     }).done(_.bind(function (resp) {
         this.set(resp);

--- a/plugins/google_analytics/web_client/main.js
+++ b/plugins/google_analytics/web_client/main.js
@@ -15,7 +15,7 @@ events.on('g:appload.after', function () {
     /*eslint-enable */
 
     restRequest({
-        type: 'GET',
+        method: 'GET',
         url: 'google_analytics/id'
     }).done(_.bind(function (resp) {
         if (resp.google_analytics_id) {

--- a/plugins/google_analytics/web_client/main.js
+++ b/plugins/google_analytics/web_client/main.js
@@ -16,7 +16,7 @@ events.on('g:appload.after', function () {
 
     restRequest({
         type: 'GET',
-        path: 'google_analytics/id'
+        url: 'google_analytics/id'
     }).done(_.bind(function (resp) {
         if (resp.google_analytics_id) {
             ga('create', resp.google_analytics_id, 'none');

--- a/plugins/google_analytics/web_client/views/ConfigView.js
+++ b/plugins/google_analytics/web_client/views/ConfigView.js
@@ -23,7 +23,7 @@ var ConfigView = View.extend({
     initialize: function () {
         restRequest({
             type: 'GET',
-            path: 'system/setting',
+            url: 'system/setting',
             data: {
                 list: JSON.stringify(['google_analytics.tracking_id'])
             }
@@ -52,7 +52,7 @@ var ConfigView = View.extend({
     _saveSettings: function (settings) {
         restRequest({
             type: 'PUT',
-            path: 'system/setting',
+            url: 'system/setting',
             data: {
                 list: JSON.stringify(settings)
             },

--- a/plugins/google_analytics/web_client/views/ConfigView.js
+++ b/plugins/google_analytics/web_client/views/ConfigView.js
@@ -22,7 +22,7 @@ var ConfigView = View.extend({
     },
     initialize: function () {
         restRequest({
-            type: 'GET',
+            method: 'GET',
             url: 'system/setting',
             data: {
                 list: JSON.stringify(['google_analytics.tracking_id'])
@@ -51,7 +51,7 @@ var ConfigView = View.extend({
 
     _saveSettings: function (settings) {
         restRequest({
-            type: 'PUT',
+            method: 'PUT',
             url: 'system/setting',
             data: {
                 list: JSON.stringify(settings)

--- a/plugins/gravatar/web_client/views/ConfigView.js
+++ b/plugins/gravatar/web_client/views/ConfigView.js
@@ -23,7 +23,7 @@ var ConfigView = View.extend({
     initialize: function () {
         restRequest({
             type: 'GET',
-            path: 'system/setting',
+            url: 'system/setting',
             data: {
                 list: JSON.stringify(['gravatar.default_image'])
             }
@@ -52,7 +52,7 @@ var ConfigView = View.extend({
     _saveSettings: function (settings) {
         restRequest({
             type: 'PUT',
-            path: 'system/setting',
+            url: 'system/setting',
             data: {
                 list: JSON.stringify(settings)
             },

--- a/plugins/gravatar/web_client/views/ConfigView.js
+++ b/plugins/gravatar/web_client/views/ConfigView.js
@@ -22,7 +22,7 @@ var ConfigView = View.extend({
 
     initialize: function () {
         restRequest({
-            type: 'GET',
+            method: 'GET',
             url: 'system/setting',
             data: {
                 list: JSON.stringify(['gravatar.default_image'])
@@ -51,7 +51,7 @@ var ConfigView = View.extend({
 
     _saveSettings: function (settings) {
         restRequest({
-            type: 'PUT',
+            method: 'PUT',
             url: 'system/setting',
             data: {
                 list: JSON.stringify(settings)

--- a/plugins/hashsum_download/web_client/views/ConfigView.js
+++ b/plugins/hashsum_download/web_client/views/ConfigView.js
@@ -26,7 +26,7 @@ var ConfigView = View.extend({
 
         restRequest({
             type: 'GET',
-            path: 'system/setting',
+            url: 'system/setting',
             data: {
                 list: JSON.stringify([
                     'hashsum_download.auto_compute'
@@ -49,7 +49,7 @@ var ConfigView = View.extend({
     _saveSettings: function (settings) {
         restRequest({
             type: 'PUT',
-            path: 'system/setting',
+            url: 'system/setting',
             data: {
                 list: JSON.stringify(settings)
             },

--- a/plugins/hashsum_download/web_client/views/ConfigView.js
+++ b/plugins/hashsum_download/web_client/views/ConfigView.js
@@ -25,7 +25,7 @@ var ConfigView = View.extend({
         });
 
         restRequest({
-            type: 'GET',
+            method: 'GET',
             url: 'system/setting',
             data: {
                 list: JSON.stringify([
@@ -48,7 +48,7 @@ var ConfigView = View.extend({
 
     _saveSettings: function (settings) {
         restRequest({
-            type: 'PUT',
+            method: 'PUT',
             url: 'system/setting',
             data: {
                 list: JSON.stringify(settings)

--- a/plugins/hashsum_download/web_client/views/FileInfoWidget.js
+++ b/plugins/hashsum_download/web_client/views/FileInfoWidget.js
@@ -31,7 +31,7 @@ if (!FileInfoWidget.prototype.events) {
 }
 FileInfoWidget.prototype.events['click .g-hashsum-compute'] = function () {
     restRequest({
-        path: `file/${this.model.id}/hashsum`,
+        url: `file/${this.model.id}/hashsum`,
         type: 'POST',
         data: {
             'progress': true

--- a/plugins/hashsum_download/web_client/views/FileInfoWidget.js
+++ b/plugins/hashsum_download/web_client/views/FileInfoWidget.js
@@ -32,7 +32,7 @@ if (!FileInfoWidget.prototype.events) {
 FileInfoWidget.prototype.events['click .g-hashsum-compute'] = function () {
     restRequest({
         url: `file/${this.model.id}/hashsum`,
-        type: 'POST',
+        method: 'POST',
         data: {
             'progress': true
         }

--- a/plugins/hdfs_assetstore/web_client/models/AssetstoreModel.js
+++ b/plugins/hdfs_assetstore/web_client/models/AssetstoreModel.js
@@ -8,7 +8,7 @@ import { restRequest } from 'girder/rest';
  */
 AssetstoreModel.hdfsImport = function (params) {
     restRequest({
-        path: 'hdfs_assetstore/' + this.get('_id') + '/import',
+        url: 'hdfs_assetstore/' + this.get('_id') + '/import',
         type: 'PUT',
         data: params,
         error: null

--- a/plugins/hdfs_assetstore/web_client/models/AssetstoreModel.js
+++ b/plugins/hdfs_assetstore/web_client/models/AssetstoreModel.js
@@ -8,7 +8,7 @@ import { restRequest } from 'girder/rest';
  */
 AssetstoreModel.hdfsImport = function (params) {
     restRequest({
-        url: 'hdfs_assetstore/' + this.get('_id') + '/import',
+        url: `hdfs_assetstore/${this.id}/import`,
         type: 'PUT',
         data: params,
         error: null

--- a/plugins/hdfs_assetstore/web_client/models/AssetstoreModel.js
+++ b/plugins/hdfs_assetstore/web_client/models/AssetstoreModel.js
@@ -9,7 +9,7 @@ import { restRequest } from 'girder/rest';
 AssetstoreModel.hdfsImport = function (params) {
     restRequest({
         url: `hdfs_assetstore/${this.id}/import`,
-        type: 'PUT',
+        method: 'PUT',
         data: params,
         error: null
     }).done(_.bind(function () {

--- a/plugins/homepage/web_client/views/ConfigView.js
+++ b/plugins/homepage/web_client/views/ConfigView.js
@@ -24,7 +24,7 @@ var ConfigView = View.extend({
     initialize: function () {
         restRequest({
             type: 'GET',
-            path: 'homepage/markdown'
+            url: 'homepage/markdown'
         }).done(_.bind(function (resp) {
             this.folder = new FolderModel({_id: resp.folderId});
             this.editor = new MarkdownWidget({
@@ -61,7 +61,7 @@ var ConfigView = View.extend({
     _saveSettings: function (settings) {
         restRequest({
             type: 'PUT',
-            path: 'system/setting',
+            url: 'system/setting',
             data: {
                 list: JSON.stringify(settings)
             },

--- a/plugins/homepage/web_client/views/ConfigView.js
+++ b/plugins/homepage/web_client/views/ConfigView.js
@@ -23,7 +23,7 @@ var ConfigView = View.extend({
 
     initialize: function () {
         restRequest({
-            type: 'GET',
+            method: 'GET',
             url: 'homepage/markdown'
         }).done(_.bind(function (resp) {
             this.folder = new FolderModel({_id: resp.folderId});
@@ -60,7 +60,7 @@ var ConfigView = View.extend({
 
     _saveSettings: function (settings) {
         restRequest({
-            type: 'PUT',
+            method: 'PUT',
             url: 'system/setting',
             data: {
                 list: JSON.stringify(settings)

--- a/plugins/homepage/web_client/views/FrontPageView.js
+++ b/plugins/homepage/web_client/views/FrontPageView.js
@@ -8,7 +8,7 @@ import { wrap } from 'girder/utilities/PluginUtils';
 wrap(FrontPageView, 'render', function (render) {
     restRequest({
         type: 'GET',
-        path: 'homepage/markdown'
+        url: 'homepage/markdown'
     }).done(_.bind(function (resp) {
         this.$el.html(renderMarkdown(resp['homepage.markdown']));
     }, this));

--- a/plugins/homepage/web_client/views/FrontPageView.js
+++ b/plugins/homepage/web_client/views/FrontPageView.js
@@ -7,7 +7,7 @@ import { wrap } from 'girder/utilities/PluginUtils';
 
 wrap(FrontPageView, 'render', function (render) {
     restRequest({
-        type: 'GET',
+        method: 'GET',
         url: 'homepage/markdown'
     }).done(_.bind(function (resp) {
         this.$el.html(renderMarkdown(resp['homepage.markdown']));

--- a/plugins/item_licenses/web_client/views/ConfigView.js
+++ b/plugins/item_licenses/web_client/views/ConfigView.js
@@ -25,7 +25,7 @@ var ConfigView = View.extend({
 
             restRequest({
                 type: 'GET',
-                path: 'item/licenses',
+                url: 'item/licenses',
                 data: {
                     'default': true
                 }
@@ -39,7 +39,7 @@ var ConfigView = View.extend({
     initialize: function () {
         restRequest({
             type: 'GET',
-            path: 'system/setting',
+            url: 'system/setting',
             data: {
                 list: JSON.stringify(['item_licenses.licenses'])
             }
@@ -66,7 +66,7 @@ var ConfigView = View.extend({
     _saveSettings: function (settings) {
         restRequest({
             type: 'PUT',
-            path: 'system/setting',
+            url: 'system/setting',
             data: {
                 list: JSON.stringify(settings)
             },

--- a/plugins/item_licenses/web_client/views/ConfigView.js
+++ b/plugins/item_licenses/web_client/views/ConfigView.js
@@ -24,7 +24,7 @@ var ConfigView = View.extend({
             event.preventDefault();
 
             restRequest({
-                type: 'GET',
+                method: 'GET',
                 url: 'item/licenses',
                 data: {
                     'default': true
@@ -38,7 +38,7 @@ var ConfigView = View.extend({
 
     initialize: function () {
         restRequest({
-            type: 'GET',
+            method: 'GET',
             url: 'system/setting',
             data: {
                 list: JSON.stringify(['item_licenses.licenses'])
@@ -65,7 +65,7 @@ var ConfigView = View.extend({
 
     _saveSettings: function (settings) {
         restRequest({
-            type: 'PUT',
+            method: 'PUT',
             url: 'system/setting',
             data: {
                 list: JSON.stringify(settings)

--- a/plugins/item_licenses/web_client/views/HierarchyWidget.js
+++ b/plugins/item_licenses/web_client/views/HierarchyWidget.js
@@ -9,7 +9,7 @@ import { wrap } from 'girder/utilities/PluginUtils';
  */
 wrap(HierarchyWidget, 'uploadDialog', function (uploadDialog) {
     restRequest({
-        type: 'GET',
+        method: 'GET',
         url: 'item/licenses'
     }).done(_.bind(function (resp) {
         this.licenses = resp;
@@ -24,7 +24,7 @@ wrap(HierarchyWidget, 'uploadDialog', function (uploadDialog) {
  */
 wrap(HierarchyWidget, 'createItemDialog', function (createItemDialog) {
     restRequest({
-        type: 'GET',
+        method: 'GET',
         url: 'item/licenses'
     }).done(_.bind(function (resp) {
         this.licenses = resp;

--- a/plugins/item_licenses/web_client/views/HierarchyWidget.js
+++ b/plugins/item_licenses/web_client/views/HierarchyWidget.js
@@ -10,7 +10,7 @@ import { wrap } from 'girder/utilities/PluginUtils';
 wrap(HierarchyWidget, 'uploadDialog', function (uploadDialog) {
     restRequest({
         type: 'GET',
-        path: 'item/licenses'
+        url: 'item/licenses'
     }).done(_.bind(function (resp) {
         this.licenses = resp;
         uploadDialog.call(this);
@@ -25,7 +25,7 @@ wrap(HierarchyWidget, 'uploadDialog', function (uploadDialog) {
 wrap(HierarchyWidget, 'createItemDialog', function (createItemDialog) {
     restRequest({
         type: 'GET',
-        path: 'item/licenses'
+        url: 'item/licenses'
     }).done(_.bind(function (resp) {
         this.licenses = resp;
         createItemDialog.call(this);

--- a/plugins/item_licenses/web_client/views/ItemView.js
+++ b/plugins/item_licenses/web_client/views/ItemView.js
@@ -33,7 +33,7 @@ wrap(ItemView, 'render', function (render) {
 wrap(ItemView, 'editItem', function (editItem) {
     restRequest({
         type: 'GET',
-        path: 'item/licenses'
+        url: 'item/licenses'
     }).done(_.bind(function (resp) {
         this.licenses = resp;
         editItem.call(this);

--- a/plugins/item_licenses/web_client/views/ItemView.js
+++ b/plugins/item_licenses/web_client/views/ItemView.js
@@ -32,7 +32,7 @@ wrap(ItemView, 'render', function (render) {
  */
 wrap(ItemView, 'editItem', function (editItem) {
     restRequest({
-        type: 'GET',
+        method: 'GET',
         url: 'item/licenses'
     }).done(_.bind(function (resp) {
         this.licenses = resp;

--- a/plugins/item_previews/web_client/views/ItemPreviewWidget.js
+++ b/plugins/item_previews/web_client/views/ItemPreviewWidget.js
@@ -76,7 +76,7 @@ var ItemPreviewWidget = View.extend({
 
             // Ajax request the JSON files to display them.
             restRequest({
-                url: 'item/' + id + '/download',
+                url: `item/${id}/download`,
                 type: 'GET',
                 error: null // don't do default error behavior (validation may fail)
             }).done((resp) => {

--- a/plugins/item_previews/web_client/views/ItemPreviewWidget.js
+++ b/plugins/item_previews/web_client/views/ItemPreviewWidget.js
@@ -76,7 +76,7 @@ var ItemPreviewWidget = View.extend({
 
             // Ajax request the JSON files to display them.
             restRequest({
-                path: 'item/' + id + '/download',
+                url: 'item/' + id + '/download',
                 type: 'GET',
                 error: null // don't do default error behavior (validation may fail)
             }).done((resp) => {

--- a/plugins/item_previews/web_client/views/ItemPreviewWidget.js
+++ b/plugins/item_previews/web_client/views/ItemPreviewWidget.js
@@ -77,7 +77,7 @@ var ItemPreviewWidget = View.extend({
             // Ajax request the JSON files to display them.
             restRequest({
                 url: `item/${id}/download`,
-                type: 'GET',
+                method: 'GET',
                 error: null // don't do default error behavior (validation may fail)
             }).done((resp) => {
                 this.$('.json[data-id="' + id + '"]').text(JSON.stringify(resp, null, '\t'));

--- a/plugins/item_tasks/web_client/views/ConfigureTasksDialog.js
+++ b/plugins/item_tasks/web_client/views/ConfigureTasksDialog.js
@@ -92,7 +92,7 @@ var ConfigureTasksDialog = View.extend({
 
         restRequest({
             url: `${this.resourceName}/${this.model.id}/item_task_json_description`,
-            type: 'POST',
+            method: 'POST',
             data,
             error: null
         }).done((job) => {
@@ -126,7 +126,7 @@ var ConfigureTasksDialog = View.extend({
 
         restRequest({
             url: `${this.resourceName}/${this.model.id}/item_task_slicer_cli_description`,
-            type: 'POST',
+            method: 'POST',
             data,
             error: null
         }).done((job) => {

--- a/plugins/item_tasks/web_client/views/ConfigureTasksDialog.js
+++ b/plugins/item_tasks/web_client/views/ConfigureTasksDialog.js
@@ -91,7 +91,7 @@ var ConfigureTasksDialog = View.extend({
         }
 
         restRequest({
-            path: `${this.resourceName}/${this.model.id}/item_task_json_description`,
+            url: `${this.resourceName}/${this.model.id}/item_task_json_description`,
             type: 'POST',
             data,
             error: null
@@ -125,7 +125,7 @@ var ConfigureTasksDialog = View.extend({
         }
 
         restRequest({
-            path: `${this.resourceName}/${this.model.id}/item_task_slicer_cli_description`,
+            url: `${this.resourceName}/${this.model.id}/item_task_slicer_cli_description`,
             type: 'POST',
             data,
             error: null

--- a/plugins/item_tasks/web_client/views/TaskRunView.js
+++ b/plugins/item_tasks/web_client/views/TaskRunView.js
@@ -182,7 +182,7 @@ const TaskRunView = View.extend({
 
         restRequest({
             url: `item_task/${this.model.id}/execution`,
-            type: 'POST',
+            method: 'POST',
             data: {
                 inputs: JSON.stringify(inputs),
                 outputs: JSON.stringify(outputs)

--- a/plugins/item_tasks/web_client/views/TaskRunView.js
+++ b/plugins/item_tasks/web_client/views/TaskRunView.js
@@ -181,7 +181,7 @@ const TaskRunView = View.extend({
         });
 
         restRequest({
-            path: `item_task/${this.model.id}/execution`,
+            url: `item_task/${this.model.id}/execution`,
             type: 'POST',
             data: {
                 inputs: JSON.stringify(inputs),

--- a/plugins/jobs/web_client/views/JobDetailsWidget.js
+++ b/plugins/jobs/web_client/views/JobDetailsWidget.js
@@ -133,7 +133,7 @@ var JobDetailsWidget = View.extend({
         const jobId = this.job.id;
         restRequest({
             url: `job/${jobId}/cancel`,
-            type: 'PUT',
+            method: 'PUT',
             error: null
         }).done(_.bind(function () {
             events.trigger('g:alert', {

--- a/plugins/jobs/web_client/views/JobDetailsWidget.js
+++ b/plugins/jobs/web_client/views/JobDetailsWidget.js
@@ -132,7 +132,7 @@ var JobDetailsWidget = View.extend({
     _cancelJob: function () {
         const jobId = this.job.id;
         restRequest({
-            path: `job/${jobId}/cancel`,
+            url: `job/${jobId}/cancel`,
             type: 'PUT',
             error: null
         }).done(_.bind(function () {

--- a/plugins/jobs/web_client/views/JobListWidget.js
+++ b/plugins/jobs/web_client/views/JobListWidget.js
@@ -316,7 +316,7 @@ var JobListWidget = View.extend({
                 })
                 .map((jobId) => restRequest({
                     url: `job/${jobId}/cancel`,
-                    type: 'PUT',
+                    method: 'PUT',
                     error: null
                 }))
         ).done((results) => {

--- a/plugins/jobs/web_client/views/JobListWidget.js
+++ b/plugins/jobs/web_client/views/JobListWidget.js
@@ -144,7 +144,7 @@ var JobListWidget = View.extend({
         });
 
         restRequest({
-            path: this.showAllJobs ? 'job/typeandstatus/all' : 'job/typeandstatus',
+            url: this.showAllJobs ? 'job/typeandstatus/all' : 'job/typeandstatus',
             method: 'GET'
         }).done((result) => {
             var typesFilter = result.types.reduce((obj, type) => {
@@ -315,7 +315,7 @@ var JobListWidget = View.extend({
                     return JobStatus.isCancelable(jobModel);
                 })
                 .map((jobId) => restRequest({
-                    path: `job/${jobId}/cancel`,
+                    url: `job/${jobId}/cancel`,
                     type: 'PUT',
                     error: null
                 }))

--- a/plugins/ldap/web_client/views/ConfigView.js
+++ b/plugins/ldap/web_client/views/ConfigView.js
@@ -43,7 +43,7 @@ var ConfigView = View.extend({
 
             restRequest({
                 url: 'system/ldap_server/status',
-                type: 'GET',
+                method: 'GET',
                 data: {
                     uri,
                     bindName,
@@ -67,7 +67,7 @@ var ConfigView = View.extend({
 
     initialize: function () {
         restRequest({
-            type: 'GET',
+            method: 'GET',
             url: 'system/setting',
             data: {
                 key: 'ldap.servers'
@@ -108,7 +108,7 @@ var ConfigView = View.extend({
         this.$('.g-validation-failed-message').empty();
 
         restRequest({
-            type: 'PUT',
+            method: 'PUT',
             url: 'system/setting',
             data: {
                 key: 'ldap.servers',

--- a/plugins/ldap/web_client/views/ConfigView.js
+++ b/plugins/ldap/web_client/views/ConfigView.js
@@ -42,7 +42,7 @@ var ConfigView = View.extend({
             const password = this.$(`#g-ldap-server-${idx}-password`).val();
 
             restRequest({
-                path: 'system/ldap_server/status',
+                url: 'system/ldap_server/status',
                 type: 'GET',
                 data: {
                     uri,
@@ -68,7 +68,7 @@ var ConfigView = View.extend({
     initialize: function () {
         restRequest({
             type: 'GET',
-            path: 'system/setting',
+            url: 'system/setting',
             data: {
                 key: 'ldap.servers'
             }
@@ -109,7 +109,7 @@ var ConfigView = View.extend({
 
         restRequest({
             type: 'PUT',
-            path: 'system/setting',
+            url: 'system/setting',
             data: {
                 key: 'ldap.servers',
                 value: JSON.stringify(servers)

--- a/plugins/oauth/web_client/views/ConfigView.js
+++ b/plugins/oauth/web_client/views/ConfigView.js
@@ -28,7 +28,7 @@ var ConfigView = View.extend({
         'change .g-ignore-registration-policy': function (event) {
             restRequest({
                 type: 'PUT',
-                path: 'system/setting',
+                url: 'system/setting',
                 data: {
                     key: 'oauth.ignore_registration_policy',
                     value: $(event.target).is(':checked')
@@ -106,7 +106,7 @@ var ConfigView = View.extend({
 
         restRequest({
             type: 'GET',
-            path: 'system/setting',
+            url: 'system/setting',
             data: {
                 list: JSON.stringify(settingKeys)
             }
@@ -163,7 +163,7 @@ var ConfigView = View.extend({
 
         restRequest({
             type: 'PUT',
-            path: 'system/setting',
+            url: 'system/setting',
             data: {
                 list: JSON.stringify(settings)
             },

--- a/plugins/oauth/web_client/views/ConfigView.js
+++ b/plugins/oauth/web_client/views/ConfigView.js
@@ -27,7 +27,7 @@ var ConfigView = View.extend({
 
         'change .g-ignore-registration-policy': function (event) {
             restRequest({
-                type: 'PUT',
+                method: 'PUT',
                 url: 'system/setting',
                 data: {
                     key: 'oauth.ignore_registration_policy',
@@ -105,7 +105,7 @@ var ConfigView = View.extend({
         }, this);
 
         restRequest({
-            type: 'GET',
+            method: 'GET',
             url: 'system/setting',
             data: {
                 list: JSON.stringify(settingKeys)
@@ -162,7 +162,7 @@ var ConfigView = View.extend({
         });
 
         restRequest({
-            type: 'PUT',
+            method: 'PUT',
             url: 'system/setting',
             data: {
                 list: JSON.stringify(settings)

--- a/plugins/oauth/web_client/views/OAuthLoginView.js
+++ b/plugins/oauth/web_client/views/OAuthLoginView.js
@@ -23,7 +23,7 @@ var OAuthLoginView = View.extend({
         this.providers = null;
 
         restRequest({
-            path: 'oauth/provider',
+            url: 'oauth/provider',
             data: {
                 redirect: redirect,
                 list: true

--- a/plugins/provenance/plugin_tests/provenanceSpec.js
+++ b/plugins/provenance/plugin_tests/provenanceSpec.js
@@ -37,7 +37,7 @@ describe('test the provenance plugin', function () {
         waitsFor(function () {
             var resp = girder.rest.restRequest({
                 url: 'system/setting',
-                type: 'GET',
+                method: 'GET',
                 data: {key: 'provenance.resources'},
                 async: false
             });

--- a/plugins/provenance/plugin_tests/provenanceSpec.js
+++ b/plugins/provenance/plugin_tests/provenanceSpec.js
@@ -36,7 +36,7 @@ describe('test the provenance plugin', function () {
         });
         waitsFor(function () {
             var resp = girder.rest.restRequest({
-                path: 'system/setting',
+                url: 'system/setting',
                 type: 'GET',
                 data: {key: 'provenance.resources'},
                 async: false

--- a/plugins/provenance/web_client/views/ConfigView.js
+++ b/plugins/provenance/web_client/views/ConfigView.js
@@ -21,7 +21,7 @@ var ConfigView = View.extend({
     },
     initialize: function () {
         restRequest({
-            type: 'GET',
+            method: 'GET',
             url: 'system/setting',
             data: {
                 list: JSON.stringify(['provenance.resources'])
@@ -50,7 +50,7 @@ var ConfigView = View.extend({
 
     _saveSettings: function (settings) {
         restRequest({
-            type: 'PUT',
+            method: 'PUT',
             url: 'system/setting',
             data: {
                 list: JSON.stringify(settings)

--- a/plugins/provenance/web_client/views/ConfigView.js
+++ b/plugins/provenance/web_client/views/ConfigView.js
@@ -22,7 +22,7 @@ var ConfigView = View.extend({
     initialize: function () {
         restRequest({
             type: 'GET',
-            path: 'system/setting',
+            url: 'system/setting',
             data: {
                 list: JSON.stringify(['provenance.resources'])
             }
@@ -51,7 +51,7 @@ var ConfigView = View.extend({
     _saveSettings: function (settings) {
         restRequest({
             type: 'PUT',
-            path: 'system/setting',
+            url: 'system/setting',
             data: {
                 list: JSON.stringify(settings)
             },

--- a/plugins/user_quota/plugin_tests/userQuotaSpec.js
+++ b/plugins/user_quota/plugin_tests/userQuotaSpec.js
@@ -216,7 +216,7 @@ describe('test the user quota plugin', function () {
         waitsFor(function () {
             var resp = girder.rest.restRequest({
                 url: 'system/setting',
-                type: 'GET',
+                method: 'GET',
                 data: {key: 'user_quota.default_user_quota'},
                 async: false
             });
@@ -375,7 +375,7 @@ describe('test the user quota plugin', function () {
         waitsFor(function () {
             var resp = girder.rest.restRequest({
                 url: 'system/setting',
-                type: 'GET',
+                method: 'GET',
                 data: {key: 'user_quota.default_collection_quota'},
                 async: false
             });

--- a/plugins/user_quota/plugin_tests/userQuotaSpec.js
+++ b/plugins/user_quota/plugin_tests/userQuotaSpec.js
@@ -215,7 +215,7 @@ describe('test the user quota plugin', function () {
         });
         waitsFor(function () {
             var resp = girder.rest.restRequest({
-                path: 'system/setting',
+                url: 'system/setting',
                 type: 'GET',
                 data: {key: 'user_quota.default_user_quota'},
                 async: false
@@ -374,7 +374,7 @@ describe('test the user quota plugin', function () {
         });
         waitsFor(function () {
             var resp = girder.rest.restRequest({
-                path: 'system/setting',
+                url: 'system/setting',
                 type: 'GET',
                 data: {key: 'user_quota.default_collection_quota'},
                 async: false

--- a/plugins/user_quota/web_client/models/extendModel.js
+++ b/plugins/user_quota/web_client/models/extendModel.js
@@ -12,7 +12,7 @@ function extendModel(Model, modelType) {
      */
     Model.prototype.updateQuotaPolicy = function () {
         restRequest({
-            url: this.resourceName + '/' + this.get('_id') + '/quota',
+            url: `${this.resourceName}/${this.id}/quota`,
             type: 'PUT',
             error: null,
             data: {
@@ -39,7 +39,7 @@ function extendModel(Model, modelType) {
         });
         if (!this.get('quotaPolicy') || force) {
             restRequest({
-                url: this.resourceName + '/' + this.get('_id') + '/quota',
+                url: `${this.resourceName}/${this.id}/quota`,
                 type: 'GET'
             }).done(_.bind(function (resp) {
                 this.set('quotaPolicy', resp.quota);

--- a/plugins/user_quota/web_client/models/extendModel.js
+++ b/plugins/user_quota/web_client/models/extendModel.js
@@ -13,7 +13,7 @@ function extendModel(Model, modelType) {
     Model.prototype.updateQuotaPolicy = function () {
         restRequest({
             url: `${this.resourceName}/${this.id}/quota`,
-            type: 'PUT',
+            method: 'PUT',
             error: null,
             data: {
                 policy: JSON.stringify(this.get('quotaPolicy'))
@@ -40,7 +40,7 @@ function extendModel(Model, modelType) {
         if (!this.get('quotaPolicy') || force) {
             restRequest({
                 url: `${this.resourceName}/${this.id}/quota`,
-                type: 'GET'
+                method: 'GET'
             }).done(_.bind(function (resp) {
                 this.set('quotaPolicy', resp.quota);
                 this.fetch();
@@ -86,7 +86,7 @@ function extendModel(Model, modelType) {
                 (!this.get('defaultQuota') || force)) {
             restRequest({
                 url: 'system/setting',
-                type: 'GET',
+                method: 'GET',
                 data: {
                     key: 'user_quota.default_' + modelType + '_quota'
                 }

--- a/plugins/user_quota/web_client/models/extendModel.js
+++ b/plugins/user_quota/web_client/models/extendModel.js
@@ -12,7 +12,7 @@ function extendModel(Model, modelType) {
      */
     Model.prototype.updateQuotaPolicy = function () {
         restRequest({
-            path: this.resourceName + '/' + this.get('_id') + '/quota',
+            url: this.resourceName + '/' + this.get('_id') + '/quota',
             type: 'PUT',
             error: null,
             data: {
@@ -39,7 +39,7 @@ function extendModel(Model, modelType) {
         });
         if (!this.get('quotaPolicy') || force) {
             restRequest({
-                path: this.resourceName + '/' + this.get('_id') + '/quota',
+                url: this.resourceName + '/' + this.get('_id') + '/quota',
                 type: 'GET'
             }).done(_.bind(function (resp) {
                 this.set('quotaPolicy', resp.quota);
@@ -85,7 +85,7 @@ function extendModel(Model, modelType) {
         if (getCurrentUser().get('admin') &&
                 (!this.get('defaultQuota') || force)) {
             restRequest({
-                path: 'system/setting',
+                url: 'system/setting',
                 type: 'GET',
                 data: {
                     key: 'user_quota.default_' + modelType + '_quota'

--- a/plugins/user_quota/web_client/views/ConfigView.js
+++ b/plugins/user_quota/web_client/views/ConfigView.js
@@ -29,7 +29,7 @@ var ConfigView = View.extend({
     initialize: function () {
         restRequest({
             type: 'GET',
-            path: 'system/setting',
+            url: 'system/setting',
             data: {
                 list: JSON.stringify([
                     'user_quota.default_user_quota',
@@ -75,7 +75,7 @@ var ConfigView = View.extend({
     _saveSettings: function (settings) {
         restRequest({
             type: 'PUT',
-            path: 'system/setting',
+            url: 'system/setting',
             data: {
                 list: JSON.stringify(settings)
             },

--- a/plugins/user_quota/web_client/views/ConfigView.js
+++ b/plugins/user_quota/web_client/views/ConfigView.js
@@ -28,7 +28,7 @@ var ConfigView = View.extend({
     },
     initialize: function () {
         restRequest({
-            type: 'GET',
+            method: 'GET',
             url: 'system/setting',
             data: {
                 list: JSON.stringify([
@@ -74,7 +74,7 @@ var ConfigView = View.extend({
 
     _saveSettings: function (settings) {
         restRequest({
-            type: 'PUT',
+            method: 'PUT',
             url: 'system/setting',
             data: {
                 list: JSON.stringify(settings)

--- a/plugins/vega/web_client/views/VegaWidget.js
+++ b/plugins/vega/web_client/views/VegaWidget.js
@@ -26,7 +26,7 @@ var VegaWidget = View.extend({
             $('#g-app-body-container')
                 .append(VegaWidgetTemplate());
             restRequest({
-                url: '/api/v1/item/' + this.item.get('_id') + '/download'
+                url: `item/${this.item.id}/download`
             })
                 .done(function (spec) {
                     vg.parse.spec(spec, function (chart) {

--- a/plugins/vega/web_client/views/VegaWidget.js
+++ b/plugins/vega/web_client/views/VegaWidget.js
@@ -26,7 +26,7 @@ var VegaWidget = View.extend({
             $('#g-app-body-container')
                 .append(VegaWidgetTemplate());
             restRequest({
-                path: '/api/v1/item/' + this.item.get('_id') + '/download'
+                url: '/api/v1/item/' + this.item.get('_id') + '/download'
             })
                 .done(function (spec) {
                     vg.parse.spec(spec, function (chart) {

--- a/plugins/worker/web_client/views/ConfigView.js
+++ b/plugins/worker/web_client/views/ConfigView.js
@@ -29,7 +29,7 @@ var ConfigView = View.extend({
     initialize: function () {
         restRequest({
             type: 'GET',
-            path: 'system/setting',
+            url: 'system/setting',
             data: {
                 list: JSON.stringify([
                     'worker.api_url',
@@ -64,7 +64,7 @@ var ConfigView = View.extend({
     _saveSettings: function (settings) {
         restRequest({
             type: 'PUT',
-            path: 'system/setting',
+            url: 'system/setting',
             data: {
                 list: JSON.stringify(settings)
             },

--- a/plugins/worker/web_client/views/ConfigView.js
+++ b/plugins/worker/web_client/views/ConfigView.js
@@ -28,7 +28,7 @@ var ConfigView = View.extend({
 
     initialize: function () {
         restRequest({
-            type: 'GET',
+            method: 'GET',
             url: 'system/setting',
             data: {
                 list: JSON.stringify([
@@ -63,7 +63,7 @@ var ConfigView = View.extend({
 
     _saveSettings: function (settings) {
         restRequest({
-            type: 'PUT',
+            method: 'PUT',
             url: 'system/setting',
             data: {
                 list: JSON.stringify(settings)


### PR DESCRIPTION
Now, vanilla Backbone Models can use `Backbone.sync`-calling methods with the Girder API. The call chain will typically be:
`Backbone.sync` -> `Backbone.ajax` -> `restRequest` -> `Backbone.$.ajax` -> `$.ajax`

`restRequest` will now expect a strict superset (just adding `girderToken`) of the parameters that `$.ajax` expects:
* Existing calls to `restRequest` have been updated to use the `url` and `method` arguments, as these are preferred by `$.ajax`, in place of `path` and `type` respectively. Use of the `url` argument is now deprecated, and will print a warning. Use of the `type` argument is also deprecated, but will not print anything, because it may still be used by Backbone.
* The `dataType` argument to `restRequest` will no longer be set to `'json'` by default . Instead, the default behavior of `$.ajax` is allowed to occur, autodetecting the response type from MIME headers,
which Girder's API will set to `'application/json'` when appropriate.

The `mockRestRequest` and `unmockRestRequest` methods are now deprecated, as mocking code for tests should not contaminate the functionality within source files. The tests using these functions have been updated to use Jasmine spies.

This PR's commits are structured to have one logical change per commit, for ease of review.