### PR TITLE
Update some dependency files

### DIFF
--- a/clients/python/requirements.txt
+++ b/clients/python/requirements.txt
@@ -1,5 +1,0 @@
-click==6.7
-diskcache==1.6.7
-requests==2.10.0
-requests_toolbelt==0.7.1
-six==1.10.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@girder/app",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -61,14 +61,14 @@
             }
         },
         "ajv": {
-            "version": "5.2.3",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
-            "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
+            "version": "5.5.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "requires": {
                 "co": "4.6.0",
                 "fast-deep-equal": "1.0.0",
-                "json-schema-traverse": "0.3.1",
-                "json-stable-stringify": "1.0.1"
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
             }
         },
         "ajv-keywords": {
@@ -199,9 +199,9 @@
             "dev": true
         },
         "asn1.js": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
-            "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+            "version": "4.9.2",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
+            "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
             "requires": {
                 "bn.js": "4.11.8",
                 "inherits": "2.0.3",
@@ -223,9 +223,9 @@
             "dev": true
         },
         "async": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-            "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+            "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
             "requires": {
                 "lodash": "4.17.4"
             }
@@ -252,10 +252,10 @@
             "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
             "requires": {
                 "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000740",
+                "caniuse-db": "1.0.30000783",
                 "normalize-range": "0.1.2",
                 "num2fraction": "1.2.2",
-                "postcss": "5.2.17",
+                "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0"
             }
         },
@@ -263,8 +263,7 @@
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
             "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "aws4": {
             "version": "1.6.0",
@@ -297,13 +296,13 @@
                 "babel-traverse": "6.26.0",
                 "babel-types": "6.26.0",
                 "babylon": "6.18.0",
-                "convert-source-map": "1.5.0",
+                "convert-source-map": "1.5.1",
                 "debug": "2.6.9",
                 "json5": "0.5.1",
                 "lodash": "4.17.4",
                 "minimatch": "3.0.4",
                 "path-is-absolute": "1.0.1",
-                "private": "0.1.7",
+                "private": "0.1.8",
                 "slash": "1.0.0",
                 "source-map": "0.5.7"
             }
@@ -469,7 +468,7 @@
             "dev": true,
             "requires": {
                 "find-up": "2.1.0",
-                "istanbul-lib-instrument": "1.8.0",
+                "istanbul-lib-instrument": "1.9.1",
                 "test-exclude": "4.1.1"
             }
         },
@@ -763,7 +762,7 @@
             "requires": {
                 "babel-core": "6.26.0",
                 "babel-runtime": "6.26.0",
-                "core-js": "2.5.1",
+                "core-js": "2.5.3",
                 "home-or-tmp": "2.0.0",
                 "lodash": "4.17.4",
                 "mkdirp": "0.5.1",
@@ -775,8 +774,8 @@
             "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
             "requires": {
-                "core-js": "2.5.1",
-                "regenerator-runtime": "0.11.0"
+                "core-js": "2.5.3",
+                "regenerator-runtime": "0.11.1"
             }
         },
         "babel-template": {
@@ -866,9 +865,9 @@
             }
         },
         "binary-extensions": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
-            "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA="
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+            "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
         },
         "bn.js": {
             "version": "4.11.8",
@@ -886,7 +885,6 @@
             "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
             "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
             "dev": true,
-            "optional": true,
             "requires": {
                 "hoek": "4.2.0"
             }
@@ -934,9 +932,9 @@
             "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
         },
         "browserify-aes": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.8.tgz",
-            "integrity": "sha512-WYCMOT/PtGTlpOKFht0YJFYcPy6pLCR98CtWfzK13zoynLlBMvAdEMSRGmgnJCw2M2j/5qxBkinZQFobieM8dQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
+            "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
             "requires": {
                 "buffer-xor": "1.0.3",
                 "cipher-base": "1.0.4",
@@ -951,7 +949,7 @@
             "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
             "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
             "requires": {
-                "browserify-aes": "1.0.8",
+                "browserify-aes": "1.1.1",
                 "browserify-des": "1.0.0",
                 "evp_bytestokey": "1.0.3"
             }
@@ -1002,8 +1000,8 @@
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
             "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
             "requires": {
-                "caniuse-db": "1.0.30000740",
-                "electron-to-chromium": "1.3.24"
+                "caniuse-db": "1.0.30000783",
+                "electron-to-chromium": "1.3.28"
             }
         },
         "buffer": {
@@ -1076,15 +1074,15 @@
             "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
             "requires": {
                 "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000740",
+                "caniuse-db": "1.0.30000783",
                 "lodash.memoize": "4.1.2",
                 "lodash.uniq": "4.5.0"
             }
         },
         "caniuse-db": {
-            "version": "1.0.30000740",
-            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000740.tgz",
-            "integrity": "sha1-A/yqoXbj7QdYlfctRsGhIUm76sk="
+            "version": "1.0.30000783",
+            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000783.tgz",
+            "integrity": "sha1-FrMNRyZqT1FcxprgMWtnDJYDzb4="
         },
         "caseless": {
             "version": "0.12.0",
@@ -1160,6 +1158,7 @@
             "requires": {
                 "anymatch": "1.3.2",
                 "async-each": "1.0.1",
+                "fsevents": "1.1.3",
                 "glob-parent": "2.0.0",
                 "inherits": "2.0.3",
                 "is-binary-path": "1.0.1",
@@ -1236,9 +1235,9 @@
             }
         },
         "clone": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-            "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+            "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
         },
         "co": {
             "version": "4.6.0",
@@ -1250,7 +1249,7 @@
             "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
             "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
             "requires": {
-                "q": "1.5.0"
+                "q": "1.5.1"
             }
         },
         "code-point-at": {
@@ -1268,15 +1267,15 @@
             "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
             "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
             "requires": {
-                "clone": "1.0.2",
-                "color-convert": "1.9.0",
+                "clone": "1.0.3",
+                "color-convert": "1.9.1",
                 "color-string": "0.3.0"
             }
         },
         "color-convert": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-            "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "requires": {
                 "color-name": "1.1.3"
             }
@@ -1391,14 +1390,14 @@
             "dev": true
         },
         "convert-source-map": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-            "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+            "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
         },
         "core-js": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-            "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+            "version": "2.5.3",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+            "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -1443,7 +1442,6 @@
             "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
             "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
             "dev": true,
-            "optional": true,
             "requires": {
                 "boom": "5.2.0"
             },
@@ -1453,7 +1451,6 @@
                     "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
                     "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "hoek": "4.2.0"
                     }
@@ -1461,9 +1458,9 @@
             }
         },
         "crypto-browserify": {
-            "version": "3.11.1",
-            "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
-            "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+            "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
             "requires": {
                 "browserify-cipher": "1.0.0",
                 "browserify-sign": "4.0.4",
@@ -1474,7 +1471,8 @@
                 "inherits": "2.0.3",
                 "pbkdf2": "3.0.14",
                 "public-encrypt": "4.0.0",
-                "randombytes": "2.0.5"
+                "randombytes": "2.0.5",
+                "randomfill": "1.0.3"
             }
         },
         "css-color-names": {
@@ -1493,7 +1491,7 @@
                 "loader-utils": "1.1.0",
                 "lodash.camelcase": "4.3.0",
                 "object-assign": "4.1.1",
-                "postcss": "5.2.17",
+                "postcss": "5.2.18",
                 "postcss-modules-extract-imports": "1.1.0",
                 "postcss-modules-local-by-default": "1.2.0",
                 "postcss-modules-scope": "1.1.0",
@@ -1567,7 +1565,7 @@
                 "defined": "1.0.0",
                 "has": "1.0.1",
                 "object-assign": "4.1.1",
-                "postcss": "5.2.17",
+                "postcss": "5.2.18",
                 "postcss-calc": "5.3.1",
                 "postcss-colormin": "2.2.2",
                 "postcss-convert-values": "2.6.1",
@@ -1635,7 +1633,7 @@
             "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.30"
+                "es5-ext": "0.10.37"
             }
         },
         "dashdash": {
@@ -1703,7 +1701,7 @@
             "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
             "dev": true,
             "requires": {
-                "clone": "1.0.2"
+                "clone": "1.0.3"
             }
         },
         "defined": {
@@ -1724,6 +1722,14 @@
                 "pify": "2.3.0",
                 "pinkie-promise": "2.0.1",
                 "rimraf": "2.2.8"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                }
             }
         },
         "delayed-stream": {
@@ -1760,13 +1766,12 @@
             }
         },
         "doctrine": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-            "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
