### PR TITLE
Fix JSONeditor spacing

### DIFF
--- a/clients/web/src/stylesheets/widgets/metadataWidget.styl
+++ b/clients/web/src/stylesheets/widgets/metadataWidget.styl
@@ -49,7 +49,7 @@
   margin-right 5px
 
   .ace_editor, textarea
-    height 400px !important
+    height 365px !important
 
   .ace_content * // @stylint ignore
     font-family monospace !important


### PR DESCRIPTION
Fixes #2189

A css rule made the editor extend 35px bellow the parent metadata element as it did not account for the height of the header.

I think :) 

