### PR TITLE
Gracefully fallback when an assetstore type no longer exists.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,7 @@ Security Fixes
 
 Changes
 -------
+* Exceptions are now all accessible in the ``exceptions`` module and are descended from the ``GirderBaseException`` class.
 
 Deprecations
 ------------

--- a/girder/api/access.py
+++ b/girder/api/access.py
@@ -20,7 +20,7 @@
 import six
 
 from girder.api import rest
-from girder.models.model_base import AccessException
+from girder.exceptions import AccessException
 from girder.models.token import Token
 from girder.utility import optionalArgumentDecorator
 

--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -30,8 +30,9 @@ import six
 import cherrypy
 
 from girder import constants, events, logprint
-from girder.api.rest import getCurrentUser, RestException, getBodyJson
+from girder.api.rest import getCurrentUser, getBodyJson
 from girder.constants import CoreEventHandler, SettingKey
+from girder.exceptions import RestException
 from girder.models.setting import Setting
 from girder.utility import config, toBool
 from girder.utility.model_importer import ModelImporter

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -32,7 +32,7 @@ import unicodedata
 from . import docs
 from girder import events, logger, logprint
 from girder.constants import SettingKey, TokenScope, SortDir
-from girder.models.model_base import AccessException, GirderException, ValidationException
+from girder.exceptions import AccessException, GirderException, ValidationException
 from girder.models.setting import Setting
 from girder.models.token import Token
 from girder.models.user import User

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -32,7 +32,8 @@ import unicodedata
 from . import docs
 from girder import events, logger, logprint
 from girder.constants import SettingKey, TokenScope, SortDir
-from girder.exceptions import AccessException, GirderException, ValidationException
+from girder.exceptions import AccessException, GirderException, ValidationException, \
+    RestException
 from girder.models.setting import Setting
 from girder.models.token import Token
 from girder.models.user import User
@@ -709,21 +710,6 @@ def _setCommonCORSHeaders():
             setResponseHeader(key, allowed_list[0])
         elif origin in allowed_list:
             setResponseHeader(key, origin)
-
-
-class RestException(Exception):
-    """
-    Throw a RestException in the case of any sort of incorrect
-    request (i.e. user/client error). Login and permission failures
-    should set a 403 code; almost all other validation errors
-    should use status 400, which is the default.
-    """
-    def __init__(self, message, code=400, extra=None):
-        self.code = code
-        self.extra = extra
-        self.message = message
-
-        Exception.__init__(self, message)
 
 
 class Resource(ModelImporter):

--- a/girder/api/sftp.py
+++ b/girder/api/sftp.py
@@ -27,7 +27,7 @@ import sys
 import time
 
 from girder import logger, logprint
-from girder.models.model_base import AccessException, ValidationException
+from girder.exceptions import AccessException, ValidationException
 from girder.models.file import File
 from girder.models.folder import Folder
 from girder.models.item import Item

--- a/girder/api/sftp.py
+++ b/girder/api/sftp.py
@@ -27,12 +27,12 @@ import sys
 import time
 
 from girder import logger, logprint
-from girder.exceptions import AccessException, ValidationException
+from girder.exceptions import AccessException, ValidationException, ResourcePathNotFound
 from girder.models.file import File
 from girder.models.folder import Folder
 from girder.models.item import Item
 from girder.models.user import User
-from girder.utility.path import lookUpPath, NotFoundException
+from girder.utility.path import lookUpPath
 from girder.utility.model_importer import ModelImporter
 from six.moves import socketserver
 
@@ -45,7 +45,7 @@ def _handleErrors(fun):
     def wrapped(*args, **kwargs):
         try:
             return fun(*args, **kwargs)
-        except NotFoundException:
+        except ResourcePathNotFound:
             return paramiko.SFTP_NO_SUCH_FILE
         except ValidationException:
             return paramiko.SFTP_FAILURE

--- a/girder/api/v1/assetstore.py
+++ b/girder/api/v1/assetstore.py
@@ -18,9 +18,10 @@
 ###############################################################################
 
 from ..describe import Description, autoDescribeRoute
-from ..rest import Resource, RestException
+from ..rest import Resource
 from girder import events
 from girder.constants import AccessType, AssetstoreType, TokenScope
+from girder.exceptions import RestException
 from girder.api import access
 from girder.models.assetstore import Assetstore as AssetstoreModel
 from girder.models.file import File

--- a/girder/api/v1/collection.py
+++ b/girder/api/v1/collection.py
@@ -22,7 +22,7 @@ from ..rest import Resource, filtermodel, setResponseHeader, setContentDispositi
 from girder.api import access
 from girder.constants import AccessType, TokenScope
 from girder.models.collection import Collection as CollectionModel
-from girder.models.model_base import AccessException
+from girder.exceptions import AccessException
 from girder.utility import ziputil
 from girder.utility.progress import ProgressContext
 

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -25,7 +25,7 @@ import six
 from ..describe import Description, autoDescribeRoute, describeRoute
 from ..rest import Resource, RestException, filtermodel
 from ...constants import AccessType, TokenScope
-from girder.models.model_base import AccessException, GirderException
+from girder.exceptions import AccessException, GirderException
 from girder.models.assetstore import Assetstore
 from girder.models.file import File as FileModel
 from girder.models.item import Item

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -23,9 +23,9 @@ import os
 import six
 
 from ..describe import Description, autoDescribeRoute, describeRoute
-from ..rest import Resource, RestException, filtermodel
+from ..rest import Resource, filtermodel
 from ...constants import AccessType, TokenScope
-from girder.exceptions import AccessException, GirderException
+from girder.exceptions import AccessException, GirderException, RestException
 from girder.models.assetstore import Assetstore
 from girder.models.file import File as FileModel
 from girder.models.item import Item

--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -18,9 +18,10 @@
 ###############################################################################
 
 from ..describe import Description, autoDescribeRoute
-from ..rest import Resource, RestException, filtermodel, setResponseHeader, setContentDisposition
+from ..rest import Resource, filtermodel, setResponseHeader, setContentDisposition
 from girder.api import access
 from girder.constants import AccessType, TokenScope
+from girder.exceptions import RestException
 from girder.models.folder import Folder as FolderModel
 from girder.utility import ziputil
 from girder.utility.progress import ProgressContext

--- a/girder/api/v1/group.py
+++ b/girder/api/v1/group.py
@@ -21,7 +21,7 @@ from ..describe import Description, autoDescribeRoute
 from ..rest import Resource, filtermodel
 from girder.api import access
 from girder.constants import AccessType, SettingKey
-from girder.models.model_base import AccessException
+from girder.exceptions import AccessException
 from girder.models.group import Group as GroupModel
 from girder.models.setting import Setting
 from girder.models.user import User

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -18,9 +18,10 @@
 ###############################################################################
 
 from ..describe import Description, autoDescribeRoute
-from ..rest import Resource, RestException, filtermodel, setResponseHeader, setContentDisposition
+from ..rest import Resource, filtermodel, setResponseHeader, setContentDisposition
 from girder.utility import ziputil
 from girder.constants import AccessType, TokenScope
