### PR TITLE
Delegate tooltip styling to the App

### DIFF
--- a/clients/web/src/templates/body/collectionPage.pug
+++ b/clients/web/src/templates/body/collectionPage.pug
@@ -2,7 +2,7 @@
 
   .btn-group.pull-right
     button.g-collection-actions-button.btn.btn-default.dropdown-toggle(
-        data-toggle="dropdown", title="Collection actions")
+        data-toggle="dropdown", title="Collection actions", data-placement='left')
       i.icon-sitemap
       |  Actions
       i.icon-down-dir

--- a/clients/web/src/templates/body/groupPage.pug
+++ b/clients/web/src/templates/body/groupPage.pug
@@ -2,7 +2,7 @@
   .btn-group.pull-right
     if (isMember || isInvited || getCurrentUser() || group.get('_accessLevel') >= AccessType.ADMIN)
       button.g-group-actions-button.btn.btn-default.dropdown-toggle(
-          data-toggle="dropdown", title="Group actions")
+          data-toggle="dropdown", title="Group actions", data-placement='left')
         i.icon-users
         |  Actions
         i.icon-down-dir

--- a/clients/web/src/templates/body/plugins.pug
+++ b/clients/web/src/templates/body/plugins.pug
@@ -32,6 +32,7 @@
                   "to breaking changes; use at your own risk.") Experimental
         if failed
           span.g-plugin-list-item-notice.g-plugin-list-item-failed-notice(
+              title='Click to see traceback',
               data-title='Failed to load plugin "' + plugin.value.name + '"',
               data-content=failed.traceback) Error
         if plugin.value.configRoute

--- a/clients/web/src/templates/widgets/editApiKeyWidget.pug
+++ b/clients/web/src/templates/widgets/editApiKeyWidget.pug
@@ -28,7 +28,7 @@
               | Only allow specific permissions for this key:
           each tokenScope in userTokenScopes
             .checkbox.disabled
-              label.g-custom-scope-description(title=tokenScope.description)
+              label.g-custom-scope-description(title=tokenScope.description, data-placement='right')
                 input.g-custom-scope-checkbox(type="checkbox", value=tokenScope.id, disabled)
                 span= tokenScope.name
           if user.get('admin')

--- a/clients/web/src/templates/widgets/groupInviteList.pug
+++ b/clients/web/src/templates/widgets/groupInviteList.pug
@@ -6,7 +6,7 @@ ul.g-group-invites
         span #{user.name()} (#{user.get('login')})
       .g-group-member-controls.pull-right
         if level >= accessType.WRITE
-          a.g-group-uninvite(title="Uninvite this user")
+          a.g-group-uninvite(title="Uninvite this user", data-placement='left')
             i.icon-block
   if (!invitees.length)
     .g-member-list-empty

--- a/clients/web/src/templates/widgets/hierarchyBreadcrumb.pug
+++ b/clients/web/src/templates/widgets/hierarchyBreadcrumb.pug
@@ -22,16 +22,16 @@ if descriptionText
 
 .pull-right
   .g-child-count-container.hide
-    .g-subfolder-count-container
+    .g-subfolder-count-container(title='total folders')
       i.icon-folder
       .g-subfolder-count
 
     if idx > 0
-      .g-item-count-container
+      .g-item-count-container(title='total items')
         i.icon-doc-text-inv
         .g-item-count
 
   if idx > 0
     .g-level-up-button-container
-      a.g-hierarchy-level-up(title="Go up one level", placement="left")
+      a.g-hierarchy-level-up(title="Go up one level", data-placement="left")
         i.icon-level-up

--- a/clients/web/src/templates/widgets/hierarchyWidget.pug
+++ b/clients/web/src/templates/widgets/hierarchyWidget.pug
@@ -4,8 +4,7 @@
   if showActions
     .g-hierarchy-actions-header
       if checkboxes
