### PR TITLE
Smaller candela

### DIFF
--- a/plugins/candela/plugin_tests/candelaSpec.js
+++ b/plugins/candela/plugin_tests/candelaSpec.js
@@ -41,7 +41,7 @@ describe('Test the candela UI.', function () {
         }, 'the candela component selector to appear');
 
         runs(function () {
-            expect($('.g-item-candela-component option').length).toBeGreaterThan(10);
+            expect($('.g-item-candela-component option').length).toBeGreaterThan(5);
             $('.g-item-candela-component').val('BarChart').change();
         });
 

--- a/plugins/candela/web_client/views/CandelaWidget.js
+++ b/plugins/candela/web_client/views/CandelaWidget.js
@@ -2,7 +2,10 @@ import _ from 'underscore';
 
 import View from 'girder/views/View';
 import events from 'girder/events';
-import candela from 'girder_plugins/candela/node/candela/dist/candela';
+import candela from 'candela';
+import 'candela/plugins/vega/load';
+import 'candela/plugins/treeheatmap/load';
+
 import datalib from 'girder_plugins/candela/node/datalib';
 
 import CandelaWidgetTemplate from '../templates/candelaWidget.pug';

--- a/plugins/candela/webpack.helper.js
+++ b/plugins/candela/webpack.helper.js
@@ -1,0 +1,22 @@
+var path = require('path');
+
+module.exports = function (config, data) {
+    var candelaDir = path.resolve(data.nodeDir, 'candela');
+
+    config.module.rules.push({
+        resource: {
+            test: new RegExp(candelaDir + '.*.js$'),
+            include: [candelaDir]
+        },
+        use: [
+            {
+                loader: 'babel-loader',
+                options: {
+                    presets: ['es2015', 'es2016']
+                }
+            }
+        ]
+    });
+
+    return config;
+};

--- a/plugins/candela/webpack.helper.js
+++ b/plugins/candela/webpack.helper.js
@@ -1,5 +1,8 @@
 var path = require('path');
 
+const es2015BabelPreset = require.resolve('babel-preset-es2015');
+const es2016BabelPreset = require.resolve('babel-preset-es2016');
+
 module.exports = function (config, data) {
     var candelaDir = path.resolve(data.nodeDir, 'candela');
 
@@ -12,7 +15,7 @@ module.exports = function (config, data) {
             {
                 loader: 'babel-loader',
                 options: {
-                    presets: ['es2015', 'es2016']
+                    presets: [es2015BabelPreset, es2016BabelPreset]
                 }
             }
         ]


### PR DESCRIPTION
Depends on #2292, which should be merged first.

Creates a smaller candela plugin by only including portions of the library (vega, treeheatmap plugins) instead of the entire bundle. Reduces the minified plugin bundle from 4.8 MB to 1 MB.

Since candela uses ES6 features, we need to add a webpack rule to use babel on the candela sources.