### PR TITLE
Update front page text

### DIFF
--- a/clients/web/src/templates/body/frontPage.pug
+++ b/clients/web/src/templates/body/frontPage.pug
@@ -67,7 +67,7 @@
         | visualization. To learn more, you can read our series of
         a(target="_blank", href="https://blog.kitware.com/tag/resonant/")  blog posts
         |  about Resonant, or
-        a(target="_blank", href="http://www.kitware.com/company/contact_kitware.php")  contact us
+        a(target="_blank", href="http://www.kitware.com/contact-us")  contact us
         |  to learn how we can help you solve your data problems.
 
       if versionInfo.git

--- a/clients/web/src/templates/body/frontPage.pug
+++ b/clients/web/src/templates/body/frontPage.pug
@@ -7,43 +7,75 @@
 .g-frontpage-body
   p.g-frontpage-paragraph
     b Welcome to Girder!
-    |  If this is your first time here, you might want to check out the
-    a(target="_blank", href='http://girder.readthedocs.org/en/latest/user-guide.html')  User Guide
-    |  to learn the basics of how to use the application.
-    |  To browse the data hosted on this server, start on the
-    a.g-collections-link  Collections
-    |  page. If you want to search for specific data on this server, use the
-    a.g-quicksearch-link  Quick Search
-    |  box at the top of the screen. Developers who want to use the Girder REST API
-    |  should check out the
-    a(href=apiRoot)  interactive web API docs
-    | .
 
-    if !currentUser
-      p.g-frontpage-paragraph
-        |  You are currently browsing anonymously. If you want to create a user
-        |  account on this server, click the
-        a.g-register-link  Register
-        |  link in the upper right corner. If you already have a user, click the
-        a.g-login-link  Log In
-        |  link. Otherwise, you will only be able to see publicly visible data
-        |  in the system.
-    else
-      p.g-frontpage-paragraph
-        |  You are currently logged in as
-        b  #{currentUser.get('login')}
-        | . You can view your
-        a.g-my-folders-link  personal data space
-        |  or go to your
-        a.g-my-account-link  user account page.
+    ul
+      if !currentUser
+        li You are currently browsing anonymously.
+        ul
+          li
+            | To explore the data hosted on this server, start with the
+            a.g-collections-link  Collections
+            |  page.
 
-    p.g-frontpage-paragraph
-      if versionInfo.git
-        | This instance of Girder was built from Git version&nbsp;
-        a.g-git-sha(
-            target="_blank", href=`https://github.com/girder/girder/tree/${versionInfo.SHA}`)= versionInfo.shortSHA
-        | .
+          li
+            | To create an account, use the
+            a.g-register-link  Register
+            |  link in the upper right corner.
+
+          li
+            | If you already have an account you can
+            a.g-login-link  log in
+            |  with the link in the upper right corner.
       else
-        | This instance of Girder was built on #{new Date(versionInfo.date).toLocaleDateString()}.
-      if versionInfo.apiVersion
-        |   API Version #{versionInfo.apiVersion}.
+        li
+          | You are currently logged in as
+          b  #{currentUser.get('login')}
+          | .
+
+          ul
+            li
+              | To explore the data hosted on this server, start with the
+              a.g-collections-link  Collections
+              |  page.
+
+            li
+              | To explore your data, go to your
+              a.g-my-folders-link  personal data space
+              |  or your
+              a.g-my-account-link  user account page
+              | .
+
+      li
+        | To learn more about Girder, including how you can host your own
+        | instance either locally or in the cloud, see the
+        a(target="_blank" href="http://girder.readthedocs.io/en/latest/user-guide.html")  User Guide
+        | , the
+        a(target="_blank" href="http://girder.readthedocs.io/en/latest")  full documentation
+        | , or visit the
+        a(target="_blank" href="https://github.com/girder/girder")  GitHub repository
+        | .
+
+      li
+        | To use Girder's REST API to interact with this server, check out the
+        a(href=`${apiRoot}`)  interactive web API docs
+        | .
+
+      li
+        | Girder is a part of
+        a(target="_blank" href="http://resonant.kitware.com")  Resonant
+        | , Kitware's open-source platform for data management, analytics, and
+        | visualization. To learn more, you can read our series of
+        a(target="_blank" href="https://blog.kitware.com/tag/resonant/")  blog posts
+        |  about Resonant, or
+        a(target="_blank" href="http://www.kitware.com/company/contact_kitware.php")  contact us
+        |  to learn how we can help you solve your data problems.
+
+      if versionInfo.git
+        li
+          | This instance of Girder was built from Git version
+          a.g-git-sha(target="_blank" href=`https://github.com/girder/girder/tree/${versionInfo.SHA}`)  #{versionInfo.shortSHA}
+          | . API version #{versionInfo.apiVersion}.
+      else
+        li
+          | This instance of Girder was built on #{new Date(versionInfo.date).toLocaleDateString()}
+          | . API version #{versionInfo.apiVersion}.

