### PR TITLE
Ignore D106 and D107 for flake8 tests.

### DIFF
--- a/tests/flake8.cfg
+++ b/tests/flake8.cfg
@@ -35,6 +35,8 @@ exclude: girder/external/*
 #     D103 - Public function (103) docstring missing.
 #     D104 - Missing docstring in public package.
 #     D105 - Missing docstring in magic method.
+#     D106 - Missing docstring in public nested class
+#     D107 - Missing docstring in __init__
 #     D200 - One-line docstrings should fit on one line with quotes.
 #     D201 - No blank lines allowed before (201) docstring.
 #     D202 - No blank lines allowed after  (202) docstring.
@@ -54,4 +56,4 @@ exclude: girder/external/*
 #     N803 - Argument name should be lowercase.
 #     N806 - Variable in function should be lowercase.
 #     N812 - Lowercase imported as non lowercase.
-ignore: D100,D101,D102,D103,D104,D105,D200,D201,D202,D203,D204,D205,D400,D401,D402,E123,E226,E241,N802,N803,N806,N812,W503
+ignore: D100,D101,D102,D103,D104,D105,D106,D107,D200,D201,D202,D203,D204,D205,D400,D401,D402,E123,E226,E241,N802,N803,N806,N812,W503


### PR DESCRIPTION
Two new error codes were added in pydocstyle as of version 2.1.0.  These D106 and D107, and are variations on codes D101 and D102, which we are ignoring.  Because these are variations, we should also ignore D106 and D107.