+from girder.exceptions import RestException
 from girder.api import access
 from girder.models.file import File
 from girder.models.folder import Folder

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -20,8 +20,9 @@
 import six
 
 from ..describe import Description, autoDescribeRoute
-from ..rest import Resource as BaseResource, RestException, setResponseHeader, setContentDisposition
+from ..rest import Resource as BaseResource, setResponseHeader, setContentDisposition
 from girder.constants import AccessType, TokenScope
+from girder.exceptions import RestException
 from girder.api import access
 from girder.utility import parseTimestamp
 from girder.utility.search import getSearchModeHandler

--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -29,7 +29,7 @@ import logging
 from girder.api import access
 from girder.constants import GIRDER_ROUTE_ID, GIRDER_STATIC_ROUTE_ID, \
     SettingKey, TokenScope, ACCESS_FLAGS, VERSION
-from girder.exceptions import GirderException, ResourcePathNotFound
+from girder.exceptions import GirderException, ResourcePathNotFound, RestException
 from girder.models.group import Group
 from girder.models.setting import Setting
 from girder.models.upload import Upload
@@ -37,7 +37,7 @@ from girder.models.user import User
 from girder.utility import config, install, plugin_utilities, system
 from girder.utility.progress import ProgressContext
 from ..describe import API_VERSION, Description, autoDescribeRoute
-from ..rest import Resource, RestException
+from ..rest import Resource
 
 ModuleStartTime = datetime.datetime.utcnow()
 LOG_BUF_SIZE = 65536

--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -29,7 +29,7 @@ import logging
 from girder.api import access
 from girder.constants import GIRDER_ROUTE_ID, GIRDER_STATIC_ROUTE_ID, \
     SettingKey, TokenScope, ACCESS_FLAGS, VERSION
-from girder.models.model_base import GirderException
+from girder.exceptions import GirderException
 from girder.models.group import Group
 from girder.models.setting import Setting
 from girder.models.upload import Upload

--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -29,13 +29,12 @@ import logging
 from girder.api import access
 from girder.constants import GIRDER_ROUTE_ID, GIRDER_STATIC_ROUTE_ID, \
     SettingKey, TokenScope, ACCESS_FLAGS, VERSION
-from girder.exceptions import GirderException
+from girder.exceptions import GirderException, ResourcePathNotFound
 from girder.models.group import Group
 from girder.models.setting import Setting
 from girder.models.upload import Upload
 from girder.models.user import User
 from girder.utility import config, install, plugin_utilities, system
-from girder.utility.path import NotFoundException
 from girder.utility.progress import ProgressContext
 from ..describe import API_VERSION, Description, autoDescribeRoute
 from ..rest import Resource, RestException
@@ -115,9 +114,9 @@ class System(Resource):
         configSection = config.getConfig().get(section)
 
         if configSection is None:
-            raise NotFoundException('No section with that name exists.')
+            raise ResourcePathNotFound('No section with that name exists.')
         elif key not in configSection:
-            raise NotFoundException('No key with that name exists.')
+            raise ResourcePathNotFound('No key with that name exists.')
         else:
             return configSection.get(key)
 

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -23,9 +23,9 @@ import datetime
 
 from ..describe import Description, autoDescribeRoute
 from girder.api import access
-from girder.api.rest import Resource, AccessException, filtermodel, setCurrentUser
+from girder.api.rest import Resource, filtermodel, setCurrentUser
 from girder.constants import AccessType, SettingKey, TokenScope
-from girder.exceptions import RestException
+from girder.exceptions import RestException, AccessException
 from girder.models.password import Password
 from girder.models.setting import Setting
 from girder.models.token import genToken, Token

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -23,8 +23,9 @@ import datetime
 
 from ..describe import Description, autoDescribeRoute
 from girder.api import access
-from girder.api.rest import Resource, RestException, AccessException, filtermodel, setCurrentUser
+from girder.api.rest import Resource, AccessException, filtermodel, setCurrentUser
 from girder.constants import AccessType, SettingKey, TokenScope
+from girder.exceptions import RestException
 from girder.models.password import Password
 from girder.models.setting import Setting
 from girder.models.token import genToken, Token

--- a/girder/exceptions.py
+++ b/girder/exceptions.py
@@ -1,0 +1,49 @@
+class AccessException(Exception):
+    """
+    Represents denial of access to a resource.
+    """
+    def __init__(self, message, extra=None):
+        self.message = message
+        self.extra = extra
+
+        Exception.__init__(self, message)
+
+
+class GirderException(Exception):
+    """
+    Represents a general exception that might occur in regular use.  From the
+    user perspective, these are failures, but not catastrophic ones.  An
+    identifier can be passed, which allows receivers to check the exception
+    without relying on the text of the message.  It is recommended that
+    identifiers are a dot-separated string consisting of the originating
+    python module and a distinct error.  For example,
+    'girder.model.assetstore.no-current-assetstore'.
+    """
+    def __init__(self, message, identifier=None):
+        self.identifier = identifier
+        self.message = message
+
+        Exception.__init__(self, message)
+
+
+class NoAssetstoreAdapter(GirderException):
+    """
+    Raised when no assetstore adapter is available.
+    """
+    identifier = 'girder.utility.assetstore.no-adapter'
+
+    def __init__(self, message='No assetstore adapter'):
+        return super(NoAssetstoreAdapter, self).__init__(message, self.identifier)
+
+
+class ValidationException(Exception):
+    """
+    Represents validation failure in the model layer. Raise this with
+    a message and an optional field property. If one of these is thrown
+    in the model during a REST request, it will respond as a 400 status.
+    """
+    def __init__(self, message, field=None):
+        self.field = field
+        self.message = message
+
+        Exception.__init__(self, message)

--- a/girder/exceptions.py
+++ b/girder/exceptions.py
@@ -1,4 +1,11 @@
-class AccessException(Exception):
+class GirderBaseException(Exception):
+    """
+    A class from which all Girder exceptions are based.
+    """
+    pass
+
+
+class AccessException(GirderBaseException):
     """
     Represents denial of access to a resource.
     """
@@ -6,10 +13,10 @@ class AccessException(Exception):
         self.message = message
         self.extra = extra
 
-        Exception.__init__(self, message)
+        super(AccessException, self).__init__(message)
 
 
-class GirderException(Exception):
+class GirderException(GirderBaseException):
     """
     Represents a general exception that might occur in regular use.  From the
     user perspective, these are failures, but not catastrophic ones.  An
@@ -23,7 +30,7 @@ class GirderException(Exception):
         self.identifier = identifier
         self.message = message
 
-        Exception.__init__(self, message)
+        super(GirderException, self).__init__(message)
 
 
 class NoAssetstoreAdapter(GirderException):
@@ -33,10 +40,10 @@ class NoAssetstoreAdapter(GirderException):
     identifier = 'girder.utility.assetstore.no-adapter'
 
     def __init__(self, message='No assetstore adapter'):
-        return super(NoAssetstoreAdapter, self).__init__(message, self.identifier)
+        super(NoAssetstoreAdapter, self).__init__(message, self.identifier)
 
 
-class ValidationException(Exception):
+class ValidationException(GirderBaseException):
     """
     Represents validation failure in the model layer. Raise this with
     a message and an optional field property. If one of these is thrown
