### PR TITLE
Prevent Moment.js locale files from being included in the Webpack build

### DIFF
--- a/clients/web/src/package.json
+++ b/clients/web/src/package.json
@@ -19,6 +19,7 @@
         "eonasdan-bootstrap-datetimepicker": "~4.17",
         "jquery": "~3.2.1",
         "jsoneditor": "~5.9.3",
+        "moment": "~2.18.1",
         "remarkable": "~1.7.1",
         "sprintf-js": "~1.0.3",
         "swagger-ui": "~2.2.10",

--- a/grunt_tasks/webpack.config.js
+++ b/grunt_tasks/webpack.config.js
@@ -68,6 +68,10 @@ module.exports = {
         // '__webpack_public_path__', since it's not always known at build-time.
     },
     plugins: [
+        // Exclude all of Moment.js's extra locale files (from where they're imported in either the
+        // ES6-source or UMD-built imports), to reduce build size.
+        new webpack.IgnorePlugin(/^\.\/locale$/, /moment(?:\/src\/lib\/locale)?$/),
+
         // Automatically detect jQuery and $ as free var in modules
         // and inject the jquery library. This is required by many jquery plugins
         new webpack.ProvidePlugin({
@@ -75,6 +79,7 @@ module.exports = {
             $: 'jquery',
             'window.jQuery': 'jquery'
         }),
+
         // Disable writing the output file if a build error occurs
         new webpack.NoEmitOnErrorsPlugin()
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,16 +5,16 @@
     "requires": true,
     "dependencies": {
         "abab": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
-            "integrity": "sha1-uB3l9ydOxOdW15fNg08wNkJyTl0=",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+            "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
             "dev": true,
             "optional": true
         },
         "abbrev": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-            "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
         "acorn": {
             "version": "3.3.0",
@@ -61,9 +61,9 @@
             }
         },
         "ajv": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
-            "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+            "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
             "requires": {
                 "co": "4.6.0",
                 "fast-deep-equal": "1.0.0",
@@ -217,9 +217,9 @@
             }
         },
         "assert-plus": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-            "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
             "dev": true
         },
         "async": {
@@ -252,7 +252,7 @@
             "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
             "requires": {
                 "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000725",
+                "caniuse-db": "1.0.30000740",
                 "normalize-range": "0.1.2",
                 "num2fraction": "1.2.2",
                 "postcss": "5.2.17",
@@ -260,10 +260,11 @@
             }
         },
         "aws-sign2": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-            "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-            "dev": true
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+            "dev": true,
+            "optional": true
         },
         "aws4": {
             "version": "1.6.0",
@@ -297,7 +298,7 @@
                 "babel-types": "6.26.0",
                 "babylon": "6.18.0",
                 "convert-source-map": "1.5.0",
-                "debug": "2.6.8",
+                "debug": "2.6.9",
                 "json5": "0.5.1",
                 "lodash": "4.17.4",
                 "minimatch": "3.0.4",
@@ -462,9 +463,9 @@
             }
         },
         "babel-plugin-istanbul": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.4.tgz",
-            "integrity": "sha1-GN3oS/POMp/d8/QQP66SFFbY5Yc=",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz",
+            "integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
             "dev": true,
             "requires": {
                 "find-up": "2.1.0",
@@ -766,7 +767,7 @@
                 "home-or-tmp": "2.0.0",
                 "lodash": "4.17.4",
                 "mkdirp": "0.5.1",
-                "source-map-support": "0.4.17"
+                "source-map-support": "0.4.18"
             }
         },
         "babel-runtime": {
@@ -800,7 +801,7 @@
                 "babel-runtime": "6.26.0",
                 "babel-types": "6.26.0",
                 "babylon": "6.18.0",
-                "debug": "2.6.8",
+                "debug": "2.6.9",
                 "globals": "9.18.0",
                 "invariant": "2.2.2",
                 "lodash": "4.17.4"
@@ -851,9 +852,9 @@
             }
         },
         "big.js": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
-            "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg="
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+            "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
         },
         "binary": {
             "version": "0.3.0",
@@ -881,12 +882,13 @@
             "dev": true
         },
         "boom": {
-            "version": "2.10.1",
-            "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-            "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+            "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
             "dev": true,
+            "optional": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "4.2.0"
             }
         },
         "bootstrap": {
@@ -1000,8 +1002,8 @@
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
             "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
             "requires": {
-                "caniuse-db": "1.0.30000725",
-                "electron-to-chromium": "1.3.20"
+                "caniuse-db": "1.0.30000740",
+                "electron-to-chromium": "1.3.24"
             }
         },
         "buffer": {
@@ -1074,15 +1076,15 @@
             "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
             "requires": {
                 "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000725",
+                "caniuse-db": "1.0.30000740",
                 "lodash.memoize": "4.1.2",
                 "lodash.uniq": "4.5.0"
             }
         },
         "caniuse-db": {
-            "version": "1.0.30000725",
-            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000725.tgz",
-            "integrity": "sha1-IPIxPXlAHgL2GEDzlpi8jFWIEaY="
+            "version": "1.0.30000740",
+            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000740.tgz",
+            "integrity": "sha1-A/yqoXbj7QdYlfctRsGhIUm76sk="
         },
         "caseless": {
             "version": "0.12.0",
@@ -1182,9 +1184,9 @@
             "dev": true
         },
         "clap": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.0.tgz",
-            "integrity": "sha1-WckP4+E3EEdG/xlGmiemNP9oyFc=",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
+            "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
             "requires": {
                 "chalk": "1.1.3"
             }
@@ -1198,14 +1200,6 @@
                 "source-map": "0.4.4"
             },
             "dependencies": {
-                "commander": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-                    "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-                    "requires": {
-                        "graceful-readlink": "1.0.1"
-                    }
-                },
                 "source-map": {
                     "version": "0.4.4",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
@@ -1341,9 +1335,12 @@
             }
         },
         "commander": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-            "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+            "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+            "requires": {
+                "graceful-readlink": "1.0.1"
+            }
         },
         "commondir": {
             "version": "1.0.1",
@@ -1425,7 +1422,7 @@
                 "cipher-base": "1.0.4",
                 "inherits": "2.0.3",
                 "ripemd160": "2.0.1",
-                "sha.js": "2.4.8"
+                "sha.js": "2.4.9"
             }
         },
         "create-hmac": {
@@ -1438,16 +1435,29 @@
                 "inherits": "2.0.3",
                 "ripemd160": "2.0.1",
                 "safe-buffer": "5.1.1",
-                "sha.js": "2.4.8"
+                "sha.js": "2.4.9"
             }
         },
         "cryptiles": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-            "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+            "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
             "dev": true,
