### PR TITLE
Include file paths in worker input specs.

### DIFF
--- a/plugins/worker/plugin_tests/configSpec.js
+++ b/plugins/worker/plugin_tests/configSpec.js
@@ -1,0 +1,72 @@
+/* globals girderTest, describe, it, waitsFor, runs, expect */
+
+girderTest.importPlugin('jobs');
+girderTest.importPlugin('worker');
+girderTest.startApp();
+
+$(function () {
+    describe('Test the settings page', function () {
+        it('create the admin user', function () {
+            girderTest.createUser(
+                'admin', 'admin@email.com', 'Admin', 'Admin', 'testpassword')();
+        });
+        it('change the worker settings', function () {
+            waitsFor(function () {
+                return $('a.g-nav-link[g-target="admin"]').length > 0;
+            }, 'admin console link to load');
+            runs(function () {
+                $('a.g-nav-link[g-target="admin"]').click();
+            });
+            waitsFor(function () {
+                return $('.g-plugins-config').length > 0;
+            }, 'the admin console to load');
+            runs(function () {
+                $('.g-plugins-config').click();
+            });
+            girderTest.waitForLoad();
+            waitsFor(function () {
+                return $('input.g-plugin-switch[key="worker"]').length > 0;
+            }, 'the plugins page to load');
+            runs(function () {
+                expect($('.g-plugin-config-link[g-route="plugins/worker/config"]').length > 0);
+                $('.g-plugin-config-link[g-route="plugins/worker/config"]').click();
+            });
+            girderTest.waitForLoad();
+            waitsFor(function () {
+                return $('#g-worker-settings-form input').length > 0;
+            }, 'worker settings to be shown');
+
+            runs(function () {
+                $('#g-worker-broker').val('amqp://guest@localhost/');
+                $('#g-worker-backend').val('amqp://guest@127.0.0.1/');
+                $('#g-worker-api-url').val('http://127.0.0.1:8080/api/v1');
+                $('#g-worker-direct-path').trigger('click');
+                $('#g-worker-settings-form input.btn-primary').click();
+            });
+            runs(function () {
+                // go back to the plugins page
+                $('.g-plugins-link').click();
+            });
+            girderTest.waitForLoad();
+            waitsFor(function () {
+                return $('input.g-plugin-switch[key="worker"]').length > 0;
+            }, 'the plugins page to load');
+            runs(function () {
+                expect($('.g-plugin-config-link[g-route="plugins/worker/config"]').length > 0);
+                $('.g-plugin-config-link[g-route="plugins/worker/config"]').click();
+            });
+            girderTest.waitForLoad();
+            waitsFor(function () {
+                return $('#g-worker-settings-form input').length > 0;
+            }, 'worker settings to be shown');
+
+            runs(function () {
+                expect($('#g-worker-broker').val()).toBe('amqp://guest@localhost/');
+                expect($('#g-worker-backend').val()).toBe('amqp://guest@127.0.0.1/');
+                expect($('#g-worker-api-url').val()).toBe('http://127.0.0.1:8080/api/v1');
+                expect($('#g-worker-direct-path').prop('checked')).toBe(true);
+            }, 'worker settings to change');
+            girderTest.waitForLoad();
+        });
+    });
+});

--- a/plugins/worker/plugin_tests/worker_test.py
+++ b/plugins/worker/plugin_tests/worker_test.py
@@ -246,6 +246,7 @@ class WorkerTestCase(base.TestCase):
     def testGirderInputSpec(self):
         # Set an API_URL so we can use the spec outside of a rest request
         self.model('setting').set(worker.PluginSettings.API_URL, 'http://127.0.0.1')
+        self.model('setting').set(worker.PluginSettings.DIRECT_PATH, True)
 
         spec = utils.girderInputSpec(self.adminFolder, resourceType='folder')
         self.assertEqual(spec['id'], str(self.adminFolder['_id']))
@@ -259,10 +260,26 @@ class WorkerTestCase(base.TestCase):
         self.assertFalse(spec['fetch_parent'])
         self.assertIn('direct_path', spec)
 
