### PR TITLE
Ensure that the "fields" parameter to "Model.load" always works

### DIFF
--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -127,7 +127,7 @@ class Folder(AccessControlledModel):
         # Ensure we include extra fields to do the migration below
         extraFields = {'baseParentId', 'baseParentType', 'parentId', 'parentCollection',
                        'name', 'lowerName'}
-        loadFields = self._overwriteFields(fields, extraFields)
+        loadFields = self._supplementFields(fields, extraFields)
 
         doc = super(Folder, self).load(
             id=id, level=level, user=user, objectId=objectId, force=force, fields=loadFields,
@@ -149,7 +149,7 @@ class Folder(AccessControlledModel):
                     'lowerName': doc['lowerName']
                 }})
 
-            self._removeOverwrittenFields(doc, fields)
+            self._removeSupplementalFields(doc, fields)
 
         return doc
 

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -124,18 +124,32 @@ class Folder(AccessControlledModel):
                       checking on this resource, set this to True.
         :type force: bool
         """
-        doc = AccessControlledModel.load(
-            self, id=id, objectId=objectId, level=level, fields=fields,
-            exc=exc, force=force, user=user)
+        # Ensure we include extra fields to do the migration below
+        extraFields = {'baseParentId', 'baseParentType', 'parentId', 'parentCollection',
+                       'name', 'lowerName'}
+        loadFields = self._overwriteFields(fields, extraFields)
 
-        if doc is not None and 'baseParentType' not in doc:
-            pathFromRoot = self.parentsToRoot(doc, user=user, force=True)
-            baseParent = pathFromRoot[0]
-            doc['baseParentId'] = baseParent['object']['_id']
-            doc['baseParentType'] = baseParent['type']
-            doc = self.save(doc, triggerEvents=False)
-        if doc is not None and 'lowerName' not in doc:
-            doc = self.save(doc, triggerEvents=False)
+        doc = super(Folder, self).load(
+            id=id, level=level, user=user, objectId=objectId, force=force, fields=loadFields,
+            exc=exc)
+
+        if doc is not None:
+            if 'baseParentType' not in doc:
+                pathFromRoot = self.parentsToRoot(doc, user=user, force=True)
+                baseParent = pathFromRoot[0]
+                doc['baseParentId'] = baseParent['object']['_id']
+                doc['baseParentType'] = baseParent['type']
+                self.update({'_id': doc['_id']}, {'$set': {
+                    'baseParentId': doc['baseParentId'],
+                    'baseParentType': doc['baseParentType']
+                }})
+            if 'lowerName' not in doc:
+                doc['lowerName'] = doc['name'].lower()
+                self.update({'_id': doc['_id']}, {'$set': {
+                    'lowerName': doc['lowerName']
+                }})
+
+            self._removeOverwrittenFields(doc, fields)
 
         return doc
 

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -109,19 +109,34 @@ class Item(acl_mixin.AccessControlMixin, Model):
         Calls AccessControlMixin.load while doing some auto-correction.
 
         Takes the same parameters as
-        :py:func:`girder.models.model_base.AccessControlledMixin.load`.
+        :py:func:`girder.models.model_base.AccessControlMixin.load`.
         """
-        doc = super(Item, self).load(id, level, user, objectId, force, fields,
-                                     exc)
+        # Ensure we include extra fields to do the migration below
+        extraFields = {'baseParentId', 'baseParentType', 'parentId', 'parentCollection',
+                       'name', 'lowerName'}
+        loadFields = self._overwriteFields(fields, extraFields)
 