--- a/clients/web/src/templates/body/frontPage.pug
+++ b/clients/web/src/templates/body/frontPage.pug
@@ -48,32 +48,32 @@
       li
         | To learn more about Girder, including how you can host your own
         | instance either locally or in the cloud, see the
-        a(target="_blank" href="http://girder.readthedocs.io/en/latest/user-guide.html")  User Guide
+        a(target="_blank", href="http://girder.readthedocs.io/en/latest/user-guide.html")  User Guide
         | , the
-        a(target="_blank" href="http://girder.readthedocs.io/en/latest")  full documentation
+        a(target="_blank", href="http://girder.readthedocs.io/en/latest")  full documentation
         | , or visit the
-        a(target="_blank" href="https://github.com/girder/girder")  GitHub repository
+        a(target="_blank", href="https://github.com/girder/girder")  GitHub repository
         | .
 
       li
         | To use Girder's REST API to interact with this server, check out the
-        a(href=`${apiRoot}`)  interactive web API docs
+        a(href=apiRoot)  interactive web API docs
         | .
 
       li
         | Girder is a part of
-        a(target="_blank" href="http://resonant.kitware.com")  Resonant
+        a(target="_blank", href="http://resonant.kitware.com")  Resonant
         | , Kitware's open-source platform for data management, analytics, and
         | visualization. To learn more, you can read our series of
-        a(target="_blank" href="https://blog.kitware.com/tag/resonant/")  blog posts
+        a(target="_blank", href="https://blog.kitware.com/tag/resonant/")  blog posts
         |  about Resonant, or
-        a(target="_blank" href="http://www.kitware.com/company/contact_kitware.php")  contact us
+        a(target="_blank", href="http://www.kitware.com/company/contact_kitware.php")  contact us
         |  to learn how we can help you solve your data problems.
 
       if versionInfo.git
         li
           | This instance of Girder was built from Git version
-          a.g-git-sha(target="_blank" href=`https://github.com/girder/girder/tree/${versionInfo.SHA}`)  #{versionInfo.shortSHA}
+          a.g-git-sha(target="_blank", href=`https://github.com/girder/girder/tree/${versionInfo.SHA}`)  #{versionInfo.shortSHA}
           | . API version #{versionInfo.apiVersion}.
       else
         li

--- a/clients/web/test/spec/routingSpec.js
+++ b/clients/web/test/spec/routingSpec.js
@@ -53,7 +53,7 @@ describe('Test routing paths', function () {
     it('logout', girderTest.logout());
     it('test routes without being logged in', function () {
         girderTest.testRoute('', false, function () {
-            return $('a.g-login-link:first').text() === ' Log In';
+            return $('a.g-login-link:first').length > 0;
         });
         girderTest.testRoute('useraccount/' + ids.admin + '/info', false,
             function () {

--- a/clients/web/test/spec/versionSpec.js
+++ b/clients/web/test/spec/versionSpec.js
@@ -12,6 +12,7 @@ describe('Test version reporting', function () {
             expect($('.g-git-sha').length).toBe(1);
             expect(!!$('.g-git-sha')
                 .text()
+                .trim()
                 .toLowerCase()
                 .match(/^[0-9a-f]+$/)
             ).toBe(true);


### PR DESCRIPTION
This is part of the "DKC facelift".

This PR is going to Girder because it's a general improvement on the front page content that every instance of Girder should have when built or installed out of the box. All the information currently shown is here, just restructured a little bit to ease reading.

There are also some links to various media we have published about Resonant and Girder, as well as a mention of Kitware and our consulting services (while of course an instance can override this text by using the homepage plugin).

To complete the "facelift" will require support from #2283 and related, upcoming PRs in the same vein as that one:
- [ ] Need to be able to independently set the banner "brand name" and the "title welcome text"
- [ ] Need to be able to set the "subtitle" text
- [ ] Need a way to customize the opening paragraph of the content itself (the part that currently reads "**Welcome to Girder!**")
- [ ] Need a way to set the banner background color
