### PR TITLE
Fix folder creator value.

### DIFF
--- a/tests/cases/setup_database_test.py
+++ b/tests/cases/setup_database_test.py
@@ -64,6 +64,9 @@ class SetupDatabaseTestCase(base.TestCase):
         self.assertDictContains({
             'public': True
         }, folder, 'manually created public folder')
+        self.assertDictContains({
+            'creatorId': user['_id']
+        }, folder, 'folder is created by expected user')
 
     def testUserImportedFolders(self):
         user = self.model('user').findOne({'login': 'importedfolders'})

--- a/tests/setup_database.py
+++ b/tests/setup_database.py
@@ -300,7 +300,7 @@ def createUsers(users):
     """
     folders = []
     for user in users:
-        for folder in folders:
+        for folder in user.get('folders', []):
             # By default set the creator under a user to that user
             folder.setdefault('creator', user['login'])
 


### PR DESCRIPTION
When creating folders specified from user entries, all folders from the preceding user are assigned the next user as the creator, not the current user.