### PR TITLE
Properly encode filenames in Content-Disposition headers.

### DIFF
--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -281,7 +281,7 @@ def setContentDisposition(filename, disposition='attachment', setHeader=True):
     safeFilename = unicodedata.normalize('NFKD', filename).encode('iso8859-1', 'ignore')
     utf8Filename = filename.encode('utf8', 'ignore')
     value = disposition + b'; filename="' + safeFilename.replace(
-        '\\', '\\\\').replace(b'"', b'\\"') + b'"'
+        b'\\', b'\\\\').replace(b'"', b'\\"') + b'"'
     if safeFilename != utf8Filename:
         quotedFilename = six.moves.urllib.parse.quote(utf8Filename)
         if not isinstance(quotedFilename, six.binary_type):

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -269,9 +269,11 @@ def setContentDisposition(filename, disposition='attachment', setHeader=True):
         Content-Disposition header, but do not set it.
     :returns: the content-disposition header value.
     """
-    if ((disposition not in ('inline', 'attachment') and
-         disposition and not disposition.startswith('form-data')) or not filename):
-        return
+    if (not disposition or (disposition not in ('inline', 'attachment') and
+                            not disposition.startswith('form-data'))):
+        raise RestException('Error: Content-Disposition is not a recognized value.')
+    if not filename:
+        raise RestException('Error: Content-Disposition filename is empty.')
     if not isinstance(disposition, six.binary_type):
         disposition = disposition.encode('iso8859-1', 'ignore')
     if not isinstance(filename, six.text_type):

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -270,7 +270,7 @@ def setContentDisposition(filename, disposition='attachment', setHeader=True):
     :returns: the content-disposition header value.
     """
     if ((disposition not in ('inline', 'attachment') and
-         not disposition.startswith('form-data')) or not filename):
+         disposition and not disposition.startswith('form-data')) or not filename):
         return
     if not isinstance(disposition, six.binary_type):
         disposition = disposition.encode('iso8859-1', 'ignore')

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -258,8 +258,8 @@ def setContentDisposition(filename, disposition='attachment', setHeader=True):
     Set the content disposition header to either inline or attachment, and
     specify a filename that is properly escaped.  See
     developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition,
-    tools.ietf.org/html/rfc2183, and tools.ietf.org/html/rfc6266 for
-    specificatioons and details.
+    tools.ietf.org/html/rfc2183, tools.ietf.org/html/rfc6266, and
+    tools.ietf.org/html/rfc5987 for specifications and details.
 
     :param filename: the filename to add to the content disposition header.
     :param disposition: either 'inline' or 'attachment'.  None is the same as
@@ -271,7 +271,8 @@ def setContentDisposition(filename, disposition='attachment', setHeader=True):
     """
     if (not disposition or (disposition not in ('inline', 'attachment') and
                             not disposition.startswith('form-data'))):
-        raise RestException('Error: Content-Disposition is not a recognized value.')
+        raise RestException(
+            'Error: Content-Disposition (%r) is not a recognized value.' % disposition)
     if not filename:
         raise RestException('Error: Content-Disposition filename is empty.')
     if not isinstance(disposition, six.binary_type):

--- a/girder/api/v1/collection.py
+++ b/girder/api/v1/collection.py
@@ -18,7 +18,7 @@
 ###############################################################################
 
 from ..describe import Description, autoDescribeRoute
-from ..rest import Resource, filtermodel, setResponseHeader
+from ..rest import Resource, filtermodel, setResponseHeader, setContentDisposition
 from girder.api import access
 from girder.constants import AccessType, TokenScope
 from girder.models.model_base import AccessException
@@ -118,8 +118,7 @@ class Collection(Resource):
     )
     def downloadCollection(self, collection, mimeFilter):
         setResponseHeader('Content-Type', 'application/zip')
-        setResponseHeader(
-            'Content-Disposition', 'attachment; filename="%s%s"' % (collection['name'], '.zip'))
+        setContentDisposition(collection['name'] + '.zip')
 
         def stream():
             zip = ziputil.ZipGenerator(collection['name'])

--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -18,7 +18,7 @@
 ###############################################################################
 
 from ..describe import Description, autoDescribeRoute
-from ..rest import Resource, RestException, filtermodel, setResponseHeader
+from ..rest import Resource, RestException, filtermodel, setResponseHeader, setContentDisposition
 from girder.api import access
 from girder.constants import AccessType, TokenScope
 from girder.utility import ziputil
@@ -127,9 +127,7 @@ class Folder(Resource):
         file containing this folder's contents, filtered by permissions.
         """
         setResponseHeader('Content-Type', 'application/zip')