+            "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
             "dev": true,
             "requires": {
-                "esutils": "2.0.2",
-                "isarray": "1.0.0"
+                "esutils": "2.0.2"
             }
         },
         "doctypes": {
@@ -1833,9 +1838,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.24",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.24.tgz",
-            "integrity": "sha1-m3uIuwXOufoBahd4M8wt3jiPIbY="
+            "version": "1.3.28",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz",
+            "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4="
         },
         "elliptic": {
             "version": "6.4.0",
@@ -1893,11 +1898,11 @@
             }
         },
         "errno": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-            "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
+            "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
             "requires": {
-                "prr": "0.0.0"
+                "prr": "1.0.1"
             }
         },
         "error-ex": {
@@ -1909,23 +1914,23 @@
             }
         },
         "es5-ext": {
-            "version": "0.10.30",
-            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.30.tgz",
-            "integrity": "sha1-cUGhaDZpfbq/qq7uQUlc4p9SyTk=",
+            "version": "0.10.37",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.37.tgz",
+            "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
             "dev": true,
             "requires": {
-                "es6-iterator": "2.0.1",
+                "es6-iterator": "2.0.3",
                 "es6-symbol": "3.1.1"
             }
         },
         "es6-iterator": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-            "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
             "dev": true,
             "requires": {
                 "d": "1.0.0",
-                "es5-ext": "0.10.30",
+                "es5-ext": "0.10.37",
                 "es6-symbol": "3.1.1"
             }
         },
@@ -1936,17 +1941,17 @@
             "dev": true,
             "requires": {
                 "d": "1.0.0",
-                "es5-ext": "0.10.30",
-                "es6-iterator": "2.0.1",
+                "es5-ext": "0.10.37",
+                "es6-iterator": "2.0.3",
                 "es6-set": "0.1.5",
                 "es6-symbol": "3.1.1",
                 "event-emitter": "0.3.5"
             }
         },
         "es6-promise": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz",
-            "integrity": "sha1-eILzCt3lskDM+n99eMVIMwlRrkI=",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+            "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
             "dev": true
         },
         "es6-set": {
@@ -1956,8 +1961,8 @@
             "dev": true,
             "requires": {
                 "d": "1.0.0",
-                "es5-ext": "0.10.30",
-                "es6-iterator": "2.0.1",
+                "es5-ext": "0.10.37",
+                "es6-iterator": "2.0.3",
                 "es6-symbol": "3.1.1",
                 "event-emitter": "0.3.5"
             }
@@ -1969,7 +1974,7 @@
             "dev": true,
             "requires": {
                 "d": "1.0.0",
-                "es5-ext": "0.10.30"
+                "es5-ext": "0.10.37"
             }
         },
         "es6-weak-map": {
@@ -1979,8 +1984,8 @@
             "dev": true,
             "requires": {
                 "d": "1.0.0",
-                "es5-ext": "0.10.30",
-                "es6-iterator": "2.0.1",
+                "es5-ext": "0.10.37",
+                "es6-iterator": "2.0.3",
                 "es6-symbol": "3.1.1"
             }
         },
@@ -2130,20 +2135,20 @@
                 "chalk": "1.1.3",
                 "concat-stream": "1.6.0",
                 "debug": "2.6.9",
-                "doctrine": "2.0.0",
+                "doctrine": "2.0.2",
                 "escope": "3.6.0",
-                "espree": "3.5.1",
+                "espree": "3.5.2",
                 "esquery": "1.0.0",
                 "estraverse": "4.2.0",
                 "esutils": "2.0.2",
                 "file-entry-cache": "2.0.0",
                 "glob": "7.0.6",
                 "globals": "9.18.0",
-                "ignore": "3.3.5",
+                "ignore": "3.3.7",
                 "imurmurhash": "0.1.4",
                 "inquirer": "0.12.0",
-                "is-my-json-valid": "2.16.1",
-                "is-resolvable": "1.0.0",
+                "is-my-json-valid": "2.17.1",
+                "is-resolvable": "1.0.1",
                 "js-yaml": "3.7.0",
                 "json-stable-stringify": "1.0.1",
                 "levn": "0.3.0",
@@ -2196,13 +2201,13 @@
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
-                "resolve": "1.4.0"
+                "resolve": "1.5.0"
             },
             "dependencies": {
                 "resolve": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-                    "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+                    "version": "1.5.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+                    "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
                     "dev": true,
                     "requires": {
                         "path-parse": "1.0.5"
@@ -2257,9 +2262,9 @@
             "dev": true
         },
         "eslint-plugin-import": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz",
-            "integrity": "sha512-HGYmpU9f/zJaQiKNQOVfHUh2oLWW3STBrCgH0sHTX1xtsxYlH1zjLh8FlQGEIdZSdTbUMaV36WaZ6ImXkenGxQ==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz",
+            "integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
             "dev": true,
             "requires": {
                 "builtin-modules": "1.1.1",
@@ -2305,6 +2310,12 @@
                         "pify": "2.3.0"
                     }
                 },
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                },
                 "read-pkg": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -2335,21 +2346,21 @@
             }
         },
         "eslint-plugin-node": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-5.2.0.tgz",
-            "integrity": "sha512-N9FLFwknT5LhRhjz1lmHguNss/MCwkrLCS4CjqqTZZTJaUhLRfDNK3zxSHL/Il3Aa0Mw+xY3T1gtsJrUNoJy8Q==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-5.2.1.tgz",
+            "integrity": "sha512-xhPXrh0Vl/b7870uEbaumb2Q+LxaEcOQ3kS1jtIXanBAwpMre1l5q/l2l/hESYJGEFKuI78bp6Uw50hlpr7B+g==",
             "dev": true,
             "requires": {
-                "ignore": "3.3.5",
+                "ignore": "3.3.7",
                 "minimatch": "3.0.4",
-                "resolve": "1.4.0",
+                "resolve": "1.5.0",
                 "semver": "5.3.0"
             },
             "dependencies": {
                 "resolve": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-                    "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+                    "version": "1.5.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+                    "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
                     "dev": true,
                     "requires": {
                         "path-parse": "1.0.5"
@@ -2364,9 +2375,9 @@
             }
         },
         "eslint-plugin-promise": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz",
-            "integrity": "sha1-ePu2/+BHIBYnVp6FpsU3OvKmj8o=",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.6.0.tgz",
+            "integrity": "sha512-YQzM6TLTlApAr7Li8vWKR+K3WghjwKcYzY0d2roWap4SLK+kzuagJX/leTetIDWsFcTFnKNJXWupDCD6aZkP2Q==",
             "dev": true
         },
         "eslint-plugin-standard": {
@@ -2393,19 +2404,19 @@
             }
         },
         "espree": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
-            "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+            "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
             "dev": true,
             "requires": {
-                "acorn": "5.1.2",
+                "acorn": "5.2.1",
                 "acorn-jsx": "3.0.1"
             },
             "dependencies": {
                 "acorn": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-                    "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+                    "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
                     "dev": true
                 }
             }
