### PR TITLE
Remove Bootstrap tooltip styling

### DIFF
--- a/clients/web/src/router.js
+++ b/clients/web/src/router.js
@@ -53,8 +53,6 @@ router.on('route', function (route, params) {
     if (!params.slice(-1)[0].dialog) {
         $('.modal').girderModal('close');
     }
-    // get rid of tooltips
-    $('.tooltip').remove();
 });
 
 export default router;

--- a/clients/web/src/templates/body/collectionPage.pug
+++ b/clients/web/src/templates/body/collectionPage.pug
@@ -2,7 +2,7 @@
 
   .btn-group.pull-right
     button.g-collection-actions-button.btn.btn-default.dropdown-toggle(
-        data-toggle="dropdown", title="Collection actions", data-placement='left')
+        data-toggle="dropdown", title="Collection actions")
       i.icon-sitemap
       |  Actions
       i.icon-down-dir

--- a/clients/web/src/templates/body/groupPage.pug
+++ b/clients/web/src/templates/body/groupPage.pug
@@ -2,7 +2,7 @@
   .btn-group.pull-right
     if (isMember || isInvited || getCurrentUser() || group.get('_accessLevel') >= AccessType.ADMIN)
       button.g-group-actions-button.btn.btn-default.dropdown-toggle(
-          data-toggle="dropdown", title="Group actions", data-placement='left')
+          data-toggle="dropdown", title="Group actions")
         i.icon-users
         |  Actions
         i.icon-down-dir

--- a/clients/web/src/templates/widgets/editApiKeyWidget.pug
+++ b/clients/web/src/templates/widgets/editApiKeyWidget.pug
@@ -28,7 +28,7 @@
               | Only allow specific permissions for this key:
           each tokenScope in userTokenScopes
             .checkbox.disabled
-              label.g-custom-scope-description(title=tokenScope.description, data-placement='right')
+              label.g-custom-scope-description(title=tokenScope.description)
                 input.g-custom-scope-checkbox(type="checkbox", value=tokenScope.id, disabled)
                 span= tokenScope.name
           if user.get('admin')

--- a/clients/web/src/templates/widgets/groupInviteList.pug
+++ b/clients/web/src/templates/widgets/groupInviteList.pug
@@ -6,7 +6,7 @@ ul.g-group-invites
         span #{user.name()} (#{user.get('login')})
       .g-group-member-controls.pull-right
         if level >= accessType.WRITE
-          a.g-group-uninvite(title="Uninvite this user", data-placement='left')
+          a.g-group-uninvite(title="Uninvite this user")
             i.icon-block
   if (!invitees.length)
     .g-member-list-empty

--- a/clients/web/src/templates/widgets/hierarchyBreadcrumb.pug
+++ b/clients/web/src/templates/widgets/hierarchyBreadcrumb.pug
@@ -33,5 +33,5 @@ if descriptionText
 
   if idx > 0
     .g-level-up-button-container
-      a.g-hierarchy-level-up(title="Go up one level", data-placement="left")
+      a.g-hierarchy-level-up(title="Go up one level")
         i.icon-level-up

--- a/clients/web/src/templates/widgets/hierarchyWidget.pug
+++ b/clients/web/src/templates/widgets/hierarchyWidget.pug
@@ -31,7 +31,7 @@
               i.icon-lock
         .btn-group
           button.g-folder-actions-button.btn.btn-sm.btn-default.dropdown-toggle(
-              data-toggle="dropdown", title=`${capitalize(type)} actions`, data-placement="left")
+              data-toggle="dropdown", title=`${capitalize(type)} actions`)
             if type === 'collection'
               i.icon-sitemap
             else if type === 'user'

--- a/clients/web/src/templates/widgets/itemBreadcrumb.pug
+++ b/clients/web/src/templates/widgets/itemBreadcrumb.pug
@@ -12,5 +12,5 @@ ol.breadcrumb
           = parent.object.name
 
   .pull-right
-    a.g-hierarchy-level-up(title="Go to parent folder", data-placement='left')
+    a.g-hierarchy-level-up(title="Go to parent folder")
       i.icon-level-up

--- a/clients/web/src/templates/widgets/metadataWidget.pug
+++ b/clients/web/src/templates/widgets/metadataWidget.pug
@@ -1,6 +1,6 @@
 if (accessLevel >= AccessType.WRITE)
   .btn-group.pull-right
-    button.g-widget-metadata-add-button.btn.btn-sm.btn-primary.btn-default.dropdown-toggle(data-toggle="dropdown", title="Add Metadata", data-placement='left')
+    button.g-widget-metadata-add-button.btn.btn-sm.btn-primary.btn-default.dropdown-toggle(data-toggle="dropdown", title="Add Metadata")
       i.icon-plus
     ul.dropdown-menu.pull-right(role="menu")
       li(role="presentation")