-        input.g-select-all(type="checkbox", data-toggle="tooltip",
-            title="Select / Unselect all")
+        input.g-select-all(type="checkbox", title="Select / Unselect all")
 
         .btn-group
           button.g-checked-actions-button.btn.btn-sm.btn-default.dropdown-toggle(
@@ -32,7 +31,7 @@
               i.icon-lock
         .btn-group
           button.g-folder-actions-button.btn.btn-sm.btn-default.dropdown-toggle(
-              data-toggle="dropdown", title=`${capitalize(type)} actions`, placement="left")
+              data-toggle="dropdown", title=`${capitalize(type)} actions`, data-placement="left")
             if type === 'collection'
               i.icon-sitemap
             else if type === 'user'

--- a/clients/web/src/templates/widgets/itemBreadcrumb.pug
+++ b/clients/web/src/templates/widgets/itemBreadcrumb.pug
@@ -12,5 +12,5 @@ ol.breadcrumb
           = parent.object.name
 
   .pull-right
-    a.g-hierarchy-level-up(title="Go to parent folder")
+    a.g-hierarchy-level-up(title="Go to parent folder", data-placement='left')
       i.icon-level-up

--- a/clients/web/src/templates/widgets/metadataWidget.pug
+++ b/clients/web/src/templates/widgets/metadataWidget.pug
@@ -1,6 +1,6 @@
 if (accessLevel >= AccessType.WRITE)
   .btn-group.pull-right
-    button.g-widget-metadata-add-button.btn.btn-sm.btn-primary.btn-default.dropdown-toggle(data-toggle="dropdown", title="Add Metadata")
+    button.g-widget-metadata-add-button.btn.btn-sm.btn-primary.btn-default.dropdown-toggle(data-toggle="dropdown", title="Add Metadata", data-placement='left')
       i.icon-plus
     ul.dropdown-menu.pull-right(role="menu")
       li(role="presentation")

--- a/clients/web/src/templates/widgets/pluginFailedNotice.pug
+++ b/clients/web/src/templates/widgets/pluginFailedNotice.pug
@@ -1,4 +1,4 @@
-.popover.g-plugin-list-item-failed-notice-popover(role="tooltip")
+.popover.g-plugin-list-item-failed-notice-popover
   .arrow
   h3.popover-title
   .popover-content.g-plugin-list-item-failed-notice-popover-content

--- a/clients/web/src/views/App.js
+++ b/clients/web/src/views/App.js
@@ -1,6 +1,11 @@
 import $ from 'jquery';
 import _ from 'underscore';
 import Backbone from 'backbone';
+import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap/js/alert';
+import 'bootstrap/js/tooltip';
+
+import 'girder/utilities/jquery/girderModal';
 
 import events from 'girder/events';
 import eventStream from 'girder/utilities/EventStream';
@@ -25,11 +30,6 @@ import 'girder/routes';
 
 import 'girder/stylesheets/layout/global.styl';
 import 'girder/stylesheets/layout/layout.styl';