@@ -2452,7 +2463,7 @@
             "dev": true,
             "requires": {
                 "d": "1.0.0",
-                "es5-ext": "0.10.30"
+                "es5-ext": "0.10.37"
             }
         },
         "event-source": {
@@ -2461,7 +2472,7 @@
             "integrity": "sha1-y6lVKMbsMmigUnlhmt9YLS+HwAU=",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.30"
+                "es5-ext": "0.10.37"
             }
         },
         "eventemitter2": {
@@ -2544,33 +2555,24 @@
             "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.2.tgz",
             "integrity": "sha1-dW7076gVXDaBgz+8NNpTuUF0bWw=",
             "requires": {
-                "async": "2.5.0",
+                "async": "2.6.0",
                 "loader-utils": "1.1.0",
                 "schema-utils": "0.3.0",
-                "webpack-sources": "1.0.1"
+                "webpack-sources": "1.1.0"
             }
         },
         "extract-zip": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz",
-            "integrity": "sha1-maBnNbbqIOqbcF13ms/8yHz/BEA=",
+            "version": "1.6.6",
+            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
+            "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
             "dev": true,
             "requires": {
                 "concat-stream": "1.6.0",
-                "debug": "2.2.0",
+                "debug": "2.6.9",
                 "mkdirp": "0.5.0",
                 "yauzl": "2.4.1"
             },
             "dependencies": {
-                "debug": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                    "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-                    "dev": true,
-                    "requires": {
-                        "ms": "0.7.1"
-                    }
-                },
                 "mkdirp": {
                     "version": "0.5.0",
                     "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
@@ -2579,12 +2581,6 @@
                     "requires": {
                         "minimist": "0.0.8"
                     }
-                },
-                "ms": {
-                    "version": "0.7.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                    "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-                    "dev": true
                 },
                 "yauzl": {
                     "version": "2.4.1",
@@ -2607,6 +2603,11 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
             "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
         },
         "fast-levenshtein": {
             "version": "2.0.6",
@@ -2702,7 +2703,7 @@
             "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
             "requires": {
                 "commondir": "1.0.1",
-                "make-dir": "1.0.0",
+                "make-dir": "1.1.0",
                 "pkg-dir": "2.0.0"
             }
         },
@@ -2783,7 +2784,6 @@
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
             "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
             "dev": true,
-            "optional": true,
             "requires": {
                 "asynckit": "0.4.0",
                 "combined-stream": "1.0.5",
@@ -2806,6 +2806,795 @@
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
+        "fsevents": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+            "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+            "optional": true,
+            "requires": {
+                "nan": "2.8.0",
+                "node-pre-gyp": "0.6.39"
+            },
+            "dependencies": {
+                "abbrev": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "ajv": {
+                    "version": "4.11.8",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "co": "4.6.0",
+                        "json-stable-stringify": "1.0.1"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "bundled": true
+                },
+                "aproba": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "are-we-there-yet": {
+                    "version": "1.1.4",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.2.9"
+                    }
+                },
+                "asn1": {
+                    "version": "0.2.3",
+                    "bundled": true,
+                    "optional": true
+                },
+                "assert-plus": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "asynckit": {
+                    "version": "0.4.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "aws-sign2": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "aws4": {
+                    "version": "1.6.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "balanced-match": {
+                    "version": "0.4.2",
+                    "bundled": true
+                },
+                "bcrypt-pbkdf": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "tweetnacl": "0.14.5"
+                    }
+                },
+                "block-stream": {
+                    "version": "0.0.9",
+                    "bundled": true,
+                    "requires": {
+                        "inherits": "2.0.3"
+                    }
+                },
+                "boom": {
+                    "version": "2.10.1",
+                    "bundled": true,
+                    "requires": {
+                        "hoek": "2.16.3"
+                    }
+                },
+                "brace-expansion": {
+                    "version": "1.1.7",
+                    "bundled": true,
+                    "requires": {
+                        "balanced-match": "0.4.2",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "buffer-shims": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "caseless": {
+                    "version": "0.12.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "co": {
+                    "version": "4.6.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "combined-stream": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "requires": {
+                        "delayed-stream": "1.0.0"
+                    }
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true
+                },
+                "console-control-strings": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "cryptiles": {
+                    "version": "2.0.5",
+                    "bundled": true,
+                    "requires": {
+                        "boom": "2.10.1"
+                    }
+                },
+                "dashdash": {
+                    "version": "1.14.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "debug": {
+                    "version": "2.6.8",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "deep-extend": {
+                    "version": "0.4.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "delayed-stream": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "delegates": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "detect-libc": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "ecc-jsbn": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "0.1.1"
+                    }
+                },
+                "extend": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "extsprintf": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "forever-agent": {
+                    "version": "0.6.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "form-data": {
+                    "version": "2.1.4",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.5",
+                        "mime-types": "2.1.15"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "fstream": {
+                    "version": "1.0.11",
+                    "bundled": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "inherits": "2.0.3",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.1"
+                    }
+                },
+                "fstream-ignore": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4"
+                    }
+                },
+                "gauge": {
+                    "version": "2.7.4",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "aproba": "1.1.1",
+                        "console-control-strings": "1.1.0",
+                        "has-unicode": "2.0.1",
+                        "object-assign": "4.1.1",
+                        "signal-exit": "3.0.2",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wide-align": "1.1.2"
+                    }
+                },
+                "getpass": {
+                    "version": "0.1.7",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "bundled": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "bundled": true
+                },
+                "har-schema": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "optional": true
+                },
+                "har-validator": {
+                    "version": "4.2.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "ajv": "4.11.8",
+                        "har-schema": "1.0.5"
+                    }
+                },
+                "has-unicode": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "hawk": {
+                    "version": "3.1.3",
+                    "bundled": true,
+                    "requires": {
+                        "boom": "2.10.1",
+                        "cryptiles": "2.0.5",
+                        "hoek": "2.16.3",
+                        "sntp": "1.0.9"
+                    }
+                },
+                "hoek": {
+                    "version": "2.16.3",
+                    "bundled": true
+                },
+                "http-signature": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "0.2.0",
+                        "jsprim": "1.4.0",
+                        "sshpk": "1.13.0"
+                    }
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true
+                },
+                "ini": {
+                    "version": "1.3.4",
+                    "bundled": true,
+                    "optional": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "number-is-nan": "1.0.1"
+                    }
+                },
+                "is-typedarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "isstream": {
+                    "version": "0.1.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "jodid25519": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "0.1.1"
+                    }
+                },
+                "jsbn": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "json-schema": {
+                    "version": "0.2.3",
+                    "bundled": true,
+                    "optional": true
+                },
+                "json-stable-stringify": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "jsonify": "0.0.0"
+                    }
+                },
+                "json-stringify-safe": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "jsonify": {
+                    "version": "0.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "jsprim": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "extsprintf": "1.0.2",
+                        "json-schema": "0.2.3",
+                        "verror": "1.3.6"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "mime-db": {
+                    "version": "1.27.0",
+                    "bundled": true
+                },
+                "mime-types": {
+                    "version": "2.1.15",
+                    "bundled": true,
+                    "requires": {
+                        "mime-db": "1.27.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "requires": {
+                        "brace-expansion": "1.1.7"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "bundled": true
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "node-pre-gyp": {
+                    "version": "0.6.39",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "detect-libc": "1.0.2",
+                        "hawk": "3.1.3",
+                        "mkdirp": "0.5.1",
+                        "nopt": "4.0.1",
+                        "npmlog": "4.1.0",
+                        "rc": "1.2.1",
+                        "request": "2.81.0",
+                        "rimraf": "2.6.1",
+                        "semver": "5.3.0",
+                        "tar": "2.2.1",
+                        "tar-pack": "3.4.0"
+                    }
+                },
+                "nopt": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "abbrev": "1.1.0",
+                        "osenv": "0.1.4"
+                    }
+                },
+                "npmlog": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "are-we-there-yet": "1.1.4",
+                        "console-control-strings": "1.1.0",
+                        "gauge": "2.7.4",
+                        "set-blocking": "2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "oauth-sign": {
+                    "version": "0.8.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "osenv": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "performance-now": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "process-nextick-args": {
+                    "version": "1.0.7",
+                    "bundled": true
+                },
+                "punycode": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "qs": {
+                    "version": "6.4.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "rc": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "deep-extend": "0.4.2",
+                        "ini": "1.3.4",
+                        "minimist": "1.2.0",
+                        "strip-json-comments": "2.0.1"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.2.9",
+                    "bundled": true,
+                    "requires": {
+                        "buffer-shims": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "1.0.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "request": {
+                    "version": "2.81.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "aws-sign2": "0.6.0",
+                        "aws4": "1.6.0",
+                        "caseless": "0.12.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.1.4",
+                        "har-validator": "4.2.1",
+                        "hawk": "3.1.3",
+                        "http-signature": "1.1.1",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.15",
+                        "oauth-sign": "0.8.2",
+                        "performance-now": "0.2.0",
+                        "qs": "6.4.0",
+                        "safe-buffer": "5.0.1",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.2",
+                        "tunnel-agent": "0.6.0",
+                        "uuid": "3.0.1"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.1",
+                    "bundled": true,
+                    "requires": {
+                        "glob": "7.1.2"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.0.1",
+                    "bundled": true
+                },
+                "semver": {
+                    "version": "5.3.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "sntp": {
+                    "version": "1.0.9",
+                    "bundled": true,
+                    "requires": {
+                        "hoek": "2.16.3"
+                    }
+                },
+                "sshpk": {
+                    "version": "1.13.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.1",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.7",
+                        "jodid25519": "1.0.2",
+                        "jsbn": "0.1.1",
+                        "tweetnacl": "0.14.5"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "safe-buffer": "5.0.1"
+                    }
+                },
+                "stringstream": {
+                    "version": "0.0.5",
+                    "bundled": true,
+                    "optional": true
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "tar": {
+                    "version": "2.2.1",
+                    "bundled": true,
+                    "requires": {
+                        "block-stream": "0.0.9",
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3"
+                    }
+                },
+                "tar-pack": {
+                    "version": "3.4.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "debug": "2.6.8",
+                        "fstream": "1.0.11",
+                        "fstream-ignore": "1.0.5",
+                        "once": "1.4.0",
+                        "readable-stream": "2.2.9",
+                        "rimraf": "2.6.1",
+                        "tar": "2.2.1",
+                        "uid-number": "0.0.6"
+                    }
+                },
+                "tough-cookie": {
+                    "version": "2.3.2",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "punycode": "1.4.1"
+                    }
+                },
+                "tunnel-agent": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "safe-buffer": "5.0.1"
+                    }
+                },
+                "tweetnacl": {
+                    "version": "0.14.5",
+                    "bundled": true,
+                    "optional": true
+                },
+                "uid-number": {
+                    "version": "0.0.6",
+                    "bundled": true,
+                    "optional": true
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "uuid": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "verror": {
+                    "version": "1.3.6",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "extsprintf": "1.0.2"
+                    }
+                },
+                "wide-align": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "string-width": "1.0.2"
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true
+                }
+            }
+        },
         "fstream": {
             "version": "0.1.31",
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
@@ -2822,7 +3611,7 @@
                     "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
                     "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
                     "requires": {
-                        "natives": "1.1.0"
+                        "natives": "1.1.1"
                     }
                 }
             }
