### PR TITLE
Webpack helpers for plugins should only affect that plugin

### DIFF
--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -389,6 +389,12 @@ module.exports = function (grunt) {
                     entry: {
                         [helperConfig.pluginEntry]: [main]
                     },
+                    module: {
+                        // We set these since webpack.helper.js functions may
+                        // expect these properties to be defined.
+                        loaders: [],
+                        rules: []
+                    },
                     output: {
                         path: path.join(paths.web_built, 'plugins', plugin),
                         filename: `${output}.min.js`,
@@ -470,8 +476,7 @@ module.exports = function (grunt) {
                 }
             }
 
-            var baseConfig = grunt.config.getRaw('webpack.options');
-            baseConfig.module.loaders = [];
+            var baseConfig = grunt.config.getRaw(`webpack.${output}_${plugin}`);
             var newConfig = webpackHelper(baseConfig, helperConfig);
             if (_.has(newConfig.module, 'loaders')) {
                 if (!_.isEmpty(newConfig.module.loaders)) {
@@ -481,7 +486,7 @@ module.exports = function (grunt) {
                 }
                 delete newConfig.module.loaders;
             }
-            grunt.config.set('webpack.options', newConfig);
+            grunt.config.set(`webpack.${output}_${plugin}`, newConfig);
         });
 
         if (config.grunt) {


### PR DESCRIPTION
When implementing the geojs plugin I discovered a bug related to the webpack helper files. To build the geojs plugin, I need to use one containing some `externals` declarations. However, I noticed that after doing that, other plugins that contained those symbols were broken at runtime (namely the jobs plugin which also references d3, but *not* as an external symbol).

After looking at plugin.js, I saw that the contents of `webpack.helper.js` for plugins was being merged into the *global* webpack options, rather than the webpack options for building that specific plugin. In fact, there was no way via the helper to modify anything other than the global options, which was inadvertently clobbering other plugins.

This PR contains a working solution, but may be controversial -- it now unconditionally merges the helper configuration with the plugin-specific config, and disallows modifying the global options. I would contend, as a straw man, that it shouldn't be necessary for plugins to modify the global stuff, and should only be modifying how they themselves are built. This is because we now link plugins dynamically, so their build processes are no longer intertwined.