### PR TITLE
Add support for image parameter types in item_tasks

### DIFF
--- a/plugins/item_tasks/plugin_tests/cli_parser_test.py
+++ b/plugins/item_tasks/plugin_tests/cli_parser_test.py
@@ -31,3 +31,17 @@ class CliParserTest(base.TestCase):
                     break
             else:
                 raise Exception('MinimumSphereActivity not added as an input')
+
+    def test_image_parameter(self):
+        """Check that parameters of type image are handled correctly."""
+        from girder.plugins.item_tasks import cli_parser
+        with open(CLI_FILE) as fd:
+            spec = cli_parser.parseSlicerCliXml(fd)
+            inputs = spec['inputs']
+
+            for input in inputs:
+                if input['name'] == 'InputImage':
+                    self.assertEqual(input['type'], 'image')
+                    break
+            else:
+                raise Exception('InputImage not added to spec.')

--- a/plugins/item_tasks/plugin_tests/tasks_test.py
+++ b/plugins/item_tasks/plugin_tests/tasks_test.py
@@ -491,8 +491,8 @@ class TasksTest(base.TestCase):
             ],
             'inputs': [{
                 'description': 'Input image to be analysed.',
-                'format': 'file',
-                'name': 'InputImage', 'type': 'file', 'id': '--InputImage',
+                'format': 'image',
+                'name': 'InputImage', 'type': 'image', 'id': '--InputImage',
                 'target': 'filepath'
             }, {
                 'description': 'Used for eliminating detections which are not in a straight line. '

--- a/plugins/item_tasks/server/cli_parser.py
+++ b/plugins/item_tasks/server/cli_parser.py
@@ -19,7 +19,7 @@ _SLICER_TO_GIRDER_WORKER_INPUT_TYPE_MAP = {
     'string-enumeration': 'string-enumeration',
     'file': 'file',
     'directory': 'folder',
-    'image': 'file',
+    'image': 'image',
     'pointfile': 'file'
 }
 
@@ -30,7 +30,7 @@ _SLICER_TO_GIRDER_WORKER_OUTPUT_TYPE_MAP = {
 }
 
 _SLICER_TYPE_TO_GIRDER_MODEL_MAP = {
-    'image': 'file',
+    'image': 'image',
     'file': 'file',
     'directory': 'folder'
 }

--- a/plugins/item_tasks/web_client/templates/fileWidget.pug
+++ b/plugins/item_tasks/web_client/templates/fileWidget.pug
@@ -10,7 +10,7 @@ block input
       - name = value.name()
 
     // different behavior for different types of inputs
-    if type === 'file'
+    if type === 'file' || type === 'image'
       +input(title, type, id, name)(placeholder='Choose an item...', readonly=true)
 
     else if type === 'directory'

--- a/plugins/item_tasks/web_client/views/TaskRunView.js
+++ b/plugins/item_tasks/web_client/views/TaskRunView.js
@@ -140,13 +140,7 @@ const TaskRunView = View.extend({
         const translate = (model) => {
             let val = model.value();
             switch (model.get('type')) {
-                case 'image': // This is an input
-                    return {
-                        mode: 'girder',
-                        resource_type: 'file',
-                        id: val.id,
-                        fileName: model.get('fileName') || null
-                    };
+                case 'image':
                 case 'file': // This is an input
                     return {
                         mode: 'girder',


### PR DESCRIPTION
Before this change slicer parameters of type "image" were added
to the item_tasks spec as type "file".  The image type is essentially
just an alias of the file type (which is really an item...).  It
is useful to distinguish between them in HistomicsTK because images
can be opened by the large_image viewer.

This would probably be a good candidate for a parameter type that
is added as an extension to item_tasks, but we need to do some
refactoring to support dynamic extensions before that is possible.