### PR TITLE
Ensure package-lock.json contains just Linux-only dependencies

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -414,7 +414,8 @@ Web client libraries in Girder core are managed via `npm <https://www.npmjs.com/
 When a new npm package is required, or an existing package is upgraded, the following
 should be done:
 
-1. Ensure that version >=5.3 of npm is installed in your development environment:
+1. Ensure that you are using a Linux development environment (macOS causes npm to produce slightly
+   different outputs) with version >=5.3 of npm installed:
 
    .. code-block:: bash
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -203,7 +203,7 @@
             "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
             "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
             "requires": {
-                "bn.js": "4.11.7",
+                "bn.js": "4.11.8",
                 "inherits": "2.0.3",
                 "minimalistic-assert": "1.0.0"
             }
@@ -252,7 +252,7 @@
             "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
             "requires": {
                 "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000709",
+                "caniuse-db": "1.0.30000715",
                 "normalize-range": "0.1.2",
                 "num2fraction": "1.2.2",
                 "postcss": "5.2.17",
@@ -272,9 +272,9 @@
             "dev": true
         },
         "babel-code-frame": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-            "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "requires": {
                 "chalk": "1.1.3",
                 "esutils": "2.0.2",
@@ -282,20 +282,20 @@
             }
         },
         "babel-core": {
-            "version": "6.25.0",
-            "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
-            "integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+            "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
             "requires": {
-                "babel-code-frame": "6.22.0",
-                "babel-generator": "6.25.0",
+                "babel-code-frame": "6.26.0",
+                "babel-generator": "6.26.0",
                 "babel-helpers": "6.24.1",
                 "babel-messages": "6.23.0",
-                "babel-register": "6.24.1",
-                "babel-runtime": "6.25.0",
-                "babel-template": "6.25.0",
-                "babel-traverse": "6.25.0",
-                "babel-types": "6.25.0",
-                "babylon": "6.17.4",
+                "babel-register": "6.26.0",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
                 "convert-source-map": "1.5.0",
                 "debug": "2.6.8",
                 "json5": "0.5.1",
@@ -308,13 +308,13 @@
             }
         },
         "babel-generator": {
-            "version": "6.25.0",
-            "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
-            "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
+            "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
             "requires": {
                 "babel-messages": "6.23.0",
-                "babel-runtime": "6.25.0",
-                "babel-types": "6.25.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
                 "detect-indent": "4.0.0",
                 "jsesc": "1.3.0",
                 "lodash": "4.17.4",
@@ -328,8 +328,8 @@
             "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
             "requires": {
                 "babel-helper-explode-assignable-expression": "6.24.1",
-                "babel-runtime": "6.25.0",
-                "babel-types": "6.25.0"
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-helper-call-delegate": {
@@ -338,19 +338,19 @@
             "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
             "requires": {
                 "babel-helper-hoist-variables": "6.24.1",
-                "babel-runtime": "6.25.0",
-                "babel-traverse": "6.25.0",
-                "babel-types": "6.25.0"
+                "babel-runtime": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-helper-define-map": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
-            "integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+            "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
             "requires": {
                 "babel-helper-function-name": "6.24.1",
-                "babel-runtime": "6.25.0",
-                "babel-types": "6.25.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
                 "lodash": "4.17.4"
             }
         },
@@ -359,9 +359,9 @@
             "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
             "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
             "requires": {
-                "babel-runtime": "6.25.0",
-                "babel-traverse": "6.25.0",
-                "babel-types": "6.25.0"
+                "babel-runtime": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-helper-function-name": {
@@ -370,10 +370,10 @@
             "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
             "requires": {
                 "babel-helper-get-function-arity": "6.24.1",
-                "babel-runtime": "6.25.0",
-                "babel-template": "6.25.0",
-                "babel-traverse": "6.25.0",
-                "babel-types": "6.25.0"
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-helper-get-function-arity": {
@@ -381,8 +381,8 @@
             "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
             "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
             "requires": {
-                "babel-runtime": "6.25.0",
-                "babel-types": "6.25.0"
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-helper-hoist-variables": {
@@ -390,8 +390,8 @@
             "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
             "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
             "requires": {
-                "babel-runtime": "6.25.0",
-                "babel-types": "6.25.0"
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-helper-optimise-call-expression": {
@@ -399,17 +399,17 @@
             "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
             "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
             "requires": {
-                "babel-runtime": "6.25.0",
-                "babel-types": "6.25.0"
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-helper-regex": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
-            "integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+            "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
             "requires": {
-                "babel-runtime": "6.25.0",
-                "babel-types": "6.25.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
                 "lodash": "4.17.4"
             }
         },
@@ -420,10 +420,10 @@
             "requires": {
                 "babel-helper-optimise-call-expression": "6.24.1",
                 "babel-messages": "6.23.0",
-                "babel-runtime": "6.25.0",
-                "babel-template": "6.25.0",
-                "babel-traverse": "6.25.0",
-                "babel-types": "6.25.0"
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-helpers": {
@@ -431,8 +431,8 @@
             "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
             "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
             "requires": {
-                "babel-runtime": "6.25.0",
-                "babel-template": "6.25.0"
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0"
             }
         },
         "babel-loader": {
@@ -450,7 +450,7 @@
             "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
             "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
             "requires": {
-                "babel-runtime": "6.25.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-check-es2015-constants": {
@@ -458,7 +458,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
             "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
             "requires": {
-                "babel-runtime": "6.25.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-istanbul": {
@@ -482,7 +482,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
             "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
             "requires": {
-                "babel-runtime": "6.25.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -490,18 +490,18 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
             "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
             "requires": {
-                "babel-runtime": "6.25.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-block-scoping": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
-            "integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+            "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
             "requires": {
-                "babel-runtime": "6.25.0",
-                "babel-template": "6.25.0",
-                "babel-traverse": "6.25.0",
-                "babel-types": "6.25.0",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
                 "lodash": "4.17.4"
             }
         },
@@ -510,15 +510,15 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
             "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
             "requires": {
-                "babel-helper-define-map": "6.24.1",
+                "babel-helper-define-map": "6.26.0",
                 "babel-helper-function-name": "6.24.1",
                 "babel-helper-optimise-call-expression": "6.24.1",
                 "babel-helper-replace-supers": "6.24.1",
                 "babel-messages": "6.23.0",
-                "babel-runtime": "6.25.0",
-                "babel-template": "6.25.0",
-                "babel-traverse": "6.25.0",
-                "babel-types": "6.25.0"
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-computed-properties": {
@@ -526,8 +526,8 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
             "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
             "requires": {
-                "babel-runtime": "6.25.0",
-                "babel-template": "6.25.0"
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-destructuring": {
@@ -535,7 +535,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
             "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
             "requires": {
-                "babel-runtime": "6.25.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-duplicate-keys": {
@@ -543,8 +543,8 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
             "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
             "requires": {
-                "babel-runtime": "6.25.0",
-                "babel-types": "6.25.0"
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-for-of": {
@@ -552,7 +552,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
             "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
             "requires": {
-                "babel-runtime": "6.25.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-function-name": {
@@ -561,8 +561,8 @@
             "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
             "requires": {
                 "babel-helper-function-name": "6.24.1",
-                "babel-runtime": "6.25.0",
-                "babel-types": "6.25.0"
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-literals": {
@@ -570,7 +570,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
             "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
             "requires": {
-                "babel-runtime": "6.25.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-modules-amd": {
@@ -578,20 +578,20 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
             "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
             "requires": {
-                "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-                "babel-runtime": "6.25.0",
-                "babel-template": "6.25.0"
+                "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-modules-commonjs": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
-            "integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
+            "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
             "requires": {
                 "babel-plugin-transform-strict-mode": "6.24.1",
-                "babel-runtime": "6.25.0",
-                "babel-template": "6.25.0",
-                "babel-types": "6.25.0"
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-modules-systemjs": {
@@ -600,8 +600,8 @@
             "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
             "requires": {
                 "babel-helper-hoist-variables": "6.24.1",
-                "babel-runtime": "6.25.0",
-                "babel-template": "6.25.0"
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-modules-umd": {
@@ -610,8 +610,8 @@
             "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
             "requires": {
                 "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-runtime": "6.25.0",
-                "babel-template": "6.25.0"
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-object-super": {
@@ -620,7 +620,7 @@
             "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
             "requires": {
                 "babel-helper-replace-supers": "6.24.1",
-                "babel-runtime": "6.25.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-parameters": {
@@ -630,10 +630,10 @@
             "requires": {
                 "babel-helper-call-delegate": "6.24.1",
                 "babel-helper-get-function-arity": "6.24.1",
-                "babel-runtime": "6.25.0",
-                "babel-template": "6.25.0",
-                "babel-traverse": "6.25.0",
-                "babel-types": "6.25.0"
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-shorthand-properties": {
@@ -641,8 +641,8 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
             "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
             "requires": {
-                "babel-runtime": "6.25.0",
-                "babel-types": "6.25.0"
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-spread": {
@@ -650,7 +650,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
             "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
             "requires": {
-                "babel-runtime": "6.25.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-sticky-regex": {
@@ -658,9 +658,9 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
             "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
             "requires": {
-                "babel-helper-regex": "6.24.1",
-                "babel-runtime": "6.25.0",
-                "babel-types": "6.25.0"
+                "babel-helper-regex": "6.26.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-template-literals": {
@@ -668,7 +668,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
             "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
             "requires": {
-                "babel-runtime": "6.25.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-typeof-symbol": {
@@ -676,7 +676,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
             "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
             "requires": {
-                "babel-runtime": "6.25.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-unicode-regex": {
@@ -684,8 +684,8 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
             "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
             "requires": {
-                "babel-helper-regex": "6.24.1",
-                "babel-runtime": "6.25.0",
+                "babel-helper-regex": "6.26.0",
+                "babel-runtime": "6.26.0",
                 "regexpu-core": "2.0.0"
             }
         },
@@ -696,15 +696,15 @@
             "requires": {
                 "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
                 "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-                "babel-runtime": "6.25.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-transform-regenerator": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
-            "integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+            "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
             "requires": {
-                "regenerator-transform": "0.9.11"
+                "regenerator-transform": "0.10.0"
             }
         },
         "babel-plugin-transform-strict-mode": {
@@ -712,8 +712,8 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
             "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
             "requires": {
-                "babel-runtime": "6.25.0",
-                "babel-types": "6.25.0"
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-preset-es2015": {
@@ -724,7 +724,7 @@
                 "babel-plugin-check-es2015-constants": "6.22.0",
                 "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
                 "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-                "babel-plugin-transform-es2015-block-scoping": "6.24.1",
+                "babel-plugin-transform-es2015-block-scoping": "6.26.0",
                 "babel-plugin-transform-es2015-classes": "6.24.1",
                 "babel-plugin-transform-es2015-computed-properties": "6.24.1",
                 "babel-plugin-transform-es2015-destructuring": "6.23.0",
@@ -733,7 +733,7 @@
                 "babel-plugin-transform-es2015-function-name": "6.24.1",
                 "babel-plugin-transform-es2015-literals": "6.22.0",
                 "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+                "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
                 "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
                 "babel-plugin-transform-es2015-modules-umd": "6.24.1",
                 "babel-plugin-transform-es2015-object-super": "6.24.1",
@@ -744,7 +744,7 @@
                 "babel-plugin-transform-es2015-template-literals": "6.22.0",
                 "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
                 "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-                "babel-plugin-transform-regenerator": "6.24.1"
+                "babel-plugin-transform-regenerator": "6.26.0"
             }
         },
         "babel-preset-es2016": {
@@ -756,50 +756,50 @@
             }
         },
         "babel-register": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
-            "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+            "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
             "requires": {
-                "babel-core": "6.25.0",
-                "babel-runtime": "6.25.0",
-                "core-js": "2.4.1",
+                "babel-core": "6.26.0",
+                "babel-runtime": "6.26.0",
+                "core-js": "2.5.0",
                 "home-or-tmp": "2.0.0",
                 "lodash": "4.17.4",
                 "mkdirp": "0.5.1",
-                "source-map-support": "0.4.15"
+                "source-map-support": "0.4.16"
             }
         },
         "babel-runtime": {
-            "version": "6.25.0",
-            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
-            "integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw=",
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+            "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
             "requires": {
-                "core-js": "2.4.1",
-                "regenerator-runtime": "0.10.5"
+                "core-js": "2.5.0",
+                "regenerator-runtime": "0.11.0"
             }
         },
         "babel-template": {
-            "version": "6.25.0",
-            "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-            "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+            "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
             "requires": {
-                "babel-runtime": "6.25.0",
-                "babel-traverse": "6.25.0",
-                "babel-types": "6.25.0",
-                "babylon": "6.17.4",
+                "babel-runtime": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
                 "lodash": "4.17.4"
             }
         },
         "babel-traverse": {
-            "version": "6.25.0",
-            "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-            "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+            "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
             "requires": {
-                "babel-code-frame": "6.22.0",
+                "babel-code-frame": "6.26.0",
                 "babel-messages": "6.23.0",
-                "babel-runtime": "6.25.0",
-                "babel-types": "6.25.0",
-                "babylon": "6.17.4",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
                 "debug": "2.6.8",
                 "globals": "9.18.0",
                 "invariant": "2.2.2",
@@ -807,20 +807,20 @@
             }
         },
         "babel-types": {
-            "version": "6.25.0",
-            "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-            "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+            "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
             "requires": {
-                "babel-runtime": "6.25.0",
+                "babel-runtime": "6.26.0",
                 "esutils": "2.0.2",
                 "lodash": "4.17.4",
                 "to-fast-properties": "1.0.3"
             }
         },
         "babylon": {
-            "version": "6.17.4",
-            "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
-            "integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw=="
+            "version": "6.18.0",
+            "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+            "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
         },
         "backbone": {
             "version": "1.3.3",
@@ -865,14 +865,14 @@
             }
         },
         "binary-extensions": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.9.0.tgz",
-            "integrity": "sha1-ZlBsFs5vTWkopbPNajPKQelB43s="
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
+            "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA="
         },
         "bn.js": {
-            "version": "4.11.7",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz",
-            "integrity": "sha512-LxFiV5mefv0ley0SzqkOPR1bC4EbpPx8LkOz5vMe/Yi15t5hzwgO/G+tc7wOtL4PZTYjwHu8JnEiSLumuSjSfA=="
+            "version": "4.11.8",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+            "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
         },
         "boolbase": {
             "version": "1.0.0",
@@ -968,7 +968,7 @@
             "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
             "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
             "requires": {
-                "bn.js": "4.11.7",
+                "bn.js": "4.11.8",
                 "randombytes": "2.0.5"
             }
         },
@@ -977,7 +977,7 @@
             "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
             "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
             "requires": {
-                "bn.js": "4.11.7",
+                "bn.js": "4.11.8",
                 "browserify-rsa": "4.0.1",
                 "create-hash": "1.1.3",
                 "create-hmac": "1.1.6",
@@ -999,8 +999,8 @@
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
             "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
             "requires": {
-                "caniuse-db": "1.0.30000709",
-                "electron-to-chromium": "1.3.16"
+                "caniuse-db": "1.0.30000715",
+                "electron-to-chromium": "1.3.18"
             }
         },
         "buffer": {
@@ -1073,22 +1073,21 @@
             "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
             "requires": {
                 "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000709",
+                "caniuse-db": "1.0.30000715",
                 "lodash.memoize": "4.1.2",
                 "lodash.uniq": "4.5.0"
             }
         },
         "caniuse-db": {
-            "version": "1.0.30000709",
-            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000709.tgz",
-            "integrity": "sha1-C2AAcrfNu/YzaodYtxua0DJo7eI="
+            "version": "1.0.30000715",
+            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000715.tgz",
+            "integrity": "sha1-C5tceVlQ37rzAaiAa6/ofxJtqMo="
         },
         "caseless": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
             "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "center-align": {
             "version": "0.1.3",
@@ -1158,7 +1157,6 @@
             "requires": {
                 "anymatch": "1.3.2",
                 "async-each": "1.0.1",
-                "fsevents": "1.1.2",
                 "glob-parent": "2.0.0",
                 "inherits": "2.0.3",
                 "is-binary-path": "1.0.1",
@@ -1199,6 +1197,14 @@
                 "source-map": "0.4.4"
             },
             "dependencies": {
+                "commander": {
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                    "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+                    "requires": {
+                        "graceful-readlink": "1.0.1"
+                    }
+                },
                 "source-map": {
                     "version": "0.4.4",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
@@ -1334,12 +1340,9 @@
             }
         },
         "commander": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-            "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-            "requires": {
-                "graceful-readlink": "1.0.1"
-            }
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+            "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
         },
         "commondir": {
             "version": "1.0.1",
@@ -1395,9 +1398,9 @@
             "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
         },
         "core-js": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-            "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
+            "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY="
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -1409,7 +1412,7 @@
             "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
             "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
             "requires": {
-                "bn.js": "4.11.7",
+                "bn.js": "4.11.8",
                 "elliptic": "6.4.0"
             }
         },
@@ -1473,7 +1476,7 @@
             "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.26.4.tgz",
             "integrity": "sha1-th6eMNuUMD5v/IkvEOzQmtAlof0=",
             "requires": {
-                "babel-code-frame": "6.22.0",
+                "babel-code-frame": "6.26.0",
                 "css-selector-tokenizer": "0.7.0",
                 "cssnano": "3.10.0",
                 "loader-utils": "1.1.0",
@@ -1621,7 +1624,7 @@
             "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.26"
+                "es5-ext": "0.10.27"
             }
         },
         "dashdash": {
@@ -1748,7 +1751,7 @@
             "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
             "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
             "requires": {
-                "bn.js": "4.11.7",
+                "bn.js": "4.11.8",
                 "miller-rabin": "4.0.0",
                 "randombytes": "2.0.5"
             }
@@ -1785,11 +1788,6 @@
                     "dev": true
                 }
             }
-        },
-        "dom-walk": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-            "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
         },
         "domain-browser": {
             "version": "1.1.7",
@@ -1832,16 +1830,16 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.16",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.16.tgz",
-            "integrity": "sha1-0OAmc1dUdwkBrjAaIWZMukXZL30="
+            "version": "1.3.18",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz",
+            "integrity": "sha1-PcyZ2j5rZl9qu8ccKK1Ros1zGpw="
         },
         "elliptic": {
             "version": "6.4.0",
             "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
             "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
             "requires": {
-                "bn.js": "4.11.7",
+                "bn.js": "4.11.8",
                 "brorand": "1.1.0",
                 "hash.js": "1.1.3",
                 "hmac-drbg": "1.0.1",
@@ -1908,9 +1906,9 @@
             }
         },
         "es5-ext": {
-            "version": "0.10.26",
-            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.26.tgz",
-            "integrity": "sha1-UbISilMbcMT2dkCTpzy+u4IYY3I=",
+            "version": "0.10.27",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.27.tgz",
+            "integrity": "sha512-3KXJRYzKXTd7xfFy5uZsJCXue55fAYQ035PRjyYk2PicllxIwcW9l3AbM/eGaw3vgVAUW4tl4xg9AXDEI6yw0w==",
             "dev": true,
             "requires": {
                 "es6-iterator": "2.0.1",
@@ -1924,7 +1922,7 @@
             "dev": true,
             "requires": {
                 "d": "1.0.0",
-                "es5-ext": "0.10.26",
+                "es5-ext": "0.10.27",
                 "es6-symbol": "3.1.1"
             }
         },
@@ -1935,7 +1933,7 @@
             "dev": true,
             "requires": {
                 "d": "1.0.0",
-                "es5-ext": "0.10.26",
+                "es5-ext": "0.10.27",
                 "es6-iterator": "2.0.1",
                 "es6-set": "0.1.5",
                 "es6-symbol": "3.1.1",
@@ -1955,7 +1953,7 @@
             "dev": true,
             "requires": {
                 "d": "1.0.0",
-                "es5-ext": "0.10.26",
+                "es5-ext": "0.10.27",
                 "es6-iterator": "2.0.1",
                 "es6-symbol": "3.1.1",
                 "event-emitter": "0.3.5"
@@ -1968,7 +1966,7 @@
             "dev": true,
             "requires": {
                 "d": "1.0.0",
-                "es5-ext": "0.10.26"
+                "es5-ext": "0.10.27"
             }
         },
         "es6-weak-map": {
@@ -1978,7 +1976,7 @@
             "dev": true,
             "requires": {
                 "d": "1.0.0",
-                "es5-ext": "0.10.26",
+                "es5-ext": "0.10.27",
                 "es6-iterator": "2.0.1",
                 "es6-symbol": "3.1.1"
             }
@@ -2066,8 +2064,8 @@
                     "dev": true,
                     "requires": {
                         "babel-messages": "6.23.0",
-                        "babel-runtime": "6.25.0",
-                        "babel-types": "6.25.0",
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0",
                         "detect-indent": "3.0.1",
                         "lodash": "4.17.4",
                         "source-map": "0.5.6"
@@ -2079,10 +2077,10 @@
                     "integrity": "sha1-8i9U+g1u639jWFJGurbmN4WPXZQ=",
                     "dev": true,
                     "requires": {
-                        "babel-code-frame": "6.22.0",
+                        "babel-code-frame": "6.26.0",
                         "babel-messages": "6.23.0",
-                        "babel-runtime": "6.25.0",
-                        "babel-types": "6.25.0",
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0",
                         "babylon": "6.14.1",
                         "debug": "2.6.8",
                         "globals": "8.18.0",
@@ -2136,13 +2134,13 @@
             "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.22.0",
+                "babel-code-frame": "6.26.0",
                 "chalk": "1.1.3",
                 "concat-stream": "1.6.0",
                 "debug": "2.6.8",
                 "doctrine": "2.0.0",
                 "escope": "3.6.0",
-                "espree": "3.4.3",
+                "espree": "3.5.0",
                 "esquery": "1.0.0",
                 "estraverse": "4.2.0",
                 "esutils": "2.0.2",
@@ -2267,9 +2265,9 @@
             }
         },
         "eslint-plugin-backbone": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-backbone/-/eslint-plugin-backbone-2.0.2.tgz",
-            "integrity": "sha1-wa4PuGJDDMpaRIZfn3E96Dst+c4=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-backbone/-/eslint-plugin-backbone-2.1.0.tgz",
+            "integrity": "sha1-c/5m6ZqkaoyDs3exakHi57O7E20=",
             "dev": true
         },
         "eslint-plugin-import": {
@@ -2409,9 +2407,9 @@
             }
         },
         "espree": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
-            "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
+            "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
             "dev": true,
             "requires": {
                 "acorn": "5.1.1",
@@ -2485,7 +2483,7 @@
             "dev": true,
             "requires": {
                 "d": "1.0.0",
-                "es5-ext": "0.10.26"
+                "es5-ext": "0.10.27"
             }
         },
         "event-source": {
@@ -2494,7 +2492,7 @@
             "integrity": "sha1-y6lVKMbsMmigUnlhmt9YLS+HwAU=",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.26"
+                "es5-ext": "0.10.27"
             }
         },
         "eventemitter2": {
@@ -2583,33 +2581,25 @@
             }
         },
         "extract-zip": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
-            "integrity": "sha1-ksz22B73Cp+kwXRxFMzvbYaIpsQ=",
+            "version": "1.6.5",
+            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz",
+            "integrity": "sha1-maBnNbbqIOqbcF13ms/8yHz/BEA=",
             "dev": true,
             "requires": {
-                "concat-stream": "1.5.0",
-                "debug": "0.7.4",
+                "concat-stream": "1.6.0",
+                "debug": "2.2.0",
                 "mkdirp": "0.5.0",
                 "yauzl": "2.4.1"
             },
             "dependencies": {
-                "concat-stream": {
-                    "version": "1.5.0",
-                    "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
-                    "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
+                "debug": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                    "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.0.6",
-                        "typedarray": "0.0.6"
+                        "ms": "0.7.1"
                     }
-                },
-                "debug": {
-                    "version": "0.7.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-                    "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
-                    "dev": true
                 },
                 "mkdirp": {
                     "version": "0.5.0",
@@ -2620,24 +2610,10 @@
                         "minimist": "0.0.8"
                     }
                 },
-                "readable-stream": {
-                    "version": "2.0.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                    "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "0.10.31",
-                        "util-deprecate": "1.0.2"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                "ms": {
+                    "version": "0.7.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                    "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
                     "dev": true
                 },
                 "yauzl": {
@@ -2859,791 +2835,6 @@
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
-        "fsevents": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-            "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
-            "optional": true,
-            "requires": {
-                "nan": "2.6.2",
-                "node-pre-gyp": "0.6.36"
-            },
-            "dependencies": {
-                "abbrev": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "ajv": {
-                    "version": "4.11.8",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "co": "4.6.0",
-                        "json-stable-stringify": "1.0.1"
-                    }
-                },
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "bundled": true
-                },
-                "aproba": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "are-we-there-yet": {
-                    "version": "1.1.4",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.2.9"
-                    }
-                },
-                "asn1": {
-                    "version": "0.2.3",
-                    "bundled": true,
-                    "optional": true
-                },
-                "assert-plus": {
-                    "version": "0.2.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "asynckit": {
-                    "version": "0.4.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "aws-sign2": {
-                    "version": "0.6.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "aws4": {
-                    "version": "1.6.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "balanced-match": {
-                    "version": "0.4.2",
-                    "bundled": true
-                },
-                "bcrypt-pbkdf": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "tweetnacl": "0.14.5"
-                    }
-                },
-                "block-stream": {
-                    "version": "0.0.9",
-                    "bundled": true,
-                    "requires": {
-                        "inherits": "2.0.3"
-                    }
-                },
-                "boom": {
-                    "version": "2.10.1",
-                    "bundled": true,
-                    "requires": {
-                        "hoek": "2.16.3"
-                    }
-                },
-                "brace-expansion": {
-                    "version": "1.1.7",
-                    "bundled": true,
-                    "requires": {
-                        "balanced-match": "0.4.2",
-                        "concat-map": "0.0.1"
-                    }
-                },
-                "buffer-shims": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "caseless": {
-                    "version": "0.12.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "co": {
-                    "version": "4.6.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "code-point-at": {
-                    "version": "1.1.0",
-                    "bundled": true
-                },
-                "combined-stream": {
-                    "version": "1.0.5",
-                    "bundled": true,
-                    "requires": {
-                        "delayed-stream": "1.0.0"
-                    }
-                },
-                "concat-map": {
-                    "version": "0.0.1",
-                    "bundled": true
-                },
-                "console-control-strings": {
-                    "version": "1.1.0",
-                    "bundled": true
-                },
-                "core-util-is": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "cryptiles": {
-                    "version": "2.0.5",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "boom": "2.10.1"
-                    }
-                },
-                "dashdash": {
-                    "version": "1.14.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "assert-plus": "1.0.0"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "optional": true
-                        }
-                    }
-                },
-                "debug": {
-                    "version": "2.6.8",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "deep-extend": {
-                    "version": "0.4.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "delayed-stream": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "delegates": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "ecc-jsbn": {
-                    "version": "0.1.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "jsbn": "0.1.1"
-                    }
-                },
-                "extend": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "extsprintf": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "forever-agent": {
-                    "version": "0.6.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "form-data": {
-                    "version": "2.1.4",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.5",
-                        "mime-types": "2.1.15"
-                    }
-                },
-                "fs.realpath": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "fstream": {
-                    "version": "1.0.11",
-                    "bundled": true,
-                    "requires": {
-                        "graceful-fs": "4.1.11",
-                        "inherits": "2.0.3",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.1"
-                    }
-                },
-                "fstream-ignore": {
-                    "version": "1.0.5",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4"
-                    }
-                },
-                "gauge": {
-                    "version": "2.7.4",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "aproba": "1.1.1",
-                        "console-control-strings": "1.1.0",
-                        "has-unicode": "2.0.1",
-                        "object-assign": "4.1.1",
-                        "signal-exit": "3.0.2",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wide-align": "1.1.2"
-                    }
-                },
-                "getpass": {
-                    "version": "0.1.7",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "assert-plus": "1.0.0"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "optional": true
-                        }
-                    }
-                },
-                "glob": {
-                    "version": "7.1.2",
-                    "bundled": true,
-                    "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
-                    }
-                },
-                "graceful-fs": {
-                    "version": "4.1.11",
-                    "bundled": true
-                },
-                "har-schema": {
-                    "version": "1.0.5",
-                    "bundled": true,
-                    "optional": true
-                },
-                "har-validator": {
-                    "version": "4.2.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "ajv": "4.11.8",
-                        "har-schema": "1.0.5"
-                    }
-                },
-                "has-unicode": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "hawk": {
-                    "version": "3.1.3",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "boom": "2.10.1",
-                        "cryptiles": "2.0.5",
-                        "hoek": "2.16.3",
-                        "sntp": "1.0.9"
-                    }
-                },
-                "hoek": {
-                    "version": "2.16.3",
-                    "bundled": true
-                },
-                "http-signature": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "assert-plus": "0.2.0",
-                        "jsprim": "1.4.0",
-                        "sshpk": "1.13.0"
-                    }
-                },
-                "inflight": {
-                    "version": "1.0.6",
-                    "bundled": true,
-                    "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
-                    }
-                },
-                "inherits": {
-                    "version": "2.0.3",
-                    "bundled": true
-                },
-                "ini": {
-                    "version": "1.3.4",
-                    "bundled": true,
-                    "optional": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "number-is-nan": "1.0.1"
-                    }
-                },
-                "is-typedarray": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "isarray": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "isstream": {
-                    "version": "0.1.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "jodid25519": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "jsbn": "0.1.1"
-                    }
-                },
-                "jsbn": {
-                    "version": "0.1.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "json-schema": {
-                    "version": "0.2.3",
-                    "bundled": true,
-                    "optional": true
-                },
-                "json-stable-stringify": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "jsonify": "0.0.0"
-                    }
-                },
-                "json-stringify-safe": {
-                    "version": "5.0.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "jsonify": {
-                    "version": "0.0.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "jsprim": {
-                    "version": "1.4.0",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "assert-plus": "1.0.0",
-                        "extsprintf": "1.0.2",
-                        "json-schema": "0.2.3",
-                        "verror": "1.3.6"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "optional": true
-                        }
-                    }
-                },
-                "mime-db": {
-                    "version": "1.27.0",
-                    "bundled": true
-                },
-                "mime-types": {
-                    "version": "2.1.15",
-                    "bundled": true,
-                    "requires": {
-                        "mime-db": "1.27.0"
-                    }
-                },
-                "minimatch": {
-                    "version": "3.0.4",
-                    "bundled": true,
-                    "requires": {
-                        "brace-expansion": "1.1.7"
-                    }
-                },
-                "minimist": {
-                    "version": "0.0.8",
-                    "bundled": true
-                },
-                "mkdirp": {
-                    "version": "0.5.1",
-                    "bundled": true,
-                    "requires": {
-                        "minimist": "0.0.8"
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "node-pre-gyp": {
-                    "version": "0.6.36",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "mkdirp": "0.5.1",
-                        "nopt": "4.0.1",
-                        "npmlog": "4.1.0",
-                        "rc": "1.2.1",
-                        "request": "2.81.0",
-                        "rimraf": "2.6.1",
-                        "semver": "5.3.0",
-                        "tar": "2.2.1",
-                        "tar-pack": "3.4.0"
-                    }
-                },
-                "nopt": {
-                    "version": "4.0.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "abbrev": "1.1.0",
-                        "osenv": "0.1.4"
-                    }
-                },
-                "npmlog": {
-                    "version": "4.1.0",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
-                    }
-                },
-                "number-is-nan": {
-                    "version": "1.0.1",
-                    "bundled": true
-                },
-                "oauth-sign": {
-                    "version": "0.8.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "object-assign": {
-                    "version": "4.1.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "once": {
-                    "version": "1.4.0",
-                    "bundled": true,
-                    "requires": {
-                        "wrappy": "1.0.2"
-                    }
-                },
-                "os-homedir": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "os-tmpdir": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "osenv": {
-                    "version": "0.1.4",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
-                    }
-                },
-                "path-is-absolute": {
-                    "version": "1.0.1",
-                    "bundled": true
-                },
-                "performance-now": {
-                    "version": "0.2.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "process-nextick-args": {
-                    "version": "1.0.7",
-                    "bundled": true
-                },
-                "punycode": {
-                    "version": "1.4.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "qs": {
-                    "version": "6.4.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "rc": {
-                    "version": "1.2.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "deep-extend": "0.4.2",
-                        "ini": "1.3.4",
-                        "minimist": "1.2.0",
-                        "strip-json-comments": "2.0.1"
-                    },
-                    "dependencies": {
-                        "minimist": {
-                            "version": "1.2.0",
-                            "bundled": true,
-                            "optional": true
-                        }
-                    }
-                },
-                "readable-stream": {
-                    "version": "2.2.9",
-                    "bundled": true,
-                    "requires": {
-                        "buffer-shims": "1.0.0",
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "1.0.1",
-                        "util-deprecate": "1.0.2"
-                    }
-                },
-                "request": {
-                    "version": "2.81.0",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "4.2.1",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.15",
-                        "oauth-sign": "0.8.2",
-                        "performance-now": "0.2.0",
-                        "qs": "6.4.0",
-                        "safe-buffer": "5.0.1",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.2",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.0.1"
-                    }
-                },
-                "rimraf": {
-                    "version": "2.6.1",
-                    "bundled": true,
-                    "requires": {
-                        "glob": "7.1.2"
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.0.1",
-                    "bundled": true
-                },
-                "semver": {
-                    "version": "5.3.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "set-blocking": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "signal-exit": {
-                    "version": "3.0.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "sntp": {
-                    "version": "1.0.9",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "hoek": "2.16.3"
-                    }
-                },
-                "sshpk": {
-                    "version": "1.13.0",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "asn1": "0.2.3",
-                        "assert-plus": "1.0.0",
-                        "bcrypt-pbkdf": "1.0.1",
-                        "dashdash": "1.14.1",
-                        "ecc-jsbn": "0.1.1",
-                        "getpass": "0.1.7",
-                        "jodid25519": "1.0.2",
-                        "jsbn": "0.1.1",
-                        "tweetnacl": "0.14.5"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "optional": true
-                        }
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "safe-buffer": "5.0.1"
-                    }
-                },
-                "string-width": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                    }
-                },
-                "stringstream": {
-                    "version": "0.0.5",
-                    "bundled": true,
-                    "optional": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "strip-json-comments": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "tar": {
-                    "version": "2.2.1",
-                    "bundled": true,
-                    "requires": {
-                        "block-stream": "0.0.9",
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3"
-                    }
-                },
-                "tar-pack": {
-                    "version": "3.4.0",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "debug": "2.6.8",
-                        "fstream": "1.0.11",
-                        "fstream-ignore": "1.0.5",
-                        "once": "1.4.0",
-                        "readable-stream": "2.2.9",
-                        "rimraf": "2.6.1",
-                        "tar": "2.2.1",
-                        "uid-number": "0.0.6"
-                    }
-                },
-                "tough-cookie": {
-                    "version": "2.3.2",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "punycode": "1.4.1"
-                    }
-                },
-                "tunnel-agent": {
-                    "version": "0.6.0",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "safe-buffer": "5.0.1"
-                    }
-                },
-                "tweetnacl": {
-                    "version": "0.14.5",
-                    "bundled": true,
-                    "optional": true
-                },
-                "uid-number": {
-                    "version": "0.0.6",
-                    "bundled": true,
-                    "optional": true
-                },
-                "util-deprecate": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "uuid": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "verror": {
-                    "version": "1.3.6",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "extsprintf": "1.0.2"
-                    }
-                },
-                "wide-align": {
-                    "version": "1.1.2",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "string-width": "1.0.2"
-                    }
-                },
-                "wrappy": {
-                    "version": "1.0.2",
-                    "bundled": true
-                }
-            }
-        },
         "fstream": {
             "version": "0.1.31",
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
@@ -3763,22 +2954,6 @@
                 "is-glob": "2.0.1"
             }
         },
-        "global": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
-            "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-            "requires": {
-                "min-document": "2.19.0",
-                "process": "0.5.2"
-            },
-            "dependencies": {
-                "process": {
-                    "version": "0.5.2",
-                    "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-                    "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
-                }
-            }
-        },
         "globals": {
             "version": "9.18.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
@@ -3804,7 +2979,7 @@
             "integrity": "sha1-ZaixKOSC3trkK3S/sN/8yqnicuY=",
             "requires": {
                 "lodash": "4.17.4",
-                "node-fetch": "1.7.1",
+                "node-fetch": "1.7.2",
                 "webpack-sources": "0.2.3",
                 "yauzl": "2.8.0"
             },
@@ -3922,22 +3097,6 @@
                 "maxmin": "1.1.0",
                 "uglify-js": "3.0.27",
                 "uri-path": "1.0.0"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "2.11.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-                    "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
-                },
-                "uglify-js": {
-                    "version": "3.0.27",
-                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.27.tgz",
-                    "integrity": "sha512-HD8CmxPXUI62v5tweiulMcP/apAtx1DXGcNZkhKQZyC+MTrTsoCBb8yPAwVrbvpgw3EpRU76bRe6axjIiCYcQg==",
-                    "requires": {
-                        "commander": "2.11.0",
-                        "source-map": "0.5.6"
-                    }
-                }
             }
         },
         "grunt-file-creator": {
@@ -4079,21 +3238,6 @@
             "requires": {
                 "chalk": "1.1.3",
                 "npm-run-path": "2.0.2"
-            },
-            "dependencies": {
-                "npm-run-path": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-                    "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-                    "requires": {
-                        "path-key": "2.0.1"
-                    }
-                },
-                "path-key": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-                    "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
-                }
             }
         },
         "grunt-webpack": {
@@ -4149,6 +3293,27 @@
                     "requires": {
                         "amdefine": "1.0.1"
                     }
+                },
+                "uglify-js": {
+                    "version": "2.8.29",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+                    "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "source-map": "0.5.6",
+                        "uglify-to-browserify": "1.0.2",
+                        "yargs": "3.10.0"
+                    },
+                    "dependencies": {
+                        "source-map": {
+                            "version": "0.5.6",
+                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                            "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
                 }
             }
         },
@@ -4156,15 +3321,13 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
             "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "har-validator": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
             "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
             "dev": true,
-            "optional": true,
             "requires": {
                 "ajv": "4.11.8",
                 "har-schema": "1.0.5"
@@ -4175,7 +3338,6 @@
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
                     "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "co": "4.6.0",
                         "json-stable-stringify": "1.0.1"
@@ -4511,7 +3673,7 @@
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "requires": {
-                "binary-extensions": "1.9.0"
+                "binary-extensions": "1.10.0"
             }
         },
         "is-buffer": {
@@ -4799,11 +3961,11 @@
             "integrity": "sha1-6f2SDkdn89Ge3HZeLWs/XMvQ7qg=",
             "dev": true,
             "requires": {
-                "babel-generator": "6.25.0",
-                "babel-template": "6.25.0",
-                "babel-traverse": "6.25.0",
-                "babel-types": "6.25.0",
-                "babylon": "6.17.4",
+                "babel-generator": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
                 "istanbul-lib-coverage": "1.1.1",
                 "semver": "5.4.1"
             }
@@ -4989,6 +4151,15 @@
             "requires": {
                 "brace": "0.4.1",
                 "jsonlint": "github:josdejong/jsonlint#fb47330e20fa9bdde149d157aee7b043e421df9e"
+            },
+            "dependencies": {
+                "jsonlint": {
+                    "version": "github:josdejong/jsonlint#fb47330e20fa9bdde149d157aee7b043e421df9e",
+                    "requires": {
+                        "JSV": "4.0.2",
+                        "nomnom": "1.8.1"
+                    }
+                }
             }
         },
         "jsonfile": {
@@ -5004,13 +4175,6 @@
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
             "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-        },
-        "jsonlint": {
-            "version": "github:josdejong/jsonlint#fb47330e20fa9bdde149d157aee7b043e421df9e",
-            "requires": {
-                "JSV": "4.0.2",
-                "nomnom": "1.8.1"
-            }
         },
         "jsonpointer": {
             "version": "4.0.1",
@@ -5415,7 +4579,7 @@
             "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
             "integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
             "requires": {
-                "bn.js": "4.11.7",
+                "bn.js": "4.11.8",
                 "brorand": "1.1.0"
             }
         },
@@ -5437,14 +4601,6 @@
             "dev": true,
             "requires": {
                 "mime-db": "1.29.0"
-            }
-        },
-        "min-document": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-            "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-            "requires": {
-                "dom-walk": "0.1.1"
             }
         },
         "minimalistic-assert": {
@@ -5508,12 +4664,6 @@
             "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
             "dev": true
         },
-        "nan": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-            "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
-            "optional": true
-        },
         "natives": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
@@ -5543,9 +4693,9 @@
             }
         },
         "node-fetch": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
-            "integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.2.tgz",
+            "integrity": "sha512-xZZUq2yDhKMIn/UgG5q//IZSNLJIwW2QxS14CNH5spuiXkITM2pUitjdq58yLSaU7m4M0wBNaM2Gh/ggY4YJig==",
             "requires": {
                 "encoding": "0.1.12",
                 "is-stream": "1.1.0"
@@ -5574,7 +4724,7 @@
                 "stream-browserify": "2.0.1",
                 "stream-http": "2.7.2",
                 "string_decoder": "0.10.31",
-                "timers-browserify": "2.0.3",
+                "timers-browserify": "2.0.4",
                 "tty-browserify": "0.0.0",
                 "url": "0.11.0",
                 "util": "0.10.3",
@@ -5648,7 +4798,7 @@
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "requires": {
-                "remove-trailing-separator": "1.0.2"
+                "remove-trailing-separator": "1.1.0"
             }
         },
         "normalize-range": {
@@ -5665,6 +4815,14 @@
                 "prepend-http": "1.0.4",
                 "query-string": "4.3.4",
                 "sort-keys": "1.1.2"
+            }
+        },
+        "npm-run-path": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+            "requires": {
+                "path-key": "2.0.1"
             }
         },
         "nth-check": {
@@ -5864,6 +5022,11 @@
             "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
             "dev": true
         },
+        "path-key": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+        },
         "path-parse": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
@@ -5901,90 +5064,23 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
             "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "phantomjs-prebuilt": {
-            "version": "2.1.14",
-            "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.14.tgz",
-            "integrity": "sha1-1T0xH8+30dCN2yQBRVjxGIxRbaA=",
+            "version": "2.1.15",
+            "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.15.tgz",
+            "integrity": "sha1-IPhugtM0nFBZF1J3RbekEeCLOQM=",
             "dev": true,
             "requires": {
                 "es6-promise": "4.0.5",
-                "extract-zip": "1.5.0",
+                "extract-zip": "1.6.5",
                 "fs-extra": "1.0.0",
                 "hasha": "2.2.0",
                 "kew": "0.7.0",
                 "progress": "1.1.8",
-                "request": "2.79.0",
+                "request": "2.81.0",
                 "request-progress": "2.0.1",
                 "which": "1.2.14"
-            },
-            "dependencies": {
-                "caseless": {
-                    "version": "0.11.0",
-                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-                    "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-                    "dev": true
-                },
-                "commander": {
-                    "version": "2.11.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-                    "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-                    "dev": true
-                },
-                "har-validator": {
-                    "version": "2.0.6",
-                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-                    "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "commander": "2.11.0",
-                        "is-my-json-valid": "2.16.0",
-                        "pinkie-promise": "2.0.1"
-                    }
-                },
-                "qs": {
-                    "version": "6.3.2",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-                    "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
-                    "dev": true
-                },
-                "request": {
-                    "version": "2.79.0",
-                    "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-                    "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-                    "dev": true,
-                    "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.11.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "2.0.6",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.16",
-                        "oauth-sign": "0.8.2",
-                        "qs": "6.3.2",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.2",
-                        "tunnel-agent": "0.4.3",
-                        "uuid": "3.1.0"
-                    }
-                },
-                "tunnel-agent": {
-                    "version": "0.4.3",
-                    "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-                    "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-                    "dev": true
-                }
             }
         },
         "pify": {
@@ -6233,7 +5329,7 @@
             "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
             "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
             "requires": {
-                "postcss": "6.0.8"
+                "postcss": "6.0.9"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -6245,9 +5341,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
-                    "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+                    "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
                     "requires": {
                         "ansi-styles": "3.2.0",
                         "escape-string-regexp": "1.0.5",
@@ -6260,11 +5356,11 @@
                     "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                 },
                 "postcss": {
-                    "version": "6.0.8",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.8.tgz",
-                    "integrity": "sha512-G6WnRmdTt2jvJvY+aY+M0AO4YlbxE+slKPZb+jG2P2U9Tyxi3h1fYZ/DgiFU6DC6bv3XIEJoZt+f/kNh8BrWFw==",
+                    "version": "6.0.9",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.9.tgz",
+                    "integrity": "sha512-bBE2AHNEBhF23TfET6AA/lFP8ah+qHOZoFJEflFG+HgvVLdTmMOrocx/4LVVDIn3w6jUssw1q2Exk1cc9UOI8w==",
                     "requires": {
-                        "chalk": "2.0.1",
+                        "chalk": "2.1.0",
                         "source-map": "0.5.6",
                         "supports-color": "4.2.1"
                     }
@@ -6285,7 +5381,7 @@
             "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
             "requires": {
                 "css-selector-tokenizer": "0.7.0",
-                "postcss": "6.0.8"
+                "postcss": "6.0.9"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -6297,9 +5393,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
-                    "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+                    "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
                     "requires": {
                         "ansi-styles": "3.2.0",
                         "escape-string-regexp": "1.0.5",
@@ -6312,11 +5408,11 @@
                     "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                 },
                 "postcss": {
-                    "version": "6.0.8",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.8.tgz",
-                    "integrity": "sha512-G6WnRmdTt2jvJvY+aY+M0AO4YlbxE+slKPZb+jG2P2U9Tyxi3h1fYZ/DgiFU6DC6bv3XIEJoZt+f/kNh8BrWFw==",
+                    "version": "6.0.9",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.9.tgz",
+                    "integrity": "sha512-bBE2AHNEBhF23TfET6AA/lFP8ah+qHOZoFJEflFG+HgvVLdTmMOrocx/4LVVDIn3w6jUssw1q2Exk1cc9UOI8w==",
                     "requires": {
-                        "chalk": "2.0.1",
+                        "chalk": "2.1.0",
                         "source-map": "0.5.6",
                         "supports-color": "4.2.1"
                     }
@@ -6337,7 +5433,7 @@
             "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
             "requires": {
                 "css-selector-tokenizer": "0.7.0",
-                "postcss": "6.0.8"
+                "postcss": "6.0.9"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -6349,9 +5445,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
-                    "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+                    "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
                     "requires": {
                         "ansi-styles": "3.2.0",
                         "escape-string-regexp": "1.0.5",
@@ -6364,11 +5460,11 @@
                     "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                 },
                 "postcss": {
-                    "version": "6.0.8",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.8.tgz",
-                    "integrity": "sha512-G6WnRmdTt2jvJvY+aY+M0AO4YlbxE+slKPZb+jG2P2U9Tyxi3h1fYZ/DgiFU6DC6bv3XIEJoZt+f/kNh8BrWFw==",
+                    "version": "6.0.9",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.9.tgz",
+                    "integrity": "sha512-bBE2AHNEBhF23TfET6AA/lFP8ah+qHOZoFJEflFG+HgvVLdTmMOrocx/4LVVDIn3w6jUssw1q2Exk1cc9UOI8w==",
                     "requires": {
-                        "chalk": "2.0.1",
+                        "chalk": "2.1.0",
                         "source-map": "0.5.6",
                         "supports-color": "4.2.1"
                     }
@@ -6389,7 +5485,7 @@
             "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
             "requires": {
                 "icss-replace-symbols": "1.1.0",
-                "postcss": "6.0.8"
+                "postcss": "6.0.9"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -6401,9 +5497,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
-                    "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+                    "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
                     "requires": {
                         "ansi-styles": "3.2.0",
                         "escape-string-regexp": "1.0.5",
@@ -6416,11 +5512,11 @@
                     "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                 },
                 "postcss": {
-                    "version": "6.0.8",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.8.tgz",
-                    "integrity": "sha512-G6WnRmdTt2jvJvY+aY+M0AO4YlbxE+slKPZb+jG2P2U9Tyxi3h1fYZ/DgiFU6DC6bv3XIEJoZt+f/kNh8BrWFw==",
+                    "version": "6.0.9",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.9.tgz",
+                    "integrity": "sha512-bBE2AHNEBhF23TfET6AA/lFP8ah+qHOZoFJEflFG+HgvVLdTmMOrocx/4LVVDIn3w6jUssw1q2Exk1cc9UOI8w==",
                     "requires": {
-                        "chalk": "2.0.1",
+                        "chalk": "2.1.0",
                         "source-map": "0.5.6",
                         "supports-color": "4.2.1"
                     }
@@ -6600,7 +5696,7 @@
             "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
             "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
             "requires": {
-                "bn.js": "4.11.7",
+                "bn.js": "4.11.8",
                 "browserify-rsa": "4.0.1",
                 "create-hash": "1.1.3",
                 "parse-asn1": "5.1.0",
@@ -6664,6 +5760,18 @@
                 "pug-walk": "1.1.4",
                 "resolve": "1.1.7",
                 "uglify-js": "2.8.29"
+            },
+            "dependencies": {
+                "uglify-js": {
+                    "version": "2.8.29",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+                    "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+                    "requires": {
+                        "source-map": "0.5.6",
+                        "uglify-to-browserify": "1.0.2",
+                        "yargs": "3.10.0"
+                    }
+                }
             }
         },
         "pug-lexer": {
@@ -6726,12 +5834,6 @@
                     "version": "4.0.13",
                     "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
                     "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-                    "dev": true
-                },
-                "commander": {
-                    "version": "2.11.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-                    "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
                     "dev": true
                 },
                 "is-expression": {
@@ -6864,8 +5966,7 @@
             "version": "6.4.0",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
             "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "query-string": {
             "version": "4.3.4",
@@ -7061,17 +6162,17 @@
             "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA="
         },
         "regenerator-runtime": {
-            "version": "0.10.5",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-            "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+            "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
         },
         "regenerator-transform": {
-            "version": "0.9.11",
-            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
-            "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.0.tgz",
+            "integrity": "sha512-0oMTqaJuM3Q6RWqts6U0/ijW3xcnY8d/KimL3IkQW1zib1gmSb1lKoFKNF+kSDmriGESlOHcwoI1XpXKNEGcLg==",
             "requires": {
-                "babel-runtime": "6.25.0",
-                "babel-types": "6.25.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
                 "private": "0.1.7"
             }
         },
@@ -7140,9 +6241,9 @@
             }
         },
         "remove-trailing-separator": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-            "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
         },
         "repeat-element": {
             "version": "1.1.2",
@@ -7167,7 +6268,6 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
             "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
             "dev": true,
-            "optional": true,
             "requires": {
                 "aws-sign2": "0.6.0",
                 "aws4": "1.6.0",
@@ -7412,9 +6512,9 @@
             "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
         },
         "source-map-support": {
-            "version": "0.4.15",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
-            "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
+            "version": "0.4.16",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.16.tgz",
+            "integrity": "sha512-A6vlydY7H/ljr4L2UOhDSajQdZQ6dMD7cLH0pzwcmwLyc9u8PNI4WGtnfDDzX7uzGL6c/T+ORL97Zlh+S4iOrg==",
             "requires": {
                 "source-map": "0.5.6"
             }
@@ -7602,7 +6702,6 @@
                     "requires": {
                         "anymatch": "1.3.2",
                         "async-each": "1.0.1",
-                        "fsevents": "1.1.2",
                         "glob-parent": "2.0.0",
                         "inherits": "2.0.3",
                         "is-binary-path": "1.0.1",
@@ -7872,11 +6971,10 @@
             "dev": true
         },
         "timers-browserify": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.3.tgz",
-            "integrity": "sha512-+JAqyNgg+M8+gXIrq2EeUr4kZqRz47Ysco7X5QKRGScRE9HIHckyHD1asozSFGeqx2nmPCgA8T5tIGVO0ML7/w==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
+            "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
             "requires": {
-                "global": "4.3.2",
                 "setimmediate": "1.0.5"
             }
         },
@@ -7947,7 +7045,6 @@
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "dev": true,
-            "optional": true,
             "requires": {
                 "safe-buffer": "5.1.1"
             }
@@ -7974,13 +7071,12 @@
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
         },
         "uglify-js": {
-            "version": "2.8.29",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-            "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+            "version": "3.0.27",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.27.tgz",
+            "integrity": "sha512-HD8CmxPXUI62v5tweiulMcP/apAtx1DXGcNZkhKQZyC+MTrTsoCBb8yPAwVrbvpgw3EpRU76bRe6axjIiCYcQg==",
             "requires": {
-                "source-map": "0.5.6",
-                "uglify-to-browserify": "1.0.2",
-                "yargs": "3.10.0"
+                "commander": "2.11.0",
+                "source-map": "0.5.6"
             }
         },
         "uglify-to-browserify": {
@@ -8238,19 +7334,9 @@
                     }
                 },
                 "camelcase": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-                },
-                "cliui": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-                    "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-                    "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wrap-ansi": "2.1.0"
-                    }
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                    "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
                 },
                 "loader-utils": {
                     "version": "0.2.17",
@@ -8271,6 +7357,29 @@
                         "has-flag": "1.0.0"
                     }
                 },
+                "uglify-js": {
+                    "version": "2.8.29",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+                    "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+                    "requires": {
+                        "source-map": "0.5.6",
+                        "uglify-to-browserify": "1.0.2",
+                        "yargs": "3.10.0"
+                    },
+                    "dependencies": {
+                        "yargs": {
+                            "version": "3.10.0",
+                            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                            "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+                            "requires": {
+                                "camelcase": "1.2.1",
+                                "cliui": "2.1.0",
+                                "decamelize": "1.2.0",
+                                "window-size": "0.1.0"
+                            }
+                        }
+                    }
+                },
                 "yargs": {
                     "version": "6.6.0",
                     "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
@@ -8289,6 +7398,23 @@
                         "which-module": "1.0.0",
                         "y18n": "3.2.1",
                         "yargs-parser": "4.2.1"
+                    },
+                    "dependencies": {
+                        "camelcase": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+                            "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+                        },
+                        "cliui": {
+                            "version": "3.2.0",
+                            "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                            "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                            "requires": {
+                                "string-width": "1.0.2",
+                                "strip-ansi": "3.0.1",
+                                "wrap-ansi": "2.1.0"
+                            }
+                        }
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
         "npm": ">=3.10"
     },
     "dependencies": {
-        "girder": "file:./clients/web/src",
         "babel-core": "^6.25.0",
         "babel-loader": "^7.1.1",
         "babel-preset-es2015": "^6.24.1",
@@ -26,6 +25,7 @@
         "extendify": "^1.0.0",
         "extract-text-webpack-plugin": "^2.1.2",
         "file-loader": "^0.11.2",
+        "girder": "file:./clients/web/src",
         "google-fonts-webpack-plugin": "^0.4.0",
         "grunt": "^1.0.1",
         "grunt-cli": "^1.2.0",


### PR DESCRIPTION
Most of the problems here are related to the fact that an optional dependency, `fsevents`, is installable on macOS and not on Linux.

By requiring the `package-lock.json` file to be generated only on Linux platforms, we:
* Prevent some installation errors on Linux, where it tries to install `fsevents` and fails
* Reduce churn of `package-lock.json`, when it's updated on different platforms
* Allow macOS users to continue using `fsevents`, albeit with a non-deterministic version