### PR TITLE
[WIP] CSS refresh

### DIFF
--- a/clients/web/src/stylesheets/body/adminConsole.styl
+++ b/clients/web/src/stylesheets/body/adminConsole.styl
@@ -10,7 +10,8 @@ ul.g-admin-options
     text-transform uppercase
     font-weight 600
     display block
-    line-height 2.2
+    line-height 52px
+    vertical-align center
     font-size 14px
     i
       margin-right 16px

--- a/clients/web/src/stylesheets/body/adminConsole.styl
+++ b/clients/web/src/stylesheets/body/adminConsole.styl
@@ -1,20 +1,23 @@
+@import "../layout/layoutVars"
+
 ul.g-admin-options
-  list-style-type none
-  font-size 18px
   padding-left 0
   margin 0
 
   >li
+    list-style-type none
+    text-decoration none
+    text-transform uppercase
+    font-weight 600
     display block
-    padding 12px 10px
-    font-weight bold
-    color #666
-
-    >a
+    line-height 2.2
+    font-size 14px
+    i
+      margin-right 16px
+      font-size 24px
+    a
       color inherit
-      display block
 
   >li:hover
-    background-color #f4f4f4
+    color $baseColor
     cursor pointer
-    color #222

--- a/clients/web/src/stylesheets/body/collectionList.styl
+++ b/clients/web/src/stylesheets/body/collectionList.styl
@@ -1,22 +1,26 @@
+@import "../layout/layoutVars"
+
 .g-collection-list-entry
 
   .g-collection-title
-    font-size 17px
+    font-size $resourceTitleSize
 
   .g-collection-right-column
-    border-left 1px solid #ddd
     padding-left 8px
     display inline
-    width 290px
+    width 320px
     font-size 14px
     float right
-    color #909090
+    color $lightColor
 
   .g-collection-description
     background-color white
     padding 8px 12px
     border-radius 3px
-    border 1px solid #dedede
+    border $border
+
+  .g-collection-created-date, .g-user-space-used
+    color $normalColor
 
 .g-collection-list-header
   padding-bottom 10px

--- a/clients/web/src/stylesheets/body/frontPage.styl
+++ b/clients/web/src/stylesheets/body/frontPage.styl
@@ -14,9 +14,7 @@
 
     .g-frontpage-subtitle
       font-size 18px
-      color $normalColor
       margin-left 2px
-      border-top $border
 
   .g-frontpage-logo-container
     position relative
@@ -42,7 +40,6 @@
   border-radius 2px
   background-color $secondaryBackgroundColor
   border $border
-  color $normalColor
 
   .g-frontpage-paragraph
     margin-top 0

--- a/clients/web/src/stylesheets/body/frontPage.styl
+++ b/clients/web/src/stylesheets/body/frontPage.styl
@@ -1,3 +1,5 @@
+@import "../layout/layoutVars"
+
 .g-frontpage-header
   padding 5px
 
@@ -6,15 +8,15 @@
     margin-left 12px
 
     .g-frontpage-title
-      font-weight bold
+      font-weight 600
       font-size 34px
-      color #222
+      color $baseColor
 
     .g-frontpage-subtitle
       font-size 18px
-      color #707070
+      color $normalColor
       margin-left 2px
-      border-top 1px solid #eee
+      border-top $border
 
   .g-frontpage-logo-container
     position relative
@@ -36,11 +38,11 @@
 .g-frontpage-body
   padding 12px 12px 0
   margin-top 10px
-
+  max-width 800px
   border-radius 2px
-  background-color #f8f8f8
-  border 1px solid #e5e5e5
-  color #555
+  background-color $secondaryBackgroundColor
+  border $border
+  color $normalColor
 
   .g-frontpage-paragraph
     margin-top 0

--- a/clients/web/src/stylesheets/body/groupList.styl
+++ b/clients/web/src/stylesheets/body/groupList.styl
@@ -1,29 +1,23 @@
+@import "../layout/layoutVars"
+
 .g-group-list-entry
   .g-group-title
-    font-size 17px
+    font-size $resourceTitleSize
 
   .g-group-description
-    color #666
-    font-size 14px
-    font-weight bold
-
-  .g-space-used
-    margin-top 2px
+    font-size $resourceSubtitleSize
 
   .g-group-right-column