@@ -2935,6 +3724,14 @@
                 "object-assign": "4.1.1",
                 "pify": "2.3.0",
                 "pinkie-promise": "2.0.1"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                }
             }
         },
         "google-fonts-webpack-plugin": {
@@ -2945,7 +3742,7 @@
                 "lodash": "4.17.4",
                 "node-fetch": "1.7.3",
                 "webpack-sources": "0.2.3",
-                "yauzl": "2.8.0"
+                "yauzl": "2.9.1"
             },
             "dependencies": {
                 "source-list-map": {
@@ -3062,28 +3859,33 @@
             "integrity": "sha1-yDYWwDVxGmwAYqKBDPHHf/xr7Ss="
         },
         "grunt-contrib-uglify": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-3.1.0.tgz",
-            "integrity": "sha512-4Dx6HOI4ipP4wOqHZEGYYLmBGMccfS6XAI8OOBCiLhLEN54CtxVdCYgT83dPdhxLpXFhNpG89frRjfqcos4H5w==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-3.2.1.tgz",
+            "integrity": "sha512-xBPwg8wuA/m+HiSh2uMADuadKEnFQt9N5OhEy35vIl945yG6095oY1H1Og3ucg0wBSOieIBn3raqStvIcwKqHg==",
             "requires": {
                 "chalk": "1.1.3",
                 "maxmin": "1.1.0",
-                "uglify-js": "3.0.28",
+                "uglify-js": "3.2.2",
                 "uri-path": "1.0.0"
             },
             "dependencies": {
                 "commander": {
-                    "version": "2.11.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-                    "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+                    "version": "2.12.2",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+                    "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA=="
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
                 },
                 "uglify-js": {
-                    "version": "3.0.28",
-                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.28.tgz",
-                    "integrity": "sha512-0h/qGay016GG2lVav3Kz174F3T2Vjlz2v6HCt+WDQpoXfco0hWwF5gHK9yh88mUYvIC+N7Z8NT8WpjSp1yoqGA==",
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.2.2.tgz",
+                    "integrity": "sha512-++1NO/zZIEdWf6cDIGceSJQPX31SqIpbVAHwFG5+240MtZqPG/NIPoinj8zlXQtAfMBqEt1Jyv2FiLP3n9gVhQ==",
                     "requires": {
-                        "commander": "2.11.0",
-                        "source-map": "0.5.7"
+                        "commander": "2.12.2",
+                        "source-map": "0.6.1"
                     }
                 }
             }
@@ -3257,9 +4059,9 @@
             }
         },
         "handlebars": {
-            "version": "4.0.10",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-            "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+            "version": "4.0.11",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+            "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
             "dev": true,
             "requires": {
                 "async": "1.5.2",
@@ -3289,17 +4091,15 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
             "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "har-validator": {
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
             "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
             "dev": true,
-            "optional": true,
             "requires": {
-                "ajv": "5.2.3",
+                "ajv": "5.5.2",
                 "har-schema": "2.0.0"
             }
         },
@@ -3356,12 +4156,11 @@
             "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
             "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
             "dev": true,
-            "optional": true,
             "requires": {
                 "boom": "4.3.1",
                 "cryptiles": "3.1.2",
                 "hoek": "4.2.0",
-                "sntp": "2.0.2"
+                "sntp": "2.1.0"
             }
         },
         "hmac-drbg": {
@@ -3423,7 +4222,6 @@
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "dev": true,
-            "optional": true,
             "requires": {
                 "assert-plus": "1.0.0",
                 "jsprim": "1.4.1",
@@ -3431,9 +4229,9 @@
             }
         },
         "https-browserify": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
-            "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI="
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+            "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
         },
         "ice-cap": {
             "version": "0.0.4",
@@ -3531,9 +4329,9 @@
             "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
         },
         "ignore": {
-            "version": "3.3.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
-            "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
+            "version": "3.3.7",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+            "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
             "dev": true
         },
         "imurmurhash": {
@@ -3596,9 +4394,9 @@
             }
         },
         "interpret": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
-            "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+            "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
         },
         "invariant": {
             "version": "2.2.2",
@@ -3628,13 +4426,13 @@
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "requires": {
-                "binary-extensions": "1.10.0"
+                "binary-extensions": "1.11.0"
             }
         },
         "is-buffer": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-            "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-builtin-module": {
             "version": "1.0.0",
@@ -3701,9 +4499,9 @@
             }
         },
         "is-my-json-valid": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