@@ -46,4 +53,27 @@ class ValidationException(Exception):
         self.field = field
         self.message = message
 
-        Exception.__init__(self, message)
+        super(ValidationException, self).__init__(message)
+
+
+class ResourcePathNotFound(ValidationException):
+    """
+    A special case of ValidationException representing the case when the resource at a
+    given path does not exist.
+    """
+    pass
+
+
+class RestException(GirderBaseException):
+    """
+    Throw a RestException in the case of any sort of incorrect
+    request (i.e. user/client error). Login and permission failures
+    should set a 403 code; almost all other validation errors
+    should use status 400, which is the default.
+    """
+    def __init__(self, message, code=400, extra=None):
+        self.code = code
+        self.extra = extra
+        self.message = message
+
+        super(RestException, self).__init__(message)

--- a/girder/models/api_key.py
+++ b/girder/models/api_key.py
@@ -19,8 +19,9 @@
 
 import datetime
 
-from .model_base import AccessControlledModel, ValidationException
+from .model_base import AccessControlledModel
 from girder.constants import AccessType, SettingKey, TokenScope
+from girder.exceptions import ValidationException
 from girder.utility import genToken
 
 

--- a/girder/models/assetstore.py
+++ b/girder/models/assetstore.py
@@ -19,8 +19,9 @@
 
 import datetime
 
-from .model_base import Model, ValidationException, GirderException
+from .model_base import Model
 from girder.constants import AssetstoreType, SortDir
+from girder.exceptions import ValidationException, GirderException, NoAssetstoreAdapter
 from girder.utility import assetstore_utilities
 from girder.utility.abstract_assetstore_adapter import AbstractAssetstoreAdapter
 
@@ -120,7 +121,7 @@ class Assetstore(Model):
 
         try:
             adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
-        except assetstore_utilities.GirderNoAssetstoreAdapterException:
+        except NoAssetstoreAdapter:
             # If the adapter doesn't exist, use the abstract adapter, since
             # this will just give the default capacity information
             adapter = AbstractAssetstoreAdapter(assetstore)

--- a/girder/models/assetstore.py
+++ b/girder/models/assetstore.py
@@ -120,7 +120,16 @@ class Assetstore(Model):
         from .file import File
         from girder.utility import assetstore_utilities
 
-        adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
+        try:
+            adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
+        except GirderException as e:
+            if e.identifier != assetstore_utilities.EXCEPTION_ID_NO_ADAPTER:
+                raise
+            # If the adapter doesn't exist, use the abstract adapter, since
+            # this will just give the default capacity information
+            from girder.utility.abstract_assetstore_adapter import AbstractAssetstoreAdapter
+
+            adapter = AbstractAssetstoreAdapter(assetstore)
         assetstore['capacity'] = adapter.capacityInfo()
         assetstore['hasFiles'] = File().findOne({'assetstoreId': assetstore['_id']}) is not None
 

--- a/girder/models/collection.py
+++ b/girder/models/collection.py
@@ -20,8 +20,9 @@
 import datetime
 import os
 
-from .model_base import AccessControlledModel, ValidationException
+from .model_base import AccessControlledModel
 from girder.constants import AccessType, SettingKey
+from girder.exceptions import ValidationException
 from girder.utility.progress import noProgress
 
 

--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -21,10 +21,10 @@ import cherrypy
 import datetime
 import six
 
-from .model_base import Model, ValidationException
+from .model_base import Model, AccessControlledModel
 from girder import events
 from girder.constants import AccessType, CoreEventHandler
-from girder.models.model_base import AccessControlledModel
+from girder.exceptions import ValidationException
 from girder.utility import acl_mixin
 
 

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -24,10 +24,10 @@ import os
 import six
 
 from bson.objectid import ObjectId
-from .model_base import AccessControlledModel, ValidationException, \
-    GirderException
+from .model_base import AccessControlledModel
 from girder import events
 from girder.constants import AccessType
+from girder.exceptions import ValidationException, GirderException
 from girder.utility.progress import noProgress, setResponseTimeLimit
 
 

--- a/girder/models/group.py
+++ b/girder/models/group.py
@@ -19,9 +19,10 @@
 
 import datetime
 
-from .model_base import AccessControlledModel, ValidationException
+from .model_base import AccessControlledModel
 from girder import events
 from girder.constants import AccessType, CoreEventHandler
+from girder.exceptions import ValidationException
 
 
 class Group(AccessControlledModel):

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -24,10 +24,11 @@ import os
 import six
 
 from bson.objectid import ObjectId
-from .model_base import Model, ValidationException, GirderException
+from .model_base import Model
 from girder import events
 from girder import logger
 from girder.constants import AccessType
+from girder.exceptions import ValidationException, GirderException
 from girder.utility import acl_mixin
 
 

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -32,6 +32,9 @@ from girder.constants import AccessType, CoreEventHandler, ACCESS_FLAGS, TEXT_SC
 from girder.external.mongodb_proxy import MongoProxy
 from girder.models import getDbConnection
 from girder.utility.model_importer import ModelImporter
+from girder.exceptions import AccessException, ValidationException
+# Import the GirderException since it was historically defined here
+from girder.exceptions import GirderException  # noqa
 
 # pymongo3 complains about extra kwargs to find(), so we must filter them.
 _allowedFindArgs = ('cursor_type', 'allow_partial_results', 'oplog_replay',
@@ -1505,44 +1508,3 @@ class AccessControlledModel(Model):
             prefixSearchFields=prefixSearchFields)
         return self.filterResultsByPermission(
             cursor, user=user, level=level, limit=limit, offset=offset)
-
-
-class AccessException(Exception):
-    """
-    Represents denial of access to a resource.
-    """
-    def __init__(self, message, extra=None):
-        self.message = message
-        self.extra = extra
-
-        Exception.__init__(self, message)
-
-
-class GirderException(Exception):
-    """
-    Represents a general exception that might occur in regular use.  From the
-    user perspective, these are failures, but not catastrophic ones.  An
-    identifier can be passed, which allows receivers to check the exception
-    without relying on the text of the message.  It is recommended that
-    identifiers are a dot-separated string consisting of the originating
-    python module and a distinct error.  For example,
-    'girder.model.assetstore.no-current-assetstore'.
-    """
-    def __init__(self, message, identifier=None):
-        self.identifier = identifier
-        self.message = message
-
-        Exception.__init__(self, message)
-
-
-class ValidationException(Exception):
-    """
-    Represents validation failure in the model layer. Raise this with
-    a message and an optional field property. If one of these is thrown
-    in the model during a REST request, it will respond as a 400 status.
-    """
-    def __init__(self, message, field=None):
-        self.field = field
-        self.message = message
-
-        Exception.__init__(self, message)

--- a/girder/models/password.py
+++ b/girder/models/password.py
@@ -23,8 +23,9 @@ import re
 import six
 
 from girder import events