-        setResponseHeader(
-            'Content-Disposition', 'attachment; filename="%s%s"' % (folder['name'], '.zip'))
-
+        setContentDisposition(folder['name'] + '.zip')
         user = self.getCurrentUser()
 
         def stream():

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -18,7 +18,7 @@
 ###############################################################################
 
 from ..describe import Description, autoDescribeRoute
-from ..rest import Resource, RestException, filtermodel, setResponseHeader
+from ..rest import Resource, RestException, filtermodel, setResponseHeader, setContentDisposition
 from girder.utility import ziputil
 from girder.constants import AccessType, TokenScope
 from girder.api import access
@@ -201,9 +201,7 @@ class Item(Resource):
 
     def _downloadMultifileItem(self, item, user):
         setResponseHeader('Content-Type', 'application/zip')
-        setResponseHeader(
-            'Content-Disposition',
-            'attachment; filename="%s%s"' % (item['name'], '.zip'))
+        setContentDisposition(item['name'] + '.zip')
 
         def stream():
             zip = ziputil.ZipGenerator(item['name'])

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -20,7 +20,7 @@
 import six
 
 from ..describe import Description, autoDescribeRoute
-from ..rest import Resource as BaseResource, RestException, setResponseHeader
+from ..rest import Resource as BaseResource, RestException, setResponseHeader, setContentDisposition
 from girder.constants import AccessType, TokenScope
 from girder.api import access
 from girder.utility import parseTimestamp
@@ -198,7 +198,7 @@ class Resource(BaseResource):
                 if not model.load(id=id, user=user, level=AccessType.READ):
                     raise RestException('Resource %s %s not found.' % (kind, id))
         setResponseHeader('Content-Type', 'application/zip')
-        setResponseHeader('Content-Disposition', 'attachment; filename="Resources.zip"')
+        setContentDisposition('Resources.zip')
 
         def stream():
             zip = ziputil.ZipGenerator()

--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -19,7 +19,7 @@ import os
 import re
 import six
 
-from girder.api.rest import setResponseHeader
+from girder.api.rest import setResponseHeader, setContentDisposition
 from girder.constants import SettingKey
 from girder.models.model_base import GirderException, ValidationException
 from girder.utility import progress, RequestBodyStream
@@ -342,14 +342,7 @@ class AbstractAssetstoreAdapter(ModelImporter):
         setResponseHeader(
             'Content-Type',
             file.get('mimeType') or 'application/octet-stream')
-        if contentDisposition == 'inline':
-            setResponseHeader(
-                'Content-Disposition',
-                'inline; filename="%s"' % file['name'])
-        else:
-            setResponseHeader(
-                'Content-Disposition',
-                'attachment; filename="%s"' % file['name'])
+        setContentDisposition(file['name'], contentDisposition)
         setResponseHeader('Content-Length', max(endByte - offset, 0))
 
         if (offset or endByte < file['size']) and file['size']:

--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -342,7 +342,7 @@ class AbstractAssetstoreAdapter(ModelImporter):
         setResponseHeader(
             'Content-Type',
             file.get('mimeType') or 'application/octet-stream')
-        setContentDisposition(file['name'], contentDisposition)
+        setContentDisposition(file['name'], contentDisposition or 'attachment')
         setResponseHeader('Content-Length', max(endByte - offset, 0))
 
         if (offset or endByte < file['size']) and file['size']:

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -27,6 +27,7 @@ import six
 import uuid
 
 from girder import logger, events