-        if doc is not None and 'baseParentType' not in doc:
-            pathFromRoot = self.parentsToRoot(doc, user=user, force=True)
-            baseParent = pathFromRoot[0]
-            doc['baseParentId'] = baseParent['object']['_id']
-            doc['baseParentType'] = baseParent['type']
-            doc = self.save(doc, triggerEvents=False)
-        if doc is not None and 'lowerName' not in doc:
-            doc = self.save(doc, triggerEvents=False)
+        doc = super(Item, self).load(
+            id=id, level=level, user=user, objectId=objectId, force=force, fields=loadFields,
+            exc=exc)
+
+        if doc is not None:
+            if 'baseParentType' not in doc:
+                pathFromRoot = self.parentsToRoot(doc, user=user, force=True)
+                baseParent = pathFromRoot[0]
+                doc['baseParentId'] = baseParent['object']['_id']
+                doc['baseParentType'] = baseParent['type']
+                self.update({'_id': doc['_id']}, {'$set': {
+                    'baseParentId': doc['baseParentId'],
+                    'baseParentType': doc['baseParentType']
+                }})
+            if 'lowerName' not in doc:
+                doc['lowerName'] = doc['name'].lower()
+                self.update({'_id': doc['_id']}, {'$set': {
+                    'lowerName': doc['lowerName']
+                }})
+
+            self._removeOverwrittenFields(doc, fields)
 
         return doc
 

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -114,7 +114,7 @@ class Item(acl_mixin.AccessControlMixin, Model):
         # Ensure we include extra fields to do the migration below
         extraFields = {'baseParentId', 'baseParentType', 'parentId', 'parentCollection',
                        'name', 'lowerName'}
-        loadFields = self._overwriteFields(fields, extraFields)
+        loadFields = self._supplementFields(fields, extraFields)
 
         doc = super(Item, self).load(
             id=id, level=level, user=user, objectId=objectId, force=force, fields=loadFields,
@@ -136,7 +136,7 @@ class Item(acl_mixin.AccessControlMixin, Model):
                     'lowerName': doc['lowerName']
                 }})
 
-            self._removeOverwrittenFields(doc, fields)
+            self._removeSupplementalFields(doc, fields)
 
         return doc
 

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -1324,7 +1324,6 @@ class AccessControlledModel(Model):
         :raises ValidationException: If an invalid ObjectId is passed.
         :returns: The matching document, or None if no match exists.
         """
-
         # Warn of str type deprecation for `fields` param
         if isinstance(fields, six.string_types):
             logger.warning('String data type for fields param is deprecated, \
@@ -1333,9 +1332,9 @@ class AccessControlledModel(Model):
 
         # Ensure we include access and public, they are needed by requireAccess
         loadFields = fields
-        overwriteFields = {'access', 'public'}
         if not force:
-            loadFields = self._overwriteFields(fields, overwriteFields)
+            extraFields = {'access', 'public'}
+            loadFields = self._overwriteFields(fields, extraFields)
 
         doc = Model.load(self, id=id, objectId=objectId, fields=loadFields, exc=exc)
 

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -631,7 +631,7 @@ class Model(ModelImporter):
     def _removeSupplementalFields(doc, fields):
         """
         Edit the document to be consistent with what the user originally requested, undoing what may
-            have been overwritten by _supplementFields().
+        have been overwritten by _supplementFields().
 
         :param doc: A document returned by MongoDB find()
         :type doc: dict

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -597,7 +597,7 @@ class Model(ModelImporter):
         return fields.get('_id', True)
 
     @staticmethod
-    def _overwriteFields(fields, overwrite):
+    def _supplementFields(fields, overwrite):
         """
         Overwrite the projection filter to either include (in the case of an inclusion filter) or
         not exclude (in the case of an exclusion filter) the contents of overwrite.
@@ -628,10 +628,10 @@ class Model(ModelImporter):
         return copy
 
     @staticmethod
-    def _removeOverwrittenFields(doc, fields):
+    def _removeSupplementalFields(doc, fields):
         """
         Edit the document to be consistent with what the user originally requested, undoing what may
-            have been overwritten by _overwriteFields().
+            have been overwritten by _supplementFields().
 
         :param doc: A document returned by MongoDB find()
         :type doc: dict
@@ -1334,14 +1334,14 @@ class AccessControlledModel(Model):
         loadFields = fields
         if not force:
             extraFields = {'access', 'public'}
-            loadFields = self._overwriteFields(fields, extraFields)
+            loadFields = self._supplementFields(fields, extraFields)
 
         doc = Model.load(self, id=id, objectId=objectId, fields=loadFields, exc=exc)
 
         if not force and doc is not None:
             self.requireAccess(doc, user, level)
 
-            self._removeOverwrittenFields(doc, fields)
+            self._removeSupplementalFields(doc, fields)
 
         return doc
 

