### PR TITLE
Allow the pythonpath to be adjusted for the client test module.

### DIFF
--- a/tests/JavascriptTests.cmake
+++ b/tests/JavascriptTests.cmake
@@ -112,6 +112,8 @@ function(add_web_client_test case specFile)
   # BASEURL (url): The base url to load for the test.
   # TEST_MODULE (python module path): Run this module rather than the default
   #     "tests.web_client_test"
+  # TEST_PYTHON_PATH: If specified, add this as the first element of the python
+  #     path when running the test module.
   # SETUP_MODULES: colon-separated list of python scripts to import at test setup time
   #     for side effects such as mocking, adding API routes, etc.
   # SETUP_DATABASE: An absolute path to a database initialization spec
@@ -124,8 +126,8 @@ function(add_web_client_test case specFile)
   set(testname "web_client_${case}")
 
   set(_options NOCOVERAGE)
-  set(_args PLUGIN ASSETSTORE WEBSECURITY BASEURL PLUGIN_DIR TIMEOUT TEST_MODULE REQUIRED_FILES
-            SETUP_MODULES ENVIRONMENT EXTERNAL_DATA SETUP_DATABASE)
+  set(_args PLUGIN ASSETSTORE WEBSECURITY BASEURL PLUGIN_DIR TIMEOUT TEST_MODULE TEST_PYTHONPATH
+            REQUIRED_FILES SETUP_MODULES ENVIRONMENT EXTERNAL_DATA SETUP_DATABASE)
   set(_multival_args RESOURCE_LOCKS ENABLEDPLUGINS)
   cmake_parse_arguments(fn "${_options}" "${_args}" "${_multival_args}" ${ARGN})
 
@@ -164,6 +166,12 @@ function(add_web_client_test case specFile)
     set(test_module "tests.web_client_test")
   endif()
 
+  if(fn_TEST_PYTHONPATH)
+    set(pythonpath "${fn_TEST_PYTHONPATH}:$ENV{PYTHONPATH}")
+  else()
+    set(pythonpath "$ENV{PYTHONPATH}")
+  endif()
+
   if(fn_EXTERNAL_DATA)
     set(_data_files "")
     foreach(_data_file ${fn_EXTERNAL_DATA})
@@ -194,7 +202,7 @@ function(add_web_client_test case specFile)
   string(REPLACE ";" " " plugins "${plugins}")
 
   set_property(TEST ${testname} PROPERTY ENVIRONMENT
-    "PYTHONPATH=$ENV{PYTHONPATH}"
+    "PYTHONPATH=${pythonpath}"
     "SPEC_FILE=${specFile}"
     "ASSETSTORE_TYPE=${assetstoreType}"
     "WEB_SECURITY=${webSecurity}"


### PR DESCRIPTION
We added the ability to specify the client test module in PR #1254.  In that PR, we started passing whatever the PYTHONPATH environment variable was to the test.  Although this allows *one* test to override the path, it fails when there are two such tests in different directories.  This allows an additional parameter (`TEST_PYTHONPATH`) to be added to aid in overriding the PYTHONPATH.  In this way, two tests that require different paths can be run in the same build.