+            "optional": true,
             "requires": {
-                "boom": "2.10.1"
+                "boom": "5.2.0"
+            },
+            "dependencies": {
+                "boom": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+                    "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "hoek": "4.2.0"
+                    }
+                }
             }
         },
         "crypto-browserify": {
@@ -1462,7 +1472,7 @@
                 "create-hmac": "1.1.6",
                 "diffie-hellman": "5.0.2",
                 "inherits": "2.0.3",
-                "pbkdf2": "3.0.13",
+                "pbkdf2": "3.0.14",
                 "public-encrypt": "4.0.0",
                 "randombytes": "2.0.5"
             }
@@ -1529,7 +1539,7 @@
                     "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
                     "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
                     "requires": {
-                        "regenerate": "1.3.2",
+                        "regenerate": "1.3.3",
                         "regjsgen": "0.2.0",
                         "regjsparser": "0.1.5"
                     }
@@ -1591,7 +1601,7 @@
             "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
             "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
             "requires": {
-                "clap": "1.2.0",
+                "clap": "1.2.3",
                 "source-map": "0.5.7"
             }
         },
@@ -1635,14 +1645,6 @@
             "dev": true,
             "requires": {
                 "assert-plus": "1.0.0"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                    "dev": true
-                }
             }
         },
         "date-now": {
@@ -1660,9 +1662,9 @@
             }
         },
         "debug": {
-            "version": "2.6.8",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-            "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
             "requires": {
                 "ms": "2.0.0"
             }
@@ -1753,7 +1755,7 @@
             "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
             "requires": {
                 "bn.js": "4.11.8",
-                "miller-rabin": "4.0.0",
+                "miller-rabin": "4.0.1",
                 "randombytes": "2.0.5"
             }
         },
@@ -1831,9 +1833,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.20",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.20.tgz",
-            "integrity": "sha1-Lu3VzLrn3cVX9orR/OnBcukV5OU="
+            "version": "1.3.24",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.24.tgz",
+            "integrity": "sha1-m3uIuwXOufoBahd4M8wt3jiPIbY="
         },
         "elliptic": {
             "version": "6.4.0",
@@ -1859,7 +1861,7 @@
             "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
             "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
             "requires": {
-                "iconv-lite": "0.4.18"
+                "iconv-lite": "0.4.19"
             }
         },
         "enhanced-resolve": {
@@ -1994,28 +1996,25 @@
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "escodegen": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-            "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
+            "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
             "dev": true,
             "optional": true,
             "requires": {
-                "esprima": "2.7.3",
-                "estraverse": "1.9.3",
+                "esprima": "3.1.3",
+                "estraverse": "4.2.0",
                 "esutils": "2.0.2",
                 "optionator": "0.8.2",
-                "source-map": "0.2.0"
+                "source-map": "0.5.7"
             },
             "dependencies": {
-                "source-map": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-                    "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+                "esprima": {
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+                    "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
                     "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "amdefine": "1.0.1"
-                    }
+                    "optional": true
                 }
             }
         },
@@ -2029,14 +2028,6 @@
                 "es6-weak-map": "2.0.2",
                 "esrecurse": "4.2.0",
                 "estraverse": "4.2.0"
-            },
-            "dependencies": {
-                "estraverse": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-                    "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-                    "dev": true
-                }
             }
         },
         "esdoc": {
@@ -2083,7 +2074,7 @@
                         "babel-runtime": "6.26.0",
                         "babel-types": "6.26.0",
                         "babylon": "6.14.1",
-                        "debug": "2.6.8",
+                        "debug": "2.6.9",
                         "globals": "8.18.0",
                         "invariant": "2.2.2",
                         "lodash": "4.17.4"
@@ -2138,10 +2129,10 @@
                 "babel-code-frame": "6.26.0",
                 "chalk": "1.1.3",
                 "concat-stream": "1.6.0",
-                "debug": "2.6.8",
+                "debug": "2.6.9",
                 "doctrine": "2.0.0",
                 "escope": "3.6.0",
-                "espree": "3.5.0",
+                "espree": "3.5.1",
                 "esquery": "1.0.0",
                 "estraverse": "4.2.0",
                 "esutils": "2.0.2",
@@ -2172,12 +2163,6 @@
                 "user-home": "2.0.0"
             },
             "dependencies": {
-                "estraverse": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-                    "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-                    "dev": true
-                },
                 "strip-bom": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -2210,7 +2195,7 @@
             "integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
             "dev": true,
             "requires": {
-                "debug": "2.6.8",
+                "debug": "2.6.9",
                 "resolve": "1.4.0"
             },
             "dependencies": {
@@ -2231,7 +2216,7 @@
             "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
             "dev": true,
             "requires": {
-                "debug": "2.6.8",
+                "debug": "2.6.9",
                 "pkg-dir": "1.0.0"
             },
             "dependencies": {
@@ -2279,7 +2264,7 @@
             "requires": {
                 "builtin-modules": "1.1.1",
                 "contains-path": "0.1.0",
-                "debug": "2.6.8",
+                "debug": "2.6.9",
                 "doctrine": "1.5.0",
                 "eslint-import-resolver-node": "0.3.1",
                 "eslint-module-utils": "2.1.1",
@@ -2350,9 +2335,9 @@
             }
         },
         "eslint-plugin-node": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-5.1.1.tgz",
-            "integrity": "sha512-3xdoEbPyyQNyGhhqttjgSO3cU/non8QDBJF8ttGaHM2h8CaY5zFIngtqW6ZbLEIvhpoFPDVwiQg61b8zanx5zQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-5.2.0.tgz",
+            "integrity": "sha512-N9FLFwknT5LhRhjz1lmHguNss/MCwkrLCS4CjqqTZZTJaUhLRfDNK3zxSHL/Il3Aa0Mw+xY3T1gtsJrUNoJy8Q==",
             "dev": true,
             "requires": {
                 "ignore": "3.3.5",
@@ -2408,9 +2393,9 @@
             }
         },
         "espree": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