+from girder.exceptions import ValidationException
 from girder.utility import config
-from .model_base import Model, ValidationException
+from .model_base import Model
 from .token import genToken
 
 

--- a/girder/models/setting.py
+++ b/girder/models/setting.py
@@ -24,8 +24,9 @@ import six
 import re
 
 from ..constants import GIRDER_ROUTE_ID, GIRDER_STATIC_ROUTE_ID, SettingDefault, SettingKey
-from .model_base import Model, ValidationException
+from .model_base import Model
 from girder import logprint
+from girder.exceptions import ValidationException
 from girder.utility import config, setting_utilities
 from bson.objectid import ObjectId
 

--- a/girder/models/token.py
+++ b/girder/models/token.py
@@ -21,7 +21,7 @@ import datetime
 import six
 
 from girder.constants import AccessType, SettingKey, TokenScope
-from girder.models.model_base import AccessException
+from girder.exceptions import AccessException
 from girder.utility import genToken
 from .model_base import AccessControlledModel
 

--- a/girder/models/upload.py
+++ b/girder/models/upload.py
@@ -24,7 +24,8 @@ from bson.objectid import ObjectId
 from girder import events
 from girder.api import rest
 from girder.constants import SettingKey
-from .model_base import Model, GirderException, ValidationException
+from .model_base import Model
+from girder.exceptions import GirderException, ValidationException
 from girder.utility import RequestBodyStream
 from girder.utility.progress import noProgress
 

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -21,9 +21,10 @@ import datetime
 import os
 import re
 
-from .model_base import AccessControlledModel, AccessException, ValidationException
+from .model_base import AccessControlledModel
 from girder import events
 from girder.constants import AccessType, CoreEventHandler, SettingKey, TokenScope
+from girder.exceptions import AccessException, ValidationException
 from girder.utility import config, mail_utils
 
 

--- a/girder/test/test_api_key.py
+++ b/girder/test/test_api_key.py
@@ -22,7 +22,7 @@ import json
 import pytest
 
 from girder.constants import SettingKey, TokenScope
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.models.api_key import ApiKey
 from girder.models.setting import Setting
 from girder.models.token import Token

--- a/girder/test/test_token.py
+++ b/girder/test/test_token.py
@@ -2,7 +2,7 @@ import pytest
 import random
 
 from girder.constants import TokenScope
-from girder.models.model_base import AccessException
+from girder.exceptions import AccessException
 from girder.models.token import genToken, Token
 from pytest_girder.assertions import assertStatus, assertStatusOk
 

--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -21,7 +21,7 @@ import six
 
 from girder.api.rest import setResponseHeader, setContentDisposition
 from girder.constants import SettingKey
-from girder.models.model_base import GirderException, ValidationException
+from girder.exceptions import GirderException, ValidationException
 from girder.models.setting import Setting
 from girder.utility import progress, RequestBodyStream
 from .model_importer import ModelImporter

--- a/girder/utility/acl_mixin.py
+++ b/girder/utility/acl_mixin.py
@@ -20,7 +20,8 @@
 import itertools
 import six
 
-from ..models.model_base import Model, AccessException
+from ..models.model_base import Model
+from ..exceptions import AccessException
 from ..constants import AccessType
 
 

--- a/girder/utility/assetstore_utilities.py
+++ b/girder/utility/assetstore_utilities.py
@@ -30,7 +30,15 @@ _assetstoreTable = {
     AssetstoreType.S3: S3AssetstoreAdapter
 }
 
-EXCEPTION_ID_NO_ADAPTER = 'girder.utility.assetstore.no-adapter'
+
+class GirderNoAssetstoreAdapterException(GirderException):
+    """
+    Raised when no assetstore adapter is available.
+    """
+    identifier = 'girder.utility.assetstore.no-adapter'
+
+    def __init__(self, message='No assetstore adapter'):
+        return super(GirderNoAssetstoreAdapterException, self).__init__(message, self.identifier)
 
 
 def getAssetstoreAdapter(assetstore, instance=True):
@@ -51,9 +59,8 @@ def getAssetstoreAdapter(assetstore, instance=True):
 
     cls = _assetstoreTable.get(storeType)
     if cls is None:
-        raise GirderException(
-            'No AssetstoreAdapter for type: %s.' % storeType,
-            EXCEPTION_ID_NO_ADAPTER)
+        raise GirderNoAssetstoreAdapterException(
+            'No AssetstoreAdapter for type: %s.' % storeType)
 
     if instance:
         return cls(assetstore)

--- a/girder/utility/assetstore_utilities.py
+++ b/girder/utility/assetstore_utilities.py
@@ -18,7 +18,7 @@
 ###############################################################################
 
 from ..constants import AssetstoreType
-from ..models.model_base import GirderException
+from ..exceptions import NoAssetstoreAdapter
 from .filesystem_assetstore_adapter import FilesystemAssetstoreAdapter
 from .gridfs_assetstore_adapter import GridFsAssetstoreAdapter
 from .s3_assetstore_adapter import S3AssetstoreAdapter
@@ -29,16 +29,6 @@ _assetstoreTable = {
     AssetstoreType.GRIDFS: GridFsAssetstoreAdapter,
     AssetstoreType.S3: S3AssetstoreAdapter
 }
-
-
-class GirderNoAssetstoreAdapterException(GirderException):
-    """
-    Raised when no assetstore adapter is available.
-    """
-    identifier = 'girder.utility.assetstore.no-adapter'
-
-    def __init__(self, message='No assetstore adapter'):
-        return super(GirderNoAssetstoreAdapterException, self).__init__(message, self.identifier)
 
 
 def getAssetstoreAdapter(assetstore, instance=True):
@@ -59,8 +49,7 @@ def getAssetstoreAdapter(assetstore, instance=True):
 
     cls = _assetstoreTable.get(storeType)
     if cls is None:
-        raise GirderNoAssetstoreAdapterException(
-            'No AssetstoreAdapter for type: %s.' % storeType)
+        raise NoAssetstoreAdapter('No AssetstoreAdapter for type: %s.' % storeType)
 
     if instance:
         return cls(assetstore)

--- a/girder/utility/assetstore_utilities.py
+++ b/girder/utility/assetstore_utilities.py
@@ -17,10 +17,11 @@
 #  limitations under the License.
 ###############################################################################
 
+from ..constants import AssetstoreType
+from ..models.model_base import GirderException
 from .filesystem_assetstore_adapter import FilesystemAssetstoreAdapter
 from .gridfs_assetstore_adapter import GridFsAssetstoreAdapter
 from .s3_assetstore_adapter import S3AssetstoreAdapter