-    border-left 1px solid #ddd
     padding-left 8px
     display inline
-    width 290px
+    width 320px
     font-size 14px
     float right
-    color #909090
+    color $lightColor
 
   .g-group-created-date
-    color #444
+    color $normalColor
 
-  .g-group-privacy
-    margin-top 3px
 
 .g-groups-list-header
   padding-bottom 10px

--- a/clients/web/src/stylesheets/body/userList.styl
+++ b/clients/web/src/stylesheets/body/userList.styl
@@ -1,6 +1,13 @@
 @import "../layout/layoutVars"
 
 .g-user-list-entry
+  // These shouldn't be needed when the user list entry divs also have g-top-level-list-entry
+  padding 11px 14px
+  background-color white
+  border-bottom $border
+  border-left $border
+  border-right $border
+
   .g-user-title
     font-size $resourceTitleSize
 
@@ -18,18 +25,9 @@
   .g-user-joined-date, .g-user-space-used
     color $normalColor
 
-
-// These shouldn't be needed when the user list entry divs also have g-top-level-list-entry
-.g-user-list-entry
-  padding 11px 14px
-  background-color white
+// This shouldn't be needed when the user list entry divs also have g-top-level-list-entry
+.g-user-list-entry:nth-child(2)
   border-top $border
-  border-left $border
-  border-right $border
-
-.g-user-list-entry:last-child
-  border-bottom $border
-
 
 .g-user-list-header
   padding-bottom 10px

--- a/clients/web/src/stylesheets/body/userList.styl
+++ b/clients/web/src/stylesheets/body/userList.styl
@@ -1,37 +1,35 @@
-.g-user-list-entry
-  padding 11px 14px
-  margin 2px 0
-  border-radius 3px
-  background-color #fafafc
-  border 1px solid #eaeaea
-  box-shadow inset 0 0 2px 2px #f4f4f4
+@import "../layout/layoutVars"
 
+.g-user-list-entry
   .g-user-title
-    font-size 17px
+    font-size $resourceTitleSize
 
   .g-user-login
-    color #666
-    font-size 16px
-    font-weight bold
-
-  .g-space-used
-    margin-top 2px
-
-  .g-user-status
-    margin-top 2px
-    color #d9534f
+    font-size $resourceSubtitleSize
 
   .g-user-right-column
-    border-left 1px solid #ddd
     padding-left 8px
     display inline
-    width 235px
+    width 320px
     font-size 14px
     float right
-    color #909090
+    color $lightColor
 
   .g-user-joined-date, .g-user-space-used
-    color #444
+    color $normalColor
+
+
+// These shouldn't be needed when the user list entry divs also have g-top-level-list-entry
+.g-user-list-entry
+  padding 11px 14px
+  background-color white
+  border-top $border
+  border-left $border
+  border-right $border
+
+.g-user-list-entry:last-child
+  border-bottom $border
+
 
 .g-user-list-header
   padding-bottom 10px

--- a/clients/web/src/stylesheets/layout/footer.styl
+++ b/clients/web/src/stylesheets/layout/footer.styl
@@ -1,7 +1,10 @@
+@import "layoutVars"
+
 #g-app-footer-container
-  border-top 1px solid #eee
+  border-top $border
   text-align center
