### PR TITLE
Switch to Open Sans.

### DIFF
--- a/clients/web/src/stylesheets/apidocs/apidocs.styl
+++ b/clients/web/src/stylesheets/apidocs/apidocs.styl
@@ -4,7 +4,7 @@ $radius = 6px
 $border = 1px solid #d7d7d7
 
 body
-  font-family "Droid Sans", sans-serif
+  font-family "Open Sans", sans-serif
   background-color #adada1
 
 .right

--- a/clients/web/src/stylesheets/layout/global.styl
+++ b/clients/web/src/stylesheets/layout/global.styl
@@ -4,7 +4,7 @@
 
 body
   // Override the default font from Bootstrap
-  font-family "Droid Sans", sans-serif !important
+  font-family "Open Sans", sans-serif !important
   padding 0
   word-wrap break-word
 

--- a/grunt_tasks/build.js
+++ b/grunt_tasks/build.js
@@ -142,8 +142,8 @@ module.exports = function (grunt) {
                     new GoogleFontsPlugin({
                         filename: 'googlefonts.css',
                         fonts: [{
-                            family: 'Droid Sans',
-                            variants: ['regular', '700']
+                            family: 'Open Sans',
+                            variants: ['regular', '700', 'italic', '700italic']
                         }]
                     })
                 ]


### PR DESCRIPTION
On 10/31/2017, Droid Sans is no longer available from Google.  Open Sans is very similar.  Open Sans has a true italic, so the italic variations have been added.

It is possible that Droid Sans will come back, but currently Google lists it as only available from Monotype.