### PR TITLE
Add security when deleting Collection

### DIFF
--- a/clients/web/src/dialog.js
+++ b/clients/web/src/dialog.js
@@ -93,7 +93,6 @@ function confirm(params) {
         el.text(params.text);
     }
     if (params['msgConfirmation']) {
-        $('#g-confirm-text').css({'max-width': '50%'});
         if (params.escapedHtml) {
             $('.g-additional-text').html(params.additionalText);
         } else {

--- a/clients/web/src/dialog.js
+++ b/clients/web/src/dialog.js
@@ -62,6 +62,11 @@ function handleOpen(name, options, nameId) {
  * @param {Boolean} [params.escapedHtml] If you want to render the text as HTML rather than
  *        plain text, set this to true to acknowledge that you have escaped any
  *        user-created data within the text to prevent XSS exploits.
+ * @param {Boolean} [params.msgConfirmation] If you want to add a new security before
+ *        perform an action. This will ask to enter a specific string "params.yesText params.name"
+ * @param {String} [params.additionalText] Additional text to display before the confirmation
+ *        input.
+ * @param {String} [params.name] The name to enter in order to confirm an action.
  * @param {Function} [params.confirmCallback]Callback function when the user confirms the action.
  */
 function confirm(params) {
@@ -70,7 +75,10 @@ function confirm(params) {
         yesText: 'Yes',
         yesClass: 'btn-danger',
         noText: 'Cancel',
-        escapedHtml: false
+        escapedHtml: false,
+        msgConfirmation: false,
+        additionalText: '',
+        name: ''
     }, params);
     $('#g-dialog-container').html(ConfirmDialogTemplate({
         params: params
@@ -78,16 +86,39 @@ function confirm(params) {
         $('#g-confirm-button').off('click');
     });
 
-    var el = $('#g-dialog-container').find('.modal-body>p');
+    let el = $('#g-dialog-container').find('.modal-body>p:first-child');
     if (params.escapedHtml) {
         el.html(params.text);
     } else {
         el.text(params.text);
     }
+    if (params['msgConfirmation']) {
+        $('#g-confirm-text').css({'max-width': '50%'});
+        if (params.escapedHtml) {
+            $('.g-additional-text').html(params.additionalText);
+        } else {
+            $('.g-additional-text').text(params.additionalText);
+        }
+    }
 
     $('#g-confirm-button').off('click').click(function () {
-        $('#g-dialog-container').modal('hide');
-        params.confirmCallback();
+        if (params['msgConfirmation']) {
+            const key = `${params.yesText.toUpperCase()} ${params.name}`;
+            let msg = $('#g-confirm-text').val();
+            if (msg.toUpperCase() === key.toUpperCase()) {
+                $('#g-dialog-container').modal('hide');
+                params.confirmCallback();
+            } else if (msg.toUpperCase() === '') {
+                $('.g-msg-error').html(`Error: You need to enter <b>'${key}'</b>.`);
+                $('.g-msg-error').css('color', 'red');
+            } else {
+                $('.g-msg-error').html(`Error: <b>'${msg}'</b> isn't <b>'${key}'</b>`);
+                $('.g-msg-error').css('color', 'red');
+            }
+        } else {
+            $('#g-dialog-container').modal('hide');
+            params.confirmCallback();
+        }
     });
 }
 

--- a/clients/web/src/dialog.js
+++ b/clients/web/src/dialog.js
@@ -86,7 +86,7 @@ function confirm(params) {
         $('#g-confirm-button').off('click');
     });
 
-    let el = $('#g-dialog-container').find('.modal-body>p:first-child');
+    const el = $('#g-dialog-container').find('.modal-body>p:first-child');
     if (params.escapedHtml) {
         el.html(params.text);
     } else {
@@ -104,7 +104,7 @@ function confirm(params) {
     $('#g-confirm-button').off('click').click(function () {
         if (params['msgConfirmation']) {
             const key = `${params.yesText.toUpperCase()} ${params.name}`;
-            let msg = $('#g-confirm-text').val();
+            const msg = $('#g-confirm-text').val();
             if (msg.toUpperCase() === key.toUpperCase()) {
                 $('#g-dialog-container').modal('hide');
                 params.confirmCallback();

--- a/clients/web/src/stylesheets/layout/global.styl
+++ b/clients/web/src/stylesheets/layout/global.styl
@@ -56,6 +56,9 @@ ul.dropdown-menu
   margin-top 5px
   width 100%
 
+#g-confirm-text
+  max-width 50%
+
 .g-info-message-container
   background-color #fffee1
   color #777

--- a/clients/web/src/templates/widgets/confirmDialog.pug
+++ b/clients/web/src/templates/widgets/confirmDialog.pug
@@ -2,6 +2,13 @@
   .modal-content
     .modal-body
       p
+      if params.msgConfirmation
+        p.g-additional-text
+        p.g-additional-instruction
+          | You need to enter '#{params.yesText.toUpperCase()} #{params.name}'
+          | and then click on the "#{params.yesText}" button
+        input#g-confirm-text.input-sm.form-control(type='text', name='confirmMsg')
+        spam.g-msg-error
     .modal-footer
       a.btn.btn-small.btn-default(data-dismiss="modal")= params.noText
       a#g-confirm-button.btn.btn-small(class=params.yesClass)= params.yesText

--- a/clients/web/src/views/body/CollectionView.js
+++ b/clients/web/src/views/body/CollectionView.js
@@ -11,7 +11,7 @@ import View from 'girder/views/View';
 import { AccessType } from 'girder/constants';
 import { cancelRestRequests } from 'girder/rest';
 import { confirm } from 'girder/dialog';
-import { renderMarkdown } from 'girder/misc';
+import { renderMarkdown, formatSize } from 'girder/misc';
 import events from 'girder/events';
 
 import CollectionPageTemplate from 'girder/templates/body/collectionPage.pug';
@@ -33,6 +33,12 @@ var CollectionView = View.extend({
                       this.model.escape('name') + '</b>?',
                 yesText: 'Delete',
                 escapedHtml: true,
+                additionalText: '<b>' + this.model.escape('name') + '</b>' +
+                                ' contains <b>' + this.model.escape('nFolders') +
+                                ' folders</b> taking up <b>' +
+                                formatSize(this.model.escape('size')) + '</b>',
+                msgConfirmation: true,
+                name: this.model.escape('name'),
                 confirmCallback: _.bind(function () {
                     this.model.on('g:deleted', function () {
                         events.trigger('g:alert', {

--- a/clients/web/src/views/body/CollectionView.js
+++ b/clients/web/src/views/body/CollectionView.js
@@ -157,13 +157,13 @@ var CollectionView = View.extend({
                     router.navigate('collections', {trigger: true});
                 }).destroy();
             }, this)
-        }
+        };
         if (this.model.get('nFolders') !== 0 || this.model.get('size') !== 0) {
             params = _.extend({
                 additionalText: '<b>' + this.model.escape('name') + '</b>' +
                                 ' contains <b>' + this.model.escape('nFolders') +
                                 ' folders</b> taking up <b>' +
-                                formatSize(this.model.escape('size')) + '</b>',
+                                formatSize(parseInt(this.model.get('size'), 10)) + '</b>',
                 msgConfirmation: true,
                 name: this.model.escape('name')
             }, params);

--- a/clients/web/src/views/body/CollectionView.js
+++ b/clients/web/src/views/body/CollectionView.js
@@ -27,31 +27,7 @@ var CollectionView = View.extend({
     events: {
         'click .g-edit-collection': 'editCollection',
         'click .g-collection-access-control': 'editAccess',
-        'click .g-delete-collection': function () {
-            confirm({
-                text: 'Are you sure you want to delete the collection <b>' +
-                      this.model.escape('name') + '</b>?',
-                yesText: 'Delete',
-                escapedHtml: true,
-                additionalText: '<b>' + this.model.escape('name') + '</b>' +
-                                ' contains <b>' + this.model.escape('nFolders') +
-                                ' folders</b> taking up <b>' +
-                                formatSize(this.model.escape('size')) + '</b>',
-                msgConfirmation: true,
-                name: this.model.escape('name'),
-                confirmCallback: _.bind(function () {
-                    this.model.on('g:deleted', function () {
-                        events.trigger('g:alert', {
-                            icon: 'ok',
-                            text: 'Collection deleted.',
-                            type: 'success',
-                            timeout: 4000
-                        });
-                        router.navigate('collections', {trigger: true});
-                    }).destroy();
-                }, this)
-            });
-        }
+        'click .g-delete-collection': 'deleteConfirmation'
     },
 
     initialize: function (settings) {
@@ -162,6 +138,37 @@ var CollectionView = View.extend({
                 this.hierarchyWidget.refreshFolderList();
             }
         }, this);
+    },
+
+    deleteConfirmation: function () {
+        let params = {
+            text: 'Are you sure you want to delete the collection <b>' +
+                  this.model.escape('name') + this.model.escape('nFolders') + '</b>?',
+            yesText: 'Delete',
+            escapedHtml: true,
+            confirmCallback: _.bind(function () {
+                this.model.on('g:deleted', function () {
+                    events.trigger('g:alert', {
+                        icon: 'ok',
+                        text: 'Collection deleted.',
+                        type: 'success',
+                        timeout: 4000
+                    });
+                    router.navigate('collections', {trigger: true});
+                }).destroy();
+            }, this)
+        }
+        if (this.model.get('nFolders') !== 0 || this.model.get('size') !== 0) {
+            params = _.extend({
+                additionalText: '<b>' + this.model.escape('name') + '</b>' +
+                                ' contains <b>' + this.model.escape('nFolders') +
+                                ' folders</b> taking up <b>' +
+                                formatSize(this.model.escape('size')) + '</b>',
+                msgConfirmation: true,
+                name: this.model.escape('name')
+            }, params);
+        }
+        confirm(params);
     }
 }, {
     /**

--- a/clients/web/src/views/widgets/CollectionInfoWidget.js
+++ b/clients/web/src/views/widgets/CollectionInfoWidget.js
@@ -11,9 +11,10 @@ import 'girder/utilities/jquery/girderModal';
 var CollectionInfoWidget = View.extend({
     initialize: function () {
         this.needToFetch = !this.model.has('nFolders');
-        if (this.needToFetch) {
+        if (this.needToFetch || this.timestamp !== this.model.get('updated')) {
             this.model.once('g:fetched.details', function () {
                 this.needToFetch = false;
+                this.timestamp = this.model.get('updated');
                 this.render();
             }, this).fetch({extraPath: 'details'});
         }

--- a/clients/web/src/views/widgets/HierarchyWidget.js
+++ b/clients/web/src/views/widgets/HierarchyWidget.js
@@ -436,7 +436,7 @@ var HierarchyWidget = View.extend({
             }, this)
         };
         if (type === 'collection' &&
-           !(this.parentModel['nFolders'] === 0 && this.parentModel['size'] === 0)) {
+           (this.parentModel.get('nFolders') !== 0 || this.parentModel.get('size') !== 0)) {
             params = _.extend({
                 name: this.parentModel.escape('name'),
                 additionalText: '<b>' + this.parentModel.escape('name') + '</b>' +

--- a/clients/web/src/views/widgets/HierarchyWidget.js
+++ b/clients/web/src/views/widgets/HierarchyWidget.js
@@ -442,7 +442,7 @@ var HierarchyWidget = View.extend({
                 additionalText: '<b>' + this.parentModel.escape('name') + '</b>' +
                                 ' contains <b>' + this.parentModel.escape('nFolders') +
                                 ' folders</b> taking up <b>' +
-                                formatSize(this.parentModel.escape('size')) + '</b>',
+                                formatSize(parseInt(this.model.get('size'), 10)) + '</b>',
                 msgConfirmation: true
             }, params);
         }

--- a/clients/web/src/views/widgets/HierarchyWidget.js
+++ b/clients/web/src/views/widgets/HierarchyWidget.js
@@ -19,7 +19,7 @@ import View from 'girder/views/View';
 import { AccessType } from 'girder/constants';
 import { confirm, handleClose } from 'girder/dialog';
 import events from 'girder/events';
-import { getModelClassByName, renderMarkdown, formatCount, capitalize } from 'girder/misc';
+import { getModelClassByName, renderMarkdown, formatCount, capitalize, formatSize } from 'girder/misc';
 import { restRequest, getApiRoot } from 'girder/rest';
 
 import HierarchyBreadcrumbTemplate from 'girder/templates/widgets/hierarchyBreadcrumb.pug';
@@ -435,6 +435,17 @@ var HierarchyWidget = View.extend({
                 });
             }, this)
         };
+        if (type === 'collection' &&
+           !(this.parentModel['nFolders'] === 0 && this.parentModel['size'] === 0)) {
+            params = _.extend({
+                name: this.parentModel.escape('name'),
+                additionalText: '<b>' + this.parentModel.escape('name') + '</b>' +
+                                ' contains <b>' + this.parentModel.escape('nFolders') +
+                                ' folders</b> taking up <b>' +
+                                formatSize(this.parentModel.escape('size')) + '</b>',
+                msgConfirmation: true
+            }, params);
+        }
         confirm(params);
     },
 

--- a/clients/web/test/spec/collectionSpec.js
+++ b/clients/web/test/spec/collectionSpec.js
@@ -304,6 +304,8 @@ describe('Test collection actions', function () {
             return $('.g-collection-list-entry').text().match('collName0').length > 0;
         }, 'new collection to appear');
 
+        girderTest.waitForLoad();
+
         runs(function () {
             $('.g-collection-link:first').click();
         });
@@ -316,14 +318,14 @@ describe('Test collection actions', function () {
             return $('.g-loading-block').length === 0;
         }, 'for all blocks to load');
 
+        girderTest.waitForLoad();
+
 // ------------------ DEBUG --------------------
         runs(function () {
             $('.g-collection-info-button').click();
         });
 
-        waitsFor(function () {
-            return $('#g-dialog-container:visible').length > 0;
-        }, 'collection info dialog to appear');
+        girderTest.waitForDialog();
 
         runs(function () {
             for (var i = 0; i < 4; i++) {
@@ -340,9 +342,8 @@ describe('Test collection actions', function () {
             $('.btn-default').click();
         });
 
-        waitsFor(function () {
-            return $('#g-dialog-container:visible').length === 0;
-        }, 'collection info dialog to be closed');
+        girderTest.waitForLoad();
+
 // ---------------------------------------------------------------
 // Issue : nFolders = 1, but the confirmation dialog doesn't show up...
         runs(function () {
@@ -360,6 +361,8 @@ describe('Test collection actions', function () {
         waitsFor(function () {
             return $('#g-confirm-button:visible').length > 0;
         }, 'delete confirmation to appear');
+
+        girderTest.waitForDialog();
 
         waitsFor(function () {
             $('#g-confirm-text').val('DELETE wrongName');
@@ -399,6 +402,8 @@ describe('Test collection actions', function () {
         waitsFor(function () {
             return $('.g-collection-list-header').length > 0;
         }, 'go back to the collections list');
+
+        girderTest.waitForLoad();
 
         runs(function () {
             expect($('.g-collection-list-entry').text()).not.toContain('collName0');

--- a/clients/web/test/spec/collectionSpec.js
+++ b/clients/web/test/spec/collectionSpec.js
@@ -27,6 +27,34 @@ describe('Test collection actions', function () {
     it('create a collection',
         girderTest.createCollection('collName0', 'coll Desc 0', 'Private'));
 
+    it('make sure nFolder is fetch', function () {
+        runs(function () {
+            $('.g-collection-info-button').click();
+        });
+
+        waitsFor(function () {
+            return $('#g-dialog-container:visible').length > 0;
+        }, 'collection info dialog to appear');
+
+        runs(function () {
+            for (var i = 0; i < 4; i++) {
+                if ($('.g-collection-info-line').eq(i).attr('property') === 'id') {
+                    var id = $('.g-bold-part').eq(i).text()
+                    var n = $('.g-bold-part').eq(i - 1).text()
+                    console.log('ID ', id, ' - nFolder ', n);
+                }
+            }
+        });
+
+        runs(function () {
+            $('.btn-default').click();
+        });
+
+        waitsFor(function () {
+            return $('#g-dialog-container:visible').length === 0;
+        }, 'collection info dialog to be closed');
+    });
+
     it('go back to collections page', function () {
         runs(function () {
             $('a.g-nav-link[g-target="collections"]').click();
@@ -288,6 +316,35 @@ describe('Test collection actions', function () {
             return $('.g-loading-block').length === 0;
         }, 'for all blocks to load');
 
+// ------------------ DEBUG --------------------
+        runs(function () {
+            $('.g-collection-info-button').click();
+        });
+
+        waitsFor(function () {
+            return $('#g-dialog-container:visible').length > 0;
+        }, 'collection info dialog to appear');
+
+        runs(function () {
+            for (var i = 0; i < 4; i++) {
+                if ($('.g-collection-info-line').eq(i).attr('property') === 'id') {
+                    var id = $('.g-bold-part').eq(i).text()
+                    var n = $('.g-bold-part').eq(i - 1).text()
+                    var size = $('.g-bold-part').eq(i - 2).text()
+                    console.log('ID ', id, ' - nFolder ', n, ' - Size', size);
+                }
+            }
+        });
+
+        runs(function () {
+            $('.btn-default').click();
+        });
+
+        waitsFor(function () {
+            return $('#g-dialog-container:visible').length === 0;
+        }, 'collection info dialog to be closed');
+// ---------------------------------------------------------------
+// Issue : nFolders = 1, but the confirmation dialog doesn't show up...
         runs(function () {
             $('.g-collection-actions-button').click();
         });
@@ -303,6 +360,37 @@ describe('Test collection actions', function () {
         waitsFor(function () {
             return $('#g-confirm-button:visible').length > 0;
         }, 'delete confirmation to appear');
+
+        waitsFor(function () {
+            $('#g-confirm-text').val('DELETE wrongName');
+            return $('#g-confirm-text').val() === 'DELETE wrongName';
+        }, 'enter the wrong message of delete confirmation');
+
+        runs(function () {
+            $('#g-confirm-button').click();
+        });
+
+        waitsFor(function () {
+            return $('.g-msg-error').is(':visible');
+        }, 'error message to be displayed');
+
+        waitsFor(function () {
+            $('#g-confirm-text').val('');
+            return $('#g-confirm-text').val() === '';
+        }, 'forget to enter the message of delete confirmation');
+
+        runs(function () {
+            $('#g-confirm-button').click();
+        });
+
+        waitsFor(function () {
+            return $('.g-msg-error').is(':visible');
+        }, 'error message to be displayed');
+
+        waitsFor(function () {
+            $('#g-confirm-text').val('DELETE collName0');
+            return $('#g-confirm-text').val() === 'DELETE collName0';
+        }, 'enter the right message of delete confirmation');
 
         runs(function () {
             $('#g-confirm-button').click();

--- a/clients/web/test/spec/collectionSpec.js
+++ b/clients/web/test/spec/collectionSpec.js
@@ -39,8 +39,8 @@ describe('Test collection actions', function () {
         runs(function () {
             for (var i = 0; i < 4; i++) {
                 if ($('.g-collection-info-line').eq(i).attr('property') === 'id') {
-                    var id = $('.g-bold-part').eq(i).text()
-                    var n = $('.g-bold-part').eq(i - 1).text()
+                    var id = $('.g-bold-part').eq(i).text();
+                    var n = $('.g-bold-part').eq(i - 1).text();
                     console.log('ID ', id, ' - nFolder ', n);
                 }
             }
@@ -320,32 +320,6 @@ describe('Test collection actions', function () {
 
         girderTest.waitForLoad();
 
-// ------------------ DEBUG --------------------
-        runs(function () {
-            $('.g-collection-info-button').click();
-        });
-
-        girderTest.waitForDialog();
-
-        runs(function () {
-            for (var i = 0; i < 4; i++) {
-                if ($('.g-collection-info-line').eq(i).attr('property') === 'id') {
-                    var id = $('.g-bold-part').eq(i).text()
-                    var n = $('.g-bold-part').eq(i - 1).text()
-                    var size = $('.g-bold-part').eq(i - 2).text()
-                    console.log('ID ', id, ' - nFolder ', n, ' - Size', size);
-                }
-            }
-        });
-
-        runs(function () {
-            $('.btn-default').click();
-        });
-
-        girderTest.waitForLoad();
-
-// ---------------------------------------------------------------
-// Issue : nFolders = 1, but the confirmation dialog doesn't show up...
         runs(function () {
             $('.g-collection-actions-button').click();
         });


### PR DESCRIPTION
This PR will add a new security on the confirm dialog box. This will ask the user to enter 'DELETE name_of_collection' and press the "Delete" button.

The dialog box confirm is reusable for any other models by adding these 3 parameters : 
- `name`: name of the element to delete
- `additionalText`: some additional text with information (like size of data, number of items or folders)
- `msgConfirmation`: true for activate the confirmation, false is the value by default

Fixes: #2469