-            "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
+            "version": "2.17.1",
+            "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
+            "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
             "dev": true,
             "requires": {
                 "generate-function": "2.0.0",
@@ -3732,13 +4530,13 @@
             "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
             "dev": true,
             "requires": {
-                "is-path-inside": "1.0.0"
+                "is-path-inside": "1.0.1"
             }
         },
         "is-path-inside": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-            "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+            "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "dev": true,
             "requires": {
                 "path-is-inside": "1.0.2"
@@ -3787,13 +4585,10 @@
             }
         },
         "is-resolvable": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-            "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-            "dev": true,
-            "requires": {
-                "tryit": "1.0.3"
-            }
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.1.tgz",
+            "integrity": "sha512-y5CXYbzvB3jTnWAZH1Nl7ykUWb6T3BcTs56HUruwBf8MhF56n1HWqhDWnVFo8GHrUPDgvUUNVhrc2U8W7iqz5g==",
+            "dev": true
         },
         "is-stream": {
             "version": "1.1.0",
@@ -3848,7 +4643,7 @@
             "requires": {
                 "abbrev": "1.0.9",
                 "async": "1.5.2",
-                "istanbul-api": "1.1.14",
+                "istanbul-api": "1.2.1",
                 "js-yaml": "3.7.0",
                 "mkdirp": "0.5.1",
                 "nopt": "3.0.6",
@@ -3877,19 +4672,19 @@
             }
         },
         "istanbul-api": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.1.14.tgz",
-            "integrity": "sha1-JbxXAffGgMD//5E95G42GaOm5oA=",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.2.1.tgz",
+            "integrity": "sha512-oFCwXvd65amgaPCzqrR+a2XjanS1MvpXN6l/MlMUTv6uiA1NOgGX+I0uyq8Lg3GDxsxPsaP1049krz3hIJ5+KA==",
             "dev": true,
             "requires": {
-                "async": "2.5.0",
+                "async": "2.6.0",
                 "fileset": "2.0.3",
                 "istanbul-lib-coverage": "1.1.1",
-                "istanbul-lib-hook": "1.0.7",
-                "istanbul-lib-instrument": "1.8.0",
-                "istanbul-lib-report": "1.1.1",
-                "istanbul-lib-source-maps": "1.2.1",
-                "istanbul-reports": "1.1.2",
+                "istanbul-lib-hook": "1.1.0",
+                "istanbul-lib-instrument": "1.9.1",
+                "istanbul-lib-report": "1.1.2",
+                "istanbul-lib-source-maps": "1.2.2",
+                "istanbul-reports": "1.1.3",
                 "js-yaml": "3.7.0",
                 "mkdirp": "0.5.1",
                 "once": "1.4.0"
@@ -3902,18 +4697,18 @@
             "dev": true
         },
         "istanbul-lib-hook": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
-            "integrity": "sha512-3U2HB9y1ZV9UmFlE12Fx+nPtFqIymzrqCksrXujm3NVbAZIJg/RfYgO1XiIa0mbmxTjWpVEVlkIZJ25xVIAfkQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
+            "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
             "dev": true,
             "requires": {
                 "append-transform": "0.4.0"
             }
         },
         "istanbul-lib-instrument": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.8.0.tgz",
-            "integrity": "sha1-ZvbJQhzJ7EcE928tsIS6kHiitTI=",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz",
+            "integrity": "sha512-RQmXeQ7sphar7k7O1wTNzVczF9igKpaeGQAG9qR2L+BS4DCJNTI9nytRmIVYevwO0bbq+2CXvJmYDuz0gMrywA==",
             "dev": true,
             "requires": {
                 "babel-generator": "6.26.0",
@@ -3926,9 +4721,9 @@
             }
         },
         "istanbul-lib-report": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
-            "integrity": "sha512-tvF+YmCmH4thnez6JFX06ujIA19WPa9YUiwjc1uALF2cv5dmE3It8b5I8Ob7FHJ70H9Y5yF+TDkVa/mcADuw1Q==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz",
+            "integrity": "sha512-UTv4VGx+HZivJQwAo1wnRwe1KTvFpfi/NYwN7DcsrdzMXwpRT/Yb6r4SBPoHWj4VuQPakR32g4PUUeyKkdDkBA==",
             "dev": true,
             "requires": {
                 "istanbul-lib-coverage": "1.1.1",
@@ -3949,18 +4744,27 @@
             }
         },
         "istanbul-lib-source-maps": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
-            "integrity": "sha512-mukVvSXCn9JQvdJl8wP/iPhqig0MRtuWuD4ZNKo6vB2Ik//AmhAKe3QnPN02dmkRe3lTudFk3rzoHhwU4hb94w==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz",
+            "integrity": "sha512-8BfdqSfEdtip7/wo1RnrvLpHVEd8zMZEDmOFEnpC6dg0vXflHt9nvoAyQUzig2uMSXfF2OBEYBV3CVjIL9JvaQ==",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
+                "debug": "3.1.0",
                 "istanbul-lib-coverage": "1.1.1",
                 "mkdirp": "0.5.1",
                 "rimraf": "2.6.2",
                 "source-map": "0.5.7"
             },
             "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
                 "rimraf": {
                     "version": "2.6.2",
                     "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -3973,12 +4777,12 @@
             }
         },
         "istanbul-reports": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-            "integrity": "sha1-D7Lj9qqZIr085F0F2KtNXo4HvU8=",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.3.tgz",
+            "integrity": "sha512-ZEelkHh8hrZNI5xDaKwPMFwDsUf5wIEI2bXAFGp1e6deR2mnEKBPhLJEgr4ZBt8Gi6Mj38E/C8kcy9XLggVO2Q==",
             "dev": true,
             "requires": {
-                "handlebars": "4.0.10"
+                "handlebars": "4.0.11"
             }
         },
         "javascript-natural-sort": {
@@ -3992,9 +4796,9 @@
             "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c="
         },
         "js-base64": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz",
-            "integrity": "sha512-Y2/+DnfJJXT1/FCwUebUhLWb3QihxiSC42+ctHLGogmW2jPY6LCapMdFZXRvVP2z6qyKW7s6qncE/9gSqZiArw=="
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
+            "integrity": "sha512-Wehd+7Pf9tFvGb+ydPm9TjYjV8X1YHOVyG8QyELZxEMqOhemVwGRmoG8iQ/soqI3n8v4xn59zaLxiCJiaaRzKA=="
         },
         "js-stringify": {
             "version": "1.0.2",
@@ -4035,7 +4839,7 @@
                 "cssom": "0.3.2",
                 "cssstyle": "0.2.37",
                 "escodegen": "1.9.0",
-                "nwmatcher": "1.4.2",
+                "nwmatcher": "1.4.3",
                 "parse5": "1.5.1",
                 "request": "2.83.0",
                 "sax": "1.2.4",
@@ -4192,7 +4996,7 @@
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "1.1.6"
             }
         },
         "klaw": {
@@ -4237,6 +5041,13 @@
                 "pify": "2.3.0",
                 "pinkie-promise": "2.0.1",
                 "strip-bom": "2.0.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                }
             }
         },
         "loader-runner": {
@@ -4412,11 +5223,11 @@
             "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI="
         },
         "make-dir": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
-            "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
+            "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
             "requires": {
-                "pify": "2.3.0"
+                "pify": "3.0.0"
             }
         },
         "map-obj": {
@@ -4503,7 +5314,7 @@
             "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
             "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
             "requires": {
-                "errno": "0.1.4",
+                "errno": "0.1.6",
                 "readable-stream": "2.3.3"
             }
         },
@@ -4641,10 +5452,16 @@
             "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
             "dev": true
         },
+        "nan": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+            "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+            "optional": true
+        },
         "natives": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
-            "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.1.tgz",
+            "integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA=="
         },
         "natural-compare": {
             "version": "1.4.0",
@@ -4679,20 +5496,20 @@
             }
         },
         "node-libs-browser": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
