### PR TITLE
Do not die if user in collection creation list is deleted

### DIFF
--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -505,14 +505,20 @@ class System(Resource):
             userDoc = self.model('user').load(
                 user['id'], force=True,
                 fields=['firstName', 'lastName', 'login'])
-            user['login'] = userDoc['login']
-            user['name'] = ' '.join((userDoc['firstName'], userDoc['lastName']))
+            if userDoc is None:
+                acList['users'].remove(user)
+            else:
+                user['login'] = userDoc['login']
+                user['name'] = ' '.join((userDoc['firstName'], userDoc['lastName']))
 
         for grp in acList['groups'][:]:
             grpDoc = self.model('group').load(
                 grp['id'], force=True, fields=['name', 'description'])
-            grp['name'] = grpDoc['name']
-            grp['description'] = grpDoc['description']
+            if grpDoc is None:
+                acList['groups'].remove(grp)
+            else:
+                grp['name'] = grpDoc['name']
+                grp['description'] = grpDoc['description']
 
         return acList
 

--- a/tests/cases/system_test.py
+++ b/tests/cases/system_test.py
@@ -756,14 +756,25 @@ class SystemTestCase(base.TestCase):
             'list': json.dumps([
                 {'key': SettingKey.COLLECTION_CREATE_POLICY, 'value': json.dumps({
                     'open': True,
-                    'users': [str(self.users[0]['_id'])],
+                    'users': [str(self.users[1]['_id'])],
                     'groups': [str(self.group['_id'])]
                 })}
             ])
         }, user=self.users[0])
+        self.assertStatusOk(resp)
 
         resp = self.request(path='/system/setting/collection_creation_policy/access',
                             method='GET', user=self.users[0])
-        self.assertEqual(resp.json['users'][0]['id'], str(self.users[0]['_id']))
-        self.assertEqual(resp.json['users'][0]['login'], str(self.users[0]['login']))
+        self.assertEqual(resp.json['users'][0]['id'], str(self.users[1]['_id']))
+        self.assertEqual(resp.json['users'][0]['login'], str(self.users[1]['login']))
         self.assertEqual(resp.json['groups'][0]['id'], str(self.group['_id']))
+
+        # Delete underlying users and groups, should be OK
+        self.model('group').remove(self.group)
+        self.model('user').remove(self.users[1])
+        resp = self.request(
+            path='/system/setting/collection_creation_policy/access', method='GET',
+            user=self.users[0])
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json['users'], [])
+        self.assertEqual(resp.json['groups'], [])


### PR DESCRIPTION
Prior to this change, if a user or group was added by an admin to the list of users/groups allowed to create collections, and then the user or group was deleted, a 500 error would be thrown when attempting to load the settings page. Now we simply remove them from the list instead.