### PR TITLE
Store the optional "reference" attribute in the item_tasks spec

### DIFF
--- a/plugins/item_tasks/plugin_tests/cli_parser_test.py
+++ b/plugins/item_tasks/plugin_tests/cli_parser_test.py
@@ -74,3 +74,14 @@ class CliParserTest(base.TestCase):
                 break
         else:
             raise Exception('InputImage not added to spec.')
+
+    def test_extra_output_reference(self):
+        """Check that the optional "reference" is added to the spec."""
+        spec = self.parse_file('nuclei_detection.xml')
+        outputs = spec['outputs']
+        for output in outputs:
+            if output['name'] == 'Output Nuclei Annotation File':
+                self.assertEqual(output['extra'].get('reference'), 'inputImageFile')
+                break
+        else:
+            raise Exception('Output file not added to spec.')

--- a/plugins/item_tasks/server/cli_parser.py
+++ b/plugins/item_tasks/server/cli_parser.py
@@ -99,7 +99,8 @@ def parseSlicerCliXml(fd):
             'name': param.label,
             'description': param.description,
             'type': typ,
-            'format': typ
+            'format': typ,
+            'extra': {'reference': param.reference}
         }
 
         if typ in ('string-enumeration', 'number-enumeration'):


### PR DESCRIPTION
This adds a new optional field in the item_tasks spec to store extra information about the parameter.  Specifically, this is needed to save the reference attribute that is defined in the cli_ctk spec.  We code codify this more explicitly on the item tasks spec, but the definition of this attribute is not terribly clear and seems to be very task specific.  For reference, here is the description:

> The attribute reference can mean different things based on the parameter type. If the parameter is a transform and the reference is transformable, then the transform hierarchy of the reference is manipulated such that the reference is under the transform. If the parameter is an image or a model, then the parameter is placed in subject hierarchy at the same level as the reference. If the parameter is an image, reference will be used to initialize lookup table of the output image.