-            "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
+            "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
             "dev": true,
             "requires": {
                 "acorn": "5.1.2",
@@ -2437,14 +2422,6 @@
             "dev": true,
             "requires": {
                 "estraverse": "4.2.0"
-            },
-            "dependencies": {
-                "estraverse": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-                    "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-                    "dev": true
-                }
             }
         },
         "esrecurse": {
@@ -2455,22 +2432,13 @@
             "requires": {
                 "estraverse": "4.2.0",
                 "object-assign": "4.1.1"
-            },
-            "dependencies": {
-                "estraverse": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-                    "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-                    "dev": true
-                }
             }
         },
         "estraverse": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-            "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
-            "dev": true,
-            "optional": true
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+            "dev": true
         },
         "esutils": {
             "version": "2.0.2",
@@ -2674,7 +2642,7 @@
             "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
             "dev": true,
             "requires": {
-                "flat-cache": "1.2.2",
+                "flat-cache": "1.3.0",
                 "object-assign": "4.1.1"
             }
         },
@@ -2775,9 +2743,9 @@
             }
         },
         "flat-cache": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-            "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+            "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
             "dev": true,
             "requires": {
                 "circular-json": "0.3.3",
@@ -2811,10 +2779,11 @@
             "dev": true
         },
         "form-data": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-            "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+            "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "asynckit": "0.4.0",
                 "combined-stream": "1.0.5",
@@ -2900,14 +2869,6 @@
             "dev": true,
             "requires": {
                 "assert-plus": "1.0.0"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                    "dev": true
-                }
             }
         },
         "girder": {
@@ -2919,7 +2880,8 @@
                 "bootstrap-switch": "3.3.4",
                 "eonasdan-bootstrap-datetimepicker": "4.17.47",
                 "jquery": "3.2.1",
-                "jsoneditor": "5.9.5",
+                "jsoneditor": "5.9.6",
+                "moment": "2.18.1",
                 "remarkable": "1.7.1",
                 "sprintf-js": "1.0.3",
                 "swagger-ui": "2.2.10",
@@ -2976,12 +2938,12 @@
             }
         },
         "google-fonts-webpack-plugin": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/google-fonts-webpack-plugin/-/google-fonts-webpack-plugin-0.4.2.tgz",
-            "integrity": "sha512-R2U78SPlRY/cKmpEQMlDgk8J6FxchY/eSUeTV89/4GGXT2n2x6lgk/iMCjAQX9o7TPusCL01Gxuplrw0jN41xg==",
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/google-fonts-webpack-plugin/-/google-fonts-webpack-plugin-0.4.3.tgz",
+            "integrity": "sha512-hygzpL205XMUpgp8k9Ybnx/3VkGkvzdvYeJ1O15sn8VaH43PfnHKNRA7Ywo0mTFY+COjN+c+rlr/GWT1/ptmOA==",
             "requires": {
                 "lodash": "4.17.4",
-                "node-fetch": "1.7.2",
+                "node-fetch": "1.7.3",
                 "webpack-sources": "0.2.3",
                 "yauzl": "2.8.0"
             },
@@ -3027,7 +2989,7 @@
                 "grunt-known-options": "1.1.0",
                 "grunt-legacy-log": "1.0.0",
                 "grunt-legacy-util": "1.0.0",
-                "iconv-lite": "0.4.18",
+                "iconv-lite": "0.4.19",
                 "js-yaml": "3.5.5",
                 "minimatch": "3.0.4",
                 "nopt": "3.0.6",
@@ -3072,7 +3034,7 @@
             "integrity": "sha1-tSWlwK/wRiL3Vw4x+SQQbxb4G0Y=",
             "requires": {
                 "chalk": "1.1.3",
-                "pug": "2.0.0-rc.3"
+                "pug": "2.0.0-rc.4"
             }
         },
         "grunt-contrib-stylus": {
@@ -3100,14 +3062,30 @@
             "integrity": "sha1-yDYWwDVxGmwAYqKBDPHHf/xr7Ss="
         },
         "grunt-contrib-uglify": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-3.0.1.tgz",
-            "integrity": "sha1-/etfk4pMgEL46Grkb2NVTo6VEcs=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-3.1.0.tgz",
+            "integrity": "sha512-4Dx6HOI4ipP4wOqHZEGYYLmBGMccfS6XAI8OOBCiLhLEN54CtxVdCYgT83dPdhxLpXFhNpG89frRjfqcos4H5w==",
             "requires": {
                 "chalk": "1.1.3",
                 "maxmin": "1.1.0",
                 "uglify-js": "3.0.28",
                 "uri-path": "1.0.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.11.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+                    "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+                },
+                "uglify-js": {
+                    "version": "3.0.28",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.28.tgz",
+                    "integrity": "sha512-0h/qGay016GG2lVav3Kz174F3T2Vjlz2v6HCt+WDQpoXfco0hWwF5gHK9yh88mUYvIC+N7Z8NT8WpjSp1yoqGA==",
+                    "requires": {
+                        "commander": "2.11.0",
+                        "source-map": "0.5.7"
+                    }
+                }
             }
         },
         "grunt-file-creator": {
@@ -3304,56 +3282,25 @@
                     "requires": {
                         "amdefine": "1.0.1"
                     }
-                },
-                "uglify-js": {
-                    "version": "2.8.29",
-                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-                    "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "source-map": "0.5.7",
-                        "uglify-to-browserify": "1.0.2",
-                        "yargs": "3.10.0"
-                    },
-                    "dependencies": {
-                        "source-map": {
-                            "version": "0.5.7",
-                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                            "dev": true,
-                            "optional": true
-                        }
-                    }
                 }
             }
         },
         "har-schema": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-            "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-            "dev": true
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "dev": true,
+            "optional": true
         },
         "har-validator": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-            "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+            "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
             "dev": true,
