### PR TITLE
Render item task descriptions as markdown

### DIFF
--- a/plugins/item_tasks/plugin_tests/tasksSpec.js
+++ b/plugins/item_tasks/plugin_tests/tasksSpec.js
@@ -81,9 +81,8 @@ describe('Run the item task', function () {
 
         runs(function () {
             expect($('.g-execute-task-link').length).toBe(1);
-            expect($('.g-execute-task-link .g-execute-task-link-header').text()).toBe(
-                'PET phantom detector CLI');
-            expect($('.g-execute-task-link .g-execute-task-link-body').text()).toContain(
+            expect($('.g-execute-task-link').text()).toBe('PET phantom detector CLI');
+            expect($('.g-execute-task-link-body').text()).toContain(
                 'Detects positions of PET/CT pocket phantoms in PET image.');
             window.location.assign($('a.g-execute-task-link').attr('href'));
         });
@@ -264,10 +263,8 @@ describe('Navigate to the new JSON task', function () {
 
         runs(function () {
             expect($('.g-execute-task-link').length).toBe(3);
-            expect($('.g-execute-task-link .g-execute-task-link-header').eq(0).text()).toBe(
-                'me/my_image:latest 0');
-            expect($('.g-execute-task-link .g-execute-task-link-header').eq(1).text()).toBe(
-                'me/my_image:latest 1');
+            expect($('.g-execute-task-link').eq(0).text()).toBe('me/my_image:latest 0');
+            expect($('.g-execute-task-link').eq(1).text()).toBe('me/my_image:latest 1');
             window.location.assign($('a.g-execute-task-link').eq(0).attr('href'));
         });
 
@@ -351,7 +348,7 @@ describe('Run task on item from item view', function () {
         }, 'tasks to load in widget');
 
         runs(function () {
-            $('.list-group-item.g-execute-task-link:contains("me/my_image:latest 1")').click();
+            $('.g-execute-task-link:contains("me/my_image:latest 1")').click();
 
             expect($('.g-selected-task-name').text()).toBe('me/my_image:latest 1');
             $('.g-submit-select-task').click();
@@ -441,8 +438,7 @@ describe('Navigate to the demo task', function () {
 
         runs(function () {
             expect($('.g-execute-task-link').length).toBe(4);
-            expect($('.g-execute-task-link .g-execute-task-link-header').eq(0).text()).toBe(
-                'item_tasks widget types demo');
+            expect($('.g-execute-task-link').eq(0).text()).toBe('item_tasks widget types demo');
             window.location.assign($('a.g-execute-task-link').eq(0).attr('href'));
         });
 
@@ -640,9 +636,8 @@ describe('Navigate to the new Slicer CLI task', function () {
 
         runs(function () {
             expect($('.g-execute-task-link').length).toBe(5);
-            expect($('.g-execute-task-link .g-execute-task-link-header').eq(4).text()).toBe(
-                'PET phantom detector CLI');
-            expect($('.g-execute-task-link .g-execute-task-link-body').eq(4).text()).toContain(
+            expect($('.g-execute-task-link').eq(4).text()).toBe('PET phantom detector CLI');
+            expect($('.g-execute-task-link-body').eq(4).text()).toContain(
                 'Detects positions of PET/CT pocket phantoms in PET image.');
             window.location.assign($('a.g-execute-task-link').eq(4).attr('href'));
         });

--- a/plugins/item_tasks/web_client/stylesheets/paginateTasksWidget.styl
+++ b/plugins/item_tasks/web_client/stylesheets/paginateTasksWidget.styl
@@ -4,3 +4,8 @@
   .g-task-pagination
     ul
       margin 0
+
+.g-execute-task-link
+  font-size 20px
+  margin-bottom 13px
+  display inline-block

--- a/plugins/item_tasks/web_client/templates/paginateTasksWidget.pug
+++ b/plugins/item_tasks/web_client/templates/paginateTasksWidget.pug
@@ -3,8 +3,6 @@
 
 .g-task-list-container.list-group
   each task in tasks
-    a.g-execute-task-link.list-group-item(
-        href=itemUrlFunc && itemUrlFunc(task),
-        data-task-id=task.id)
-      h4.g-execute-task-link-header.list-group-item-heading= task.name()
-      .g-execute-task-link-body.list-group-item-text= task.get('description')
+    .g-execute-task-link-wrapper.list-group-item
+      a.g-execute-task-link.list-group-item-heading(data-task-id=task.id, href=itemUrlFunc && itemUrlFunc(task))= task.name()
+      .g-execute-task-link-body.list-group-item-text!= renderMarkdown(task.get('description'))

--- a/plugins/item_tasks/web_client/views/PaginateTasksWidget.js
+++ b/plugins/item_tasks/web_client/views/PaginateTasksWidget.js
@@ -1,5 +1,6 @@
 import View from 'girder/views/View';
 import PaginateWidget from 'girder/views/widgets/PaginateWidget';
+import { renderMarkdown } from 'girder/misc';
 
 import ItemTaskCollection from '../collections/ItemTaskCollection';
 import template from '../templates/paginateTasksWidget.pug';
@@ -44,7 +45,8 @@ var PaginateTasksWidget = View.extend({
     render: function () {
         this.$el.html(template({
             tasks: this.collection.toArray(),
-            itemUrlFunc: this.itemUrlFunc
+            itemUrlFunc: this.itemUrlFunc,
+            renderMarkdown
         }));
 
         this.paginateWidget.setElement(this.$('.g-task-pagination')).render();


### PR DESCRIPTION
Since item descriptions are rendered as markdown, and the auto-generated slicer CLI descriptions contain markdown, we should render these as markdown as well. After, looks like:

![screen shot 2017-08-23 at 1 56 11 pm](https://user-images.githubusercontent.com/555959/29630638-da9b8b5a-880a-11e7-9252-8938aef33328.png)
