### PR TITLE
Support simple async function calls

### DIFF
--- a/girder/events.py
+++ b/girder/events.py
@@ -124,8 +124,12 @@ class ForegroundEventsDaemon(object):
     def stop(self):
         pass
 
-    def trigger(self, eventName, info=None, callback=None):
-        event = trigger(eventName, info, async=False, daemon=True)
+    def trigger(self, eventName=None, info=None, callback=None):
+        if eventName is None:
+            event = Event(None, info, async=False)
+        else:
+            event = trigger(eventName, info, async=False, daemon=True)
+
         if callable(callback):
             callback(event)
 
@@ -155,8 +159,11 @@ class AsyncEventsThread(threading.Thread):
         while not self.terminate:
             try:
                 eventName, info, callback = self.eventQueue.get(block=False)
+                if eventName is None:
+                    event = Event(None, info, async=True)
+                else:
+                    event = trigger(eventName, info, async=True, daemon=True)
 
-                event = trigger(eventName, info, async=True, daemon=True)
                 if callable(callback):
                     callback(event)
             except queue.Empty:
@@ -169,7 +176,7 @@ class AsyncEventsThread(threading.Thread):
 
         girder.logprint.info('Stopped asynchronous event manager thread.')
 
-    def trigger(self, eventName, info=None, callback=None):
+    def trigger(self, eventName=None, info=None, callback=None):
         """
         Adds a new event on the queue to trigger asynchronously.
 

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -440,11 +440,11 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
             }
             matching = File().find(q, limit=2, fields=[])
             if matching.count(True) == 1:
-                events.daemon.trigger('_s3_assetstore_delete_file', {
+                events.daemon.trigger(info={
                     'client': self.client,
                     'bucket': self.assetstore['bucket'],
                     'key': file['s3Key']
-                })
+                }, callback=_deleteFileImpl)
 
     def fileUpdated(self, file):
         """
@@ -602,6 +602,3 @@ def makeBotoConnectParams(accessKeyId, secret, service=None, region=None, inferC
 
 def _deleteFileImpl(event):
     event.info['client'].delete_object(Bucket=event.info['bucket'], Key=event.info['key'])
-
-
-events.bind('_s3_assetstore_delete_file', '_s3_assetstore_delete_file', _deleteFileImpl)


### PR DESCRIPTION
Prior to this change, all async events went through the global event registry as a broadcast. This new syntax makes it easy to trigger anonymous async function calls, without the need for a broadcast. The call looks like:

    girder.events.daemon.trigger(info=..., callback=_myFn)

If you do not need to pass any info, the `info` kwarg can be omitted.

@opadron PTAL