+            "optional": true,
             "requires": {
-                "ajv": "4.11.8",
-                "har-schema": "1.0.5"
-            },
-            "dependencies": {
-                "ajv": {
-                    "version": "4.11.8",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-                    "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-                    "dev": true,
-                    "requires": {
-                        "co": "4.6.0",
-                        "json-stable-stringify": "1.0.1"
-                    }
-                }
+                "ajv": "5.2.3",
+                "har-schema": "2.0.0"
             }
         },
         "has": {
@@ -3405,15 +3352,16 @@
             }
         },
         "hawk": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-            "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+            "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
             "dev": true,
+            "optional": true,
             "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.0",
+                "sntp": "2.0.2"
             }
         },
         "hmac-drbg": {
@@ -3427,9 +3375,9 @@
             }
         },
         "hoek": {
-            "version": "2.16.3",
-            "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-            "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+            "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
             "dev": true
         },
         "home-or-tmp": {
@@ -3471,12 +3419,13 @@
             }
         },
         "http-signature": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-            "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "dev": true,
+            "optional": true,
             "requires": {
-                "assert-plus": "0.2.0",
+                "assert-plus": "1.0.0",
                 "jsprim": "1.4.1",
                 "sshpk": "1.13.1"
             }
@@ -3567,9 +3516,9 @@
             }
         },
         "iconv-lite": {
-            "version": "0.4.18",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-            "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA=="
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+            "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
         },
         "icss-replace-symbols": {
             "version": "1.1.0",
@@ -3647,9 +3596,9 @@
             }
         },
         "interpret": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-            "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A="
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
+            "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA="
         },
         "invariant": {
             "version": "2.2.2",
@@ -4005,17 +3954,17 @@
             "integrity": "sha512-mukVvSXCn9JQvdJl8wP/iPhqig0MRtuWuD4ZNKo6vB2Ik//AmhAKe3QnPN02dmkRe3lTudFk3rzoHhwU4hb94w==",
             "dev": true,
             "requires": {
-                "debug": "2.6.8",
+                "debug": "2.6.9",
                 "istanbul-lib-coverage": "1.1.1",
                 "mkdirp": "0.5.1",
-                "rimraf": "2.6.1",
+                "rimraf": "2.6.2",
                 "source-map": "0.5.7"
             },
             "dependencies": {
                 "rimraf": {
-                    "version": "2.6.1",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-                    "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+                    "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
                     "dev": true,
                     "requires": {
                         "glob": "7.0.6"
@@ -4043,9 +3992,9 @@
             "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c="
         },
         "js-base64": {
-            "version": "2.1.9",
-            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
-            "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4="
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz",
+            "integrity": "sha512-Y2/+DnfJJXT1/FCwUebUhLWb3QihxiSC42+ctHLGogmW2jPY6LCapMdFZXRvVP2z6qyKW7s6qncE/9gSqZiArw=="
         },
         "js-stringify": {
             "version": "1.0.2",
@@ -4080,18 +4029,18 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "abab": "1.0.3",
+                "abab": "1.0.4",
                 "acorn": "2.7.0",
                 "acorn-globals": "1.0.9",
                 "cssom": "0.3.2",
                 "cssstyle": "0.2.37",
-                "escodegen": "1.8.1",
-                "nwmatcher": "1.4.1",
+                "escodegen": "1.9.0",
+                "nwmatcher": "1.4.2",
                 "parse5": "1.5.1",
-                "request": "2.81.0",
+                "request": "2.83.0",
                 "sax": "1.2.4",
                 "symbol-tree": "3.2.2",
-                "tough-cookie": "2.3.2",
+                "tough-cookie": "2.3.3",
                 "webidl-conversions": "2.0.1",
                 "whatwg-url-compat": "0.6.5",
                 "xml-name-validator": "2.0.1"
@@ -4156,9 +4105,9 @@
             "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
         },
         "jsoneditor": {
-            "version": "5.9.5",
-            "resolved": "https://registry.npmjs.org/jsoneditor/-/jsoneditor-5.9.5.tgz",
-            "integrity": "sha512-WuHscgvDMNA2K6aNBQQNqfBcF6Hd7mx/AB7uxO5hYnV7TsDsDZAzCTxCbqaWoR4/Iv/VVYcNsOMTUZttGau9Wg==",
+            "version": "5.9.6",
+            "resolved": "https://registry.npmjs.org/jsoneditor/-/jsoneditor-5.9.6.tgz",
+            "integrity": "sha512-CV/TmcewPp58GZg36rHtmOZOSZqnQod1DoqvGdQcHeDv6zR8MmQ78KDNdl4JFzj6YJGUAMqNolGexBlZ1Hpgsg==",
             "requires": {
                 "ajv": "5.2.0",
                 "brace": "0.10.0",
@@ -4213,14 +4162,6 @@
                 "extsprintf": "1.3.0",
                 "json-schema": "0.2.3",
                 "verror": "1.10.0"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                    "dev": true
-                }
             }
         },
         "jstransformer": {
@@ -4308,7 +4249,7 @@
             "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
             "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
             "requires": {
-                "big.js": "3.1.3",
+                "big.js": "3.2.0",
                 "emojis-list": "2.1.0",
                 "json5": "0.5.1"
             }
@@ -4611,9 +4552,9 @@
             }
         },
         "miller-rabin": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
-            "integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+            "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
             "requires": {
                 "bn.js": "4.11.8",
                 "brorand": "1.1.0"
@@ -4716,8 +4657,8 @@
             "resolved": "https://registry.npmjs.org/needle/-/needle-0.11.0.tgz",
             "integrity": "sha1-AqcbAI6vfVWuifuf12hbe4jXvCk=",
             "requires": {
-                "debug": "2.6.8",
-                "iconv-lite": "0.4.18"
+                "debug": "2.6.9",
+                "iconv-lite": "0.4.19"
             }
         },
         "nib": {
@@ -4729,9 +4670,9 @@
             }
         },
         "node-fetch": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.2.tgz",