-
-import 'girder/utilities/jquery/girderModal';
-
-import 'bootstrap/dist/css/bootstrap.css';
-import 'bootstrap/js/alert';
 
 var App = View.extend({
     /**
@@ -180,6 +180,18 @@ var App = View.extend({
             return;
         }
         this.$el.html(LayoutTemplate());
+
+        // Set the default placement to 'auto' for all styled tooltips. Individual elements with
+        // tooltips may override this by setting a "data-placement" attribute on themselves.
+        $.fn.tooltip.Constructor.DEFAULTS.placement = 'auto';
+        // Apply styled tooltip behavior to any elements with a natural tooltip ("title" attribute).
+        this.$el.tooltip({
+            selector: '[title]',
+            // Setting "container" seems to prevent tooltip jitter near the edges of the screen.
+            // Also, placing it inside the "#g-app-body-container" will ensure that broken tooltips
+            // are cleaned up after every page navigation.
+            container: this.$('#g-app-body-container')
+        });
 
         this.globalNavView.setElement(this.$('#g-global-nav-container')).render();
         this.headerView.setElement(this.$('#g-app-header-container')).render();

--- a/clients/web/src/views/body/AssetstoresView.js
+++ b/clients/web/src/views/body/AssetstoresView.js
@@ -20,7 +20,6 @@ import 'girder/stylesheets/body/assetstores.styl';
 import 'as-jqplot/dist/jquery.jqplot.js';
 import 'as-jqplot/dist/jquery.jqplot.css'; // jquery.jqplot.min.css
 import 'as-jqplot/dist/plugins/jqplot.pieRenderer.js';
-import 'bootstrap/js/tooltip';
 
 /**
  * This private data structure is a dynamic way to map assetstore types to the views
@@ -88,7 +87,6 @@ var AssetstoresView = View.extend({
         }));
 
         this.newAssetstoreWidget.setElement(this.$('#g-new-assetstore-container')).render();
-        this.$('.g-assetstore-button-container[title]').tooltip();
 
         _.each(this.$('.g-assetstore-capacity-chart'),
             this.capacityChart, this);

--- a/clients/web/src/views/body/CollectionView.js
+++ b/clients/web/src/views/body/CollectionView.js
@@ -19,7 +19,6 @@ import CollectionPageTemplate from 'girder/templates/body/collectionPage.pug';
 import 'girder/stylesheets/body/collectionPage.styl';
 
 import 'bootstrap/js/dropdown';
-import 'bootstrap/js/tooltip';
 
 /**
  * This view shows a single collection's page.
@@ -136,13 +135,6 @@ var CollectionView = View.extend({
         this.folderEdit = false;
         this.folderCreate = false;
         this.itemCreate = false;
-
-        this.$('.g-collection-actions-button').tooltip({
-            container: 'body',
-            placement: 'left',
-            animation: false,
-            delay: {show: 100}
-        });
 
         if (this.edit) {
             this.editCollection();

--- a/clients/web/src/views/body/GroupView.js
+++ b/clients/web/src/views/body/GroupView.js
@@ -23,7 +23,6 @@ import 'girder/stylesheets/body/groupPage.styl';
 
 import 'bootstrap/js/dropdown';
 import 'bootstrap/js/tab';
-import 'bootstrap/js/tooltip';
 
 /**
  * This view shows a single group's page.
@@ -171,19 +170,6 @@ var GroupView = View.extend({
         }
 
         this._updateRolesLists();
-
-        this.$('.g-group-actions-button,a[title]').tooltip({
-            container: this.$el,
-            placement: 'left',
-            animation: false,
-            delay: {show: 100}
-        });
-        this.$('.g-group-list-header[title]').tooltip({
-            container: this.$el,
-            placement: 'top',
-            animation: false,
-            delay: {show: 100}
-        });
 
         router.navigate('group/' + this.model.get('_id') + '/' +
                                this.tab, {replace: true});

--- a/clients/web/src/views/body/ItemView.js
+++ b/clients/web/src/views/body/ItemView.js
@@ -20,7 +20,6 @@ import ItemPageTemplate from 'girder/templates/body/itemPage.pug';
 import 'girder/stylesheets/body/itemPage.styl';
 
 import 'bootstrap/js/dropdown';
-import 'bootstrap/js/tooltip';
 
 /**
  * This view shows a single item's page.
@@ -122,13 +121,6 @@ var ItemView = View.extend({
                 renderMarkdown: renderMarkdown,
                 DATE_SECOND: DATE_SECOND
             }));
-
-            this.$('.g-item-actions-button,.g-upload-into-item').tooltip({
-                container: 'body',
-                placement: 'left',
-                animation: false,
-                delay: {show: 100}
-            });
 
             this.fileListWidget = new FileListWidget({
                 el: this.$('.g-item-files-container'),

--- a/clients/web/src/views/body/PluginsView.js
+++ b/clients/web/src/views/body/PluginsView.js
@@ -15,7 +15,6 @@ import PluginsTemplate from 'girder/templates/body/plugins.pug';
 import 'girder/utilities/jquery/girderEnable';
 import 'girder/stylesheets/body/plugins.styl';
 
-import 'bootstrap/js/tooltip';
 import 'bootstrap-switch'; // /dist/js/bootstrap-switch.js',
 import 'bootstrap-switch/dist/css/bootstrap3/bootstrap-switch.css';
 
@@ -146,23 +145,6 @@ var PluginsView = View.extend({
 
                 this._updatePlugins();
             });
-        this.$('.g-plugin-config-link').tooltip({
-            container: this.$el,
-            animation: false,
-            placement: 'bottom',
-            delay: { show: 100 }
-        });
-        this.$('.g-plugin-list-item-experimental-notice').tooltip({
-            container: this.$el,
-            animation: false,
-            delay: { show: 100 }
-        });
-        this.$('.g-plugin-list-item-failed-notice').tooltip({
-            title: 'Click to see traceback',
-            container: this.$el,
-            animation: false,
-            delay: { show: 100 }
-        });
         this.$('.g-plugin-list-item-failed-notice').popover({
             container: this.$el,
             template: PluginFailedNoticeTemplate()

--- a/clients/web/src/views/body/SystemConfigurationView.js
+++ b/clients/web/src/views/body/SystemConfigurationView.js
@@ -13,7 +13,6 @@ import SystemConfigurationTemplate from 'girder/templates/body/systemConfigurati
 import 'girder/stylesheets/body/systemConfig.styl';
 
 import 'bootstrap/js/collapse';
-import 'bootstrap/js/tooltip';
 import 'bootstrap/js/transition';
 import 'bootstrap-switch'; // /dist/js/bootstrap-switch.js',
 import 'bootstrap-switch/dist/css/bootstrap3/bootstrap-switch.css';
@@ -134,12 +133,6 @@ var SystemConfigurationView = View.extend({
                                 }),
             JSON: window.JSON
         }));
-
-        this.$('input[title]').tooltip({
-            container: this.$el,
-            animation: false,
-            delay: { show: 200 }
-        });
 
         var enableCollectionCrreationPolicy = this.settings['core.collection_create_policy'] ? this.settings['core.collection_create_policy'].open : false;
 

--- a/clients/web/src/views/widgets/AccessWidget.js
+++ b/clients/web/src/views/widgets/AccessWidget.js
@@ -16,8 +16,6 @@ import { restRequest } from 'girder/rest';
 
 import 'girder/stylesheets/widgets/accessWidget.styl';
 
-import 'bootstrap/js/tooltip';
-
 import 'girder/utilities/jquery/girderModal';
 
 /**
@@ -164,7 +162,6 @@ var AccessWidget = View.extend({
                 })
             }));
         }, this);
-
         this._makeTooltips();
 
         this.searchWidget.setElement(this.$('.g-search-field-container')).render();
@@ -175,16 +172,6 @@ var AccessWidget = View.extend({
     },
 
     _makeTooltips: function () {
-        this.$('.g-access-action-container a,.g-tooltip').tooltip({
-            placement: 'bottom',
-            animation: false,
-            delay: { show: 100 }
-        });
-
-        this.$('.g-flag-label span').tooltip({
-            placement: 'bottom'
-        });
-
         // Re-binding popovers actually breaks them, so we make sure to
         // only bind ones that aren't already bound.
         _.each(this.$('.g-action-manage-flags'), (el) => {
@@ -268,7 +255,6 @@ var AccessWidget = View.extend({
                     noAccessFlag: this.noAccessFlag,
                     flagList: this.flagList
                 }));
-
                 this._makeTooltips();
             }, this).fetch();
         }

--- a/clients/web/src/views/widgets/ApiKeyListWidget.js
+++ b/clients/web/src/views/widgets/ApiKeyListWidget.js
@@ -103,7 +103,6 @@ var ApiKeyListWidget = View.extend({
             moment: moment
         }));
 
-        this.$('button').tooltip();
         this.$('.g-show-api-key').popover({
             container: this.$('.g-api-key-table'),
             placement: 'top'

--- a/clients/web/src/views/widgets/EditApiKeyWidget.js
+++ b/clients/web/src/views/widgets/EditApiKeyWidget.js
@@ -94,11 +94,6 @@ var EditApiKeyWidget = View.extend({
         modal.trigger($.Event('ready.girder.modal', {relatedTarget: modal}));
 
         this.$('#g-api-key-name').focus();
-        this.$('.g-custom-scope-description').tooltip({
-            placement: 'right',
-            viewport: this.$el,
-            trigger: 'hover'
-        });
 
         return this;
     },

--- a/clients/web/src/views/widgets/FileListWidget.js
+++ b/clients/web/src/views/widgets/FileListWidget.js
@@ -13,8 +13,6 @@ import events from 'girder/events';
 
 import FileListTemplate from 'girder/templates/widgets/fileList.pug';
 
-import 'bootstrap/js/tooltip';
-
 /**
  * This widget shows a list of files in a given item.
  */
@@ -129,12 +127,6 @@ var FileListWidget = View.extend({
             formatSize: formatSize,
             parentItem: this.parentItem
         }));
-
-        this.$('.g-file-list-entry a[title]').tooltip({
-            container: 'body',
-            placement: 'auto',
-            delay: 100
-        });
 
         if (this.fileEdit) {
             this.editFileDialog(this.fileEdit);

--- a/clients/web/src/views/widgets/GroupAdminsWidget.js
+++ b/clients/web/src/views/widgets/GroupAdminsWidget.js
@@ -11,7 +11,6 @@ import events from 'girder/events';
 import GroupAdminListTemplate from 'girder/templates/widgets/groupAdminList.pug';
 
 import 'bootstrap/js/dropdown';
-import 'bootstrap/js/tooltip';
 
 /**
  * This view shows a list of administrators of a group.
@@ -81,13 +80,6 @@ var GroupAdminsWidget = View.extend({
             admins: this.admins,
             accessType: AccessType
         }));
-
-        this.$('.g-group-admin-demote').tooltip({
-            container: 'body',
-            placement: 'left',
-            animation: false,
-            delay: {show: 100}
-        });
 
         return this;
     }

--- a/clients/web/src/views/widgets/GroupInvitesWidget.js
+++ b/clients/web/src/views/widgets/GroupInvitesWidget.js
@@ -8,8 +8,6 @@ import { confirm } from 'girder/dialog';
 
 import GroupInviteListTemplate from 'girder/templates/widgets/groupInviteList.pug';
 
-import 'bootstrap/js/tooltip';
-
 /**
  * This view shows a list of pending invitations to the group.
  */
@@ -50,13 +48,6 @@ var GroupInvitesWidget = View.extend({
             invitees: this.collection.toArray(),
             accessType: AccessType
         }));
-
-        this.$('a[title]').tooltip({
-            container: this.$el,
-            placement: 'left',
-            animation: false,
-            delay: {show: 100}
-        });
 
         return this;
     }

