### PR TITLE
Add the pytest tests to the ctest test list.

### DIFF
--- a/cmake/run_circleci.sh
+++ b/cmake/run_circleci.sh
@@ -20,6 +20,8 @@ esac
 
 mkdir $HOME/build
 
+ctest -R '^py_coverage_reset$' -VV -S $HOME/girder/cmake/circle_continuous.cmake
+
 if [ "$TEST_GROUP" == "python" ]; then
     if ! pytest --tb=long --junit-xml=$CIRCLE_TEST_REPORTS/pytest-${CIRCLE_NODE_INDEX}.xml; then
         touch $HOME/build/test_failed
@@ -27,7 +29,7 @@ if [ "$TEST_GROUP" == "python" ]; then
 fi
 
 # pytest also generates coverage, so don't reset coverage at the start of the run
-ctest -E '^py_coverage_reset$' -VV -S $HOME/girder/cmake/circle_continuous.cmake
+ctest -E '^(py_coverage_reset|server_pytest_core)$' -VV -S $HOME/girder/cmake/circle_continuous.cmake
 
 # Convert CTest output to Junit and ensure CircleCI will include it in its summary
 pip install scikit-ci-addons==0.15.0

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,6 +68,8 @@ if(RUN_CORE_TESTS)
   add_python_test(py_client.cli BIND_SERVER RESOURCE_LOCKS py_client_test_dir)
   add_python_test(py_client.lib BIND_SERVER RESOURCE_LOCKS py_client_test_dir)
 
+  add_pytest_test(core)
+
   add_web_client_test(data_filesystem "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE filesystem)
   add_web_client_test(data_gridfs "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE gridfs)
   add_web_client_test(data_gridfsrs "${PROJECT_SOURCE_DIR}/clients/web/test/spec/dataSpec.js" ASSETSTORE gridfsrs RESOURCE_LOCKS replicaset REQUIRED_FILES "${MONGOD_EXECUTABLE}")

--- a/tests/PythonTests.cmake
+++ b/tests/PythonTests.cmake
@@ -26,6 +26,8 @@ else()
   set(_separator ":")
 endif()
 
+find_program(PYTEST_EXECUTABLE NAMES pytest)
+
 function(python_tests_init)
   if(PYTHON_COVERAGE)
     add_test(
@@ -183,5 +185,20 @@ function(add_python_test case)
     girder_ExternalData_add_target("${name}_data")
   endif()
 
+  set_property(TEST ${name} PROPERTY LABELS girder_python)
+endfunction()
+
+function(add_pytest_test case)
+  set(name "server_pytest_${case}")
+
+  add_test(
+    NAME ${name}
+    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+    COMMAND "${PYTEST_EXECUTABLE}" --tb=long --cov-append
+  )
+  if(PYTHON_COVERAGE)
+    set_property(TEST ${name} APPEND PROPERTY DEPENDS py_coverage_reset)
+    set_property(TEST py_coverage_combine APPEND PROPERTY DEPENDS ${name})
+  endif()
   set_property(TEST ${name} PROPERTY LABELS girder_python)
 endfunction()


### PR DESCRIPTION
This runs the pytest tests as one of the ctest tests so that the entire project can still be tested with a single command and that coverage is collected together.

I recognize that we want to move away from CMake eventually, but until we do, I think that we need to maintain it.

This is marked as a work-in-progress because it will currently run the pytest tests twice in Circle.  Either we can remove the special pytest code there, or we can leave what is there and change how we invoke ctest.  Opinions?