### PR TITLE
Stop exceptions from being swallowed in certain testing conditions

### DIFF
--- a/pytest_girder/pytest_girder/fixtures.py
+++ b/pytest_girder/pytest_girder/fixtures.py
@@ -101,7 +101,8 @@ def server(db, request):
 
     cherrypy.server.unsubscribe()
     cherrypy.config.update({'environment': 'embedded',
-                            'log.screen': False})
+                            'log.screen': False,
+                            'request.throw_errors': True})
     cherrypy.engine.start()
 
     yield server

--- a/tests/base.py
+++ b/tests/base.py
@@ -87,6 +87,9 @@ def startServer(mock=True, mockS3=False):
         logHandler.setLevel(logging.DEBUG)
         cherrypy.log.error_log.addHandler(logHandler)
 
+    # Tell CherryPy to throw exceptions in request handling code
+    cherrypy.config.update({'request.throw_errors': True})
+
     mockSmtp.start()
     if mockS3:
         global mockS3Server


### PR DESCRIPTION
> CherryPy manages thrown exceptions and returns 500 errors when
encountering them. Internally within @endpoint decorated routes in
Girder (most of our REST API), we manage the logic of
exception/response handling ourselves. However, in non @endpoint
decorated routes (the webroot class) - CherryPy swallows the
exceptions and prints an internal server error. This commit tells
CherryPy to instead propagate our exceptions up when testing, giving
us the actual exceptions raised when failures occur on webroot
endpoints.