--- a/girder/utility/acl_mixin.py
+++ b/girder/utility/acl_mixin.py
@@ -55,7 +55,7 @@ class AccessControlMixin(object):
             extraFields = {'attachedToId', 'attachedToType'}
             if self.resourceParent:
                 extraFields.add(self.resourceParent)
-            loadFields = self._overwriteFields(fields, extraFields)
+            loadFields = self._supplementFields(fields, extraFields)
 
         doc = Model.load(self, id=id, objectId=objectId, fields=loadFields, exc=exc)
 
@@ -68,7 +68,7 @@ class AccessControlMixin(object):
                 loadId = doc.get('attachedToId')
             self.model(loadType).load(loadId, level=level, user=user, exc=exc)
 
-            self._removeOverwrittenFields(doc, fields)
+            self._removeSupplementalFields(doc, fields)
 
         return doc
 

--- a/girder/utility/acl_mixin.py
+++ b/girder/utility/acl_mixin.py
@@ -50,7 +50,14 @@ class AccessControlMixin(object):
         Takes the same parameters as
         :py:func:`girder.models.model_base.AccessControlledModel.load`.
         """
-        doc = Model.load(self, id=id, objectId=objectId, fields=fields, exc=exc)
+        loadFields = fields
+        if not force:
+            extraFields = {'attachedToId', 'attachedToType'}
+            if self.resourceParent:
+                extraFields.add(self.resourceParent)
+            loadFields = self._overwriteFields(fields, extraFields)
+
+        doc = Model.load(self, id=id, objectId=objectId, fields=loadFields, exc=exc)
 
         if not force and doc is not None:
             if doc.get(self.resourceParent):
@@ -60,6 +67,8 @@ class AccessControlMixin(object):
                 loadType = doc.get('attachedToType')
                 loadId = doc.get('attachedToId')
             self.model(loadType).load(loadId, level=level, user=user, exc=exc)
+
+            self._removeOverwrittenFields(doc, fields)
 
         return doc
 

--- a/plugins/jobs/server/models/job.py
+++ b/plugins/jobs/server/models/job.py
@@ -287,7 +287,7 @@ class Job(AccessControlledModel):
         kwargs['fields'] = self._computeFields(kwargs)
         job = super(Job, self).load(*args, **kwargs)
 
-        if job and isinstance(job['kwargs'], six.string_types):
+        if job and isinstance(job.get('kwargs'), six.string_types):
             job['kwargs'] = json_util.loads(job['kwargs'])
         if job and isinstance(job.get('log'), six.string_types):
             # Legacy support: log used to be just a string, but we want to

--- a/tests/cases/item_test.py
+++ b/tests/cases/item_test.py
@@ -625,20 +625,22 @@ class ItemTestCase(base.TestCase):
         item = self.model('item').createItem(
             'My Item Name', creator=self.users[0], folder=self.publicFolder,
             description=None)
-        self.assertEqual(item['lowerName'], 'my item name (1)')
+        # test if non-strings are coerced
         self.assertEqual(item['description'], '')
-        # test if non-strings are coerced and if just missing lowerName is
-        # corrected.
         item['description'] = 1
+        item = self.model('item').save(item)
+        item = self.model('item').findOne({'_id': item['_id']})
+        self.assertEqual(item['description'], '1')
+        # test if just missing lowerName is corrected.
+        self.assertEqual(item['lowerName'], 'my item name (1)')
         del item['lowerName']
         item = self.model('item').save(item, validate=False)
-        item = self.model('item').find({'_id': item['_id']})[0]
+        item = self.model('item').findOne({'_id': item['_id']})
         self.assertNotHasKeys(item, ('lowerName', ))
         self.model('item').load(item['_id'], force=True)
-        item = self.model('item').find({'_id': item['_id']})[0]
+        item = self.model('item').findOne({'_id': item['_id']})
         self.assertHasKeys(item, ('lowerName', ))
         self.assertEqual(item['lowerName'], 'my item name (1)')
-        self.assertEqual(item['description'], '1')
 
     def testParentsToRoot(self):
         """