-            "integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
+            "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
             "requires": {
                 "assert": "1.4.1",
-                "browserify-zlib": "0.1.4",
+                "browserify-zlib": "0.2.0",
                 "buffer": "4.9.1",
                 "console-browserify": "1.1.0",
                 "constants-browserify": "1.0.0",
-                "crypto-browserify": "3.11.1",
+                "crypto-browserify": "3.12.0",
                 "domain-browser": "1.1.7",
                 "events": "1.1.1",
-                "https-browserify": "0.0.1",
-                "os-browserify": "0.2.1",
+                "https-browserify": "1.0.0",
+                "os-browserify": "0.3.0",
                 "path-browserify": "0.0.0",
                 "process": "0.11.10",
                 "punycode": "1.4.1",
@@ -4700,7 +5517,7 @@
                 "readable-stream": "2.3.3",
                 "stream-browserify": "2.0.1",
                 "stream-http": "2.7.2",
-                "string_decoder": "0.10.31",
+                "string_decoder": "1.0.3",
                 "timers-browserify": "2.0.4",
                 "tty-browserify": "0.0.0",
                 "url": "0.11.0",
@@ -4708,10 +5525,18 @@
                 "vm-browserify": "0.0.4"
             },
             "dependencies": {
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                "browserify-zlib": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+                    "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+                    "requires": {
+                        "pako": "1.0.6"
+                    }
+                },
+                "pako": {
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+                    "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
                 }
             }
         },
@@ -4786,9 +5611,9 @@
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "nwmatcher": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.2.tgz",
-            "integrity": "sha512-QMkCGQFYp5p+zwU3INntLmz1HMfSx9dMVJMYKmE1yuSf/22Wjo6VPFa405mCLUuQn9lbQvH2DZN9lt10ZNvtAg==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
+            "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==",
             "dev": true,
             "optional": true
         },
@@ -4859,9 +5684,9 @@
             }
         },
         "os-browserify": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
-            "integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8="
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+            "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
         },
         "os-homedir": {
             "version": "1.0.2",
@@ -4909,8 +5734,8 @@
             "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
             "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
             "requires": {
-                "asn1.js": "4.9.1",
-                "browserify-aes": "1.0.8",
+                "asn1.js": "4.9.2",
+                "browserify-aes": "1.1.1",
                 "create-hash": "1.1.3",
                 "evp_bytestokey": "1.0.3",
                 "pbkdf2": "3.0.14"
@@ -4982,6 +5807,13 @@
                 "graceful-fs": "4.1.11",
                 "pify": "2.3.0",
                 "pinkie-promise": "2.0.1"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                }
             }
         },
         "pbkdf2": {
@@ -5005,179 +5837,29 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "phantomjs-prebuilt": {
-            "version": "2.1.15",
-            "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.15.tgz",
-            "integrity": "sha1-IPhugtM0nFBZF1J3RbekEeCLOQM=",
+            "version": "2.1.16",
+            "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
+            "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
             "dev": true,
             "requires": {
-                "es6-promise": "4.0.5",
-                "extract-zip": "1.6.5",
+                "es6-promise": "4.1.1",
+                "extract-zip": "1.6.6",
                 "fs-extra": "1.0.0",
                 "hasha": "2.2.0",
                 "kew": "0.7.0",
                 "progress": "1.1.8",
-                "request": "2.81.0",
+                "request": "2.83.0",
                 "request-progress": "2.0.1",
                 "which": "1.2.14"
-            },
-            "dependencies": {
-                "ajv": {
-                    "version": "4.11.8",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-                    "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-                    "dev": true,
-                    "requires": {
-                        "co": "4.6.0",
-                        "json-stable-stringify": "1.0.1"
-                    }
-                },
-                "assert-plus": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                    "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-                    "dev": true
-                },
-                "aws-sign2": {
-                    "version": "0.6.0",
-                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                    "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-                    "dev": true
-                },
-                "boom": {
-                    "version": "2.10.1",
-                    "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                    "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-                    "dev": true,
-                    "requires": {
-                        "hoek": "2.16.3"
-                    }
-                },
-                "cryptiles": {
-                    "version": "2.0.5",
-                    "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                    "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-                    "dev": true,
-                    "requires": {
-                        "boom": "2.10.1"
-                    }
-                },
-                "form-data": {
-                    "version": "2.1.4",
-                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-                    "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-                    "dev": true,
-                    "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.5",
-                        "mime-types": "2.1.17"
-                    }
-                },
-                "har-schema": {
-                    "version": "1.0.5",
-                    "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-                    "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-                    "dev": true
-                },
-                "har-validator": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-                    "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-                    "dev": true,
-                    "requires": {
-                        "ajv": "4.11.8",
-                        "har-schema": "1.0.5"
-                    }
-                },
-                "hawk": {
-                    "version": "3.1.3",
-                    "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-                    "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-                    "dev": true,
-                    "requires": {
-                        "boom": "2.10.1",
-                        "cryptiles": "2.0.5",
-                        "hoek": "2.16.3",
-                        "sntp": "1.0.9"
-                    }
-                },
-                "hoek": {
-                    "version": "2.16.3",
-                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                    "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-                    "dev": true
-                },
-                "http-signature": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-                    "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-                    "dev": true,
-                    "requires": {
-                        "assert-plus": "0.2.0",
-                        "jsprim": "1.4.1",
-                        "sshpk": "1.13.1"
-                    }
-                },
-                "performance-now": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-                    "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-                    "dev": true
-                },
-                "qs": {
-                    "version": "6.4.0",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-                    "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-                    "dev": true
-                },
-                "request": {
-                    "version": "2.81.0",
-                    "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-                    "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-                    "dev": true,
-                    "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "4.2.1",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.17",
-                        "oauth-sign": "0.8.2",
-                        "performance-now": "0.2.0",
-                        "qs": "6.4.0",
-                        "safe-buffer": "5.1.1",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.3",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.1.0"
-                    }
-                },
-                "sntp": {
-                    "version": "1.0.9",
-                    "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                    "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-                    "dev": true,
-                    "requires": {
-                        "hoek": "2.16.3"
-                    }
-                }
             }
         },
         "pify": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         },
         "pinkie": {
             "version": "2.0.4",
@@ -5240,12 +5922,12 @@
             "dev": true
         },
         "postcss": {
-            "version": "5.2.17",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
-            "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+            "version": "5.2.18",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+            "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
             "requires": {
                 "chalk": "1.1.3",
-                "js-base64": "2.3.2",
+                "js-base64": "2.4.0",
                 "source-map": "0.5.7",
                 "supports-color": "3.2.3"
             },
@@ -5265,7 +5947,7 @@
             "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
             "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
             "requires": {
-                "postcss": "5.2.17",
+                "postcss": "5.2.18",
                 "postcss-message-helpers": "2.0.0",
                 "reduce-css-calc": "1.3.0"
             }
@@ -5276,7 +5958,7 @@
             "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
             "requires": {
                 "colormin": "1.1.2",
-                "postcss": "5.2.17",
+                "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0"
             }
         },
@@ -5285,7 +5967,7 @@
             "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
             "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
             "requires": {
-                "postcss": "5.2.17",
+                "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0"
             }
         },
@@ -5294,7 +5976,7 @@
             "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
             "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
             "requires": {
-                "postcss": "5.2.17"
+                "postcss": "5.2.18"
             }
         },
         "postcss-discard-duplicates": {
@@ -5302,7 +5984,7 @@
             "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
             "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
             "requires": {
-                "postcss": "5.2.17"
+                "postcss": "5.2.18"
             }
         },
         "postcss-discard-empty": {
@@ -5310,7 +5992,7 @@
             "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
             "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
             "requires": {
-                "postcss": "5.2.17"
+                "postcss": "5.2.18"
             }
         },
         "postcss-discard-overridden": {
@@ -5318,7 +6000,7 @@
             "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
             "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
             "requires": {
-                "postcss": "5.2.17"
+                "postcss": "5.2.18"
             }
         },
         "postcss-discard-unused": {
@@ -5326,7 +6008,7 @@
             "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
             "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
             "requires": {
-                "postcss": "5.2.17",
+                "postcss": "5.2.18",
                 "uniqs": "2.0.0"
             }
         },
