### PR TITLE
Single POST uploads from the python client.

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -913,6 +913,14 @@ class GirderClient(object):
         if reference:
             params['reference'] = reference
 
+        if size <= self.MAX_CHUNK_SIZE and self.getServerVersion() >= ['2', '3']:
+            chunk = stream.read(size)
+            if isinstance(chunk, six.text_type):
+                chunk = chunk.encode('utf8')
+            with self.progressReporterCls(label=filename, length=size) as reporter:
+                return self.post(
+                    'file', params, data=_ProgressBytesIO(chunk, reporter=reporter))
+
         obj = self.post('file', params)
 
         if '_id' not in obj:

--- a/tests/cases/upload_test.py
+++ b/tests/cases/upload_test.py
@@ -224,8 +224,10 @@ class UploadTestCase(base.TestCase):
         can delete partial uploads that are older than a certain date.
         """
         completeUpload = self._uploadFile('complete_upload')
-        # test uploading large files
-        self._uploadFile('complete_upload', largeFile=True)
+        # test uploading large files and one-chunk files
+        self._uploadFile('complete_large_upload', largeFile=True)
+        self._uploadFileWithInitialChunk('one_chunk_upload', oneChunk=True)
+        # test partial uploads
         partialUploads = []
         for largeFile in (False, True):
             for partial in range(3):
@@ -233,11 +235,11 @@ class UploadTestCase(base.TestCase):
                     'partial_upload_%d_%s' % (partial, str(largeFile)),
                     partial, largeFile))
         # The admin user should see all of the partial uploads, but not the
-        # complete upload
+        # complete uploads
         resp = self.request(path='/system/uploads', user=self.admin)
         self.assertStatusOk(resp)
         self.assertEqual(len(resp.json), len(partialUploads))
-        # We shouldn't be able to delete the completed upload
+        # We shouldn't be able to delete a completed upload
         resp = self.request(
             path='/system/uploads', method='DELETE', user=self.admin,
             params={'uploadId': completeUpload['_id']})


### PR DESCRIPTION
Change the girder python client to use a single POST for uploads when possible.  This only applies to small files being sent to a sufficient Girder version.

This takes advantage of the change in PR #2111.  Our tests go through both the old and new code paths.