### PR TITLE
Fix the systemConfiguration template to fit in the style of the page

### DIFF
--- a/clients/web/src/templates/body/systemConfiguration.pug
+++ b/clients/web/src/templates/body/systemConfiguration.pug
@@ -8,11 +8,13 @@ form.g-settings-form(role="form")
           type="text", value=settings['core.brand_name'] || '',
           placeholder=`Default: ${defaults['core.brand_name'] || 'none'}`,
           title="The brand name of the application.")
+    .form-group
       label(for="g-core-contact-email-address") Contact email address
       input#g-core-contact-email-address.form-control.input-sm(
           type="text", value=settings['core.contact_email_address'] || '',
           placeholder=`Default: ${defaults['core.contact_email_address'] || 'none'}`,
           title="The contact email address for users to obtain support with this instance.")
+    .form-group
       label(for="g-core-banner-color") Banner Color
       #g-core-banner-color-container
         input#g-core-banner-color.form-control.input-sm(


### PR DESCRIPTION
The view missed some space between each label : 
![screenshot from 2017-09-27 12-59-22](https://user-images.githubusercontent.com/29961430/30926712-0dc7874c-a384-11e7-8c84-47934760eed6.png)

Adding the class `.form-goup` fix that : 
![screenshot from 2017-09-27 12-59-47](https://user-images.githubusercontent.com/29961430/30926716-0f0709d4-a384-11e7-96a4-76e9773f3951.png)
