### PR TITLE
Fix rest requests honoring `type`.

### DIFF
--- a/clients/web/src/rest.js
+++ b/clients/web/src/rest.js
@@ -104,6 +104,7 @@ setStaticRoot(
 let restRequest = function (opts) {
     opts = opts || {};
     const defaults = {
+        dataType: 'json',
         method: 'GET',
         girderToken: getCurrentToken() || cookie.find('girderToken'),
 
@@ -171,6 +172,10 @@ let restRequest = function (opts) {
         throw new Error('restRequest requires a "url" argument');
     }
     args.url = `${getApiRoot()}${args.url.substring(0, 1) === '/' ? '' : '/'}${args.url}`;
+    if (args.type) {
+        args.method = args.type;
+        delete args.method;
+    }
 
     if (args.girderToken) {
         args.headers = args.headers || {};

--- a/clients/web/src/rest.js
+++ b/clients/web/src/rest.js
@@ -172,9 +172,11 @@ let restRequest = function (opts) {
         throw new Error('restRequest requires a "url" argument');
     }
     args.url = `${getApiRoot()}${args.url.substring(0, 1) === '/' ? '' : '/'}${args.url}`;
+    // jQuery's ajax method prefers `method` over `type`.  Since we specify a
+    // default `method`, if the caller supplies a `type`, use it instead.
     if (args.type) {
         args.method = args.type;
-        delete args.method;
+        delete args.type;
     }
 
     if (args.girderToken) {

--- a/clients/web/src/rest.js
+++ b/clients/web/src/rest.js
@@ -104,7 +104,6 @@ setStaticRoot(
 let restRequest = function (opts) {
     opts = opts || {};
     const defaults = {
-        dataType: 'json',
         // the default `method` (aliased as `type`) is 'GET'
         girderToken: getCurrentToken() || cookie.find('girderToken'),
 

--- a/clients/web/src/rest.js
+++ b/clients/web/src/rest.js
@@ -105,7 +105,7 @@ let restRequest = function (opts) {
     opts = opts || {};
     const defaults = {
         dataType: 'json',
-        method: 'GET',
+        // the default `method` (aliased as `type`) is 'GET'
         girderToken: getCurrentToken() || cookie.find('girderToken'),
 
         error: (error, status) => {
@@ -172,12 +172,6 @@ let restRequest = function (opts) {
         throw new Error('restRequest requires a "url" argument');
     }
     args.url = `${getApiRoot()}${args.url.substring(0, 1) === '/' ? '' : '/'}${args.url}`;
-    // jQuery's ajax method prefers `method` over `type`.  Since we specify a
-    // default `method`, if the caller supplies a `type`, use it instead.
-    if (args.type) {
-        args.method = args.type;
-        delete args.type;
-    }
 
     if (args.girderToken) {
         args.headers = args.headers || {};


### PR DESCRIPTION
An unintentional breaking change was introduced in PR #2273.  Before, our ajax defaults (rightly or wrongly) preferred `type` over `method`, and set a default `type`.  jQuery's ajax call prefers `method`, so if a caller used either `type` *or* `method`, we would honor the caller's value.  Now, since we set a default `method`, if a caller uses `method`, it is ignored.

Further, we had previous set the dataType default to 'json'.  PR #2273 removed this, which then allows jQuery to use "Intelligent Guess".  Since this is also a breaking change, I've reverted it.