### PR TITLE
Make item tasks modal focus the first input field

### DIFF
--- a/plugins/item_tasks/web_client/views/ConfigureTasksDialog.js
+++ b/plugins/item_tasks/web_client/views/ConfigureTasksDialog.js
@@ -57,12 +57,17 @@ var ConfigureTasksDialog = View.extend({
             currentImage: currentImage,
             currentTaskName: currentTaskName,
             currentSlicerCliArgs
-        })).girderModal(this);
+        })).girderModal(this).on('shown.bs.modal', () => {
+            this.$('input:first').focus();
+        });
 
         // Clear validation error message when switching tabs
         this.$('a[data-toggle="tab"]')
             .on('hide.bs.tab', (e) => {
                 this.$('.g-validation-failed-message').text('');
+            })
+            .on('shown.bs.tab', (e) => {
+                this.$($(e.currentTarget).attr('href') + ' input:first').focus();
             });
 
         return this;


### PR DESCRIPTION
This commit makes all tabs of the "Auto-configure task items" modal
put focus on their first input, this happens both on render and on
toggling of different tabs.