--- a/clients/web/src/views/widgets/GroupMembersWidget.js
+++ b/clients/web/src/views/widgets/GroupMembersWidget.js
@@ -14,7 +14,6 @@ import GroupMemberListTemplate from 'girder/templates/widgets/groupMemberList.pu
 
 import 'bootstrap/js/collapse';
 import 'bootstrap/js/dropdown';
-import 'bootstrap/js/tooltip';
 import 'bootstrap/js/transition';
 
 import 'girder/utilities/jquery/girderModal';
@@ -161,13 +160,6 @@ var GroupMembersWidget = View.extend({
             types: ['user'],
             parentView: this
         }).off().on('g:resultClicked', this._inviteUser, this).render();
-
-        this.$('.g-group-member-remove,.g-group-member-promote').tooltip({
-            container: 'body',
-            placement: 'left',
-            animation: false,
-            delay: {show: 100}
-        });
 
         return this;
     },

--- a/clients/web/src/views/widgets/GroupModsWidget.js
+++ b/clients/web/src/views/widgets/GroupModsWidget.js
@@ -10,8 +10,6 @@ import events from 'girder/events';
 
 import GroupModListTemplate from 'girder/templates/widgets/groupModList.pug';
 
-import 'bootstrap/js/tooltip';
-
 /**
  * This view shows a list of moderators of a group.
  */