@@ -5335,7 +6017,7 @@
             "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
             "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
             "requires": {
-                "postcss": "5.2.17",
+                "postcss": "5.2.18",
                 "uniqid": "4.1.1"
             }
         },
@@ -5345,7 +6027,7 @@
             "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
             "requires": {
                 "has": "1.0.1",
-                "postcss": "5.2.17",
+                "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0"
             }
         },
@@ -5354,7 +6036,7 @@
             "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
             "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
             "requires": {
-                "postcss": "5.2.17"
+                "postcss": "5.2.18"
             }
         },
         "postcss-merge-rules": {
@@ -5364,7 +6046,7 @@
             "requires": {
                 "browserslist": "1.7.7",
                 "caniuse-api": "1.6.1",
-                "postcss": "5.2.17",
+                "postcss": "5.2.18",
                 "postcss-selector-parser": "2.2.3",
                 "vendors": "1.0.1"
             }
@@ -5380,7 +6062,7 @@
             "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
             "requires": {
                 "object-assign": "4.1.1",
-                "postcss": "5.2.17",
+                "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0"
             }
         },
@@ -5389,7 +6071,7 @@
             "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
             "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
             "requires": {
-                "postcss": "5.2.17",
+                "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0"
             }
         },
@@ -5399,7 +6081,7 @@
             "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
             "requires": {
                 "alphanum-sort": "1.0.2",
-                "postcss": "5.2.17",
+                "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0",
                 "uniqs": "2.0.0"
             }
@@ -5411,7 +6093,7 @@
             "requires": {
                 "alphanum-sort": "1.0.2",
                 "has": "1.0.1",
-                "postcss": "5.2.17",
+                "postcss": "5.2.18",
                 "postcss-selector-parser": "2.2.3"
             }
         },
@@ -5420,7 +6102,7 @@
             "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
             "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
             "requires": {
-                "postcss": "6.0.12"
+                "postcss": "6.0.14"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -5428,17 +6110,17 @@
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
                     "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                     "requires": {
-                        "color-convert": "1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-                    "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+                    "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
                     "requires": {
                         "ansi-styles": "3.2.0",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.4.0"
+                        "supports-color": "4.5.0"
                     }
                 },
                 "has-flag": {
@@ -5447,19 +6129,24 @@
                     "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                 },
                 "postcss": {
-                    "version": "6.0.12",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.12.tgz",
-                    "integrity": "sha512-K6SLofXEK43FBSyZ6/ExQV7ji24OEw4tEY6x1CAf7+tcoMWJoO24Rf3rVFVpk+5IQL1e1Cy3sTKfg7hXuLzafg==",
+                    "version": "6.0.14",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+                    "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
                     "requires": {
-                        "chalk": "2.1.0",
-                        "source-map": "0.5.7",
-                        "supports-color": "4.4.0"
+                        "chalk": "2.3.0",
+                        "source-map": "0.6.1",
+                        "supports-color": "4.5.0"
                     }
                 },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                },
                 "supports-color": {
-                    "version": "4.4.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-                    "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+                    "version": "4.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+                    "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
                     "requires": {
                         "has-flag": "2.0.0"
                     }
@@ -5472,7 +6159,7 @@
             "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
             "requires": {
                 "css-selector-tokenizer": "0.7.0",
-                "postcss": "6.0.12"
+                "postcss": "6.0.14"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -5480,17 +6167,17 @@
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
                     "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                     "requires": {
-                        "color-convert": "1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-                    "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+                    "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
                     "requires": {
                         "ansi-styles": "3.2.0",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.4.0"
+                        "supports-color": "4.5.0"
                     }
                 },
                 "has-flag": {
@@ -5499,19 +6186,24 @@
                     "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                 },
                 "postcss": {
-                    "version": "6.0.12",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.12.tgz",
-                    "integrity": "sha512-K6SLofXEK43FBSyZ6/ExQV7ji24OEw4tEY6x1CAf7+tcoMWJoO24Rf3rVFVpk+5IQL1e1Cy3sTKfg7hXuLzafg==",
+                    "version": "6.0.14",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+                    "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
                     "requires": {
-                        "chalk": "2.1.0",
-                        "source-map": "0.5.7",
-                        "supports-color": "4.4.0"
+                        "chalk": "2.3.0",
+                        "source-map": "0.6.1",
+                        "supports-color": "4.5.0"
                     }
                 },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                },
                 "supports-color": {
-                    "version": "4.4.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-                    "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+                    "version": "4.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+                    "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
                     "requires": {
                         "has-flag": "2.0.0"
                     }
@@ -5524,7 +6216,7 @@
             "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
             "requires": {
                 "css-selector-tokenizer": "0.7.0",
-                "postcss": "6.0.12"
+                "postcss": "6.0.14"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -5532,17 +6224,17 @@
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
                     "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                     "requires": {
-                        "color-convert": "1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-                    "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+                    "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
                     "requires": {
                         "ansi-styles": "3.2.0",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.4.0"
+                        "supports-color": "4.5.0"
                     }
                 },
                 "has-flag": {
@@ -5551,19 +6243,24 @@
                     "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                 },
                 "postcss": {
-                    "version": "6.0.12",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.12.tgz",
-                    "integrity": "sha512-K6SLofXEK43FBSyZ6/ExQV7ji24OEw4tEY6x1CAf7+tcoMWJoO24Rf3rVFVpk+5IQL1e1Cy3sTKfg7hXuLzafg==",
+                    "version": "6.0.14",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+                    "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
                     "requires": {
-                        "chalk": "2.1.0",
-                        "source-map": "0.5.7",
-                        "supports-color": "4.4.0"
+                        "chalk": "2.3.0",
+                        "source-map": "0.6.1",
+                        "supports-color": "4.5.0"
                     }
                 },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                },
                 "supports-color": {
-                    "version": "4.4.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-                    "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+                    "version": "4.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+                    "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
                     "requires": {
                         "has-flag": "2.0.0"
                     }
@@ -5576,7 +6273,7 @@
             "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
             "requires": {
                 "icss-replace-symbols": "1.1.0",
-                "postcss": "6.0.12"
+                "postcss": "6.0.14"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -5584,17 +6281,17 @@
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
                     "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                     "requires": {
-                        "color-convert": "1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-                    "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+                    "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
                     "requires": {
                         "ansi-styles": "3.2.0",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.4.0"
+                        "supports-color": "4.5.0"
                     }
                 },
                 "has-flag": {
@@ -5603,19 +6300,24 @@
                     "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                 },
                 "postcss": {
-                    "version": "6.0.12",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.12.tgz",
-                    "integrity": "sha512-K6SLofXEK43FBSyZ6/ExQV7ji24OEw4tEY6x1CAf7+tcoMWJoO24Rf3rVFVpk+5IQL1e1Cy3sTKfg7hXuLzafg==",
+                    "version": "6.0.14",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+                    "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
                     "requires": {
-                        "chalk": "2.1.0",
-                        "source-map": "0.5.7",
-                        "supports-color": "4.4.0"
+                        "chalk": "2.3.0",
+                        "source-map": "0.6.1",
+                        "supports-color": "4.5.0"
                     }
                 },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                },
                 "supports-color": {
-                    "version": "4.4.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-                    "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+                    "version": "4.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+                    "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
                     "requires": {
                         "has-flag": "2.0.0"
                     }
@@ -5627,7 +6329,7 @@
             "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
             "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
             "requires": {
-                "postcss": "5.2.17"
+                "postcss": "5.2.18"
             }
         },
         "postcss-normalize-url": {
@@ -5637,7 +6339,7 @@
             "requires": {
                 "is-absolute-url": "2.1.0",
                 "normalize-url": "1.9.1",
-                "postcss": "5.2.17",
+                "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0"
             }
         },
@@ -5646,7 +6348,7 @@
             "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
             "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
             "requires": {
-                "postcss": "5.2.17",
+                "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0"
             }
         },
@@ -5655,7 +6357,7 @@
             "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
             "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
             "requires": {
-                "postcss": "5.2.17",
+                "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0"
             }
         },
@@ -5664,7 +6366,7 @@
             "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
             "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
             "requires": {
-                "postcss": "5.2.17"
+                "postcss": "5.2.18"
             }
         },
         "postcss-reduce-transforms": {
@@ -5673,7 +6375,7 @@
             "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
             "requires": {
                 "has": "1.0.1",
-                "postcss": "5.2.17",
+                "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0"
             }
         },
