### PR TITLE
WIP: Support dynamic content sizes for multi-part upload

### DIFF
--- a/girder/test/test_multipart_upload.py
+++ b/girder/test/test_multipart_upload.py
@@ -1,0 +1,47 @@
+import pytest
+import six
+
+from girder.models.upload import Upload
+
+
+@pytest.fixture
+def folder(user):
+    from girder.models.folder import Folder
+    folder = Folder().createFolder(user, 'some-folder')
+
+    yield folder
+
+    Folder().remove(folder)
+
+
+@pytest.fixture
+def item(folder, user):
+    from girder.models.item import Item
+    item = Item().createItem('some-item', user, folder)
+
+    yield item
+
+    Item().remove(item)
+
+
+@pytest.fixture
+def filesystemAssetstore(db, tmpdir):
+    from girder.models.assetstore import Assetstore
+    assetstore = Assetstore().createFilesystemAssetstore(name='test-assetstore',
+                                                         root=tmpdir.strpath)
+
+    yield assetstore
+
+    Assetstore().remove(assetstore)
+
+
+def testMultipartUploadOfUnknownSize(db, filesystemAssetstore, item, user):
+    fileBytes = six.BytesIO(b'abcdefgh')
+    upload = Upload().createUpload(user=user, name=item['name'], parentType='item',
+                                   parent=item, assetstore=filesystemAssetstore)
+
+    for chunk in fileBytes:
+        Upload().handleChunk(upload, chunk)
+
+    createdFile = Upload().finalizeUpload(upload, filesystemAssetstore)
+    assert createdFile['size'] == 8

--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -362,7 +362,7 @@ class AbstractAssetstoreAdapter(ModelImporter):
         :param chunkSize: the chunk size that needs to be validated.
         :type chunkSize: a non-negative integer or None if unknown.
         """
-        if 'received' not in upload or 'size' not in upload:
+        if 'received' not in upload or 'size' not in upload or upload['size'] is None:
             return
         if chunkSize is None:
             return

--- a/girder/utility/filesystem_assetstore_adapter.py
+++ b/girder/utility/filesystem_assetstore_adapter.py
@@ -181,7 +181,7 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
 
         with open(upload['tempFile'], 'a+b') as tempFile:
             size = 0
-            while not upload['received'] + size > upload['size']:
+            while True:
                 data = chunk.read(BUF_SIZE)
                 if not data:
                     break


### PR DESCRIPTION
Warning: this was written off the cuff only with the FS assetstore.

> This should allow the uploader to stream data into Girder without
knowing the final size ahead of time, useful for dynamic outputs from
analyses or other data sources which may be larger than normal.

One of the advantages of multipart upload is the ability to stream data to the server as it's being created (without knowing the exact total byte count). This PR alters the upload model to allow the size to be `None` - in which case the bytes are done being sent when `finalizeUpload` is called and the resulting `size` is `upload['received']`. Applications that were passing `size` should continue to function as they did before.

AFAICT, this doesn't seem to cause any conceptual problems with our existing assetstores since both S3 and GridFS allow for this behavior.

This needs:
- To be tweaked to work with other assetstores
- More tests
- More sanity checking