### PR TITLE
Change pytest_girder's "drop-db" argument to "keep-db"

### DIFF
--- a/pytest_girder/pytest_girder/fixtures.py
+++ b/pytest_girder/pytest_girder/fixtures.py
@@ -26,7 +26,7 @@ def db(request):
 
     Provides a Mongo test database named after the requesting test function. Mongo databases are
     created/destroyed based on the URI provided with the --mongo-uri option and tear-down
-    semantics are handled by the --drop-db option.
+    behavior is modified by the --keep-db option.
     """
     from girder.models import _dbClients, getDbConnection, pymongo
     from girder.models.model_base import _modelSingletons
@@ -35,7 +35,7 @@ def db(request):
     mockDb = request.config.getoption('--mock-db')
     dbUri = request.config.getoption('--mongo-uri')
     dbName = 'girder_test_%s' % hashlib.md5(request.node.name.encode('utf8')).hexdigest()
-    dropDb = request.config.getoption('--drop-db')
+    keepDb = request.config.getoption('--keep-db')
     executable_methods = mongodb_proxy.EXECUTABLE_MONGO_METHODS
     realMongoClient = pymongo.MongoClient
 
@@ -48,15 +48,14 @@ def db(request):
     # Force getDbConnection from models to return our connection
     _dbClients[(None, None)] = connection
 
-    if dropDb in ('pre', 'both'):
-        connection.drop_database(dbName)
+    connection.drop_database(dbName)
 
     for model in _modelSingletons:
         model.reconnect()
 
     yield connection
 
-    if dropDb in ('post', 'both'):
+    if not keepDb:
         connection.drop_database(dbName)
 
     connection.close()

--- a/pytest_girder/pytest_girder/plugin.py
+++ b/pytest_girder/pytest_girder/plugin.py
@@ -8,7 +8,5 @@ def pytest_addoption(parser):
     group.addoption('--mongo-uri', action='store', default='mongodb://localhost:27017',
                     help=('The base URI to the MongoDB instance to use for database connections, '
                           'default is mongodb://localhost:27017'))
-    group.addoption('--drop-db', action='store', default='both',
-                    choices=('both', 'pre', 'post', 'never'),
-                    help='When to destroy testing databases, default is both '
-                    '(before and after running tests)')
+    group.addoption('--keep-db', action='store_true', default=False,
+                    help='Whether to destroy testing databases after running tests.')

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ basepython = python2.7
 commands = pytest \
            --tb=long \
            --junit-xml="{env:CIRCLE_WORKING_DIRECTORY}/girder/build/test/artifacts/pytest-2.7.xml" \
-           --drop-db=never
+           --keep-db
 
 [testenv:circleci-py35]
 passenv = CIRCLE_WORKING_DIRECTORY
@@ -23,4 +23,4 @@ basepython = python3.5
 commands = pytest \
            --tb=long \
            --junit-xml="{env:CIRCLE_WORKING_DIRECTORY}/girder/build/test/artifacts/pytest-3.5.xml" \
-           --drop-db=never
+           --keep-db


### PR DESCRIPTION
Tests should always be run on a clean database (there are / should be other pytest-compatible mechanisms to pre-populate test data). Accordingly, the "drop-db" option can be simplified to a boolean "keep-db" option. The default of "keep-db" is false (to destroy the database after testing), to prevent naive execution of "pytest" from leaving unwanted database clutter.

CI will run with "keep-db" enabled, to allow inspection of the database state after SSHing into a CI machine.