### PR TITLE
Add docker file for python 3

### DIFF
--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -1,0 +1,35 @@
+FROM node:6
+MAINTAINER Kitware, Inc. <kitware@kitware.com>
+
+EXPOSE 8080
+
+RUN mkdir /girder
+RUN mkdir /girder/logs
+
+RUN apt-get update && apt-get install -qy software-properties-common python-software-properties && \
+  apt-get update && apt-get install -qy \
+    build-essential \
+    git \
+    libffi-dev \
+    libsasl2-dev \
+    libldap2-dev \
+    libpython3-dev && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
+
+WORKDIR /girder
+COPY girder /girder/girder
+COPY clients /girder/clients
+COPY plugins /girder/plugins
+COPY scripts /girder/scripts
+COPY grunt_tasks /girder/grunt_tasks
+COPY Gruntfile.js /girder/Gruntfile.js
+COPY setup.py /girder/setup.py
+COPY package.json /girder/package.json
+COPY README.rst /girder/README.rst
+
+RUN pip install -e .[plugins]
+RUN girder-install web --all-plugins
+
+ENTRYPOINT ["python3", "-m", "girder"]


### PR DESCRIPTION
This PR adds a docker file for python 3. Feels a like yucky, lots of cut and paste. Suggestions welcome. We will need to tweak docker hub to build and tag this file as well.