### PR TITLE
Allow The Browser Widget Deferred Validation

### DIFF
--- a/clients/web/src/views/body/FilesystemImportView.js
+++ b/clients/web/src/views/body/FilesystemImportView.js
@@ -39,9 +39,13 @@ var FilesystemImportView = View.extend({
             helpText: 'Browse to a location to select it as the destination.',
             submitText: 'Select Destination',
             validate: function (id) {
+                var isValid = $.Deferred();
                 if (!id) {
-                    return 'Please select a valid root.';
+                    isValid.reject('Please select a valid root.');
+                } else {
+                    isValid.resolve();
                 }
+                return isValid.promise();
             }
         });
         this.listenTo(this._browserWidgetView, 'g:saved', function (val) {

--- a/clients/web/src/views/body/FilesystemImportView.js
+++ b/clients/web/src/views/body/FilesystemImportView.js
@@ -38,9 +38,9 @@ var FilesystemImportView = View.extend({
             titleText: 'Destination',
             helpText: 'Browse to a location to select it as the destination.',
             submitText: 'Select Destination',
-            validate: function (id) {
-                var isValid = $.Deferred();
-                if (!id) {
+            validate: function (model) {
+                let isValid = $.Deferred();
+                if (!model) {
                     isValid.reject('Please select a valid root.');
                 } else {
                     isValid.resolve();

--- a/clients/web/src/views/widgets/BrowserWidget.js
+++ b/clients/web/src/views/widgets/BrowserWidget.js
@@ -49,7 +49,7 @@ var BrowserWidget = View.extend({
         // store options
         settings = settings || {};
         this.titleText = settings.titleText || 'Select an item';
-        this.validate = settings.validate || function () {};
+        this.validate = settings.validate || _.constant($.Deferred().resolve().promise());
         this.helpText = settings.helpText;
         this.showItems = settings.showItems;
         this.showPreview = _.isUndefined(settings.showPreview) ? true : !!settings.showPreview;

--- a/clients/web/src/views/widgets/BrowserWidget.js
+++ b/clients/web/src/views/widgets/BrowserWidget.js
@@ -152,16 +152,7 @@ var BrowserWidget = View.extend({
     },
 
     /**
-     * _validate independently validates the input-element and the selected-model.
-     * The 4 possible outcomes of this validation are as follows...
-     *
-     * Case |  input-element  |  selected-model
-     *  1.  |      Valid      |      Valid
-     *  2.  |      Valid      |     Invalid
-     *  3.  |     Invalid     |      Valid
-     *  4.  |     Invalid     |     Invalid
-     *
-     * The code path for each case is commented inline
+     * Independently validate the input-element and the selected-model.
      */
     _validate: function () {
         // Validate input element
@@ -193,8 +184,8 @@ var BrowserWidget = View.extend({
             }
         }
 
-        let invalidInputElement;
-        let invalidSelectedModel;
+        let invalidInputElement = null;
+        let invalidSelectedModel = null;
         // We want to wait until both promises to run to completion, which only happens if they're
         // accepted. So, chain an extra handler on to them, which transforms a rejection into an
         // acceptance.
@@ -218,24 +209,28 @@ var BrowserWidget = View.extend({
                 this.$('.g-input-element').removeClass('has-error');
                 this.$('.g-validation-failed-message').addClass('hidden').html('');
 
-                // Case 1
+                // The 4 possible outcomes of this validation are as follows...
+                //
+                // Case |  input-element  |  selected-model
+                //  1.  |      Valid      |      Valid
+                //  2.  |      Valid      |     Invalid
+                //  3.  |     Invalid     |      Valid
+                //  4.  |     Invalid     |     Invalid
                 if (!invalidInputElement && !invalidSelectedModel) {
+                    // Case 1
                     this.root = this._hierarchyView.parentModel;
                     this.$el.modal('hide');
                     this.trigger('g:saved', selectedModel, this.$('#g-input-element').val());
-                }
-                // Case 2
-                else if (!invalidInputElement && invalidSelectedModel) {
+                } else if (!invalidInputElement && invalidSelectedModel) {
+                    // Case 2
                     this.$('.g-selected-model').addClass('has-error');
                     this.$('.g-validation-failed-message').removeClass('hidden').text(invalidSelectedModel);
-                }
-                // Case 3
-                else if (invalidInputElement && !invalidSelectedModel) {
+                } else if (invalidInputElement && !invalidSelectedModel) {
+                    // Case 3
                     this.$('.g-input-element').addClass('has-error');
                     this.$('.g-validation-failed-message').removeClass('hidden').text(invalidInputElement);
-                }
-                // Case 4
-                else if (invalidInputElement && invalidSelectedModel) {
+                } else if (invalidInputElement && invalidSelectedModel) {
+                    // Case 4
                     this.$('.g-selected-model').addClass('has-error');
                     this.$('.g-input-element').addClass('has-error');
                     this.$('.g-validation-failed-message').removeClass('hidden').html(

--- a/clients/web/src/views/widgets/BrowserWidget.js
+++ b/clients/web/src/views/widgets/BrowserWidget.js
@@ -174,6 +174,7 @@ var BrowserWidget = View.extend({
                 if (this.input && this.input.validate) {
                     var message = this.input.validate(this.$('#g-input-element').val());
                     if (message === undefined) {
+                        console.warn('Static validation is deprecated, return a promise instead');
                         return undefined;
                     } else if (_.isFunction(message.then)) {
                         return message;
@@ -189,6 +190,7 @@ var BrowserWidget = View.extend({
                 // Validate selected-model
                 var message = this.validate(selectedModel);
                 if (message === undefined) {
+                    console.warn('Static validation is deprecated, return a promise instead');
                     return undefined;
                 } else if (_.isFunction(message.then)) {
                     return message;
@@ -202,6 +204,7 @@ var BrowserWidget = View.extend({
                 // Validate selected-model
                 var message = this.validate(selectedModel);
                 if (message === undefined) {
+                    console.warn('Static validation is deprecated, return a promise instead');
                     return undefined;
                 } else if (_.isFunction(message.then)) {
                     return message;

--- a/clients/web/src/views/widgets/BrowserWidget.js
+++ b/clients/web/src/views/widgets/BrowserWidget.js
@@ -161,13 +161,12 @@ var BrowserWidget = View.extend({
         let inputValidation;
         if (this.input && this.input.validate) {
             inputValidation = this.input.validate(this.$('#g-input-element').val());
-            if (!_.isFunction(inputValidation.then)) {
+            if (inputValidation === undefined) {
                 console.warn('Static validation is deprecated, return a promise instead');
-                if (inputValidation === undefined) {
-                    inputValidation = $.Deferred().resolve().promise();
-                } else {
-                    inputValidation = $.Deferred().reject(inputValidation).promise();
-                }
+                inputValidation = $.Deferred().resolve().promise();
+            } else if (!_.isFunction(inputValidation.then)) {
+                console.warn('Static validation is deprecated, return a promise instead');
+                inputValidation = $.Deferred().reject(inputValidation).promise();
             }
         } else {
             // No validator is implicit acceptance
@@ -177,13 +176,12 @@ var BrowserWidget = View.extend({
         // Validate selected element
         const selectedModel = this.selectedModel();
         let selectedValidation = this.validate(selectedModel);
-        if (!_.isFunction(selectedValidation.then)) {
+        if (selectedValidation === undefined) {
             console.warn('Static validation is deprecated, return a promise instead');
-            if (selectedValidation === undefined) {
-                selectedValidation = $.Deferred().resolve().promise();
-            } else {
-                selectedValidation = $.Deferred().reject(selectedValidation).promise();
-            }
+            selectedValidation = $.Deferred().resolve().promise();
+        } else if (!_.isFunction(selectedValidation.then)) {
+            console.warn('Static validation is deprecated, return a promise instead');
+            selectedValidation = $.Deferred().reject(selectedValidation).promise();
         }
 
         let invalidInputElement = null;

--- a/clients/web/src/views/widgets/BrowserWidget.js
+++ b/clients/web/src/views/widgets/BrowserWidget.js
@@ -16,7 +16,9 @@ import 'girder/utilities/jquery/girderModal';
  */
 var BrowserWidget = View.extend({
     events: {
-        'click .g-submit-button': '_submitButton'
+        'click .g-submit-button': function () {
+            this._validate();
+        }
     },
 
     /**
@@ -27,8 +29,10 @@ var BrowserWidget = View.extend({
      * @param {string} [submitText="Save"] Text to display on the submit button
      * @param {boolean} [showItems=false] Show items in the hierarchy widget
      * @param {boolean} [showPreview=true] Show a preview of the current object id
-     * @param {function} [validate] A validation function returning a promise that returns a string
-        to be displayed on error, or undefined if valid.
+     * @param {function} [validate] A validation function, which is passed the selected model as a
+        parameter, and which should return a promise. The returned promise should resolve if the
+        selection is acceptable and reject with a string value (as an error message) if the
+        selection is unacceptable.
      * @param {object} [rootSelectorSettings] Settings passed to the root selector widget
      * @param {boolean} [showMetadata=false] Show the metadata editor inside the hierarchy widget
      * @param {Model} [root] The default root model to pass to the hierarchy widget
@@ -41,8 +45,10 @@ var BrowserWidget = View.extend({
      *   as in a "Save As" dialog.  The default (false) hides this element.
      * @param {string} [input.label="Name"] A label for the input element.
      * @param {string} [input.default] The default value
-     * @param {function} [input.validate] A validation function returning a promise that returns a
-        string to be displayed on error, or undefined if valid.
+     * @param {function} [input.validate] A validation function, which is passed the value of the
+        user-specified input element as a parameter, and which should return a promise. The returned
+        promise should resolve if the selection is acceptable and reject with a string value (as an
+        error message) if the selection is unacceptable.
      * @param {string} [input.placeholder] A placeholder string for the input element.
      */
     initialize: function (settings) {
@@ -145,10 +151,6 @@ var BrowserWidget = View.extend({
             return;
         }
         this._resetSelection(this._hierarchyView.parentModel);
-    },
-
-    _submitButton: function () {
-        this._validate();
     },
 
     /**

--- a/clients/web/test/spec/browserSpec.js
+++ b/clients/web/test/spec/browserSpec.js
@@ -446,8 +446,8 @@ describe('Test the hierarchy browser modal', function () {
             view = new girder.views.widgets.BrowserWidget({
                 parentView: null,
                 el: testEl,
-                validate: () => {
-                    return $.Deferred().resolve().promise();
+                validate: function (val) {
+                    return $.Deferred().reject('invalid').promise();
                 }
             }).render();
             waitsFor(function () {
@@ -581,12 +581,14 @@ describe('Test the hierarchy browser modal', function () {
                     default: 'default',
                     placeholder: 'placeholder',
                     validate: function (val) {
+                        var isValid = $.Deferred();
                         validateCalledWith = val;
-                        if (!validateReturn) {
-                            return $.Deferred().reject(validateReturn).promise();
+                        if (validateReturn) {
+                            isValid.reject(validateReturn);
                         } else {
-                            return $.Deferred().resolve().promise();
+                            isValid.resolve();
                         }
+                        return isValid.promise();
                     }
                 }
             }).render();

--- a/clients/web/test/spec/browserSpec.js
+++ b/clients/web/test/spec/browserSpec.js
@@ -446,7 +446,9 @@ describe('Test the hierarchy browser modal', function () {
             view = new girder.views.widgets.BrowserWidget({
                 parentView: null,
                 el: testEl,
-                validate: _.constant('invalid')
+                validate: () => {
+                    return $.Deferred().resolve().promise();
+                }
             }).render();
             waitsFor(function () {
                 return $(view.$el).is(':visible');
@@ -580,7 +582,11 @@ describe('Test the hierarchy browser modal', function () {
                     placeholder: 'placeholder',
                     validate: function (val) {
                         validateCalledWith = val;
-                        return validateReturn;
+                        if (!validateReturn) {
+                            return $.Deferred().reject(validateReturn).promise();
+                        } else {
+                            return $.Deferred().resolve().promise();
+                        }
                     }
                 }
             }).render();

--- a/clients/web/test/spec/browserSpec.js
+++ b/clients/web/test/spec/browserSpec.js
@@ -458,7 +458,7 @@ describe('Test the hierarchy browser modal', function () {
             });
             waitsFor(function () {
                 return $('.g-validation-failed-message').text();
-            }, 'validation to complete');
+            }, 'validation to fail');
             runs(function () {
                 expect(view.$el.hasClass('in')).toBe(true);
                 expect(view.$('.g-validation-failed-message').text()).toBe('invalid');
@@ -610,7 +610,7 @@ describe('Test the hierarchy browser modal', function () {
             });
             waitsFor(function () {
                 return $('.g-validation-failed-message').text();
-            }, 'validation to complete');
+            }, 'validation to fail');
             runs(function () {
                 expect(validateCalledWith).toBe('input value');
                 expect(view.$('.g-validation-failed-message').text()).toBe('invalid');

--- a/clients/web/test/spec/browserSpec.js
+++ b/clients/web/test/spec/browserSpec.js
@@ -453,6 +453,11 @@ describe('Test the hierarchy browser modal', function () {
             });
             runs(function () {
                 view.$('.g-submit-button').click();
+            });
+            waitsFor(function () {
+                return $('.g-validation-failed-message').text();
+            }, 'validation to complete');
+            runs(function () {
                 expect(view.$el.hasClass('in')).toBe(true);
                 expect(view.$('.g-validation-failed-message').text()).toBe('invalid');
                 expect(view.$('.g-validation-falied-message').hasClass('hidden')).toBe(false);
@@ -594,7 +599,11 @@ describe('Test the hierarchy browser modal', function () {
                 // test an invalid input
                 view.$('#g-input-element').val('input value');
                 view.$('.g-submit-button').click();
-
+            });
+            waitsFor(function () {
+                return $('.g-validation-failed-message').text();
+            }, 'validation to complete');
+            runs(function () {
                 expect(validateCalledWith).toBe('input value');
                 expect(view.$('.g-validation-failed-message').text()).toBe('invalid');
                 expect(view.$('.g-validation-failed-message').hasClass('hidden')).toBe(false);

--- a/plugins/item_tasks/plugin_tests/tasksSpec.js
+++ b/plugins/item_tasks/plugin_tests/tasksSpec.js
@@ -165,7 +165,15 @@ describe('Run the item task', function () {
 
         runs(function () {
             // check invalid parent
+            $('.g-validation-failed-message').text('');
             $('.modal-dialog .g-submit-button').click();
+        });
+
+        waitsFor(function () {
+            return $('.g-validation-failed-message').text();
+        }, 'validation to complete');
+
+        runs(function() {
             expect($('.g-validation-failed-message').text()).toMatch(/Invalid parent type/);
             $('.modal-dialog .g-folder-list-link:first').click();
         });
@@ -176,7 +184,15 @@ describe('Run the item task', function () {
 
         runs(function () {
             // check no name provided
+            $('.g-validation-failed-message').text('');
             $('.modal-dialog .g-submit-button').click();
+        });
+
+        waitsFor(function () {
+            return $('.g-validation-failed-message').text();
+        }, 'validation to complete');
+
+        runs(function () {
             expect($('.g-validation-failed-message').text()).toMatch(/Please provide an item name/);
 
             $('#g-input-element').val('out.txt');

--- a/plugins/item_tasks/plugin_tests/tasksSpec.js
+++ b/plugins/item_tasks/plugin_tests/tasksSpec.js
@@ -165,13 +165,12 @@ describe('Run the item task', function () {
 
         runs(function () {
             // check invalid parent
-            $('.g-validation-failed-message').text('');
             $('.modal-dialog .g-submit-button').click();
         });
 
         waitsFor(function () {
             return $('.g-validation-failed-message').text();
-        }, 'validation to complete');
+        }, 'validation to fail');
 
         runs(function() {
             expect($('.g-validation-failed-message').text()).toMatch(/Invalid parent type/);
@@ -184,13 +183,12 @@ describe('Run the item task', function () {
 
         runs(function () {
             // check no name provided
-            $('.g-validation-failed-message').text('');
             $('.modal-dialog .g-submit-button').click();
         });
 
         waitsFor(function () {
             return $('.g-validation-failed-message').text();
-        }, 'validation to complete');
+        }, 'validation to fail');
 
         runs(function () {
             expect($('.g-validation-failed-message').text()).toMatch(/Please provide an item name/);

--- a/plugins/item_tasks/web_client/views/ControlWidget.js
+++ b/plugins/item_tasks/web_client/views/ControlWidget.js
@@ -179,13 +179,13 @@ var ControlWidget = View.extend({
             input = false,
             preview = true,
             validate = () => {
-                return $.Deferred().resolve().reject();
+                return $.Deferred().resolve().promise();
             },
             type = this.model.get('type'),
             title, help;
 
-        var validationPromise = function (condition, message) {
-            var isValid = $.Deferred();
+        let validationPromise = function (condition, message) {
+            let isValid = $.Deferred();
             if (!condition) {
                 isValid.reject(message);
             } else {
@@ -234,7 +234,7 @@ var ControlWidget = View.extend({
                 label: 'Name',
                 placeholder: 'Choose a name for the new item',
                 validate: (val) => {
-                    // validation on the "new folder name"\
+                    // validation on the "new folder name"
                     return validationPromise(val, 'Please provide an item name.');
                 },
                 default: this.model.get('fileName')

--- a/plugins/item_tasks/web_client/views/ControlWidget.js
+++ b/plugins/item_tasks/web_client/views/ControlWidget.js
@@ -219,9 +219,9 @@ var ControlWidget = View.extend({
             };
             // validation on the parent model
             validate = (model) => {
-                var type = model.get('_modelType');
-                var condition = _.contains(['folder', 'collection', 'user'], type);
-                var message = 'Invalid parent type, please choose a collection, folder, or user.';
+                let type = model.get('_modelType');
+                let condition = _.contains(['folder', 'collection', 'user'], type);
+                let message = 'Invalid parent type, please choose a collection, folder, or user.';
                 return validationPromise(condition, message);
             };
             preview = false;
@@ -241,9 +241,9 @@ var ControlWidget = View.extend({
             };
             // validation on the parent model
             validate = (model) => {
-                var type = model.get('_modelType');
-                var condition = type === 'folder';
-                var message = 'Invalid parent type, please choose a folder.';
+                let type = model.get('_modelType');
+                let condition = type === 'folder';
+                let message = 'Invalid parent type, please choose a folder.';
                 return validationPromise(condition, message);
             };
             preview = false;

--- a/plugins/item_tasks/web_client/views/ControlWidget.js
+++ b/plugins/item_tasks/web_client/views/ControlWidget.js
@@ -178,10 +178,21 @@ var ControlWidget = View.extend({
         var showItems = false,
             input = false,
             preview = true,
-            validate = _.noop,
+            validate = () => {
+                return $.Deferred().resolve().reject();
+            },
             type = this.model.get('type'),
             title, help;
 
+        var validationPromise = function (condition, message) {
+            var isValid = $.Deferred();
+            if (!condition) {
+                isValid.reject(message);
+            } else {
+                isValid.resolve();
+            }
+            return isValid.promise();
+        };
         // Customize the browser widget according the argument type
         if (type === 'file' || type === 'image') {
             showItems = true;
@@ -202,18 +213,16 @@ var ControlWidget = View.extend({
                 placeholder: 'Choose a name for the new folder',
                 validate: (val) => {
                     // validation on the "new item name"
-                    if (!val) {
-                        return 'Please provide a folder name.';
-                    }
+                    return validationPromise(val, 'Please provide a folder name.');
                 },
                 default: this.model.get('fileName')
             };
             // validation on the parent model
             validate = (model) => {
                 var type = model.get('_modelType');
-                if (!_.contains(['folder', 'collection', 'user'], type)) {
-                    return 'Invalid parent type, please choose a collection, folder, or user.';
-                }
+                var condition = _.contains(['folder', 'collection', 'user'], type);
+                var message = 'Invalid parent type, please choose a collection, folder, or user.';
+                return validationPromise(condition, message);
             };
             preview = false;
         }
@@ -225,19 +234,17 @@ var ControlWidget = View.extend({
                 label: 'Name',
                 placeholder: 'Choose a name for the new item',
                 validate: (val) => {
-                    // validation on the "new folder name"
-                    if (!val) {
-                        return 'Please provide an item name.';
-                    }
+                    // validation on the "new folder name"\
+                    return validationPromise(val, 'Please provide an item name.');
                 },
                 default: this.model.get('fileName')
             };
             // validation on the parent model
             validate = (model) => {
                 var type = model.get('_modelType');
-                if (type !== 'folder') {
-                    return 'Invalid parent type, please choose a folder.';
-                }
+                var condition = type === 'folder';
+                var message = 'Invalid parent type, please choose a folder.';
+                return validationPromise(condition, message);
             };
             preview = false;
         }


### PR DESCRIPTION
While maintaining its original functionality of accepting a validation function that takes input and returns a string, the BrowserWidget can now accept a validation function that takes input and returns a promise as to allow deferred validation. 