-  background-image linear-gradient(to bottom, #f6f6f6 0, #fff 5px)
+  margin 20px 20px 20px $navWidth + 20px
+  color $normalColor
 
 .g-quick-search-form
   >.form-group
@@ -11,9 +14,13 @@
     display inline !important
 
 .g-footer-info
-  margin-bottom 10px
+  margin-bottom 20px
 
 .g-footer-links
   margin 15px auto 10px
   a
     margin 0 10px
+
+@media (max-width: 720px)
+  #g-app-footer-container
+    margin 20px

--- a/clients/web/src/stylesheets/layout/footer.styl
+++ b/clients/web/src/stylesheets/layout/footer.styl
@@ -4,7 +4,6 @@
   border-top $border
   text-align center
   margin 20px 20px 20px $navWidth + 20px
-  color $normalColor
 
 .g-quick-search-form
   >.form-group

--- a/clients/web/src/stylesheets/layout/global.styl
+++ b/clients/web/src/stylesheets/layout/global.styl
@@ -2,11 +2,14 @@
  * Place global styles in this file.
  */
 
+@import "layoutVars"
+
 body
   // Override the default font from Bootstrap
   font-family "Open Sans", sans-serif !important
   padding 0
   word-wrap break-word
+  color $normalColor !important
 
 i
   font-smoothing antialiased
@@ -14,6 +17,9 @@ i
 a
   cursor pointer
   text-decoration none !important
+
+b
+  font-weight 600 !important
 
 .g-clear-both
   clear both
@@ -111,7 +117,7 @@ textarea
   display inline-block
   overflow hidden
   white-space nowrap
-  width calc(100% - 350px)
+  width calc(100% - 380px)
   position relative
 
   .g-text-fade
@@ -128,21 +134,21 @@ textarea
   display inline-block
   line-height 40px
   vertical-align top
-  color #888
+  color $normalColor
   margin-right 10px
-  border-right 1px solid #dedede
   padding-right 5px
   font-size 18px
   margin-left -5px
 
 .g-top-level-list-entry
   padding 11px 14px
-  margin 2px 0
-  border-radius 3px
-  background-color #fafafc
-  border 1px solid #eaeaea
-  box-shadow inset 0 0 2px 2px #f4f4f4
+  background-color white
+  border-top $border
+  border-left $border
+  border-right $border
 
   &[public="false"]
-    box-shadow inset 0 0 2px 2px #fff0e0
-    background-color #fff9ea
+    background-color $privateColor
+
+.g-top-level-list-entry:last-child
+  border-bottom $border

--- a/clients/web/src/stylesheets/layout/global.styl
+++ b/clients/web/src/stylesheets/layout/global.styl
@@ -134,7 +134,6 @@ textarea
   display inline-block
   line-height 40px
   vertical-align top
-  color $normalColor
   margin-right 10px
   padding-right 5px
   font-size 18px
@@ -143,12 +142,12 @@ textarea
 .g-top-level-list-entry
   padding 11px 14px
   background-color white
-  border-top $border
+  border-bottom $border
   border-left $border
   border-right $border
 
   &[public="false"]
     background-color $privateColor
 
-.g-top-level-list-entry:last-child
-  border-bottom $border
+.g-top-level-list-entry:nth-child(2)
+  border-top $border

--- a/clients/web/src/stylesheets/layout/globalNav.styl
+++ b/clients/web/src/stylesheets/layout/globalNav.styl
@@ -2,11 +2,11 @@
 
 ul.g-global-nav
   padding-left 0
-  width 260px
 
   .g-nav-link
     display block
-    line-height 2.2
+    line-height 52px
+    vertical-align middle
     font-size 14px
     color $lightColor
     i
@@ -18,14 +18,16 @@ ul.g-global-nav
     text-decoration none
     text-transform uppercase
     font-weight 600
+    padding-left 20px
 
   >li:hover:not(.g-active)
     .g-nav-link
-      color $normalColor
+      color $baseColor
 
   >li.g-active
     pointer-events none
     cursor default
+    background white
     .g-nav-link
       color $baseColor
 

--- a/clients/web/src/stylesheets/layout/globalNav.styl
+++ b/clients/web/src/stylesheets/layout/globalNav.styl
@@ -1,56 +1,33 @@
-$navLinkBorder=1px solid #e0e0e0
-$emptyBorder=1px solid transparent
-$minHeight=500px
-
-.g-global-nav-main
-  box-shadow inset -1px 0 0 #eee
-  background-image linear-gradient(to left, #f4f4f4 0, #fff 7px)
-  min-height $minHeight - 12px
-  padding 15px 0 20px 6px
-
-.g-global-nav-fade
-  height 12px
-  box-shadow inset -1px 0 0 #f5f5f5
-  background-image linear-gradient(to left, #f4f4f4 0, #fff 4px)
-
-.g-nav-link
-  display block
-  line-height 2.2
-  font-size 17px
-  color #4a4a4a
-  padding-left 12px
-  i
-    color #888
-    margin 3px
+@import "layoutVars"
 
 ul.g-global-nav
   padding-left 0
+  width 260px
+
+  .g-nav-link
+    display block
+    line-height 2.2
+    font-size 14px
+    color $lightColor
+    i
+      margin-right 16px
+      font-size 24px
 
   >li
-    border $emptyBorder
     list-style-type none
     text-decoration none
+    text-transform uppercase
+    font-weight 600
 
   >li:hover:not(.g-active)
-    background-color #fafafa
     .g-nav-link
-      position relative
-      color #222
-    i
-      color #333
+      color $normalColor
 
   >li.g-active
     pointer-events none
     cursor default
-    background-color white
-    border-top $navLinkBorder
-    border-bottom $navLinkBorder
-    border-left $navLinkBorder
-    box-shadow -1px 1px 3px rgba(0, 0, 0, 0.05)
     .g-nav-link
-      color black
-    i
-      color black
+      color $baseColor
 
 @media (max-width: 720px)
   .g-nav-link
@@ -60,37 +37,12 @@ ul.g-global-nav
 
   ul.g-global-nav
     width 100%
-    border-bottom $navLinkBorder
     >li
       display inline-block
       padding 4px 5px
-      border $emptyBorder
-    >li.g-active
-      box-shadow none
-      border-bottom $emptyBorder
-      border-left $navLinkBorder
-      border-right $navLinkBorder
-      border-top $navLinkBorder
-    >li:not(.g-active)
-      background-color #f1f1f1
-
-@media (min-width: 721px)
-  ul.g-global-nav
-    >li:hover:not(.g-active)
-      .g-nav-link:after
-        content ""
-        position absolute
-        width 4px
-        top -1px
-        bottom -1px
-        right -1px
-        background-color #ffcc00
 
 @media (max-width: 720px)
   .g-global-nav-main
     padding 0
-    box-shadow none
     background-image none
     min-height 0
-  .g-global-nav-fade
-    display none

--- a/clients/web/src/stylesheets/layout/header.styl
+++ b/clients/web/src/stylesheets/layout/header.styl
@@ -1,17 +1,25 @@
 @import "layoutVars"
 
 .g-header-wrapper
+  display flex
+  color $normalColor
   height $headerHeight
   vertical-align middle
-  padding 0 15px
+  padding 0 20px
+  background white
+  border-bottom $border
 
 .g-app-title
   display inline
-  font-size 25px
-  font-weight bold
+  font-size 20px
+  font-weight 600
   margin-right 35px
   line-height $headerHeight
   cursor pointer
+  flex 1
+
+.g-app-title:hover
+  color $baseColor
 
 .g-quick-search-form
   display inline-block
@@ -22,7 +30,6 @@
 
 .g-current-user-wrapper
   display inline
-  float right
 
 @media (max-width: 720px)
   .g-app-title

--- a/clients/web/src/stylesheets/layout/header.styl
+++ b/clients/web/src/stylesheets/layout/header.styl
@@ -2,7 +2,6 @@
 
 .g-header-wrapper
   display flex
-  color $normalColor
   height $headerHeight
   vertical-align middle
   padding 0 20px
@@ -17,9 +16,6 @@
   line-height $headerHeight
   cursor pointer
   flex 1
-
-.g-app-title:hover
-  color $baseColor
 
 .g-quick-search-form
   display inline-block

--- a/clients/web/src/stylesheets/layout/headerUser.styl
+++ b/clients/web/src/stylesheets/layout/headerUser.styl
@@ -4,11 +4,11 @@
   line-height $headerHeight
 
   a
-    color white
+    color $normalColor
     display inline-block
 
     &:hover
-      color #e0e0e0
+      color $baseColor
 
   .g-user-dropdown-link
     display inline-block

--- a/clients/web/src/stylesheets/layout/headerUser.styl
+++ b/clients/web/src/stylesheets/layout/headerUser.styl
@@ -4,11 +4,7 @@
   line-height $headerHeight
 
   a
-    color $normalColor
     display inline-block
-
-    &:hover
-      color $baseColor
 
   .g-user-dropdown-link
     display inline-block

--- a/clients/web/src/stylesheets/layout/headerUser.styl
+++ b/clients/web/src/stylesheets/layout/headerUser.styl
@@ -5,6 +5,7 @@
 
   a
     display inline-block
+    color inherit
 
   .g-user-dropdown-link
     display inline-block

--- a/clients/web/src/stylesheets/layout/layout.styl
+++ b/clients/web/src/stylesheets/layout/layout.styl
@@ -63,12 +63,11 @@
 
   #g-global-nav-container
     width $navWidth
-    padding 10px 20px
+    padding-top 10px
     position fixed
     top $headerHeight
     bottom 0
     box-sizing border-box
-    border-right $border
 
 @media (max-width: 720px)
   #g-global-nav-container

--- a/clients/web/src/stylesheets/layout/layout.styl
+++ b/clients/web/src/stylesheets/layout/layout.styl
@@ -12,7 +12,7 @@
 
 #g-app-body-container.g-empty-layout
   margin 0
-  padding 10px
+  padding 20px
 
 #g-alerts-container
   position fixed
@@ -54,15 +54,21 @@
   overflow hidden
   text-overflow ellipsis
 
+#g-global-nav-container
+  background-color $secondaryBackgroundColor
+
 @media (min-width: 721px)
   #g-app-body-container.g-default-layout
-    padding 10px + $headerHeight 10px 10px 10px
-    margin-left $navWidth + 1px
+    margin (10px + $headerHeight) 20px 10px (20px + $navWidth)
 
   #g-global-nav-container
+    width $navWidth
+    padding 10px 20px
     position fixed
     top $headerHeight
-    width $navWidth
+    bottom 0
+    box-sizing border-box
+    border-right $border
 
 @media (max-width: 720px)
   #g-global-nav-container

--- a/clients/web/src/stylesheets/layout/layoutVars.styl
+++ b/clients/web/src/stylesheets/layout/layoutVars.styl
@@ -1,4 +1,4 @@
-$navWidth = 180px
+$navWidth = 310px
 $minHeight = 500px
 $headerHeight = 52px
 $headerZ = 50
@@ -7,3 +7,18 @@ $modalZ = 1040
 $progressZ = $modalZ + 100
 $alertsZ = $progressZ + 100
 $quickSearchWidth = 220px
+
+$baseColor = #333
+$normalColor = alpha($baseColor, .7)
+$lightColor = alpha($baseColor, .5)
+
+$accentColor = #0097d8
+
+$secondaryBackgroundColor = alpha($baseColor, .05)
+
+$border = 1px solid alpha($baseColor, .1)
+
+$resourceTitleSize = 16px
+$resourceSubtitleSize = 14px
+
+$privateColor = #fff9ee

--- a/clients/web/src/stylesheets/layout/layoutVars.styl
+++ b/clients/web/src/stylesheets/layout/layoutVars.styl
@@ -1,4 +1,4 @@
-$navWidth = 310px
+$navWidth = 230px
 $minHeight = 500px
 $headerHeight = 52px
 $headerZ = 50
@@ -9,8 +9,8 @@ $alertsZ = $progressZ + 100
 $quickSearchWidth = 220px
 
 $baseColor = #333
-$normalColor = alpha($baseColor, 0.7)
-$lightColor = alpha($baseColor, 0.5)
+$normalColor = alpha($baseColor, 0.85)
+$lightColor = alpha($baseColor, 0.7)
 
 $accentColor = #0097d8
 

--- a/clients/web/src/stylesheets/layout/layoutVars.styl
+++ b/clients/web/src/stylesheets/layout/layoutVars.styl
@@ -9,14 +9,14 @@ $alertsZ = $progressZ + 100
 $quickSearchWidth = 220px
 
 $baseColor = #333
-$normalColor = alpha($baseColor, .7)
-$lightColor = alpha($baseColor, .5)
+$normalColor = alpha($baseColor, 0.7)
+$lightColor = alpha($baseColor, 0.5)
 
 $accentColor = #0097d8
 
-$secondaryBackgroundColor = alpha($baseColor, .05)
+$secondaryBackgroundColor = alpha($baseColor, 0.05)
 
-$border = 1px solid alpha($baseColor, .1)
+$border = 1px solid alpha($baseColor, 0.1)
 
 $resourceTitleSize = 16px
 $resourceSubtitleSize = 14px

--- a/clients/web/src/views/layout/HeaderView.js
+++ b/clients/web/src/views/layout/HeaderView.js
@@ -46,10 +46,6 @@ var LayoutHeaderView = View.extend({
             textColor: textColor
         }));
         this.userView.setElement(this.$('.g-current-user-wrapper')).render();
-        if (textColor !== '#ffffff') {
-            // We will lose the hover color by setting this, so only do that if necessary
-            this.userView.$('.g-user-text a').css('color', textColor);
-        }
         this.searchWidget.setElement(this.$('.g-quick-search-container')).render();
 
         return this;

--- a/clients/web/src/views/layout/HeaderView.js
+++ b/clients/web/src/views/layout/HeaderView.js
@@ -70,7 +70,7 @@ var LayoutHeaderView = View.extend({
         );
         const L = 0.2126 * linearRBG[0] + 0.7152 * linearRBG[1] + 0.0722 * linearRBG[2];
         return ((L + 0.05) / (0.0 + 0.05) > (1.0 + 0.05) / (L + 0.05))
-            ? '#000000'
+            ? 'inherit'
             : '#ffffff';
     }
 });

