### PR TITLE
Harden routing tests.

### DIFF
--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -636,7 +636,7 @@ girderTest.addScript = function (url) {
     girderTest.promise = girderTest.promise
         .then(_.partial($.getScript, url))
         .catch(function () {
-            throw 'Failed to load script: ' + url;
+            throw new Error('Failed to load script: ' + url);
         });
 };
 
@@ -809,13 +809,13 @@ girderTest.testRoute = function (route, hasDialog, testFunc) {
         girder.router.navigate(route, {trigger: true});
     });
 
+    if (testFunc) {
+        waitsFor(testFunc, 'testRoute: test function failed, route=' + route);
+    }
     if (hasDialog) {
         girderTest.waitForDialog('testRoute: waitForDialog failed, route=' + route);
     } else {
         girderTest.waitForLoad('testRoute: waitForLoad failed, route=' + route);
-    }
-    if (testFunc) {
-        waitsFor(testFunc, 'testRoute: test function failed, route=' + route);
     }
 };
 


### PR DESCRIPTION
Switch the order of some of the routing test tests.  Before, we waited for rest requests to be done then for the routing test-specific test.  This now waits for the routing-specific test first.  If there is a delay between routing and any of the loading actions, no rest requests might be active, the routing condition is then detected, and then the loading actions start.  Future tests may fail because they expect the loading actions to be complete and initiate another action while.

In testing this repeatedly, I saw 4 failures in 250 tests before this change and 0 after.  I don't know if this will resolve all failure cases, but it does harden the test and should have no ill effects.