### PR TITLE
Set a maximum height for modal dialogs.

### DIFF
--- a/clients/web/src/stylesheets/layout/global.styl
+++ b/clients/web/src/stylesheets/layout/global.styl
@@ -72,6 +72,9 @@ ul.dropdown-menu
 
 .modal-content
   border-radius 0
+  max-height calc(100vh - 60px)
+  overflow-y auto
+  margin 30px auto
 
 .modal-backdrop.in
   opacity 0.35


### PR DESCRIPTION
Currently, if a modal dialog is tall, the webpage as a whole gets a scrollbar and the dialog extends past the bottom.  I think it looks better to have the dialog have a scroll bar (since the page may already be scrolled).  The bootstrap css has different margins depending on window size; this makes one policy that is consistent.

This has the virtue that scrolling within the dialog doesn't affect the scroll position on the underlying main page.