### PR TITLE
Enforce an older version of pydocstyle

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ pep8==1.7.0
 pyflakes==1.5.0
 
 # dependencies of flake8-docstrings
-pep257==0.7.0
+pydocstyle==2.0.0
 
 # dependencies of mock
 funcsigs==1.0.2


### PR DESCRIPTION
This fixes a bug present in flake8-docstrings, ref: https://gitlab.com/pycqa/flake8-docstrings/issues/23

Also, the dependence on pep257 was a historical artifact that is now unnecessary.