-from girder.constants import AssetstoreType
 
 
 _assetstoreTable = {
@@ -28,6 +29,8 @@ _assetstoreTable = {
     AssetstoreType.GRIDFS: GridFsAssetstoreAdapter,
     AssetstoreType.S3: S3AssetstoreAdapter
 }
+
+EXCEPTION_ID_NO_ADAPTER = 'girder.utility.assetstore.no-adapter'
 
 
 def getAssetstoreAdapter(assetstore, instance=True):
@@ -48,7 +51,9 @@ def getAssetstoreAdapter(assetstore, instance=True):
 
     cls = _assetstoreTable.get(storeType)
     if cls is None:
-        raise Exception('No AssetstoreAdapter for type: %s.' % storeType)
+        raise GirderException(
+            'No AssetstoreAdapter for type: %s.' % storeType,
+            EXCEPTION_ID_NO_ADAPTER)
 
     if instance:
         return cls(assetstore)

--- a/girder/utility/filesystem_assetstore_adapter.py
+++ b/girder/utility/filesystem_assetstore_adapter.py
@@ -29,7 +29,7 @@ import tempfile
 
 from girder import events, logger
 from girder.api.rest import setResponseHeader
-from girder.models.model_base import ValidationException, GirderException
+from girder.exceptions import ValidationException, GirderException
 from girder.models.file import File
 from girder.models.folder import Folder
 from girder.models.item import Item

--- a/girder/utility/gridfs_assetstore_adapter.py
+++ b/girder/utility/gridfs_assetstore_adapter.py
@@ -29,7 +29,7 @@ from girder import logger
 from girder.api.rest import setResponseHeader
 from girder.external.mongodb_proxy import MongoProxy
 from girder.models import getDbConnection
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.models.file import File
 from . import hash_state
 from .abstract_assetstore_adapter import AbstractAssetstoreAdapter

--- a/girder/utility/path.py
+++ b/girder/utility/path.py
@@ -22,17 +22,10 @@
 import re
 from ..constants import AccessType
 from ..exceptions import AccessException, GirderException, ValidationException
+from ..exceptions import ResourcePathNotFound as NotFoundException
 from .model_importer import ModelImporter
 from girder.models.collection import Collection
 from girder.models.user import User
-
-
-class NotFoundException(ValidationException):
-    """
-    A special case of ValidationException representing the case when the resource at a
-    given path does not exist.
-    """
-    pass
 
 
 def encode(token):

--- a/girder/utility/path.py
+++ b/girder/utility/path.py
@@ -21,7 +21,7 @@
 
 import re
 from ..constants import AccessType
-from ..models.model_base import AccessException, GirderException, ValidationException
+from ..exceptions import AccessException, GirderException, ValidationException
 from .model_importer import ModelImporter
 from girder.models.collection import Collection
 from girder.models.user import User

--- a/girder/utility/path.py
+++ b/girder/utility/path.py
@@ -22,10 +22,14 @@
 import re
 from ..constants import AccessType
 from ..exceptions import AccessException, GirderException, ValidationException
-from ..exceptions import ResourcePathNotFound as NotFoundException
+from ..exceptions import ResourcePathNotFound
 from .model_importer import ModelImporter
 from girder.models.collection import Collection
 from girder.models.user import User
+
+
+# Expose the ResourcePathNotFound exception as its original name
+NotFoundException = ResourcePathNotFound
 
 
 def encode(token):
@@ -116,7 +120,7 @@ def lookUpToken(token, parentType, parent):
             return candidateChild, candidateModel
 
     # if no folder, item, or file matches, give up
-    raise NotFoundException('Child resource not found: %s(%s)->%s' % (
+    raise ResourcePathNotFound('Child resource not found: %s(%s)->%s' % (
         parentType, parent.get('name', parent.get('_id')), token))
 
 
@@ -150,7 +154,7 @@ def lookUpPath(path, user=None, test=False, filter=True, force=False):
                     'document': None
                 }
             else:
-                raise NotFoundException('User not found: %s' % username)
+                raise ResourcePathNotFound('User not found: %s' % username)
 
     elif model == 'collection':
         collectionName = pathArray[1]
@@ -163,7 +167,7 @@ def lookUpPath(path, user=None, test=False, filter=True, force=False):
                     'document': None
                 }
             else:
-                raise NotFoundException('Collection not found: %s' % collectionName)
+                raise ResourcePathNotFound('Collection not found: %s' % collectionName)
 
     else:
         raise ValidationException('Invalid path format')
@@ -186,7 +190,7 @@ def lookUpPath(path, user=None, test=False, filter=True, force=False):
                 'document': None
             }
         else:
-            raise NotFoundException('Path not found: %s' % path)
+            raise ResourcePathNotFound('Path not found: %s' % path)
 
     if filter:
         document = ModelImporter.model(model).filter(document, user)

--- a/girder/utility/plugin_utilities.py
+++ b/girder/utility/plugin_utilities.py
@@ -44,7 +44,7 @@ from pkg_resources import iter_entry_points
 from girder import logprint
 from girder.constants import GIRDER_ROUTE_ID, GIRDER_STATIC_ROUTE_ID, PACKAGE_DIR, ROOT_DIR, \
     ROOT_PLUGINS_PACKAGE, SettingKey
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.models.setting import Setting
 from girder.utility import mail_utils
 

--- a/girder/utility/progress.py
+++ b/girder/utility/progress.py
@@ -22,7 +22,7 @@ import datetime
 import time
 
 from girder.models.notification import Notification, ProgressState
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.api.rest import RestException
 
 

--- a/girder/utility/progress.py
+++ b/girder/utility/progress.py
@@ -22,8 +22,7 @@ import datetime
 import time
 
 from girder.models.notification import Notification, ProgressState
-from girder.exceptions import ValidationException
-from girder.api.rest import RestException
+from girder.exceptions import ValidationException, RestException
 
 
 class ProgressContext(object):

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -28,7 +28,7 @@ import uuid
 
 from girder import logger, events
 from girder.api.rest import setContentDisposition
-from girder.models.model_base import GirderException, ValidationException
+from girder.exceptions import GirderException, ValidationException
 from girder.models.file import File
 from girder.models.folder import Folder
 from girder.models.item import Item

--- a/girder/utility/search.py
+++ b/girder/utility/search.py
@@ -18,7 +18,8 @@
 ###############################################################################
 from functools import partial
 
-from girder.models.model_base import ModelImporter, GirderException
+from girder.models.model_base import ModelImporter
+from girder.exceptions import GirderException
 
 _allowedSearchMode = {}
 

--- a/plugins/authorized_upload/server/rest.py
+++ b/plugins/authorized_upload/server/rest.py
@@ -21,7 +21,7 @@ from girder.api import access
 from girder.api.describe import describeRoute, Description
 from girder.api.rest import loadmodel, Resource
 from girder.constants import AccessType, SettingKey, TokenScope
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.models.setting import Setting
 from girder.models.token import Token
 from girder.utility import mail_utils

--- a/plugins/autojoin/server/__init__.py
+++ b/plugins/autojoin/server/__init__.py
@@ -1,7 +1,7 @@
 import jsonschema
 
 from girder import events
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.utility import setting_utilities
 from girder.models.group import Group
 from girder.models.setting import Setting

--- a/plugins/celery_jobs/server/__init__.py
+++ b/plugins/celery_jobs/server/__init__.py
@@ -20,7 +20,7 @@
 import celery
 
 from girder import events
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.utility import setting_utilities
 from girder.utility.model_importer import ModelImporter
 from girder.plugins.jobs.constants import JobStatus