+from girder.api.rest import setContentDisposition
 from girder.models.model_base import GirderException, ValidationException
 from .abstract_assetstore_adapter import AbstractAssetstoreAdapter
 
@@ -106,7 +107,7 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
 
     def _getRequestHeaders(self, upload):
         return {
-            'Content-Disposition': 'attachment; filename="%s"' % upload['name'],
+            'Content-Disposition': setContentDisposition(upload['name'], setHeader=False),
             'Content-Type': upload.get('mimeType', ''),
             'x-amz-acl': 'private',
             'x-amz-meta-uploader-id': str(upload['userId']),

--- a/plugins/hashsum_download/server/__init__.py
+++ b/plugins/hashsum_download/server/__init__.py
@@ -24,7 +24,7 @@ import warnings
 from girder import events
 from girder.api import access
 from girder.api.describe import autoDescribeRoute, Description
-from girder.api.rest import RestException, setRawResponse, setResponseHeader
+from girder.api.rest import RestException, setRawResponse, setResponseHeader, setContentDisposition
 from girder.api.v1.file import File
 from girder.constants import AccessType, TokenScope
 from girder.models.model_base import ValidationException
@@ -77,7 +77,7 @@ class HashedFile(File):
 
         setResponseHeader('Content-Length', len(hash))
         setResponseHeader('Content-Type', 'text/plain')
-        setResponseHeader('Content-Disposition', 'attachment; filename="%s"' % name)
+        setContentDisposition(name)
         setRawResponse()
 
         return hash

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -792,7 +792,7 @@ class FileTestCase(base.TestCase):
         file = self._testUploadFile(filename)
         file = self.model('file').load(file['_id'], force=True)
         testval = 'filename="%s"; filename*=UTF-8\'\'%s' % (
-            filename.replace('"', '').encode('ascii', 'ignore').decode('utf8'),
+            filename.replace('"', '\\"').encode('iso8859-1', 'ignore').decode('utf8'),
             six.moves.urllib.parse.quote(filename.encode('utf8', 'ignore')))
         self._testDownloadFile(file, chunk1 + chunk2, testval)
 

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -24,7 +24,6 @@ import json
 import moto
 import os
 import shutil
-import six
 import zipfile
 
 from hashlib import sha512
@@ -791,9 +790,10 @@ class FileTestCase(base.TestCase):
                    u'\u0639\u064a\u0646\u0629 \u6a23\u54c1 \U0001f603'
         file = self._testUploadFile(filename)
         file = self.model('file').load(file['_id'], force=True)
-        testval = 'filename="%s"; filename*=UTF-8\'\'%s' % (
-            filename.replace('"', '\\"').encode('iso8859-1', 'ignore').decode('utf8'),
-            six.moves.urllib.parse.quote(filename.encode('utf8', 'ignore')))
+        testval = 'filename="Unicode \\"sample\\"     "; filename*=UTF-8\'\'' \
+            'Unicode%20%22sample%22%20%F0%90%82%88%20%D0%BE%D0%B1%D1%80%D0' \
+            '%B0%D0%B7%D0%B5%D1%86%20%D8%B9%D9%8A%D9%86%D8%A9%20%E6%A8%A3%E5' \
+            '%93%81%20%F0%9F%98%83'
         self._testDownloadFile(file, chunk1 + chunk2, testval)
 
     def testGridFsAssetstore(self):

--- a/tests/cases/rest_util_test.py
+++ b/tests/cases/rest_util_test.py
@@ -129,3 +129,24 @@ class RestUtilTestCase(unittest.TestCase):
 
         with six.assertRaisesRegex(self, rest.RestException, 'Parameter "hello" is required.'):
             resource.requireParams(['hello'], None)
+
+    def testSetContentDisposition(self):
+        self.assertIsNone(rest.setContentDisposition(
+            'filename', 'unknown', False))
+        self.assertEqual(rest.setContentDisposition(
+            'filename', setHeader=False), 'attachment; filename="filename"')
+        self.assertEqual(rest.setContentDisposition(
+            'filename', 'inline', setHeader=False), 'inline; filename="filename"')
+        self.assertEqual(rest.setContentDisposition(
+            'filename', 'form-data; name="chunk"', setHeader=False),
+            'form-data; name="chunk"; filename="filename"')
+        self.assertEqual(rest.setContentDisposition(
+            'file "name"', setHeader=False),
+            'attachment; filename="file name"; filename*=UTF-8\'\'file%20%22name%22')
+        self.assertEqual(rest.setContentDisposition(
+            u'\u043e\u0431\u0440\u0430\u0437\u0435\u0446', setHeader=False),
+            'attachment; filename=""; filename*=UTF-8\'\''
+            '%D0%BE%D0%B1%D1%80%D0%B0%D0%B7%D0%B5%D1%86')
+        self.assertEqual(rest.setContentDisposition(
+            u'\U0001f603', setHeader=False),
+            'attachment; filename=""; filename*=UTF-8\'\'%F0%9F%98%83')

--- a/tests/cases/rest_util_test.py
+++ b/tests/cases/rest_util_test.py
@@ -134,15 +134,20 @@ class RestUtilTestCase(unittest.TestCase):
         self.assertIsNone(rest.setContentDisposition(
             'filename', 'unknown', False))
         self.assertEqual(rest.setContentDisposition(
-            'filename', setHeader=False), 'attachment; filename="filename"')
+            'filename', setHeader=False),
+            'attachment; filename="filename"')
         self.assertEqual(rest.setContentDisposition(
-            'filename', 'inline', setHeader=False), 'inline; filename="filename"')
+            'filename', 'inline', setHeader=False),
+            'inline; filename="filename"')
         self.assertEqual(rest.setContentDisposition(
             'filename', 'form-data; name="chunk"', setHeader=False),
             'form-data; name="chunk"; filename="filename"')
         self.assertEqual(rest.setContentDisposition(
             'file "name"', setHeader=False),
-            'attachment; filename="file name"; filename*=UTF-8\'\'file%20%22name%22')
+            'attachment; filename="file \\"name\\""')
+        self.assertEqual(rest.setContentDisposition(
+            'file\\name', setHeader=False),
+            'attachment; filename="file\\\\name"')
         self.assertEqual(rest.setContentDisposition(
             u'\u043e\u0431\u0440\u0430\u0437\u0435\u0446', setHeader=False),
             'attachment; filename=""; filename*=UTF-8\'\''

--- a/tests/cases/rest_util_test.py
+++ b/tests/cases/rest_util_test.py
@@ -131,8 +131,13 @@ class RestUtilTestCase(unittest.TestCase):
             resource.requireParams(['hello'], None)
 
     def testSetContentDisposition(self):
-        self.assertIsNone(rest.setContentDisposition(
-            'filename', 'unknown', False))
+        with six.assertRaisesRegex(
+                self, rest.RestException,
+                'Error: Content-Disposition is not a recognized value.'):
+            rest.setContentDisposition('filename', 'unknown', False)
+        with six.assertRaisesRegex(
+                self, rest.RestException, 'Error: Content-Disposition filename is empty.'):
+            rest.setContentDisposition('', setHeader=False)
         self.assertEqual(rest.setContentDisposition(
             'filename', setHeader=False),
             'attachment; filename="filename"')

--- a/tests/cases/rest_util_test.py
+++ b/tests/cases/rest_util_test.py
@@ -133,7 +133,7 @@ class RestUtilTestCase(unittest.TestCase):
     def testSetContentDisposition(self):
         with six.assertRaisesRegex(
                 self, rest.RestException,
-                'Error: Content-Disposition is not a recognized value.'):
+                'Error: Content-Disposition \(.*\) is not a recognized value.'):
             rest.setContentDisposition('filename', 'unknown', False)
         with six.assertRaisesRegex(
                 self, rest.RestException, 'Error: Content-Disposition filename is empty.'):


### PR DESCRIPTION
Prior to this, names that included quotes or unicode codepoints might produce broken Content-Dispositions.