@@ -5693,7 +6395,7 @@
             "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
             "requires": {
                 "is-svg": "2.1.0",
-                "postcss": "5.2.17",
+                "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0",
                 "svgo": "0.7.2"
             }
@@ -5704,7 +6406,7 @@
             "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
             "requires": {
                 "alphanum-sort": "1.0.2",
-                "postcss": "5.2.17",
+                "postcss": "5.2.18",
                 "uniqs": "2.0.0"
             }
         },
@@ -5719,7 +6421,7 @@
             "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
             "requires": {
                 "has": "1.0.1",
-                "postcss": "5.2.17",
+                "postcss": "5.2.18",
                 "uniqs": "2.0.0"
             }
         },
@@ -5749,9 +6451,9 @@
             }
         },
         "private": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-            "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+            "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
         },
         "process": {
             "version": "0.11.10",
@@ -5778,9 +6480,9 @@
             }
         },
         "prr": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-            "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+            "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
         },
         "public-encrypt": {
             "version": "4.0.0",
@@ -5895,7 +6597,7 @@
             "dev": true,
             "requires": {
                 "acorn": "4.0.13",
-                "commander": "2.11.0",
+                "commander": "2.12.2",
                 "css-selector-parser": "1.3.0",
                 "find-line-column": "0.5.2",
                 "glob": "7.0.6",
@@ -5916,9 +6618,9 @@
                     "dev": true
                 },
                 "commander": {
-                    "version": "2.11.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-                    "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+                    "version": "2.12.2",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+                    "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
                     "dev": true
                 },
                 "is-expression": {
@@ -6043,16 +6745,15 @@
             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
         "q": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
-            "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE="
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
         },
         "qs": {
             "version": "6.5.1",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
             "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "query-string": {
             "version": "4.3.4",
@@ -6095,7 +6796,7 @@
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "requires": {
-                                "is-buffer": "1.1.5"
+                                "is-buffer": "1.1.6"
                             }
                         }
                     }
@@ -6105,7 +6806,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "requires": {
-                        "is-buffer": "1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -6115,6 +6816,15 @@
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
             "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
             "requires": {
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "randomfill": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
+            "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+            "requires": {
+                "randombytes": "2.0.5",
                 "safe-buffer": "5.1.1"
             }
         },
@@ -6248,9 +6958,9 @@
             "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
         },
         "regenerator-runtime": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-            "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
         },
         "regenerator-transform": {
             "version": "0.10.1",
@@ -6259,7 +6969,7 @@
             "requires": {
                 "babel-runtime": "6.26.0",
                 "babel-types": "6.26.0",
-                "private": "0.1.7"
+                "private": "0.1.8"
             }
         },
         "regex-cache": {
@@ -6353,7 +7063,6 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
             "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
             "dev": true,
-            "optional": true,
             "requires": {
                 "aws-sign2": "0.7.0",
                 "aws4": "1.6.0",
@@ -6481,7 +7190,7 @@
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
             "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
             "requires": {
-                "ajv": "5.2.3"
+                "ajv": "5.5.2"
             }
         },
         "semver": {
@@ -6520,7 +7229,7 @@
             "dev": true,
             "requires": {
                 "glob": "7.0.6",
-                "interpret": "1.0.4",
+                "interpret": "1.1.0",
                 "rechoir": "0.6.2"
             }
         },
@@ -6572,11 +7281,10 @@
             }
         },
         "sntp": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-            "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+            "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
             "dev": true,
-            "optional": true,
             "requires": {
                 "hoek": "4.2.0"
             }
@@ -6782,6 +7490,7 @@
                     "requires": {
                         "anymatch": "1.3.2",
                         "async-each": "1.0.1",
+                        "fsevents": "1.1.3",
                         "glob-parent": "2.0.0",
                         "inherits": "2.0.3",
                         "is-binary-path": "1.0.1",
@@ -7074,9 +7783,9 @@
             "integrity": "sha1-zu78cXp2xDFvEm0LnbqlXX598Bo="
         },
         "toposort": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.4.tgz",
-            "integrity": "sha1-qGEHaQy+6MrkOzSdL2AWJQCSTfw="
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.6.tgz",
+            "integrity": "sha1-wxdI5V0hDv/AD9zcfW5o19e7nOw="
         },
         "tough-cookie": {
             "version": "2.3.3",
@@ -7108,12 +7817,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
             "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
-        },
-        "tryit": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-            "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
-            "dev": true
         },
         "tty-browserify": {
             "version": "0.0.0",
@@ -7343,7 +8046,7 @@
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
             "integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
             "requires": {
-                "async": "2.5.0",
+                "async": "2.6.0",
                 "chokidar": "1.7.0",
                 "graceful-fs": "4.1.11"
             }
@@ -7369,33 +8072,33 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.7.0.tgz",
             "integrity": "sha512-MjAA0ZqO1ba7ZQJRnoCdbM56mmFpipOPUv/vQpwwfSI42p5PVDdoiuK2AL2FwFUVgT859Jr43bFZXRg/LNsqvg==",
             "requires": {
-                "acorn": "5.1.2",
+                "acorn": "5.2.1",
                 "acorn-dynamic-import": "2.0.2",
                 "ajv": "4.11.8",
                 "ajv-keywords": "1.5.1",
-                "async": "2.5.0",
+                "async": "2.6.0",
                 "enhanced-resolve": "3.4.1",
-                "interpret": "1.0.4",
+                "interpret": "1.1.0",
                 "json-loader": "0.5.7",
                 "json5": "0.5.1",
                 "loader-runner": "2.3.0",
                 "loader-utils": "0.2.17",
                 "memory-fs": "0.4.1",
                 "mkdirp": "0.5.1",
-                "node-libs-browser": "2.0.0",
+                "node-libs-browser": "2.1.0",
                 "source-map": "0.5.7",
                 "supports-color": "3.2.3",
                 "tapable": "0.2.8",
                 "uglify-js": "2.8.29",
                 "watchpack": "1.4.0",
-                "webpack-sources": "1.0.1",
+                "webpack-sources": "1.1.0",
                 "yargs": "6.6.0"
             },
             "dependencies": {
                 "acorn": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-                    "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+                    "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
                 },
                 "ajv": {
                     "version": "4.11.8",
@@ -7463,18 +8166,23 @@
             }
         },
         "webpack-sources": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
-            "integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
+            "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
             "requires": {
                 "source-list-map": "2.0.0",
-                "source-map": "0.5.7"
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-list-map": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
                     "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
                 }
             }
         },
@@ -7604,9 +8312,9 @@
             }
         },
         "yauzl": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.8.0.tgz",
-            "integrity": "sha1-eUUK/yKyqcWkHvVOAtuQfM+/nuI=",
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
+            "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
             "requires": {
                 "buffer-crc32": "0.2.13",
                 "fd-slicer": "1.0.1"


### PR DESCRIPTION
* Remove the Python client's "requirements.txt" file
  * The abstract requirements in "setup.py" are the correct place for this information. Concrete / frozen dependencies are not needed.
* Generate a new package-lock.json, with npm 5.6