--- a/tests/cases/model_test.py
+++ b/tests/cases/model_test.py
@@ -85,14 +85,14 @@ class ModelTestCase(base.TestCase):
         overrideFields = {'access', 'public'}
 
         copy = dict(inclusionProjDict)
-        retval = Model._overwriteFields(inclusionProjDict, overrideFields)
+        retval = Model._supplementFields(inclusionProjDict, overrideFields)
         assertItemsEqual(retval, inclusionProjDict)
         assertItemsEqual(inclusionProjDict, copy)
-        retval = Model._overwriteFields(inclusionProjList, overrideFields)
+        retval = Model._supplementFields(inclusionProjList, overrideFields)
         assertItemsEqual(retval, inclusionProjList)
-        retval = Model._overwriteFields(exclusionProjDict, {'newValue'})
+        retval = Model._supplementFields(exclusionProjDict, {'newValue'})
         assertItemsEqual(retval, exclusionProjDict)
-        retval = Model._overwriteFields(inclusionProjDict, {'newValue'})
+        retval = Model._supplementFields(inclusionProjDict, {'newValue'})
         assertItemsEqual(retval, {
             'public': True,
             'access': True,
@@ -100,7 +100,7 @@ class ModelTestCase(base.TestCase):
             'login': True,
             'newValue': True
         })
-        retval = Model._overwriteFields(exclusionProjDict, overrideFields)
+        retval = Model._supplementFields(exclusionProjDict, overrideFields)
         assertItemsEqual(retval, {'email': False, 'login': False})
 
         doc = {
@@ -113,7 +113,7 @@ class ModelTestCase(base.TestCase):
             'firstName': 'first',
             'lastName': 'last'
         }
-        Model._removeOverwrittenFields(doc, exclusionProjDict)
+        Model._removeSupplementalFields(doc, exclusionProjDict)
         assertItemsEqual(doc, {
             'password': 'password1',
             'admin': False,
@@ -130,7 +130,7 @@ class ModelTestCase(base.TestCase):
             'firstName': 'first',
             'lastName': 'last'
         }
-        Model._removeOverwrittenFields(doc, inclusionProjList)
+        Model._removeSupplementalFields(doc, inclusionProjList)
         assertItemsEqual(doc, {
             'public': True,
             'access': True,
@@ -147,7 +147,7 @@ class ModelTestCase(base.TestCase):
             'firstName': 'first',
             'lastName': 'last'
         }
-        Model._removeOverwrittenFields(doc, inclusionProjDict)
+        Model._removeSupplementalFields(doc, inclusionProjDict)
         assertItemsEqual(doc, {
             'public': True,
             'access': True,
@@ -155,10 +155,10 @@ class ModelTestCase(base.TestCase):
             'login': 'login'})
 
         # Test None edge cases
-        retval = Model._overwriteFields(None, {'access', 'public'})
+        retval = Model._supplementFields(None, {'access', 'public'})
         self.assertIsNone(retval)
         copy = dict(doc)
-        Model._removeOverwrittenFields(doc, None)
+        Model._removeSupplementalFields(doc, None)
         assertItemsEqual(copy, doc)
 
         # Test '_id': False inclusion edge case
@@ -177,7 +177,7 @@ class ModelTestCase(base.TestCase):
             'lastName': True
         }
         overwrite = {'_id', 'login'}
-        retval = Model._overwriteFields(fields, overwrite)
+        retval = Model._supplementFields(fields, overwrite)
         assertItemsEqual(retval, overwrittenFields)
         doc = {
             '_id': 'id',
@@ -186,7 +186,7 @@ class ModelTestCase(base.TestCase):
             'firstName': 'fname',
             'lastName': 'lname'
         }
-        Model._removeOverwrittenFields(doc, fields)
+        Model._removeSupplementalFields(doc, fields)
         assertItemsEqual(doc, {
             'login': 'login',
             'email': 'email@email.com',


### PR DESCRIPTION
This implements the new utilities from #2352 across all `Model.load` methods.

Commits are separated logically:
* Ensure that the `fields` parameter to `Model.load` always works
* Logically reorder some statements in `item_test`
* Rename `_overwriteFields` and `_removeOverwrittenFields`