### PR TITLE
Improve the wait condition for the swagger test.

### DIFF
--- a/clients/web/test/spec/swaggerSpec.js
+++ b/clients/web/test/spec/swaggerSpec.js
@@ -6,10 +6,12 @@ describe('Test the swagger pages', function () {
         runs(function () {
             expect($('li#resource_system.resource .heading h2 a').text()).toBe('system');
         });
-        // There seems to be some delay between the link showing and when swaggerUi actually
-        // binds the event handler. We don't have a good hook into that binding, so we hack
-        // it with a 0.1s delay instead.
-        waits(100);
+        // There seems to be some delay between the link showing and when
+        // swaggerUi actually binds the event handler.  Wait until jquery
+        // reports that the event is bound
+        waitsFor(function () {
+            return $._data($('li#resource_system.resource .heading h2 a')[0], 'events') !== undefined;
+        }, 'events to be bound');
         runs(function () {
             $('li#resource_system.resource .heading h2 a').click();
         });


### PR DESCRIPTION
Instead of waiting an arbitrary time, wait until the condition we need is satisfied.

There have been some intermittent failures of the swagger test on CI.  This may fix them if they are time dependent.