### PR TITLE
Add support for using dogpile.cache within Girder

### DIFF
--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -27,11 +27,13 @@ import six
 import sys
 import traceback
 
+from dogpile.cache.util import kwarg_function_key_generator
 from . import docs
 from girder import events, logger, logprint
 from girder.constants import SettingKey, TokenScope, SortDir
 from girder.models.model_base import AccessException, GirderException, ValidationException
 from girder.utility import toBool, config, JsonEncoder, optionalArgumentDecorator
+from girder.utility.cache import requestCache
 from girder.utility.model_importer import ModelImporter
 from six.moves import range, urllib
 
@@ -135,44 +137,7 @@ def iterBody(length=READ_BUFFER_LEN, strictLength=False):
             yield buf
 
 
-def _cacheAuthUser(fun):
-    """
-    This decorator for getCurrentUser ensures that the authentication procedure
-    is only performed once per request, and is cached on the request for
-    subsequent calls to getCurrentUser().
-    """
-    def inner(returnToken=False, *args, **kwargs):
-        if not returnToken and hasattr(cherrypy.request, 'girderUser'):
-            return cherrypy.request.girderUser
-
-        user = fun(returnToken, *args, **kwargs)
-        if isinstance(user, tuple):
-            setCurrentUser(user[0])
-        else:
-            setCurrentUser(user)
-
-        return user
-    return inner
-
-
-def _cacheAuthToken(fun):
-    """
-    This decorator for getCurrentToken ensures that the token lookup
-    is only performed once per request, and is cached on the request for
-    subsequent calls to getCurrentToken().
-    """
-    def inner(*args, **kwargs):
-        if hasattr(cherrypy.request, 'girderToken'):
-            return cherrypy.request.girderToken
-
-        token = fun(*args, **kwargs)
-        setattr(cherrypy.request, 'girderToken', token)
-
-        return token
-    return inner
-
-
-@_cacheAuthToken
+@requestCache.cache_on_arguments(function_key_generator=kwarg_function_key_generator)
 def getCurrentToken(allowCookie=False):
     """
     Returns the current valid token object that was passed via the token header
@@ -196,13 +161,16 @@ def getCurrentToken(allowCookie=False):
         tokenStr = cherrypy.request.cookie['girderToken'].value
 
     if not tokenStr:
-        return None
+        token = None
+    else:
+        token = ModelImporter.model('token').load(tokenStr, force=True,
+                                                  objectId=False)
 
-    return ModelImporter.model('token').load(tokenStr, force=True,
-                                             objectId=False)
+    setattr(cherrypy.request, 'girderToken', token)
+    return token
 
 
-@_cacheAuthUser
+@requestCache.cache_on_arguments(function_key_generator=kwarg_function_key_generator)
 def getCurrentUser(returnToken=False):
     """
     Returns the currently authenticated user based on the token header or
@@ -222,6 +190,8 @@ def getCurrentUser(returnToken=False):
     token = getCurrentToken()
 
     def retVal(user, token):
+        setCurrentUser(user)
+
         if returnToken:
             return user, token
         else:

--- a/girder/conf/girder.dist.cfg
+++ b/girder/conf/girder.dist.cfg
@@ -60,3 +60,17 @@ login_description = "Login must be at least 4 characters, start with a letter, a
 password_regex = ".{6}.*"
 # Text that will be presented to the user if their password fails the regex
 password_description = "Password must be at least 6 characters."
+
+[cache]
+enabled = False
+# Arguments to the global cache must be prefixed with cache.global.
+# arguments are backend-specific, examples of existing cache backends can be found here:
+# http://dogpilecache.readthedocs.io/en/latest/api.html#module-dogpile.cache.backends.memory
+cache.global.backend = "dogpile.cache.memory"
+
+# Arguments to the per-request cache must be prefixed with cache.request.
+# per-request caching is meant to store data that will expire within the life cycle
+# of one request, as a result it may contain sensitive information that could be leaked
+# between requests if not cached correctly.
+# Do not change this unless you know exactly what you're doing.
+cache.request.backend = "cherrypy_request"

--- a/girder/utility/cache.py
+++ b/girder/utility/cache.py
@@ -1,0 +1,28 @@
+import cherrypy
+from dogpile.cache import make_region, register_backend
+from dogpile.cache.backends.memory import MemoryBackend
+
+
+class CherrypyRequestBackend(MemoryBackend):
+    """
+    A memory backed cache for individual CherryPy requests.
+
+    This provides a cache backend for dogpile.cache which is designed
+    to work in a thread-safe manner using cherrypy.request, a thread local
+    storage that only lasts for the duration of a request.
+    """
+    def __init__(self, arguments):
+        pass
+
+    @property
+    def _cache(self):
+        if not hasattr(cherrypy.request, '_girderCache'):
+            setattr(cherrypy.request, '_girderCache', {})
+
+        return cherrypy.request._girderCache
+
+
+register_backend('cherrypy_request', 'girder.utility.cache', 'CherrypyRequestBackend')
+
+cache = make_region(name='girder.cache')
+requestCache = make_region(name='girder.request')

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ install_reqs = [
     'boto3',
     'CherryPy',
     'click',
+    'dogpile.cache',
     'filelock',
     'jsonschema',
     'Mako',


### PR DESCRIPTION
First, a few things to note for [dogpile.cache](https://bitbucket.org/zzzeek/dogpile.cache):
- It's a small, simple library which is actively maintained
- It's created/maintained by the author of SQLAlchemy and Mako (among others).
- It aims to be glue code for caching backends, and nothing more
    - The author has explicitly stated that he does not want to maintain a large number of backends, and has instead designed the library in a way that can be very easily extended.

This PR does the following:
- Creates a custom backend for using `cherrypy.request` which is local to each individual request thread
- Creates 2 cache "regions", one for per-request caching and one for global caching
- Replaces some custom caching done in Girder with the provided decorators from dogpile
- Adds caching to the setting model as a proof of concept

This PR is WIP for a couple of reasons:
1) @manthey is planning on being the first to utilize this in order to port a caching mechanism from large image. I'd like to wait on merging this until the first users can see what's wrong with it.
2) Tests