--- a/clients/web/src/views/App.js
+++ b/clients/web/src/views/App.js
@@ -3,7 +3,6 @@ import _ from 'underscore';
 import Backbone from 'backbone';
 import 'bootstrap/dist/css/bootstrap.css';
 import 'bootstrap/js/alert';
-import 'bootstrap/js/tooltip';
 
 import 'girder/utilities/jquery/girderModal';
 
@@ -180,18 +179,6 @@ var App = View.extend({
             return;
         }
         this.$el.html(LayoutTemplate());
-
-        // Set the default placement to 'auto' for all styled tooltips. Individual elements with
-        // tooltips may override this by setting a "data-placement" attribute on themselves.
-        $.fn.tooltip.Constructor.DEFAULTS.placement = 'auto';
-        // Apply styled tooltip behavior to any elements with a natural tooltip ("title" attribute).
-        this.$el.tooltip({
-            selector: '[title]',
-            // Setting "container" seems to prevent tooltip jitter near the edges of the screen.
-            // Also, placing it inside the "#g-app-body-container" will ensure that broken tooltips
-            // are cleaned up after every page navigation.
-            container: this.$('#g-app-body-container')
-        });
 
         this.globalNavView.setElement(this.$('#g-global-nav-container')).render();
         this.headerView.setElement(this.$('#g-app-header-container')).render();

--- a/clients/web/src/views/View.js
+++ b/clients/web/src/views/View.js
@@ -72,39 +72,6 @@ var View = Backbone.View.extend({
      */
     unregisterChildView: function (child) {
         this._childViews = _.without(this._childViews, child);
-    },
-
-    /**
-     * Disable Bootstrap tooltips at and below the level of "targetEl".
-     */
-    _disableBootstrapTooltips: function (targetEl) {
-        // While binding to "show.bs.tooltip" and calling "event.preventDefault()" is sufficient to
-        // prevent Bootstrap tooltips from actually appearing, the default browser-rendered tooltips
-        // will no longer be displayed, due to the fact that Bootstrap still initializes all
-        // tooltip-eligible elements as 'Bootstrap tooltips', which has the side effect of renaming
-        // the "title" attribute.
-        //
-        // For dynamically-created elements, this initialization is done
-        // during the "hover" and "focus" pseudo-events (which Bootstrap translates to the real
-        // "mouseenter", "mouseleave", "focusin", and "focusout" events in the "tooltip" namespace).
-        // Blocking these events from reaching Bootstrap is complicated by the fact that
-        // "mouseenter" and "mouseleave" don't bubble, so they can't be caught at the "targetEl"
-        // and have "stopPropagation()" be called to stop the bubbling up to where the tooltip
-        // handler is attached.
-        //
-        // So, here we add a "[title]" selector, to cause our handler to run when any
-        // tooltip-containing element directly receives one of our target event. Despite the fact
-        // that some of these events do not technically bubble, both this and the Bootstrap event
-        // handlers are delegated, and thus are handled in ascending DOM order from the original
-        // target; accordingly our handler (attached to the "targetEl") will be run first, and able
-        // to "stopPropagation()" up to the Bootstrap tooltip handler (typically attached to the
-        // root element of the App).
-        targetEl.on(
-            'mouseenter.tooltip mouseleave.tooltip focusin.tooltip focusout.tooltip',
-            '[title]',
-            (event) => {
-                event.stopPropagation();
-            });
     }
 });
 

--- a/clients/web/src/views/body/PluginsView.js
+++ b/clients/web/src/views/body/PluginsView.js
@@ -1,5 +1,8 @@
 import $ from 'jquery';
 import _ from 'underscore';
+// Bootstrap tooltip is required by popover
+import 'bootstrap/js/tooltip';
+import 'bootstrap/js/popover';
 
 import events from 'girder/events';
 import router from 'girder/router';

--- a/clients/web/src/views/widgets/AccessWidget.js
+++ b/clients/web/src/views/widgets/AccessWidget.js
@@ -1,5 +1,8 @@
 import $ from 'jquery';
 import _ from 'underscore';
+// Bootstrap tooltip is required by popover
+import 'bootstrap/js/tooltip';
+import 'bootstrap/js/popover';
 
 import accessEditorNonModalTemplate from 'girder/templates/widgets/accessEditorNonModal.pug';
 import accessEditorTemplate from 'girder/templates/widgets/accessEditor.pug';
@@ -366,7 +369,7 @@ var AccessWidget = View.extend({
 
     removeAccessEntry: function (event) {
         var sel = '.g-user-access-entry,.g-group-access-entry';
-        $(event.currentTarget).tooltip('hide').parents(sel).remove();
+        $(event.currentTarget).parents(sel).remove();
     },
 
     privacyChanged: function () {

--- a/clients/web/src/views/widgets/ApiKeyListWidget.js
+++ b/clients/web/src/views/widgets/ApiKeyListWidget.js
@@ -1,6 +1,9 @@
 import $ from 'jquery';
 import _ from 'underscore';
 import moment from 'moment';
+// Bootstrap tooltip is required by popover
+import 'bootstrap/js/tooltip';
+import 'bootstrap/js/popover';
 
 import ApiKeyCollection from 'girder/collections/ApiKeyCollection';
 import EditApiKeyWidget from 'girder/views/widgets/EditApiKeyWidget';

--- a/clients/web/src/views/widgets/HierarchyWidget.js
+++ b/clients/web/src/views/widgets/HierarchyWidget.js
@@ -91,7 +91,6 @@ var HierarchyWidget = View.extend({
         'click a.g-delete-checked': 'deleteCheckedDialog',
         'click .g-list-checkbox': 'checkboxListener',
         'change .g-select-all': function (e) {
-            $(e.currentTarget).tooltip('hide');
             this.folderListView.checkAll(e.currentTarget.checked);
 
             if (this.itemListView) {

--- a/clients/web/src/views/widgets/MetadataWidget.js
+++ b/clients/web/src/views/widgets/MetadataWidget.js
@@ -151,8 +151,6 @@ var MetadatumEditWidget = View.extend({
         'click .g-widget-metadata-save-button': 'save',
         'click .g-widget-metadata-delete-button': 'deleteMetadatum',
         'click .g-widget-metadata-toggle-button': function (event) {
-            const target = $(event.currentTarget);
-            target.tooltip('destroy');
             var editorType;
             // @todo modal
             // in the future this event will have the new editorType (assuming a dropdown)
@@ -192,7 +190,6 @@ var MetadatumEditWidget = View.extend({
     deleteMetadatum: function (event) {
         event.stopImmediatePropagation();
         const target = $(event.currentTarget);
-        target.tooltip('destroy');
         var metadataList = target.parent().parent();
         var params = {
             text: 'Are you sure you want to delete the metadatum <b>' +
@@ -214,7 +211,6 @@ var MetadatumEditWidget = View.extend({
     cancelEdit: function (event) {
         event.stopImmediatePropagation();
         const target = $(event.currentTarget);
-        target.tooltip('destroy');
         var curRow = target.parent().parent();
         if (this.newDatum) {
             curRow.remove();
@@ -226,7 +222,6 @@ var MetadatumEditWidget = View.extend({
     save: function (event, value) {
         event.stopImmediatePropagation();
         const target = $(event.currentTarget);
-        target.tooltip('destroy');
         var curRow = target.parent(),
             tempKey = curRow.find('.g-widget-metadata-key-input').val(),
             tempValue = (value !== undefined) ? value : curRow.find('.g-widget-metadata-value-input').val();
@@ -333,10 +328,6 @@ var JsonMetadatumEditWidget = MetadatumEditWidget.extend({
                 });
             }
         });
-        // JSONEditor removes tooltip-containing elements without destroying their
-        // Bootstrap-styled tooltips first. To fix this, disable Bootstrap tooltips within all
-        // JSONEditor elements.
-        this._disableBootstrapTooltips(jsonEditorEl);
 
         if (this.value !== undefined) {
             this.editor.setText(JSON.stringify(this.value));

--- a/clients/web/src/views/widgets/SearchFieldWidget.js
+++ b/clients/web/src/views/widgets/SearchFieldWidget.js
@@ -1,5 +1,8 @@
 import $ from 'jquery';
 import _ from 'underscore';
+// Bootstrap tooltip is required by popover
+import 'bootstrap/js/tooltip';
+import 'bootstrap/js/popover';
 
 import View from 'girder/views/View';
 import { restRequest } from 'girder/rest';
@@ -10,8 +13,6 @@ import SearchModeSelectTemplate from 'girder/templates/widgets/searchModeSelect.
 import SearchResultsTemplate from 'girder/templates/widgets/searchResults.pug';
 
 import 'girder/stylesheets/widgets/searchFieldWidget.styl';
-
-import 'bootstrap/js/popover';
 
 /**
  * This widget provides a text field that will search any set of data types


### PR DESCRIPTION
All tooltips-containing elements (i.e. those with a `title` attribute) will now use native browser tooltips.