-            "integrity": "sha512-xZZUq2yDhKMIn/UgG5q//IZSNLJIwW2QxS14CNH5spuiXkITM2pUitjdq58yLSaU7m4M0wBNaM2Gh/ggY4YJig==",
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+            "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
             "requires": {
                 "encoding": "0.1.12",
                 "is-stream": "1.1.0"
@@ -4779,7 +4720,7 @@
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
             "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
             "requires": {
-                "abbrev": "1.1.0"
+                "abbrev": "1.1.1"
             }
         },
         "normalize-package-data": {
@@ -4845,9 +4786,9 @@
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "nwmatcher": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.1.tgz",
-            "integrity": "sha1-eumwew6oBNt+JfBctf5Al9TklJ8=",
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.2.tgz",
+            "integrity": "sha512-QMkCGQFYp5p+zwU3INntLmz1HMfSx9dMVJMYKmE1yuSf/22Wjo6VPFa405mCLUuQn9lbQvH2DZN9lt10ZNvtAg==",
             "dev": true,
             "optional": true
         },
@@ -4972,7 +4913,7 @@
                 "browserify-aes": "1.0.8",
                 "create-hash": "1.1.3",
                 "evp_bytestokey": "1.0.3",
-                "pbkdf2": "3.0.13"
+                "pbkdf2": "3.0.14"
             }
         },
         "parse-glob": {
@@ -5044,15 +4985,15 @@
             }
         },
         "pbkdf2": {
-            "version": "3.0.13",
-            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.13.tgz",
-            "integrity": "sha512-+dCHxDH+djNtjgWmvVC/my3SYBAKpKNqKSjLkp+GtWWYe4XPE+e/PSD2aCanlEZZnqPk2uekTKNC/ccbwd2X2Q==",
+            "version": "3.0.14",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
+            "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
             "requires": {
                 "create-hash": "1.1.3",
                 "create-hmac": "1.1.6",
                 "ripemd160": "2.0.1",
                 "safe-buffer": "5.1.1",
-                "sha.js": "2.4.8"
+                "sha.js": "2.4.9"
             }
         },
         "pend": {
@@ -5061,10 +5002,11 @@
             "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
         },
         "performance-now": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-            "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-            "dev": true
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+            "dev": true,
+            "optional": true
         },
         "phantomjs-prebuilt": {
             "version": "2.1.15",
@@ -5081,6 +5023,155 @@
                 "request": "2.81.0",
                 "request-progress": "2.0.1",
                 "which": "1.2.14"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "4.11.8",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+                    "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+                    "dev": true,
+                    "requires": {
+                        "co": "4.6.0",
+                        "json-stable-stringify": "1.0.1"
+                    }
+                },
+                "assert-plus": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                    "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+                    "dev": true
+                },
+                "aws-sign2": {
+                    "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                    "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+                    "dev": true
+                },
+                "boom": {
+                    "version": "2.10.1",
+                    "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                    "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                    "dev": true,
+                    "requires": {
+                        "hoek": "2.16.3"
+                    }
+                },
+                "cryptiles": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                    "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                    "dev": true,
+                    "requires": {
+                        "boom": "2.10.1"
+                    }
+                },
+                "form-data": {
+                    "version": "2.1.4",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+                    "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+                    "dev": true,
+                    "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.5",
+                        "mime-types": "2.1.17"
+                    }
+                },
+                "har-schema": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+                    "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+                    "dev": true
+                },
+                "har-validator": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+                    "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "4.11.8",
+                        "har-schema": "1.0.5"
+                    }
+                },
+                "hawk": {
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                    "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+                    "dev": true,
+                    "requires": {
+                        "boom": "2.10.1",
+                        "cryptiles": "2.0.5",
+                        "hoek": "2.16.3",
+                        "sntp": "1.0.9"
+                    }
+                },
+                "hoek": {
+                    "version": "2.16.3",
+                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                    "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+                    "dev": true
+                },
+                "http-signature": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                    "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "0.2.0",
+                        "jsprim": "1.4.1",
+                        "sshpk": "1.13.1"
+                    }
+                },
+                "performance-now": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+                    "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+                    "dev": true
+                },
+                "qs": {
+                    "version": "6.4.0",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+                    "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+                    "dev": true
+                },
+                "request": {
+                    "version": "2.81.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+                    "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+                    "dev": true,
+                    "requires": {
+                        "aws-sign2": "0.6.0",
+                        "aws4": "1.6.0",
+                        "caseless": "0.12.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.1.4",
+                        "har-validator": "4.2.1",
+                        "hawk": "3.1.3",
+                        "http-signature": "1.1.1",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.17",
+                        "oauth-sign": "0.8.2",
+                        "performance-now": "0.2.0",
+                        "qs": "6.4.0",
+                        "safe-buffer": "5.1.1",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.3",
+                        "tunnel-agent": "0.6.0",
+                        "uuid": "3.1.0"
+                    }
+                },
+                "sntp": {
+                    "version": "1.0.9",
+                    "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                    "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                    "dev": true,
+                    "requires": {
+                        "hoek": "2.16.3"
+                    }
+                }
             }
         },
         "pify": {
@@ -5154,7 +5245,7 @@
             "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
             "requires": {
                 "chalk": "1.1.3",
-                "js-base64": "2.1.9",
+                "js-base64": "2.3.2",
                 "source-map": "0.5.7",
                 "supports-color": "3.2.3"
             },
@@ -5329,7 +5420,7 @@
             "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
             "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
             "requires": {
-                "postcss": "6.0.10"
+                "postcss": "6.0.12"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -5356,9 +5447,9 @@
                     "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                 },
                 "postcss": {
-                    "version": "6.0.10",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.10.tgz",
-                    "integrity": "sha512-7WOpqea/cQHH1XUXdN1mqoFFmhigW3KAXJ+ssMOk/f6mKmwqFgqqdwsnjLGH+wuY+kwaJvT4whHcfKt5kWga0A==",
+                    "version": "6.0.12",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.12.tgz",
+                    "integrity": "sha512-K6SLofXEK43FBSyZ6/ExQV7ji24OEw4tEY6x1CAf7+tcoMWJoO24Rf3rVFVpk+5IQL1e1Cy3sTKfg7hXuLzafg==",
                     "requires": {
                         "chalk": "2.1.0",
                         "source-map": "0.5.7",
@@ -5381,7 +5472,7 @@
             "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
             "requires": {
                 "css-selector-tokenizer": "0.7.0",
-                "postcss": "6.0.10"
+                "postcss": "6.0.12"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -5408,9 +5499,9 @@
                     "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                 },
                 "postcss": {
-                    "version": "6.0.10",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.10.tgz",
-                    "integrity": "sha512-7WOpqea/cQHH1XUXdN1mqoFFmhigW3KAXJ+ssMOk/f6mKmwqFgqqdwsnjLGH+wuY+kwaJvT4whHcfKt5kWga0A==",
+                    "version": "6.0.12",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.12.tgz",
+                    "integrity": "sha512-K6SLofXEK43FBSyZ6/ExQV7ji24OEw4tEY6x1CAf7+tcoMWJoO24Rf3rVFVpk+5IQL1e1Cy3sTKfg7hXuLzafg==",
                     "requires": {
                         "chalk": "2.1.0",
                         "source-map": "0.5.7",
@@ -5433,7 +5524,7 @@
             "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
             "requires": {
                 "css-selector-tokenizer": "0.7.0",
-                "postcss": "6.0.10"
+                "postcss": "6.0.12"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -5460,9 +5551,9 @@
                     "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                 },
                 "postcss": {
-                    "version": "6.0.10",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.10.tgz",
-                    "integrity": "sha512-7WOpqea/cQHH1XUXdN1mqoFFmhigW3KAXJ+ssMOk/f6mKmwqFgqqdwsnjLGH+wuY+kwaJvT4whHcfKt5kWga0A==",
+                    "version": "6.0.12",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.12.tgz",
+                    "integrity": "sha512-K6SLofXEK43FBSyZ6/ExQV7ji24OEw4tEY6x1CAf7+tcoMWJoO24Rf3rVFVpk+5IQL1e1Cy3sTKfg7hXuLzafg==",
                     "requires": {
                         "chalk": "2.1.0",
                         "source-map": "0.5.7",
@@ -5485,7 +5576,7 @@
             "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
             "requires": {
                 "icss-replace-symbols": "1.1.0",
-                "postcss": "6.0.10"
+                "postcss": "6.0.12"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -5512,9 +5603,9 @@
                     "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                 },
                 "postcss": {
-                    "version": "6.0.10",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.10.tgz",
-                    "integrity": "sha512-7WOpqea/cQHH1XUXdN1mqoFFmhigW3KAXJ+ssMOk/f6mKmwqFgqqdwsnjLGH+wuY+kwaJvT4whHcfKt5kWga0A==",
+                    "version": "6.0.12",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.12.tgz",
+                    "integrity": "sha512-K6SLofXEK43FBSyZ6/ExQV7ji24OEw4tEY6x1CAf7+tcoMWJoO24Rf3rVFVpk+5IQL1e1Cy3sTKfg7hXuLzafg==",
                     "requires": {
                         "chalk": "2.1.0",
                         "source-map": "0.5.7",
@@ -5704,16 +5795,16 @@
             }
         },
         "pug": {
-            "version": "2.0.0-rc.3",
-            "resolved": "https://registry.npmjs.org/pug/-/pug-2.0.0-rc.3.tgz",
-            "integrity": "sha512-AGEWoQ6SHw7fNiaioEvAEelAYmFTvMTVAUxf4hUCLb5pb2HmN6yLGb/SwPFFaOiqSdxyxSmBVtL/I4VHOF9UPA==",
+            "version": "2.0.0-rc.4",
+            "resolved": "https://registry.npmjs.org/pug/-/pug-2.0.0-rc.4.tgz",
+            "integrity": "sha512-SL7xovj6E2Loq9N0UgV6ynjMLW4urTFY/L/Fprhvz13Xc5vjzkjZjI1QHKq31200+6PSD8PyU6MqrtCTJj6/XA==",
             "requires": {
-                "pug-code-gen": "1.1.1",
-                "pug-filters": "2.1.4",
+                "pug-code-gen": "2.0.0",
+                "pug-filters": "2.1.5",
                 "pug-lexer": "3.1.0",
-                "pug-linker": "3.0.2",
-                "pug-load": "2.0.8",
-                "pug-parser": "3.0.1",
+                "pug-linker": "3.0.3",
+                "pug-load": "2.0.9",
+                "pug-parser": "4.0.0",
                 "pug-runtime": "2.0.3",
                 "pug-strip-comments": "1.0.2"
             }
@@ -5729,9 +5820,9 @@
             }
         },
         "pug-code-gen": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-1.1.1.tgz",
-            "integrity": "sha1-HPcnRO8qA56uajNAyqoRBYcSWOg=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-2.0.0.tgz",
+            "integrity": "sha512-E4oiJT+Jn5tyEIloj8dIJQognbiNNp0i0cAJmYtQTFS0soJ917nlIuFtqVss3IXMEyQKUew3F4gIkBpn18KbVg==",
             "requires": {
                 "constantinople": "3.1.0",
                 "doctypes": "1.1.0",
@@ -5749,29 +5840,17 @@
             "integrity": "sha1-U659nSm7A89WRJOgJhCfVMR/XyY="
         },
         "pug-filters": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-2.1.4.tgz",
-            "integrity": "sha512-0irOV5M9VhvRBWFGIvkrDDRWnhFpRgedO+yYEKnosgcowTrEnXGhEY/ZXlPM858upi7MqH8ZMXeRz3yTfXEzzQ==",
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-2.1.5.tgz",
+            "integrity": "sha512-xkw71KtrC4sxleKiq+cUlQzsiLn8pM5+vCgkChW2E6oNOzaqTSIBKIQ5cl4oheuDzvJYCTSYzRaVinMUrV4YLQ==",
             "requires": {
                 "clean-css": "3.4.28",
                 "constantinople": "3.1.0",
                 "jstransformer": "1.0.0",
                 "pug-error": "1.3.2",
-                "pug-walk": "1.1.4",
+                "pug-walk": "1.1.5",
                 "resolve": "1.1.7",
                 "uglify-js": "2.8.29"
-            },
-            "dependencies": {
-                "uglify-js": {
-                    "version": "2.8.29",
-                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-                    "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-                    "requires": {
-                        "source-map": "0.5.7",
-                        "uglify-to-browserify": "1.0.2",
-                        "yargs": "3.10.0"
-                    }
-                }
             }
         },
         "pug-lexer": {
@@ -5801,12 +5880,12 @@
             }
         },
         "pug-linker": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-3.0.2.tgz",
-            "integrity": "sha512-8D+XJs5lF2batwEv7UtS0kSklX+k9HapU9UeBmCAJ+XP82idk8XIBu0aV+L5j8rupdyW3fdfKQ/tznMHvqEg6g==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-3.0.3.tgz",
+            "integrity": "sha512-DCKczglCXOzJ1lr4xUj/lVHYvS+lGmR2+KTCjZjtIpdwaN7lNOoX2SW6KFX5X4ElvW+6ThwB+acSUg08UJFN5A==",
             "requires": {
                 "pug-error": "1.3.2",
-                "pug-walk": "1.1.4"
+                "pug-walk": "1.1.5"
             }
         },
         "pug-lint": {
@@ -5836,6 +5915,12 @@
                     "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
                     "dev": true
                 },
+                "commander": {
+                    "version": "2.11.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+                    "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+                    "dev": true
+                },
                 "is-expression": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-3.0.0.tgz",
@@ -5860,12 +5945,12 @@
             }
         },
         "pug-load": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-2.0.8.tgz",
-            "integrity": "sha512-1T8GaRSyV4Oc3vEPuxB1VwHE4fpU2iYUK6gPLcxXPAiU1k9sYiuRWwBI2vra1oTTmpqwn1GiYFMg1jO74Eb2fA==",
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-2.0.9.tgz",
+            "integrity": "sha512-BDdZOCru4mg+1MiZwRQZh25+NTRo/R6/qArrdWIf308rHtWA5N9kpoUskRe4H6FslaQujC+DigH9LqlBA4gf6Q==",
             "requires": {
                 "object-assign": "4.1.1",
-                "pug-walk": "1.1.4"
+                "pug-walk": "1.1.5"
             }
         },
         "pug-loader": {
@@ -5874,7 +5959,7 @@
             "integrity": "sha1-uGkpRBOiIY8KfdkqlT5ZIoNnbBA=",
             "requires": {
                 "loader-utils": "0.2.17",
-                "pug-walk": "1.1.4",
+                "pug-walk": "1.1.5",
                 "resolve": "1.1.7"
             },
             "dependencies": {
@@ -5883,7 +5968,7 @@
                     "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
                     "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
                     "requires": {
-                        "big.js": "3.1.3",
+                        "big.js": "3.2.0",
                         "emojis-list": "2.1.0",
                         "json5": "0.5.1",
                         "object-assign": "4.1.1"
@@ -5892,9 +5977,9 @@
             }
         },
         "pug-parser": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-3.0.1.tgz",
-            "integrity": "sha512-YNcfPtamkJ6Blgdev1keI1rK5UZ5TtYS4r1lZw1/lhFhyEVAwKtzOsv6aqxI0xBWfCia/vNWhdtdaqoMRB2jcQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-4.0.0.tgz",
+            "integrity": "sha512-ocEUFPdLG9awwFj0sqi1uiZLNvfoodCMULZzkRqILryIWc/UUlDlxqrKhKjAIIGPX/1SNsvxy63+ayEGocGhQg==",
             "requires": {
                 "pug-error": "1.3.2",
                 "token-stream": "0.0.1"
@@ -5914,9 +5999,9 @@
             }
         },
         "pug-walk": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.4.tgz",
-            "integrity": "sha512-29oDmQ4Z5nXJnaVQ/PTLdY3pRBCHcb1dvNhvVZ+c1bOv4cKRbwRD6mm0ZDVVzzZmSC8DctqbVtRgLzNJVQFHMw=="
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.5.tgz",
+            "integrity": "sha512-rJlH1lXerCIAtImXBze3dtKq/ykZMA4rpO9FnPcIgsWcxZLOvd8zltaoeOVFyBSSqCkhhJWbEbTMga8UxWUUSA=="
         },
         "pullstream": {
             "version": "0.4.1",
@@ -5963,10 +6048,11 @@
             "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE="
         },
         "qs": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-            "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-            "dev": true
+            "version": "6.5.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+            "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+            "dev": true,
+            "optional": true
         },
         "query-string": {
             "version": "4.3.4",
@@ -6157,9 +6243,9 @@
             }
         },
         "regenerate": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-            "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA="
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+            "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
         },
         "regenerator-runtime": {
             "version": "0.11.0",
@@ -6189,7 +6275,7 @@
             "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
             "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
             "requires": {
-                "regenerate": "1.3.2",
+                "regenerate": "1.3.3",
                 "regjsgen": "0.2.0",
                 "regjsparser": "0.1.5"
             }
@@ -6263,31 +6349,32 @@
             }
         },
         "request": {
-            "version": "2.81.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-            "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+            "version": "2.83.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+            "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
             "dev": true,
+            "optional": true,
             "requires": {
-                "aws-sign2": "0.6.0",
+                "aws-sign2": "0.7.0",
                 "aws4": "1.6.0",
                 "caseless": "0.12.0",
                 "combined-stream": "1.0.5",
                 "extend": "3.0.1",
                 "forever-agent": "0.6.1",
-                "form-data": "2.1.4",
-                "har-validator": "4.2.1",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
+                "form-data": "2.3.1",
+                "har-validator": "5.0.3",
+                "hawk": "6.0.2",
+                "http-signature": "1.2.0",
                 "is-typedarray": "1.0.0",
                 "isstream": "0.1.2",
                 "json-stringify-safe": "5.0.1",
                 "mime-types": "2.1.17",
                 "oauth-sign": "0.8.2",
-                "performance-now": "0.2.0",
-                "qs": "6.4.0",
+                "performance-now": "2.1.0",
+                "qs": "6.5.1",
                 "safe-buffer": "5.1.1",
                 "stringstream": "0.0.5",
-                "tough-cookie": "2.3.2",
+                "tough-cookie": "2.3.3",
                 "tunnel-agent": "0.6.0",
                 "uuid": "3.1.0"
             }
@@ -6394,7 +6481,7 @@
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
             "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
             "requires": {
-                "ajv": "5.2.2"
+                "ajv": "5.2.3"
             }
         },
         "semver": {
@@ -6418,11 +6505,12 @@
             "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
         },
         "sha.js": {
-            "version": "2.4.8",
-            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
-            "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
+            "version": "2.4.9",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz",
+            "integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.1"
             }
         },
         "shelljs": {
@@ -6432,7 +6520,7 @@
             "dev": true,
             "requires": {
                 "glob": "7.0.6",
-                "interpret": "1.0.3",
+                "interpret": "1.0.4",
                 "rechoir": "0.6.2"
             }
         },