-        spec = utils.girderInputSpec(self.sampleFile, resourceType='file', allowDirectPath=False)
+        self.model('setting').set(worker.PluginSettings.DIRECT_PATH, False)
+        spec = utils.girderInputSpec(self.sampleFile, resourceType='file')
         self.assertFalse(spec['fetch_parent'])
         self.assertNotIn('direct_path', spec)
 
+        self.model('setting').set(worker.PluginSettings.DIRECT_PATH, True)
         spec = utils.girderInputSpec(self.sampleFile, resourceType='file', fetchParent=True)
         self.assertTrue(spec['fetch_parent'])
         self.assertNotIn('direct_path', spec)
+
+    def testDirectPathSettingValidation(self):
+        # Test the setting
+        resp = self.request('/system/setting', method='PUT', params={
+            'key': worker.PluginSettings.DIRECT_PATH,
+            'value': 'bad value'
+        }, user=self.admin)
+        self.assertStatus(resp, 400)
+        self.assertEqual(resp.json['message'], 'The direct path setting must be true or false.')
+        resp = self.request('/system/setting', method='PUT', params={
+            'key': worker.PluginSettings.DIRECT_PATH,
+            'value': 'false'
+        }, user=self.admin)
+        self.assertStatusOk(resp)

--- a/plugins/worker/plugin_tests/worker_test.py
+++ b/plugins/worker/plugin_tests/worker_test.py
@@ -66,6 +66,10 @@ class WorkerTestCase(base.TestCase):
         self.adminFolder = six.next(self.model('folder').childFolders(
             parent=self.admin, parentType='user', user=self.admin))
         self.adminToken = self.model('token').createToken(self.admin)
+        sampleData = b'Hello world'
+        self.sampleFile = self.model('upload').uploadFromFile(
+            obj=six.BytesIO(sampleData), size=len(sampleData), name='Sample',
+            parentType='folder', parent=self.adminFolder, user=self.admin)
 
     def testWorker(self):
         # Test the settings
@@ -238,3 +242,27 @@ class WorkerTestCase(base.TestCase):
         job = self.model('job', 'jobs').load(job['_id'], force=True,
                                              includeLog=True)
         self.assertIn('job ran', job['log'])
+
+    def testGirderInputSpec(self):
+        # Set an API_URL so we can use the spec outside of a rest request
+        self.model('setting').set(worker.PluginSettings.API_URL, 'http://127.0.0.1')
+
+        spec = utils.girderInputSpec(self.adminFolder, resourceType='folder')
+        self.assertEqual(spec['id'], str(self.adminFolder['_id']))
+        self.assertEqual(spec['resource_type'], 'folder')
+        self.assertFalse(spec['fetch_parent'])
+        self.assertNotIn('direct_path', spec)
+
+        spec = utils.girderInputSpec(self.sampleFile, resourceType='file')
+        self.assertEqual(spec['id'], str(self.sampleFile['_id']))
+        self.assertEqual(spec['resource_type'], 'file')
+        self.assertFalse(spec['fetch_parent'])
+        self.assertIn('direct_path', spec)
+
+        spec = utils.girderInputSpec(self.sampleFile, resourceType='file', allowDirectPath=False)
+        self.assertFalse(spec['fetch_parent'])
+        self.assertNotIn('direct_path', spec)
+
+        spec = utils.girderInputSpec(self.sampleFile, resourceType='file', fetchParent=True)
+        self.assertTrue(spec['fetch_parent'])
+        self.assertNotIn('direct_path', spec)

--- a/plugins/worker/server/__init__.py
+++ b/plugins/worker/server/__init__.py
@@ -195,6 +195,12 @@ def validateApiUrl(doc):
         raise ValidationException('API URL must start with http:// or https://.', 'value')
 
 
+@setting_utilities.validator(PluginSettings.DIRECT_PATH)
+def _validateAutoCompute(doc):
+    if not isinstance(doc['value'], bool):
+        raise ValidationException('The direct path setting must be true or false.')
+
+
 def validateJobStatus(event):
     """Allow our custom job status values."""
     if CustomJobStatus.isValid(event.info):

