### PR TITLE
Fix a bug in `girder-install --watch-plugin`

### DIFF
--- a/grunt_tasks/plugin.js
+++ b/grunt_tasks/plugin.js
@@ -449,8 +449,19 @@ module.exports = function (grunt) {
                         dependencies: ['build'] // plugin builds must run after core build
                     }
                 };
+
+                var baseConfig = configOpts.webpack[`${output}_${plugin}`];
+                var newConfig = webpackHelper(baseConfig, helperConfig);
+                if (_.has(newConfig.module, 'loaders')) {
+                    if (!_.isEmpty(newConfig.module.loaders)) {
+                        grunt.log.writeln(`  >> "module.loaders" is deprecated, use "module.rules" in ${webpackHelperFile} instead.`.yellow);
+                        newConfig.module.rules = newConfig.module.rules || [];
+                        newConfig.module.rules = newConfig.module.rules.concat(newConfig.module.loaders);
+                    }
+                    delete newConfig.module.loaders;
+                }
+                grunt.config.set(`webpack.${output}_${plugin}`, newConfig);
             }
-            grunt.config.merge(configOpts);
 
             // If the plugin config has no webpack section, no defaultLoaders
             // property in the webpack section, or the defaultLoaders is
@@ -475,18 +486,7 @@ module.exports = function (grunt) {
                     grunt.config.set(selector, loaders.concat(loaderIncludes));
                 }
             }
-
-            var baseConfig = grunt.config.getRaw(`webpack.${output}_${plugin}`);
-            var newConfig = webpackHelper(baseConfig, helperConfig);
-            if (_.has(newConfig.module, 'loaders')) {
-                if (!_.isEmpty(newConfig.module.loaders)) {
-                    grunt.log.writeln(`  >> "module.loaders" is deprecated, use "module.rules" in ${webpackHelperFile} instead.`.yellow);
-                    newConfig.module.rules = newConfig.module.rules || [];
-                    newConfig.module.rules = newConfig.module.rules.concat(newConfig.module.loaders);
-                }
-                delete newConfig.module.loaders;
-            }
-            grunt.config.set(`webpack.${output}_${plugin}`, newConfig);
+            grunt.config.merge(configOpts);
         });
 
         if (config.grunt) {


### PR DESCRIPTION
This fixes a bug in `--watch-plugin` caused by https://github.com/girder/girder/pull/2305

```
Loading "plugin.js" tasks...ERROR
>> TypeError: Cannot read property 'module' of undefined
```

raised at `grunt_tasks/plugin.js:481` because when a plugin is configured but not built, the configuration object is not created.  This moves the generation of the configuration outside of the `buildPlugin` block.  Because it still isn't added to the `default` object, the plugin will not be built.