@@ -6484,12 +6572,13 @@
             }
         },
         "sntp": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-            "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
+            "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
             "dev": true,
+            "optional": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "4.2.0"
             }
         },
         "sort-keys": {
@@ -6511,9 +6600,9 @@
             "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "source-map-support": {
-            "version": "0.4.17",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.17.tgz",
-            "integrity": "sha512-30c1Ch8FSjV0FwC253iftbbj0dU/OXoSg1LAEGZJUlGgjTNj6cu+DVqJWWIZJY5RXLWV4eFtR+4ouo0VIOYOTg==",
+            "version": "0.4.18",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+            "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
             "requires": {
                 "source-map": "0.5.7"
             }
@@ -6555,14 +6644,6 @@
                 "getpass": "0.1.7",
                 "jsbn": "0.1.1",
                 "tweetnacl": "0.14.5"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                    "dev": true
-                }
             }
         },
         "stampit": {
@@ -6801,7 +6882,7 @@
             "integrity": "sha1-QrlWCTHKcJDOhRWnmLqeaqPW3Hk=",
             "requires": {
                 "css-parse": "1.7.0",
-                "debug": "2.6.8",
+                "debug": "2.6.9",
                 "glob": "7.0.6",
                 "mkdirp": "0.5.1",
                 "sax": "0.5.8",
@@ -6993,14 +7074,14 @@
             "integrity": "sha1-zu78cXp2xDFvEm0LnbqlXX598Bo="
         },
         "toposort": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.3.tgz",
-            "integrity": "sha1-8CzYp0vYvi/A6YYRw7rLlaFxhpw="
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.4.tgz",
+            "integrity": "sha1-qGEHaQy+6MrkOzSdL2AWJQCSTfw="
         },
         "tough-cookie": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-            "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+            "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
             "dev": true,
             "requires": {
                 "punycode": "1.4.1"
@@ -7070,12 +7151,13 @@
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
         },
         "uglify-js": {
-            "version": "3.0.28",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.28.tgz",
-            "integrity": "sha512-0h/qGay016GG2lVav3Kz174F3T2Vjlz2v6HCt+WDQpoXfco0hWwF5gHK9yh88mUYvIC+N7Z8NT8WpjSp1yoqGA==",
+            "version": "2.8.29",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+            "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
             "requires": {
-                "commander": "2.11.0",
-                "source-map": "0.5.7"
+                "source-map": "0.5.7",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.10.0"
             }
         },
         "uglify-to-browserify": {
@@ -7236,14 +7318,6 @@
                 "assert-plus": "1.0.0",
                 "core-util-is": "1.0.2",
                 "extsprintf": "1.3.0"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                    "dev": true
-                }
             }
         },
         "vm-browserify": {
@@ -7301,7 +7375,7 @@
                 "ajv-keywords": "1.5.1",
                 "async": "2.5.0",
                 "enhanced-resolve": "3.4.1",
-                "interpret": "1.0.3",
+                "interpret": "1.0.4",
                 "json-loader": "0.5.7",
                 "json5": "0.5.1",
                 "loader-runner": "2.3.0",
@@ -7333,16 +7407,26 @@
                     }
                 },
                 "camelcase": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                    "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+                },