--- a/plugins/worker/server/constants.py
+++ b/plugins/worker/server/constants.py
@@ -29,3 +29,4 @@ class PluginSettings(object):
     BROKER = 'worker.broker'
     BACKEND = 'worker.backend'
     API_URL = 'worker.api_url'
+    DIRECT_PATH = 'worker.direct_path'

--- a/plugins/worker/server/utils.py
+++ b/plugins/worker/server/utils.py
@@ -34,8 +34,7 @@ def getWorkerApiUrl():
 
 
 def girderInputSpec(resource, resourceType='file', name=None, token=None,
-                    dataType='string', dataFormat='text', fetchParent=False,
-                    allowDirectPath=True):
+                    dataType='string', dataFormat='text', fetchParent=False):
     """
     Downstream plugins that are building Girder worker jobs that use Girder IO
     should use this to generate the input specs more easily.
@@ -58,11 +57,6 @@ def girderInputSpec(resource, resourceType='file', name=None, token=None,
     :param fetchParent: Whether to fetch the whole parent resource of the
         specified resource as a side effect.
     :type fetchParent: bool
-    :param allowDirectPath: If True and the resource is a file that can be
-        reached via a path (e.g., on a filesystem assetstore), report that path
-        as part of the spec.  If fetchParent is True, this is ignored and the
-        direct path is not included.
-    :type allowDirectPath: bool
     """
     if isinstance(token, dict):
         token = token['_id']
@@ -79,7 +73,8 @@ def girderInputSpec(resource, resourceType='file', name=None, token=None,
         'fetch_parent': fetchParent
     }
 
-    if allowDirectPath and resourceType == 'file' and not fetchParent:
+    if (resourceType == 'file' and not fetchParent and
+            ModelImporter.model('setting').get(PluginSettings.DIRECT_PATH)):
         # If we are adding a file and it exists on the local filesystem include
         # that location.  This can permit the user of the specification to
         # access the file directly instead of downloading the file.

--- a/plugins/worker/web_client/templates/configView.pug
+++ b/plugins/worker/web_client/templates/configView.pug
@@ -16,5 +16,10 @@ form#g-worker-settings-form(role="form")
     label.control-label(for="g-worker-api-url") Alternative Girder API URL
     input#g-worker-api-url.input-sm.form-control(
       type="text", placeholder="API URL (default: auto-detected)")
+  .checkbox
+    label.control-label(for="g-worker-direct-path")
+      input#g-worker-direct-path(type="checkbox")
+      span When possible, send local file paths to the worker to avoid downloading files
+
   p#g-worker-settings-error-message.g-validation-failed-message
   input.btn.btn-sm.btn-primary(type="submit", value="Save")

--- a/plugins/worker/web_client/views/ConfigView.js
+++ b/plugins/worker/web_client/views/ConfigView.js
@@ -22,6 +22,9 @@ var ConfigView = View.extend({
             }, {
                 key: 'worker.backend',
                 value: this.$('#g-worker-backend').val().trim()
+            }, {
+                key: 'worker.direct_path',
+                value: this.$('#g-worker-direct-path').is(':checked')
             }]);
         }
     },
@@ -34,7 +37,8 @@ var ConfigView = View.extend({
                 list: JSON.stringify([
                     'worker.api_url',
                     'worker.broker',
-                    'worker.backend'
+                    'worker.backend',
+                    'worker.direct_path'
                 ])
             }
         }).done(_.bind(function (resp) {
@@ -42,6 +46,7 @@ var ConfigView = View.extend({
             this.$('#g-worker-api-url').val(resp['worker.api_url']);
             this.$('#g-worker-broker').val(resp['worker.broker']);
             this.$('#g-worker-backend').val(resp['worker.backend']);
+            this.$('#g-worker-direct-path').prop('checked', resp['worker.direct_path']);
         }, this));
     },
 


### PR DESCRIPTION
When available and not prohibited, include the direct path of a girder file in the worker input spec for a file.  If fetchParent is requested, the path is not included.

This won't have any effect unless an appropriate version of girder_worker is used (see https://github.com/girder/girder_worker/pull/199).