### PR TITLE
Fix complex plugin dependencies parsing.

### DIFF
--- a/girder/models/setting.py
+++ b/girder/models/setting.py
@@ -203,7 +203,7 @@ class Setting(Model):
             raise ValidationException('Plugins enabled setting must be a list.', 'value')
 
         # Add all transitive dependencies and store in toposorted order
-        doc['value'] = list(plugin_utilities.getToposortedPlugins(doc['value'], logNew=True))
+        doc['value'] = list(plugin_utilities.getToposortedPlugins(doc['value']))
 
     @staticmethod
     @setting_utilities.validator(SettingKey.ADD_TO_GROUP_POLICY)

--- a/girder/models/setting.py
+++ b/girder/models/setting.py
@@ -203,7 +203,7 @@ class Setting(Model):
             raise ValidationException('Plugins enabled setting must be a list.', 'value')
 
         # Add all transitive dependencies and store in toposorted order
-        doc['value'] = list(plugin_utilities.getToposortedPlugins(doc['value']))
+        doc['value'] = list(plugin_utilities.getToposortedPlugins(doc['value'], logNew=True))
 
     @staticmethod
     @setting_utilities.validator(SettingKey.ADD_TO_GROUP_POLICY)

--- a/girder/utility/plugin_utilities.py
+++ b/girder/utility/plugin_utilities.py
@@ -122,7 +122,7 @@ def loadPlugins(plugins, root, appconf, apiRoot=None, buildDag=True):
     return root, appconf, apiRoot
 
 
-def getToposortedPlugins(plugins=None, ignoreMissing=False, keys=('dependencies',), logNew=False):
+def getToposortedPlugins(plugins=None, ignoreMissing=False, keys=('dependencies',)):
     """
     Given a set of plugins to load, construct the full DAG of required plugins
     to load and yields them in toposorted order.
@@ -136,8 +136,6 @@ def getToposortedPlugins(plugins=None, ignoreMissing=False, keys=('dependencies'
     :type ignoreMissing: bool
     :param keys: Keys that should be used to determine dependencies.
     :type keys: list of str
-    :param logNew: if True, log plugins added because of dependencies.
-    :type logNew: boolean
     """
     allPlugins = findAllPlugins()
     dag = {}
@@ -166,7 +164,7 @@ def getToposortedPlugins(plugins=None, ignoreMissing=False, keys=('dependencies'
             if dep in visited:
                 continue
             visited.add(dep)
-            if dep not in plugins and logNew:
+            if dep not in plugins:
                 logger.info('Adding plugin %s because %s requires it' % (dep, plugin))
             addDeps(dep)
 

--- a/tests/cases/system_test.py
+++ b/tests/cases/system_test.py
@@ -280,6 +280,16 @@ class SystemTestCase(base.TestCase):
         self.assertEqual(resp.json['message'],
                          ("Required plugin a_plugin_that_does_not_exist"
                           " does not exist."))
+        resp = self.request(
+            path='/system/plugins', method='PUT', user=self.users[0],
+            params={'plugins': '["has_deps", "has_sub_deps"]'})
+        self.assertStatusOk(resp)
+        enabled = resp.json['value']
+        self.assertEqual(len(enabled), 6)
+        self.assertTrue('test_plugin' in enabled)
+        self.assertTrue('does_nothing' in enabled)
+        self.assertTrue('has_other_deps' in enabled)
+        self.assertTrue('plugin_yaml' in enabled)
         self.unmockPluginDir()
 
     def testBadPlugin(self):

--- a/tests/test_plugins/has_other_deps/plugin.json
+++ b/tests/test_plugins/has_other_deps/plugin.json
@@ -1,0 +1,3 @@
+{
+    "dependencies": ["plugin_yaml"]
+}

--- a/tests/test_plugins/has_sub_deps/plugin.json
+++ b/tests/test_plugins/has_sub_deps/plugin.json
@@ -1,0 +1,4 @@
+{
+    "dependencies": ["test_plugin", "has_other_deps"]
+}
+


### PR DESCRIPTION
If plugins A and B are enabled, and plugin A depends on plugin C, and B depends on C and D, and D depends on E, the dependencies of plugin D are never analyzed if plugin A is examined before B (and, hence, plugin E won't be added).

Also, when the plugins are toggled via settings, log why other plugins are enabled.