### PR TITLE
Create a "2.x-maintenance" branch, which is always synced with "master"

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -42,3 +42,4 @@ deployment:
     commands:
       - curl 'https://doc.esdoc.org/api/create' -X POST --data-urlencode "gitUrl=git@github.com:girder/girder.git"
       - ./scripts/galaxy_deploy.sh
+      - git push git@github.com:girder/girder.git master:2.x-maintenance

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -107,8 +107,13 @@ Install from Git repository
 Obtain the Girder source code by cloning the Git repository on
 `GitHub <https://github.com>`_: ::
 
-    git clone https://github.com/girder/girder.git
+    git clone -b 2.x-maintenance https://github.com/girder/girder.git
     cd girder
+
+.. note:: Note, it is strongly recommended that downstream (i.e. for production or to
+   support plugin development) users installing from Git track the ``2.x-maintenance`` branch, as
+   this branch will always point to the latest version (which is typically pre-release) in the 2.x.x
+   series.
 
 To run the server, you must install some external Python package
 dependencies: ::

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -107,7 +107,7 @@ Install from Git repository
 Obtain the Girder source code by cloning the Git repository on
 `GitHub <https://github.com>`_: ::
 
-    git clone -b 2.x-maintenance https://github.com/girder/girder.git
+    git clone --branch 2.x-maintenance https://github.com/girder/girder.git
     cd girder
 
 .. note:: Note, it is strongly recommended that downstream (i.e. for production or to


### PR DESCRIPTION
This creates a `2.x-maintenance` branch, to correspond to the existing [`1.x-maintenance` branch](https://github.com/girder/girder/tree/1.x-maintenance). The semantics of `2.x-maintenance` are: "always points to the latest version (released or otherwise) in the 2.x.x series".

This provides a semantically stable ref for downstream plugins / projects to track after 3.0 has been released, before they are able to undertake the effort of a 2->3 migration. This concept (as `1.x-maintenance`) has already proven useful for some downstream users.