+                "cliui": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                    "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                    "requires": {
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wrap-ansi": "2.1.0"
+                    }
                 },
                 "loader-utils": {
                     "version": "0.2.17",
                     "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
                     "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
                     "requires": {
-                        "big.js": "3.1.3",
+                        "big.js": "3.2.0",
                         "emojis-list": "2.1.0",
                         "json5": "0.5.1",
                         "object-assign": "4.1.1"
@@ -7354,29 +7438,6 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "requires": {
                         "has-flag": "1.0.0"
-                    }
-                },
-                "uglify-js": {
-                    "version": "2.8.29",
-                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-                    "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-                    "requires": {
-                        "source-map": "0.5.7",
-                        "uglify-to-browserify": "1.0.2",
-                        "yargs": "3.10.0"
-                    },
-                    "dependencies": {
-                        "yargs": {
-                            "version": "3.10.0",
-                            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-                            "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-                            "requires": {
-                                "camelcase": "1.2.1",
-                                "cliui": "2.1.0",
-                                "decamelize": "1.2.0",
-                                "window-size": "0.1.0"
-                            }
-                        }
                     }
                 },
                 "yargs": {
@@ -7397,23 +7458,6 @@
                         "which-module": "1.0.0",
                         "y18n": "3.2.1",
                         "yargs-parser": "4.2.1"
-                    },
-                    "dependencies": {
-                        "camelcase": {
-                            "version": "3.0.0",
-                            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-                            "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-                        },
-                        "cliui": {
-                            "version": "3.2.0",
-                            "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-                            "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-                            "requires": {
-                                "string-width": "1.0.2",
-                                "strip-ansi": "3.0.1",
-                                "wrap-ansi": "2.1.0"
-                            }
-                        }
                     }
                 }
             }


### PR DESCRIPTION
Also, add Moment.js as an explicit dependency, as it's used directly.

This reduces the production build size by about 10%.

Note, while this excludes locale files from the built, it does not remove any localization functionality from Girder, as the non-default locales were never actually being enabled or used at runtime. If we wanted to support alternate date localizations in the future, we'd need to start including some files into the build (un-ignoring them), but we'd also need to globally configure Moment at run time to use them, according to some set of conditions.