--- a/plugins/curation/server/__init__.py
+++ b/plugins/curation/server/__init__.py
@@ -19,8 +19,9 @@
 
 from girder.api import access
 from girder.api.describe import Description, describeRoute
-from girder.api.rest import Resource, loadmodel, RestException
+from girder.api.rest import Resource, loadmodel
 from girder.constants import AccessType, TokenScope
+from girder.exceptions import RestException
 from girder.models.folder import Folder
 from girder.models.user import User
 from girder.utility import mail_utils

--- a/plugins/geospatial/server/geospatial.py
+++ b/plugins/geospatial/server/geospatial.py
@@ -25,8 +25,9 @@ from pymongo.errors import OperationFailure
 
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
-from girder.api.rest import Resource, RestException, filtermodel
+from girder.api.rest import Resource, filtermodel
 from girder.constants import AccessType
+from girder.exceptions import RestException
 from girder.models.folder import Folder
 from girder.models.item import Item
 

--- a/plugins/google_analytics/server/__init__.py
+++ b/plugins/google_analytics/server/__init__.py
@@ -17,7 +17,7 @@
 #  limitations under the License.
 ###############################################################################
 
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.utility import setting_utilities
 from . import constants, rest
 

--- a/plugins/hashsum_download/plugin_tests/hashsum_download_test.py
+++ b/plugins/hashsum_download/plugin_tests/hashsum_download_test.py
@@ -21,7 +21,7 @@ import hashlib
 import six
 import time
 
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.models.file import File
 from girder.models.folder import Folder
 from girder.models.setting import Setting

--- a/plugins/hashsum_download/server/__init__.py
+++ b/plugins/hashsum_download/server/__init__.py
@@ -24,10 +24,10 @@ import warnings
 from girder import events
 from girder.api import access
 from girder.api.describe import autoDescribeRoute, Description
-from girder.api.rest import RestException, setRawResponse, setResponseHeader, setContentDisposition
+from girder.api.rest import setRawResponse, setResponseHeader, setContentDisposition
 from girder.api.v1.file import File
 from girder.constants import AccessType, TokenScope
-from girder.exceptions import ValidationException
+from girder.exceptions import ValidationException, RestException
 from girder.models.file import File as FileModel
 from girder.models.setting import Setting
 from girder.utility import setting_utilities

--- a/plugins/hashsum_download/server/__init__.py
+++ b/plugins/hashsum_download/server/__init__.py
@@ -27,7 +27,7 @@ from girder.api.describe import autoDescribeRoute, Description
 from girder.api.rest import RestException, setRawResponse, setResponseHeader, setContentDisposition
 from girder.api.v1.file import File
 from girder.constants import AccessType, TokenScope
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.models.file import File as FileModel
 from girder.models.setting import Setting
 from girder.utility import setting_utilities

--- a/plugins/hdfs_assetstore/server/assetstore.py
+++ b/plugins/hdfs_assetstore/server/assetstore.py
@@ -26,7 +26,7 @@ import uuid
 
 from girder import logger
 from girder.api.rest import setResponseHeader
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.utility.abstract_assetstore_adapter import AbstractAssetstoreAdapter
 
 

--- a/plugins/hdfs_assetstore/server/rest.py
+++ b/plugins/hdfs_assetstore/server/rest.py
@@ -21,7 +21,8 @@ import posixpath
 
 from girder.api import access
 from girder.api.describe import Description, describeRoute
-from girder.api.rest import Resource, loadmodel, RestException
+from girder.api.rest import Resource, loadmodel
+from girder.exceptions import RestException
 from girder.models.file import File
 from girder.models.folder import Folder
 from girder.models.item import Item

--- a/plugins/homepage/server/constants.py
+++ b/plugins/homepage/server/constants.py
@@ -20,7 +20,7 @@
 import six
 
 from girder.constants import AccessType
-from girder.models.model_base import AccessException, ValidationException
+from girder.exceptions import AccessException, ValidationException
 from girder.models.file import File
 from girder.utility import setting_utilities
 

--- a/plugins/item_licenses/plugin_tests/item_licenses_test.py
+++ b/plugins/item_licenses/plugin_tests/item_licenses_test.py
@@ -19,7 +19,7 @@
 
 import six
 
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.models.folder import Folder
 from girder.models.setting import Setting
 from girder.models.user import User

--- a/plugins/item_licenses/server/__init__.py
+++ b/plugins/item_licenses/server/__init__.py
@@ -21,7 +21,7 @@ import six
 
 from girder import events
 from girder.constants import AccessType, SettingDefault
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.models.item import Item
 from girder.models.setting import Setting
 from girder.utility import setting_utilities

