### PR TITLE
Use --option=value format for slicer command line options

### DIFF
--- a/plugins/item_tasks/plugin_tests/tasks_test.py
+++ b/plugins/item_tasks/plugin_tests/tasks_test.py
@@ -27,6 +27,9 @@ class TasksTest(base.TestCase):
         folders = self.model('folder').childFolders(self.admin, parentType='user', user=self.admin)
         self.privateFolder, self.publicFolder = list(folders)
 
+        # show full diff when objects don't match
+        self.maxDiff = None
+
     def testAddItemTasksToFolderFromJson(self):
         """
         Test adding item tasks to a folder from a JSON spec.
@@ -476,16 +479,15 @@ class TasksTest(base.TestCase):
             'mode': 'docker',
             'docker_image': 'johndoe/foo:v5',
             'container_args': [
-                '--foo', 'bar', '--InputImage', '$input{--InputImage}',
-                '--MaximumLineStraightnessDeviation',
-                '$input{--MaximumLineStraightnessDeviation}', '--MaximumRadius',
-                '$input{--MaximumRadius}', '--MaximumSphereDistance',
-                '$input{--MaximumSphereDistance}', '--MinimumRadius',
-                '$input{--MinimumRadius}', '--MinimumSphereActivity',
-                '$input{--MinimumSphereActivity}', '--MinimumSphereDistance',
-                '$input{--MinimumSphereDistance}', '--SpheresPerPhantom',
-                '$input{--SpheresPerPhantom}', '$flag{--StrictSorting}',
-                '--DetectedPoints', '$output{--DetectedPoints}'
+                '--foo', 'bar', '--InputImage=$input{--InputImage}',
+                '--MaximumLineStraightnessDeviation=$input{--MaximumLineStraightnessDeviation}',
+                '--MaximumRadius=$input{--MaximumRadius}',
+                '--MaximumSphereDistance=$input{--MaximumSphereDistance}',
+                '--MinimumRadius=$input{--MinimumRadius}',
+                '--MinimumSphereActivity=$input{--MinimumSphereActivity}',
+                '--MinimumSphereDistance=$input{--MinimumSphereDistance}',
+                '--SpheresPerPhantom=$input{--SpheresPerPhantom}', '$flag{--StrictSorting}',
+                '--DetectedPoints=$output{--DetectedPoints}'
             ],
             'inputs': [{
                 'description': 'Input image to be analysed.',

--- a/plugins/item_tasks/server/cli_parser.py
+++ b/plugins/item_tasks/server/cli_parser.py
@@ -121,15 +121,12 @@ def parseSlicerCliXml(fd):
         if param.typ == 'boolean':
             info['args'].append('$flag{%s}' % name)
         else:
-            info['args'] += [name, '$input{%s}' % name]
+            info['args'].append('%s=$input{%s}' % (name, name))
 
     for param in outputOpts:
         name = param.flag or param.longflag
         info['outputs'].append(ioSpec(name, param))
-        info['args'] += [
-            name,
-            '$output{%s}' % name
-        ]
+        info['args'].append('%s=$output{%s}' % (name, name))
 
     for param in inputArgs:
         info['inputs'].append(ioSpec(param.name, param, True))


### PR DESCRIPTION
Some CLI's accept values that begin with a dash.  For these arguments to be parsed correctly, they have to passed as `--option=-1` rather than `--option -1`.