### PR TITLE
Allow setting the swagger produces value.

### DIFF
--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -83,6 +83,7 @@ class Description(object):
         self._params = []
         self._responses = {}
         self._consumes = []
+        self._produces = []
         self._responseClass = None
         self._responseClassArray = False
         self._notes = None
@@ -127,6 +128,9 @@ class Description(object):
 
         if self._consumes:
             resp['consumes'] = self._consumes
+
+        if self._produces:
+            resp['produces'] = self._produces
 
         if self._deprecated:
             resp['deprecated'] = True
@@ -375,6 +379,13 @@ class Description(object):
 
     def consumes(self, value):
         self._consumes.append(value)
+        return self
+
+    def produces(self, value):
+        if isinstance(value, (list, tuple)):
+            self._produces.extend(value)
+        else:
+            self._produces.append(value)
         return self
 
     def notes(self, notes):

--- a/girder/api/v1/collection.py
+++ b/girder/api/v1/collection.py
@@ -112,6 +112,7 @@ class Collection(Resource):
         .modelParam('id', model='collection', level=AccessType.READ)
         .jsonParam('mimeFilter', 'JSON list of MIME types to include.', requireArray=True,
                    required=False)
+        .produces('application/zip')
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the collection.', 403)
     )

--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -117,6 +117,7 @@ class Folder(Resource):
         .modelParam('id', model='folder', level=AccessType.READ)
         .jsonParam('mimeFilter', 'JSON list of MIME types to include.', required=False,
                    requireArray=True)
+        .produces('application/zip')
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the folder.', 403)
     )

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -232,7 +232,8 @@ class Item(Resource):
     @autoDescribeRoute(
         Description('Download the contents of an item.')
         .modelParam('id', model='item', level=AccessType.READ)
-        .param('offset', 'Byte offset into the file.', dataType='int', default=0)
+        .param('offset', 'Byte offset into the file.', dataType='int',
+               required=False, default=0)
         .param('format', 'If unspecified, items with one file are downloaded '
                'as that file, and other items are downloaded as a zip '
                'archive.  If \'zip\', a zip archive is always sent.',
@@ -244,6 +245,8 @@ class Item(Resource):
         .param('extraParameters', 'Arbitrary data to send along with the '
                'download request, only applied for single file '
                'items.', required=False)
+        # single file items could produce other types, too.
+        .produces(['application/zip', 'application/octet-stream'])
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )

--- a/girder/api/v1/notification.py
+++ b/girder/api/v1/notification.py
@@ -67,6 +67,7 @@ class Notification(Resource):
                dataType='integer', required=False, default=DEFAULT_STREAM_TIMEOUT)
         .param('since', 'Filter out events before this time stamp.',
                dataType='integer', required=False)
+        .produces('text/event-stream')
         .errorResponse()
         .errorResponse('You are not logged in.', 403)
     )

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -175,6 +175,7 @@ class Resource(BaseResource):
                    '"folder": [(folder id 1)]}.', requireObject=True)
         .param('includeMetadata', 'Include any metadata in JSON files in the '
                'archive.', required=False, dataType='boolean', default=False)
+        .produces('application/zip')
         .errorResponse('Unsupported or unknown resource type.')
         .errorResponse('Invalid resources format.')
         .errorResponse('No resources specified.')

--- a/plugins/hashsum_download/server/__init__.py
+++ b/plugins/hashsum_download/server/__init__.py
@@ -63,6 +63,7 @@ class HashedFile(File):
         .param('algo', 'The hashsum algorithm.', paramType='path', lower=True,
                enum=SUPPORTED_ALGORITHMS)
         .notes('This is meant to be used in conjunction with CMake\'s ExternalData module.')
+        .produces('text/plain')
         .errorResponse()
         .errorResponse('Read access was denied on the file.', 403)
     )

--- a/tests/cases/api_describe_test.py
+++ b/tests/cases/api_describe_test.py
@@ -578,3 +578,55 @@ class ApiDescribeTestCase(base.TestCase):
         self.assertIn('get', resp.json['paths']['/old_resource/deprecated'])
         self.assertIn('deprecated', resp.json['paths']['/old_resource/deprecated']['get'])
         self.assertTrue(resp.json['paths']['/old_resource/deprecated']['get']['deprecated'])
+
+    def testProduces(self):
+        """
+        Test that a route marked as producing a list of mime types reports
+        that information properly.
+        """
+        class ProducesResource(Resource):
+            def __init__(self):
+                super(ProducesResource, self).__init__()
+                self.resourceName = 'produces_resource'
+                self.route('GET', (), self.handler)
+                self.route('GET', ('produces1',), self.producesHandler)
+                self.route('GET', ('produces2',), self.produces2Handler)
+
+            @access.public
+            @describe.describeRoute(
+                describe.Description('Handler')
+            )
+            def handler(self, params):
+                return None
+
+            @access.public
+            @describe.describeRoute(
+                describe.Description('Produces handler')
+                .produces('image/jpeg')
+            )
+            def producesHandler(self, params):
+                return None
+
+            @access.public
+            @describe.describeRoute(
+                describe.Description('Produces 2 handler')
+                .produces('image/tiff')
+                .produces(['image/jpeg', 'image/png'])
+            )
+            def produces2Handler(self, params):
+                return None
+
+        server.root.api.v1.produces_resource = ProducesResource()
+
+        resp = self.request(path='/describe', method='GET')
+        self.assertStatusOk(resp)
+        self.assertIn('paths', resp.json)
+        self.assertIn('/produces_resource', resp.json['paths'])
+        self.assertIn('/produces_resource/produces1', resp.json['paths'])
+        self.assertIn('/produces_resource/produces2', resp.json['paths'])
+        self.assertNotIn('produces', resp.json['paths']['/produces_resource']['get'])
+        self.assertIn('produces', resp.json['paths']['/produces_resource/produces1']['get'])
+        self.assertEqual(resp.json['paths']['/produces_resource/produces1']['get']['produces'],
+                         ['image/jpeg'])
+        self.assertEqual(resp.json['paths']['/produces_resource/produces2']['get']['produces'],
+                         ['image/tiff', 'image/jpeg', 'image/png'])


### PR DESCRIPTION
For endpoints which do not generate json responses, setting the swagger `produces` value can let the swagger-ui display the results (e.g., for images) or at least not throw warnings (e.g., for event streams and zip files).