--- a/plugins/item_tasks/server/cli_parser.py
+++ b/plugins/item_tasks/server/cli_parser.py
@@ -1,7 +1,7 @@
 import ctk_cli
 import itertools
 
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 
 _SLICER_TO_GIRDER_WORKER_INPUT_TYPE_MAP = {
     'boolean': 'boolean',

--- a/plugins/item_tasks/server/json_tasks.py
+++ b/plugins/item_tasks/server/json_tasks.py
@@ -1,7 +1,8 @@
 from girder.api import access
 from girder.api.describe import autoDescribeRoute, Description
-from girder.api.rest import boundHandler, filtermodel, RestException
+from girder.api.rest import boundHandler, filtermodel
 from girder.constants import AccessType
+from girder.exceptions import RestException
 from girder.models.folder import Folder
 from girder.models.item import Item
 from girder.models.token import Token

--- a/plugins/item_tasks/server/rest.py
+++ b/plugins/item_tasks/server/rest.py
@@ -6,7 +6,7 @@ from girder.api import access
 from girder.api.describe import autoDescribeRoute, Description
 from girder.api.rest import ensureTokenScopes, filtermodel, Resource
 from girder.constants import AccessType, TokenScope
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.models.item import Item
 from girder.models.token import Token
 from girder.plugins.jobs.models.job import Job

--- a/plugins/item_tasks/server/slicer_cli_tasks.py
+++ b/plugins/item_tasks/server/slicer_cli_tasks.py
@@ -2,8 +2,9 @@ import json
 
 from girder.api import access
 from girder.api.describe import autoDescribeRoute, Description
-from girder.api.rest import boundHandler, filtermodel, RestException
+from girder.api.rest import boundHandler, filtermodel
 from girder.constants import AccessType
+from girder.exceptions import RestException
 from girder.models.folder import Folder
 from girder.models.item import Item
 from girder.models.token import Token

--- a/plugins/jobs/plugin_tests/jobs_test.py
+++ b/plugins/jobs/plugin_tests/jobs_test.py
@@ -23,7 +23,7 @@ import time
 from tests import base
 from girder import events
 from girder.constants import AccessType
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.models.user import User
 from girder.models.token import Token
 

--- a/plugins/jobs/server/models/job.py
+++ b/plugins/jobs/server/models/job.py
@@ -23,7 +23,8 @@ from bson import json_util
 
 from girder import events
 from girder.constants import AccessType, SortDir
-from girder.models.model_base import AccessControlledModel, ValidationException
+from girder.exceptions import ValidationException
+from girder.models.model_base import AccessControlledModel
 from girder.models.notification import Notification
 from girder.models.token import Token
 from girder.models.user import User

--- a/plugins/ldap/plugin_tests/ldap_test.py
+++ b/plugins/ldap/plugin_tests/ldap_test.py
@@ -20,7 +20,7 @@
 import ldap
 import mock
 
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.models.setting import Setting
 from girder.models.user import User
 from tests import base

--- a/plugins/ldap/server/__init__.py
+++ b/plugins/ldap/server/__init__.py
@@ -25,7 +25,7 @@ from girder import events, logger
 from girder.api import access
 from girder.api.describe import autoDescribeRoute, Description
 from girder.api.rest import boundHandler
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.models.setting import Setting
 from girder.models.user import User
 from girder.utility import setting_utilities

--- a/plugins/mongo_search/server/__init__.py
+++ b/plugins/mongo_search/server/__init__.py
@@ -21,9 +21,10 @@ import bson.json_util
 
 from girder import events
 from girder.constants import AccessType
+from girder.exceptions import RestException
 from girder.utility.model_importer import ModelImporter
 from girder.api.describe import Description, describeRoute
-from girder.api.rest import Resource, RestException
+from girder.api.rest import Resource
 from girder.api import access
 
 

--- a/plugins/oauth/plugin_tests/oauth_test.py
+++ b/plugins/oauth/plugin_tests/oauth_test.py
@@ -27,7 +27,7 @@ import requests
 import six
 
 from girder.constants import SettingKey
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.models.setting import Setting
 from girder.models.token import Token
 from girder.models.user import User

--- a/plugins/oauth/server/__init__.py
+++ b/plugins/oauth/server/__init__.py
@@ -19,7 +19,7 @@
 
 from girder import events
 from girder.constants import SettingDefault, SortDir
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.models.user import User
 from girder.utility import setting_utilities
 from . import rest, constants, providers

--- a/plugins/oauth/server/providers/base.py
+++ b/plugins/oauth/server/providers/base.py
@@ -22,8 +22,8 @@ import re
 import requests
 import six
 
-from girder.api.rest import RestException
 from girder.constants import SettingKey
+from girder.exceptions import RestException
 from girder.models.setting import Setting
 from girder.models.user import User
 from girder.utility import config, model_importer

--- a/plugins/oauth/server/providers/bitbucket.py
+++ b/plugins/oauth/server/providers/bitbucket.py
@@ -19,7 +19,8 @@
 
 from six.moves import urllib
 
-from girder.api.rest import getApiUrl, RestException
+from girder.api.rest import getApiUrl
+from girder.exceptions import RestException
 from girder.models.setting import Setting
 from .base import ProviderBase
 from .. import constants

--- a/plugins/oauth/server/providers/box.py
+++ b/plugins/oauth/server/providers/box.py
@@ -19,7 +19,8 @@
 
 from six.moves import urllib
 
-from girder.api.rest import getApiUrl, RestException
+from girder.api.rest import getApiUrl
+from girder.exceptions import RestException
 from girder.models.setting import Setting
 from .base import ProviderBase
 from .. import constants

--- a/plugins/oauth/server/providers/github.py
+++ b/plugins/oauth/server/providers/github.py
@@ -19,7 +19,8 @@
 
 from six.moves import urllib
 
-from girder.api.rest import getApiUrl, RestException
+from girder.api.rest import getApiUrl
+from girder.exceptions import RestException
 from girder.models.setting import Setting
 from .base import ProviderBase
 from .. import constants

--- a/plugins/oauth/server/providers/globus.py
+++ b/plugins/oauth/server/providers/globus.py
@@ -19,7 +19,8 @@
 
 from six.moves import urllib
 
-from girder.api.rest import getApiUrl, RestException
+from girder.api.rest import getApiUrl
+from girder.exceptions import RestException
 from girder.models.setting import Setting
 from .base import ProviderBase
 from .. import constants

--- a/plugins/oauth/server/providers/google.py
+++ b/plugins/oauth/server/providers/google.py
@@ -19,7 +19,8 @@
 
 from six.moves import urllib
 
-from girder.api.rest import getApiUrl, RestException
+from girder.api.rest import getApiUrl
+from girder.exceptions import RestException
 from girder.models.setting import Setting
 from .base import ProviderBase
 from .. import constants

--- a/plugins/oauth/server/providers/linkedin.py
+++ b/plugins/oauth/server/providers/linkedin.py
@@ -19,7 +19,8 @@
 
 from six.moves import urllib
 
-from girder.api.rest import getApiUrl, RestException
+from girder.api.rest import getApiUrl
+from girder.exceptions import RestException
 from girder.models.setting import Setting
 from .base import ProviderBase
 from .. import constants

--- a/plugins/oauth/server/rest.py
+++ b/plugins/oauth/server/rest.py
@@ -23,8 +23,9 @@ import six
 
 from girder import events
 from girder.constants import AccessType
+from girder.exceptions import RestException
 from girder.api.describe import Description, autoDescribeRoute
-from girder.api.rest import Resource, RestException
+from girder.api.rest import Resource
 from girder.api import access
 from girder.models.setting import Setting
 from girder.models.token import Token

--- a/plugins/provenance/server/__init__.py
+++ b/plugins/provenance/server/__init__.py
@@ -20,7 +20,7 @@
 import six
 
 from girder import events
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.utility import setting_utilities
 from . import constants
 from .resource import ResourceExt

--- a/plugins/provenance/server/resource.py
+++ b/plugins/provenance/server/resource.py
@@ -25,8 +25,9 @@ from bson.objectid import ObjectId
 from girder import events
 from girder.api import access
 from girder.api.describe import Description, describeRoute
-from girder.api.rest import Resource, RestException
+from girder.api.rest import Resource
 from girder.constants import AccessType
+from girder.exceptions import RestException
 from girder.models.model_base import AccessControlledModel
 from girder.models.file import File
 from girder.models.item import Item

--- a/plugins/terms/server/__init__.py
+++ b/plugins/terms/server/__init__.py
@@ -23,9 +23,10 @@ import hashlib
 from girder import events
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
-from girder.api.rest import boundHandler, RestException
+from girder.api.rest import boundHandler
 from girder.api.v1.collection import Collection
 from girder.constants import AccessType, TokenScope
+from girder.exceptions import RestException
 from girder.models.collection import Collection as CollectionModel
 from girder.models.user import User
 

--- a/plugins/thumbnails/server/rest.py
+++ b/plugins/thumbnails/server/rest.py
@@ -19,8 +19,9 @@
 
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
-from girder.api.rest import filtermodel, Resource, RestException
+from girder.api.rest import filtermodel, Resource
 from girder.constants import AccessType
+from girder.exceptions import RestException
 from girder.models.file import File
 from girder.plugins.jobs.models.job import Job
 from . import utils

--- a/plugins/user_quota/plugin_tests/user_quota_test.py
+++ b/plugins/user_quota/plugin_tests/user_quota_test.py
@@ -23,7 +23,7 @@ import os
 
 from tests import base
 from girder.constants import AssetstoreType, SettingKey
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.models.assetstore import Assetstore
 from girder.models.collection import Collection
 from girder.models.folder import Folder

--- a/plugins/user_quota/server/__init__.py
+++ b/plugins/user_quota/server/__init__.py
@@ -18,7 +18,7 @@
 ###############################################################################
 
 from girder import events
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.utility import setting_utilities
 from . import constants
 from .quota import QuotaPolicy, ValidateSizeQuota

--- a/plugins/user_quota/server/quota.py
+++ b/plugins/user_quota/server/quota.py
@@ -25,7 +25,7 @@ from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
 from girder.api.rest import Resource, RestException
 from girder.constants import AccessType
-from girder.models.model_base import GirderException, ValidationException
+from girder.exceptions import GirderException, ValidationException
 from girder.models.assetstore import Assetstore
 from girder.models.collection import Collection
 from girder.models.file import File

--- a/plugins/user_quota/server/quota.py
+++ b/plugins/user_quota/server/quota.py
@@ -23,9 +23,9 @@ from bson.objectid import ObjectId, InvalidId
 from girder import logger
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
-from girder.api.rest import Resource, RestException
+from girder.api.rest import Resource
 from girder.constants import AccessType
-from girder.exceptions import GirderException, ValidationException
+from girder.exceptions import GirderException, ValidationException, RestException
 from girder.models.assetstore import Assetstore
 from girder.models.collection import Collection
 from girder.models.file import File

--- a/plugins/worker/server/__init__.py
+++ b/plugins/worker/server/__init__.py
@@ -22,7 +22,7 @@ from celery.result import AsyncResult
 
 from girder import events, logger
 from girder.constants import AccessType
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.plugins.jobs.constants import JobStatus
 from girder.plugins.jobs.models.job import Job
 from girder.models.setting import Setting

--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -36,7 +36,7 @@ from girder.models.assetstore import Assetstore
 from girder.models.file import File
 from girder.models.folder import Folder
 from girder.models.item import Item
-from girder.models.model_base import GirderException
+from girder.exceptions import GirderException
 from girder.models.upload import Upload
 from girder.models.user import User
 from girder.utility import assetstore_utilities

--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -36,6 +36,7 @@ from girder.models.assetstore import Assetstore
 from girder.models.file import File
 from girder.models.folder import Folder
 from girder.models.item import Item
+from girder.models.model_base import GirderException
 from girder.models.upload import Upload
 from girder.models.user import User
 from girder.utility import assetstore_utilities
@@ -1004,3 +1005,10 @@ class AssetstoreTestCase(base.TestCase):
         resp = self.request(
             path='/file/%s/download' % file['_id'], user=self.admin, isJson=False)
         self.assertStatusOk(resp)
+
+    def testUnknownAssetstoreType(self):
+        assetstore = Assetstore().save({'name': 'Sample', 'type': 'unknown'}, validate=False)
+        with self.assertRaises(GirderException):
+            assetstore_utilities.getAssetstoreAdapter(assetstore)
+        Assetstore().addComputedInfo(assetstore)
+        self.assertEqual(assetstore['capacity']['total'], None)

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -32,7 +32,7 @@ from .. import base, mock_s3
 from girder import events
 from girder.constants import SettingKey
 from girder.models import getDbConnection
-from girder.models.model_base import AccessException, GirderException
+from girder.exceptions import AccessException, GirderException
 from girder.models.assetstore import Assetstore
 from girder.models.collection import Collection
 from girder.models.file import File

--- a/tests/cases/notification_test.py
+++ b/tests/cases/notification_test.py
@@ -21,7 +21,7 @@ import time
 
 from .. import base
 
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.models.notification import ProgressState
 from girder.models.token import Token
 from girder.models.user import User

--- a/tests/cases/routes_test.py
+++ b/tests/cases/routes_test.py
@@ -21,7 +21,7 @@ from .. import base
 from girder.api import access
 from girder.api.describe import Description, describeRoute
 from girder.api.rest import Resource, RestException
-from girder.models.model_base import GirderException
+from girder.exceptions import GirderException
 from girder.models.setting import Setting
 from girder.constants import SettingKey, SettingDefault
 

--- a/tests/cases/routes_test.py
+++ b/tests/cases/routes_test.py
@@ -20,8 +20,8 @@
 from .. import base
 from girder.api import access
 from girder.api.describe import Description, describeRoute
-from girder.api.rest import Resource, RestException
-from girder.exceptions import GirderException
+from girder.api.rest import Resource
+from girder.exceptions import GirderException, RestException
 from girder.models.setting import Setting
 from girder.constants import SettingKey, SettingDefault
 

--- a/tests/cases/setting_test.py
+++ b/tests/cases/setting_test.py
@@ -19,7 +19,7 @@
 
 import six
 from .. import base
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.models.setting import Setting
 from girder.utility import setting_utilities
 

--- a/tests/cases/system_test.py
+++ b/tests/cases/system_test.py
@@ -29,7 +29,7 @@ from girder.api import access
 from girder.api.describe import describeRoute, API_VERSION
 from girder.api.rest import getApiUrl, loadmodel, Resource
 from girder.constants import AccessType, SettingKey, SettingDefault, registerAccessFlag, ROOT_DIR
-from girder.models.model_base import AccessException, ValidationException
+from girder.exceptions import AccessException, ValidationException
 from girder.models.collection import Collection
 from girder.models.file import File
 from girder.models.folder import Folder

--- a/tests/cases/user_test.py
+++ b/tests/cases/user_test.py
@@ -27,7 +27,7 @@ from .. import base
 
 from girder import events
 from girder.constants import AccessType, SettingKey, TokenScope
-from girder.models.model_base import ValidationException
+from girder.exceptions import ValidationException
 from girder.models.folder import Folder
 from girder.models.group import Group
 from girder.models.setting import Setting

--- a/tests/setup_database.py
+++ b/tests/setup_database.py
@@ -22,7 +22,8 @@ import os
 import tempfile
 import warnings
 
-from girder.models.model_base import ModelImporter, GirderException
+from girder.models.model_base import ModelImporter
+from girder.exceptions import GirderException
 from girder.constants import SettingKey
 
 warnings.warn(

--- a/tests/web_client_test.py
+++ b/tests/web_client_test.py
@@ -26,8 +26,9 @@ import time
 from girder import config
 from girder.api import access
 from girder.api.describe import Description, describeRoute
-from girder.api.rest import Resource, RestException
+from girder.api.rest import Resource
 from girder.constants import registerAccessFlag, ROOT_DIR
+from girder.exceptions import RestException
 from girder.models.folder import Folder
 from girder.models.upload import Upload
 from girder.utility.progress import ProgressContext


### PR DESCRIPTION
When a plugin supplying an assetstore fails to load, existing assetstores can't load the appropriate adapter.  We can't add capacity information, and that failure made it impossible to list the assetstore (including in the web client).  This falls back to adding unknown capacity information.