### PR TITLE
Add a girder-client console script

### DIFF
--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -60,7 +60,8 @@ setup(
     zip_safe=False,
     entry_points={
         'console_scripts': [
-            'girder-cli = girder_client.cli:main'
+            'girder-cli = girder_client.cli:main',
+            'girder-client = girder_client.cli:main'
         ]
     }
 )


### PR DESCRIPTION
> It was somewhat confusing that the package name on PyPI is
"girder-client" while the actual executable is girder-cli. This adds a
duplicate console script named girder-client, effectively aliasing
girder-client to girder-cli.