--- a/clients/web/src/views/widgets/SearchFieldWidget.js
+++ b/clients/web/src/views/widgets/SearchFieldWidget.js
@@ -129,6 +129,7 @@ var SearchFieldWidget = View.extend({
         this.$('.g-search-options-button').popover({
             trigger: 'manual',
             html: true,
+            placement: 'bottom',
             viewport: {
                 selector: 'body',
                 padding: 10
@@ -145,6 +146,7 @@ var SearchFieldWidget = View.extend({
         this.$('.g-search-mode-choose').popover({
             trigger: 'manual',
             html: true,
+            placement: 'bottom',
             viewport: {
                 selector: 'body',
                 padding: 10

--- a/girder/constants.py
+++ b/girder/constants.py
@@ -192,7 +192,7 @@ class SettingDefault:
     """
     defaults = {
         SettingKey.BRAND_NAME: 'Girder',
-        SettingKey.BANNER_COLOR: '#3F3B3B',
+        SettingKey.BANNER_COLOR: '#FFFFFF',
         SettingKey.PLUGINS_ENABLED: [],
         SettingKey.COOKIE_LIFETIME: 180,
         SettingKey.EMAIL_FROM_ADDRESS: 'Girder <no-reply@girder.org>',

--- a/grunt_tasks/build.js
+++ b/grunt_tasks/build.js
@@ -143,7 +143,7 @@ module.exports = function (grunt) {
                         filename: 'googlefonts.css',
                         fonts: [{
                             family: 'Open Sans',
-                            variants: ['regular', '700', 'italic', '700italic']
+                            variants: ['regular', '600', 'italic', '600italic']
                         }]
                     })
                 ]


### PR DESCRIPTION
Feedback welcome/appreciated. I've spent a little time the last few days doing a refresh of the Girder CSS. Some high-level changes:

* Using Open Sans instead of Droid Sans to update the look and feel. I am able to use the same build path as before to get the font from Google Fonts.
* Softer colors. The colors are Stylus variables so we could easily bump up the contrast if it's too soft.
* Use of flex styling. It could be used in many more places, but for now I've updated the title bar so that it does not need float left. The search box has moved from the left to the right side.
* Less busy interface. I've removed most instances of box shadows.
* Consistent top-level lists. Collections, Users, and Groups pages were not uniform in their styling - now they are much closer.
* The left panel is now fixed in position (unless in mobile responsive layout mode), so scrolling down will not make the menu items get lost.

![image](https://user-images.githubusercontent.com/81305/31559393-6f3dcb34-b01e-11e7-91e3-d70b29de00cd.png)

Other than some minor things (font update in build, update Python/JS to support the custom title bar styles), all changes are in Stylus files only. The DOM looks exactly as it did before, so there are no incompatible things apart from if code/plugins assumed certain styling.

If folks think it is ok, I believe this could be merged without doing much more (it's already touching several files). There is plenty of opportunity for additional incremental updates to improve style and consistency.

This should likely wait to go in until we disconnect 2.x maintenance from master. This (or whatever this evolves into) could be billed as a modernized interface for 3.0.