### PR TITLE
Developer-Installation Documentation

### DIFF
--- a/docs/dev-installation.rst
+++ b/docs/dev-installation.rst
@@ -9,7 +9,7 @@ Virtual Machine
 +++++++++++++++ 
  
 The easiest way to develop for girder is within a virtual machine using Vagrant.
-For this, you need `Vagrant <https://www.vagrantup.com/downloads.html`_ and `VirtualBox <https://www.virtualbox.org/wiki/Downloads>`_. 
+For this, you need `Vagrant <https://www.vagrantup.com/downloads.html>`_ and `VirtualBox <https://www.virtualbox.org/wiki/Downloads>`_. 
 Girder is tested to work seamlessly with Vagrant 2.0 and VirtualBox 5.1. 
  
 Once you have those installed, obtain the Girder source code by cloning the Git 

--- a/docs/dev-installation.rst
+++ b/docs/dev-installation.rst
@@ -1,25 +1,25 @@
 
-Developer Installation 
-====================== 
- 
+Developer Installation
+======================
+
 You can either install Girder natively on your machine or inside a virtual
-machine (VM) with Vagrant. 
- 
-Virtual Machine 
-+++++++++++++++ 
- 
+machine (VM) with Vagrant.
+
+Virtual Machine
++++++++++++++++
+
 The easiest way to develop for Girder is within a VM using Vagrant.
-For this, you need `Vagrant <https://www.vagrantup.com/downloads.html>`_ and `VirtualBox <https://www.virtualbox.org/wiki/Downloads>`_. 
-Girder is tested to work seamlessly with Vagrant 2.0 and VirtualBox 5.1. 
- 
-Once you have those installed, obtain the Girder source code by cloning the Git 
+For this, you need `Vagrant <https://www.vagrantup.com/downloads.html>`_ and `VirtualBox <https://www.virtualbox.org/wiki/Downloads>`_.
+Girder is tested to work seamlessly with Vagrant 2.0 and VirtualBox 5.1.
+
+Once you have those installed, obtain the Girder source code by cloning the Git
 repository on `GitHub <https://github.com/girder/girder>`_:
 
 .. code-block:: bash
- 
+
     git clone https://github.com/girder/girder.git
     cd girder
- 
+
 Inside of the Girder directory, simply run:
 
 .. code-block:: bash
@@ -29,7 +29,7 @@ Inside of the Girder directory, simply run:
 This creates a VM running Ubuntu 14.04, then automatically installs Girder
 within it. After it completes, Girder will be up and running at
 http://localhost:9080/ on the host machine.
- 
+
 The VM is linked to your local Girder directory, so changes made locally will
 impact the Girder instance running in the VM.
 

--- a/docs/dev-installation.rst
+++ b/docs/dev-installation.rst
@@ -2,73 +2,53 @@
 Developer Installation 
 ====================== 
  
-You can either install Girder natively on you machine or inside a virtual
-machine with Vagrant. 
+You can either install Girder natively on your machine or inside a virtual
+machine (VM) with Vagrant. 
  
 Virtual Machine 
 +++++++++++++++ 
  
-The easiest way to develop for girder is within a virtual machine using Vagrant.
+The easiest way to develop for Girder is within a VM using Vagrant.
 For this, you need `Vagrant <https://www.vagrantup.com/downloads.html>`_ and `VirtualBox <https://www.virtualbox.org/wiki/Downloads>`_. 
 Girder is tested to work seamlessly with Vagrant 2.0 and VirtualBox 5.1. 
  
 Once you have those installed, obtain the Girder source code by cloning the Git 
-repository on `GitHub <https://github.com>`_: :: 
+repository on `GitHub <https://github.com/girder/girder>`_:
+
+.. code-block:: bash
  
-    git clone https://github.com/girder/girder.git 
-    cd girder 
+    git clone https://github.com/girder/girder.git
+    cd girder
  
-Inside of the Girder directory, simply run: :: 
-     
-    vagrant up 
+Inside of the Girder directory, simply run:
+
+.. code-block:: bash
+
+    vagrant up
+
+This creates a VM running Ubuntu 14.04, then automatically installs Girder
+within it. After it completes, Girder will be up and running at
+http://localhost:9080/ on the host machine.
  
-This creates a Virtual Ubuntu 14.04 machine with all the necessary requirements. 
-After it completes, Girder will be up and running at http://localhost:9080/ 
- 
-The VM is linked to your local Girder directory, so changes made locally will 
-impact the Girder instance running in the VM.  
- 
-To access the VM, inside of the Girder directory, run: :: 
- 
-    vagrant ssh 
- 
-This takes you inside of VM. 
- 
- 
-Native Installation 
-+++++++++++++++++++  
- 
-Before you install, see the :doc:`prerequisites` guide to make sure you 
-have all required system packages installed. 
- 
-Obtain the Girder source code by cloning the Git repository on 
-`GitHub <https://github.com>`_: :: 
- 
-    git clone https://github.com/girder/girder.git 
-    cd girder 
- 
-To run the server, you must install some external Python package 
-dependencies: :: 
- 
-    pip install -e . 
- 
-or: :: 
- 
-    pip install -e .[plugins] 
- 
-to install the plugins as well. 
- 
-.. note:: This will install the most recent versions of all dependencies. 
-   You can also try to run ``pip install -r requirements.txt`` to duplicate 
-   the exact versions used by our CI testing environment; however, this 
-   can lead to problems if you are installing other libraries in the same 
-   virtual or system environment. 
- 
-To build the client-side code project, cd into the root of the repository 
-and run: :: 
- 
-    girder-install web 
- 
-This will run multiple `Grunt <http://gruntjs.com>`_ tasks, to build all of 
-the Javascript and CSS files needed to run the web client application. 
- 
+The VM is linked to your local Girder directory, so changes made locally will
+impact the Girder instance running in the VM.
+
+To access the VM, run from the Girder directory:
+
+.. code-block:: bash
+
+    vagrant ssh
+
+This takes you inside of the VM. From here, you might want to restart the server:
+
+.. code-block:: bash
+
+    sudo service girder restart
+
+rebuild the web client:
+
+.. code-block:: bash
+
+    girder-install web --dev
+
+For more development documentation, see `During Development <development.html#during-development>`__

