### PR TITLE
Always JSON encode setting values

### DIFF
--- a/devops/ansible/roles/girder/library/girder.py
+++ b/devops/ansible/roles/girder/library/girder.py
@@ -1849,10 +1849,7 @@ class GirderClientModule(GirderClient):
 
             params = {
                 'key': key,
-                'value': (
-                    json.dumps(value)
-                    if isinstance(value, (list, dict)) else value
-                )
+                'value': json.dumps(value)
             }
 
             try:


### PR DESCRIPTION
Otherwise type information is lost and validation of settings may fail. For example setting a boolean value in a playbook gets converted to a python boolean (True or False). This is sent in the the request as the string 'True' or 'False'. When the setting value it received a json.loads(...) is performed and the value is still a str rather then an boolean. By encode as JSON, True or False would become 'true' or 'false', which is decode correctly.