### PR TITLE
Change the default for pytest to drop databases.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = --verbose --showlocals --cov=girder --cov-append --cov-config=.coveragerc --cov-report=""
+addopts = --verbose --showlocals --cov=girder --cov-append --cov-config=.coveragerc --cov-report="" --drop-db=post
 testpaths = girder/test

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = --verbose --showlocals --cov=girder --cov-append --cov-config=.coveragerc --cov-report="" --drop-db=post
+addopts = --verbose --showlocals --cov=girder --cov-append --cov-config=.coveragerc --cov-report=""
 testpaths = girder/test

--- a/pytest_girder/pytest_girder/fixtures.py
+++ b/pytest_girder/pytest_girder/fixtures.py
@@ -48,7 +48,7 @@ def db(request):
     # Force getDbConnection from models to return our connection
     _dbClients[(None, None)] = connection
 
-    if dropDb == 'pre':
+    if dropDb in ('pre', 'both'):
         connection.drop_database(dbName)
 
     for model in _modelSingletons:
@@ -56,7 +56,7 @@ def db(request):
 
     yield connection
 
-    if dropDb == 'post':
+    if dropDb in ('post', 'both'):
         connection.drop_database(dbName)
 
     connection.close()

--- a/pytest_girder/pytest_girder/plugin.py
+++ b/pytest_girder/pytest_girder/plugin.py
@@ -8,5 +8,7 @@ def pytest_addoption(parser):
     group.addoption('--mongo-uri', action='store', default='mongodb://localhost:27017',
                     help=('The base URI to the MongoDB instance to use for database connections, '
                           'default is mongodb://localhost:27017'))
-    group.addoption('--drop-db', action='store', default='post', choices=('pre', 'post', 'never'),
-                    help='When to destroy testing databases, default is post (after running tests)')
+    group.addoption('--drop-db', action='store', default='both',
+                    choices=('both', 'pre', 'post', 'never'),
+                    help='When to destroy testing databases, default is both '
+                    '(before and after running tests)')

--- a/pytest_girder/pytest_girder/plugin.py
+++ b/pytest_girder/pytest_girder/plugin.py
@@ -8,5 +8,5 @@ def pytest_addoption(parser):
     group.addoption('--mongo-uri', action='store', default='mongodb://localhost:27017',
                     help=('The base URI to the MongoDB instance to use for database connections, '
                           'default is mongodb://localhost:27017'))
-    group.addoption('--drop-db', action='store', default='pre', choices=('pre', 'post', 'never'),
-                    help='When to destroy testing databases, default is pre (before running tests)')
+    group.addoption('--drop-db', action='store', default='post', choices=('pre', 'post', 'never'),
+                    help='When to destroy testing databases, default is post (after running tests)')

--- a/tox.ini
+++ b/tox.ini
@@ -14,11 +14,13 @@ passenv = CIRCLE_WORKING_DIRECTORY
 basepython = python2.7
 commands = pytest \
            --tb=long \
-           --junit-xml="{env:CIRCLE_WORKING_DIRECTORY}/girder/build/test/artifacts/pytest-2.7.xml"
+           --junit-xml="{env:CIRCLE_WORKING_DIRECTORY}/girder/build/test/artifacts/pytest-2.7.xml" \
+           --drop-db=never
 
 [testenv:circleci-py35]
 passenv = CIRCLE_WORKING_DIRECTORY
 basepython = python3.5
 commands = pytest \
            --tb=long \
-           --junit-xml="{env:CIRCLE_WORKING_DIRECTORY}/girder/build/test/artifacts/pytest-3.5.xml"
+           --junit-xml="{env:CIRCLE_WORKING_DIRECTORY}/girder/build/test/artifacts/pytest-3.5.xml" \
+           --drop-db=never


### PR DESCRIPTION
Otherwise, when running tests locally, one ends up with lots of databases in the local mongo instance.  This change matches the behavior we have on the non-pytest tests.