### PR TITLE
Fix the terms client test.

### DIFF
--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -636,7 +636,7 @@ girderTest.addScript = function (url) {
     girderTest.promise = girderTest.promise
         .then(_.partial($.getScript, url))
         .catch(function () {
-            throw 'Failed to load script: ' + url;
+            throw new Error('Failed to load script: ' + url);
         });
 };
 

--- a/plugins/terms/plugin_tests/termsSpec.js
+++ b/plugins/terms/plugin_tests/termsSpec.js
@@ -1,3 +1,5 @@
+/* global girderTest, describe, it, expect, runs, waitsFor, girder, beforeEach */
+
 girderTest.importPlugin('terms');
 girderTest.startApp();
 
@@ -65,12 +67,20 @@ describe('Navigate to a non-collection folder and item', function () {
         waitsFor(function () {
             return $('.g-item-count-container:visible').length === 1;
         });
+        girderTest.waitForLoad();
         runs(function () {
             expect($('.g-hierarchy-breadcrumb-bar>.breadcrumb>.active').text()).toBe('Public');
             var folderId = window.location.hash.split('/')[3];
             expect(folderId).toMatch(/[0-9a-f]{24}/);
             window.location.assign('#folder/' + folderId);
         });
+        // after setting a window location, waitForLoad is insufficient, as the
+        // page hasn't yet started making requests and it looks similar to
+        // before the location change.  Wait for the user header to be hidden,
+        // and then wait for load.
+        waitsFor(function () {
+            return $('.g-user-header').length === 0;
+        }, 'the user header to go away');
         girderTest.waitForLoad();
         waitsFor(function () {
             return $('.g-item-count-container:visible').length === 1;
@@ -79,10 +89,10 @@ describe('Navigate to a non-collection folder and item', function () {
 
     it('create an item', function () {
         runs(function () {
-            return $('.g-create-item').click();
+            $('.g-create-item').click();
         });
-        // This causes the test to fail
-        // girderTest.waitForDialog();
+        girderTest.waitForDialog();
+
         waitsFor(function () {
             return $('.modal-body input#g-name').length > 0;
         });


### PR DESCRIPTION
When we use `window.location.assign`, make sure to wait for something that we expect to change.  Just doing `girderTest.waitForLoad()` is insufficient, since window.assign doesn't cause the change to start until the next time slice, and `waitForLoad` will return immediately that things are loaded (probably a `waits(1)` would have worked instead of the `waitsFor` that was added, but that seems more brittle).

Once we've properly waited for the `window.location.assign`, fix waiting for creating an item.  A comment was added that waiting caused a test to fail, which was a good indication that we *weren't* waiting for the correct thing.

Also, fix throwing an error in the test utilities to use the error constructor.