@@ -71,13 +69,6 @@ var GroupModsWidget = View.extend({
             moderators: this.moderators,
             accessType: AccessType
         }));
-
-        this.$('.g-group-mod-demote.g-group-mod-promote,.g-group-mod-remove').tooltip({
-            container: 'body',
-            placement: 'left',
-            animation: false,
-            delay: {show: 100}
-        });
 
         return this;
     }

--- a/clients/web/src/views/widgets/HierarchyWidget.js
+++ b/clients/web/src/views/widgets/HierarchyWidget.js
@@ -28,7 +28,6 @@ import HierarchyWidgetTemplate from 'girder/templates/widgets/hierarchyWidget.pu
 import 'girder/stylesheets/widgets/hierarchyWidget.styl';
 
 import 'bootstrap/js/dropdown';
-import 'bootstrap/js/tooltip';
 
 var pickedResources = null;
 
@@ -92,6 +91,7 @@ var HierarchyWidget = View.extend({
         'click a.g-delete-checked': 'deleteCheckedDialog',
         'click .g-list-checkbox': 'checkboxListener',
         'change .g-select-all': function (e) {
+            $(e.currentTarget).tooltip('hide');
             this.folderListView.checkAll(e.currentTarget.checked);
 
             if (this.itemListView) {
@@ -294,17 +294,6 @@ var HierarchyWidget = View.extend({
                 this.metadataWidget.setElement(this.$('.g-folder-metadata')).render();
             }
         }
-
-        this.$('[title]').tooltip({
-            container: this.$el,
-            animation: false,
-            delay: {
-                show: 100
-            },
-            placement: function () {
-                return this.$element.attr('placement') || 'top';
-            }
-        });
 
         if (this.upload) {
             this.uploadDialog();

--- a/clients/web/src/views/widgets/ItemBreadcrumbWidget.js
+++ b/clients/web/src/views/widgets/ItemBreadcrumbWidget.js
@@ -5,8 +5,6 @@ import View from 'girder/views/View';
 
 import IteamBreadcrumbTemplate from 'girder/templates/widgets/itemBreadcrumb.pug';
 
-import 'bootstrap/js/tooltip';
-
 /**
  * Renders the a breadcrumb for the item page
  */
@@ -32,13 +30,6 @@ var ItemBreadcrumbWidget = View.extend({
         this.$el.html(IteamBreadcrumbTemplate({
             parentChain: this.parentChain
         }));
-
-        this.$('.g-hierarchy-level-up').tooltip({
-            container: this.$el,
-            placement: 'left',
-            animation: false,
-            delay: {show: 100}
-        });
 
         return this;
     }

--- a/clients/web/src/views/widgets/ItemListWidget.js
+++ b/clients/web/src/views/widgets/ItemListWidget.js
@@ -80,12 +80,6 @@ var ItemListWidget = View.extend({
             showSizes: this._showSizes
         }));
 
-        this.$('.g-item-list-entry a[title]').tooltip({
-            container: 'body',
-            placement: 'auto',
-            delay: 100
-        });
-
         return this;
     },
 

--- a/clients/web/src/views/widgets/MetadataWidget.js
+++ b/clients/web/src/views/widgets/MetadataWidget.js
@@ -19,7 +19,6 @@ import JSONEditor from 'jsoneditor/dist/jsoneditor.js'; // can't 'jsoneditor'
 import 'jsoneditor/dist/jsoneditor.css';
 
 import 'bootstrap/js/dropdown';
-import 'bootstrap/js/tooltip';
 
 var MetadatumWidget = View.extend({
     className: 'g-widget-metadata-row',
@@ -289,13 +288,6 @@ var MetadatumEditWidget = View.extend({
         }));
         this.$el.find('.g-widget-metadata-key-input').focus();
 
-        this.$('[title]').tooltip({
-            container: this.$el,
-            placement: 'bottom',
-            animation: false,
-            delay: {show: 100}
-        });
-
         return this;
     }
 });
@@ -502,13 +494,6 @@ var MetadataWidget = View.extend({
                 onMetadataAdded: this.onMetadataAdded
             }).render().$el);
         }, this);