--- a/docs/dev-installation.rst
+++ b/docs/dev-installation.rst
@@ -39,13 +39,13 @@ To access the VM, run from the Girder directory:
 
     vagrant ssh
 
-This takes you inside of the VM. From here, you might want to restart the server:
+This takes you inside the VM. From here, you might want to restart the server:
 
 .. code-block:: bash
 
     sudo service girder restart
 
-rebuild the web client:
+To rebuild the web client:
 
 .. code-block:: bash
 

--- a/docs/dev-installation.rst
+++ b/docs/dev-installation.rst
@@ -1,0 +1,74 @@
+
+Developer Installation 
+====================== 
+ 
+You can either install Girder natively on you machine or inside a virtual
+machine with Vagrant. 
+ 
+Virtual Machine 
++++++++++++++++ 
+ 
+The easiest way to develop for girder is within a virtual machine using Vagrant.
+For this, you need `Vagrant <https://www.vagrantup.com/downloads.html`_ and `VirtualBox <https://www.virtualbox.org/wiki/Downloads>`_. 
+Girder is tested to work seamlessly with Vagrant 2.0 and VirtualBox 5.1. 
+ 
+Once you have those installed, obtain the Girder source code by cloning the Git 
+repository on `GitHub <https://github.com>`_: :: 
+ 
+    git clone https://github.com/girder/girder.git 
+    cd girder 
+ 
+Inside of the Girder directory, simply run: :: 
+     
+    vagrant up 
+ 
+This creates a Virtual Ubuntu 14.04 machine with all the necessary requirements. 
+After it completes, Girder will be up and running at http://localhost:9080/ 
+ 
+The VM is linked to your local Girder directory, so changes made locally will 
+impact the Girder instance running in the VM.  
+ 
+To access the VM, inside of the Girder directory, run: :: 
+ 
+    vagrant ssh 
+ 
+This takes you inside of VM. 
+ 
+ 
+Native Installation 
++++++++++++++++++++  
+ 
+Before you install, see the :doc:`prerequisites` guide to make sure you 
+have all required system packages installed. 
+ 
+Obtain the Girder source code by cloning the Git repository on 
+`GitHub <https://github.com>`_: :: 
+ 
+    git clone https://github.com/girder/girder.git 
+    cd girder 
+ 
+To run the server, you must install some external Python package 
+dependencies: :: 
+ 
+    pip install -e . 
+ 
+or: :: 
+ 
+    pip install -e .[plugins] 
+ 
+to install the plugins as well. 
+ 
+.. note:: This will install the most recent versions of all dependencies. 
+   You can also try to run ``pip install -r requirements.txt`` to duplicate 
+   the exact versions used by our CI testing environment; however, this 
+   can lead to problems if you are installing other libraries in the same 
+   virtual or system environment. 
+ 
+To build the client-side code project, cd into the root of the repository 
+and run: :: 
+ 
+    girder-install web 
+ 
+This will run multiple `Grunt <http://gruntjs.com>`_ tasks, to build all of 
+the Javascript and CSS files needed to run the web client application. 
+ 

--- a/docs/developer-docs.rst
+++ b/docs/developer-docs.rst
@@ -4,6 +4,7 @@ Developer Documentation
 .. toctree::
    :maxdepth: 2
 
+   dev-installation
    api-docs
    development
    plugin-development

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -29,13 +29,10 @@ For more options for building the web client, run: ::
 Vagrant
 ^^^^^^^
 
-A shortcut to going through the installation steps for development is to use
-`Vagrant <https://www.vagrantup.com>`_ to setup the environment on a
-`VirtualBox <https://www.virtualbox.org>`_ virtual machine. To setup this
-environment run ``vagrant up`` in the root of the repository. This will spin up
-and provision a virtual machine, provided you have Vagrant and VirtualBox
-installed. Vagrant uses `Ansible <https://ansible.com>`_ for provisioning Girder and its various
-dependencies.
+A shortcut to going through the development environment configuration steps is
+to use `Vagrant <https://www.vagrantup.com>`_ to setup the environment on a
+`VirtualBox <https://www.virtualbox.org>`_ virtual machine. For more
+documentation on how to set this up, see `Developer Installation <dev-installation.html>`__
 
 .. seealso::
 


### PR DESCRIPTION
Girder's documentation could benefit from having installation instructions specifically for developers. This adds some instruction for getting Vagrant up and running as well as includes the instructions for installing via git. 