### PR TITLE
improve argument handling in girder ansible module

### DIFF
--- a/devops/ansible/roles/girder/library/girder.py
+++ b/devops/ansible/roles/girder/library/girder.py
@@ -876,6 +876,84 @@ EXAMPLES = '''
 '''
 
 
+def unjsonify(a):
+    '''Convert json parts to python objects.
+
+    Tries to convert a json string or a compund object consisting of partial
+    json strings to a full python object.  Returns either a json scalar (string,
+    int, float), a list or dict of json scalars, or any combination of lists and
+    dicts that eventually end at json scalars.
+
+    Note that this function does not detect cycles in an object graph and, if
+    provided an object with one, will run until out of memory, at the stack
+    limit, or until at some other run-time limit.
+    '''
+
+    # if string, try to loads() it
+    if isinstance(a, basestring):
+        try:
+            a = json.loads(a)
+            # pass-through to below
+        except ValueError:
+            return a
+
+    if isinstance(a, list):
+        return [unjsonify(x) for x in a]
+
+    if isinstance(a, dict):
+        return {str(k):unjsonify(v) for k,v in a.items()}
+
+
+def deep_equals(a, b):
+    '''Simplified deep comparison for DAG Python objects.
+
+    Note that this function does not detect cycles in an object graph and, if
+    provided an object with one, will run until out of memory, at the stack
+    limit, or until at some other run-time limit.
+    '''
+
+    is_int = isinstance(a, int)
+    is_float = isinstance(a, float)
+    is_string = isinstance(a, basestring)
+
+    is_scalar = is_int or is_float or is_string
+
+    if is_scalar:
+        if ((is_int and not isinstance(b, int)) or
+                (is_float and not isinstance(b, float)) or
+                (is_string and not isinstance(b, basestring))):
+            return False
+
+        return a == b
+
+    if isinstance(a, list):
+        if not isinstance(b, list):
+            return False
+
+        if len(a) != len(b):
+            return False
+
+        return all(deep_equals(x, y) for x,y in zip(a, b))
+
+    if isinstance(a, dict):
+        if not isinstance(b, dict):
+            return False
+
+        if len(a) != len(b):
+            return False
+
+        a_keys = list(sorted(a.keys()))
+        b_keys = list(sorted(b.keys()))
+
+        if not deep_equals(a_keys, b_keys):
+            return False
+
+        return all(deep_equals(a[k], b[k]) for k in a_keys)
+
+    # we don't deal with any other sort of compound value
+    return False
+
+
 def class_spec(cls, include=None):
     include = include if include is not None else []
 
@@ -1804,15 +1882,21 @@ class GirderClientModule(GirderClient):
 
     def setting(self, key, value=None):
         ret = {}
-        json_value = isinstance(value, (list, dict))
+
+        if value is None:
+            value = ''
 
         if self.module.params['state'] == 'present':
             # Get existing setting value to determine self.changed
             existing_value = self.get('system/setting', parameters={'key': key})
 
+            if existing_value is None:
+                existing_value = ''
+
             params = {
                 'key': key,
-                'value': json.dumps(value) if json_value else value
+                'value': json.dumps(value)
+                         if isinstance(value, (list, dict)) else value
             }
 
             try:
@@ -1820,12 +1904,9 @@ class GirderClientModule(GirderClient):
             except requests.HTTPError as e:
                 self.fail(e.response.json()['message'])
 
-            if response and isinstance(value, list):
-                self.changed = set(existing_value) != set(value)
-            elif response and isinstance(value, dict):
-                self.changed = set(existing_value.items()) != set(value.items())
-            elif response:
-                self.changed = existing_value != value
+            if response:
+                self.changed = deep_equals(
+                        unjsonify(existing_value), unjsonify(value))
 
             if self.changed:
                 ret['previous_value'] = existing_value


### PR DESCRIPTION
Specifically, fixes two issues in how the girder ansible module handles parameters given to its `setting` mode.

First, the module fails to handle the case of None for `value` (default value) and of None for `existing_value` (returned from girder server).

Second, the module tries to compare the new and existing values of a setting for the sake of idempotency, but seems to use a few simple heuristics that assume certain hashability properties of the two values.  Specifically, it seems to require that the values be limited to simple, or first-order compoundness.  For example, it accepts a compound object of scalars, but not a compound object of such compound objects.  This causes trouble when combined with Ansible's insistance on deserializing anything that looks like JSON at a configuration document's leaves.

To address both these issues, this commit makes two major changes.  First, it adds a function for canonicalizing the values.  This canonicalization is performed by deserializing valid JSON strings into Python objects, and/or traversing such objects looking for valid JSON fragments to deserialize.  Second, the comparison heuristics are replaced with a full deep comparison to most accurately determine if a system setting had, in fact, been changed.