-
-        this.$('.g-widget-metadata-add-button').tooltip({
-            container: this.$el,
-            placement: 'left',
-            animation: false,
-            delay: {show: 100}
-        });
 
         return this;
     }

--- a/clients/web/src/views/widgets/SearchFieldWidget.js
+++ b/clients/web/src/views/widgets/SearchFieldWidget.js
@@ -11,7 +11,6 @@ import SearchResultsTemplate from 'girder/templates/widgets/searchResults.pug';
 
 import 'girder/stylesheets/widgets/searchFieldWidget.styl';
 
-import 'bootstrap/js/tooltip';
 import 'bootstrap/js/popover';
 
 /**
@@ -125,10 +124,6 @@ var SearchFieldWidget = View.extend({
             modes: this.modes,
             currentMode: this.currentMode
         }));
-
-        this.$('[title]').tooltip({
-            placement: 'auto'
-        });
 
         this.$('.g-search-options-button').popover({
             trigger: 'manual',

--- a/clients/web/src/views/widgets/TimelineWidget.js
+++ b/clients/web/src/views/widgets/TimelineWidget.js
@@ -6,8 +6,6 @@ import TimelineTemplate from 'girder/templates/widgets/timeline.pug';
 
 import 'girder/stylesheets/widgets/timelineWidget.styl';
 
-import 'bootstrap/js/tooltip';
-
 /**
  * This widget displays a timeline of events. This is visualized as a line (a bar)
  * with two sorts of primitives overlaid:
@@ -95,10 +93,6 @@ var TimelineWidget = View.extend({
             var classes = segment.class ? [segment.class] : [this.defaultSegmentClass];
             var color = segment.color ? `background-color: ${segment.color}` : '';
 
-            if (segment.tooltip) {
-                classes.push('g-tooltip');
-            }
-
             return {
                 class: classes.join(' '),
                 left: (100 * (start - this.startTime) / range).toFixed(1) + '%',
@@ -114,10 +108,6 @@ var TimelineWidget = View.extend({
             var time = this.numeric ? point.time : new Date(point.time);
             var classes = point.class ? [point.class] : [this.defaultPointClass];
             var color = point.color ? `background-color: ${point.color}` : '';
-
-            if (point.tooltip) {
-                classes.push('g-tooltip');
-            }
 
             return {
                 class: classes.join(' '),
@@ -157,11 +147,6 @@ var TimelineWidget = View.extend({
             startLabel: this.startLabel,
             endLabel: this.endLabel
         }));
-
-        this.$('.g-tooltip').tooltip({
-            delay: 100,
-            container: this.$el
-        });
 
         return this;
     }

--- a/plugins/autojoin/web_client/views/ConfigView.js
+++ b/plugins/autojoin/web_client/views/ConfigView.js
@@ -97,13 +97,6 @@ var ConfigView = View.extend({
             parentView: this
         }).render();
 
-        this.$('[title]').tooltip({
-            container: this.$el,
-            placement: 'left',
-            animation: false,
-            delay: {show: 100}
-        });
-
         return this;
     },
 

--- a/plugins/hashsum_download/web_client/views/FileInfoWidget.js
+++ b/plugins/hashsum_download/web_client/views/FileInfoWidget.js
@@ -21,8 +21,6 @@ wrap(FileInfoWidget, 'render', function (render) {
         AccessType
     }));
 
-    this.$('.g-keyfile-download').tooltip();
-
     return this;
 });
 

--- a/plugins/hdfs_assetstore/web_client/views/AssetstoresView.js
+++ b/plugins/hdfs_assetstore/web_client/views/AssetstoresView.js
@@ -28,8 +28,4 @@ wrap(AssetstoresView, 'render', function (render) {
             })
         );
     }, this);
-
-    this.$('.g-hdfs-import-button').tooltip({
-        delay: 200
-    });
 });

--- a/plugins/thumbnails/web_client/views/FileListWidget.js
+++ b/plugins/thumbnails/web_client/views/FileListWidget.js
@@ -16,11 +16,6 @@ wrap(FileListWidget, 'render', function (render) {
 
     if (this.parentItem.getAccessLevel() >= AccessType.WRITE) {
         this.$('.g-file-actions-container').prepend(FileListWidgetCreateButtonTemplate());
-        this.$('.g-create-thumbnail').tooltip({
-            container: 'body',
-            placement: 'auto',
-            delay: 100
-        });
     }
 
     return this;

--- a/plugins/thumbnails/web_client/views/FlowView.js
+++ b/plugins/thumbnails/web_client/views/FlowView.js
@@ -56,10 +56,6 @@ var FlowView = View.extend({
             AccessType: AccessType
         }));
 
-        this.$('.g-thumbnail-actions-container a').tooltip({
-            delay: 100
-        });
-
         return this;
     }
 });


### PR DESCRIPTION
This delegates all styled tooltip behavior to the top-level App. This removes many lines of code, while ensuring that all tooltips are styled consistently. Previously, many tooltips were not styled with the Bootstrap effect.