### PR TITLE
Make MongoDB 3.2 the minimum supported version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,11 @@ jobs:
       - image: girder/girder_test:latest-py2
       # Use the oldest supported MongoDB
       - image: circleci/mongo:3.2-ram
+        # The "ephemeralForTest" storage engine https://docs.mongodb.com/v3.2/release-notes/3.2/#ephemeralfortest-storage-engine
+        # is likely a free (and poorly documented) analogue to the enterprise-only "inMemory"
+        # storage engine. We can pass alternate options to "mongod" by overwriting the default "CMD"
+        # used to start the Docker image: https://github.com/circleci/circleci-images/blob/master/mongo/resources/Dockerfile-ram.template
+        command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
 
     working_directory: /home/circleci/project # as $CIRCLE_WORKING_DIRECTORY
 
@@ -108,6 +113,7 @@ jobs:
       - image: girder/girder_test:latest-py3
       # Use the latest MongoDB
       - image: circleci/mongo:3.6-ram
+        command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
 
     working_directory: /home/circleci/project # as $CIRCLE_WORKING_DIRECTORY
 
@@ -144,6 +150,7 @@ jobs:
     docker:
       - image: girder/girder_test:latest-py3
       - image: circleci/mongo:3.6-ram
+        command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
 
     working_directory: /home/circleci/project # as $CIRCLE_WORKING_DIRECTORY
 
@@ -269,6 +276,7 @@ jobs:
     docker:
       - image: girder/girder_test:latest-py2
       - image: circleci/mongo:3.2-ram
+        command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
     working_directory: /home/circleci/project # as $CIRCLE_WORKING_DIRECTORY
     steps:
       - attach_workspace:
@@ -378,6 +386,7 @@ jobs:
     docker:
       - image: girder/girder_test:latest-py3
       - image: circleci/mongo:3.6-ram
+        command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
     working_directory: /home/circleci/project # as $CIRCLE_WORKING_DIRECTORY
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       # This image uses the oldest version of many dependencies
       - image: girder/girder_test:latest-py2
       # Use the oldest supported MongoDB
-      - image: mongo:2.6
+      - image: circleci/mongo:3.2-ram
 
     working_directory: /home/circleci/project # as $CIRCLE_WORKING_DIRECTORY
 
@@ -226,7 +226,7 @@ jobs:
             ANSIBLE_ROLES_PATH: girder/devops/ansible/roles:girder/devops/ansible/examples/girder-dev-environment/roles
       - run:
           name: Install Girder via ansible
-          command: pyenv exec ansible-playbook --inventory-file="localhost," --connection=local girder/devops/ansible/examples/girder-dev-environment/site.yml --extra-vars="{'girder_version':'$CIRCLE_BRANCH', 'girder_repo':'$CIRCLE_REPOSITORY_URL', 'girder_path':'$CIRCLE_WORKING_DIRECTORY/girder', 'girder_clone':false, 'girder_update':false, 'girder_web':false, 'mongodb_version':'2.6.12'}"
+          command: pyenv exec ansible-playbook --inventory-file="localhost," --connection=local girder/devops/ansible/examples/girder-dev-environment/site.yml --extra-vars="{'girder_version':'$CIRCLE_BRANCH', 'girder_repo':'$CIRCLE_REPOSITORY_URL', 'girder_path':'$CIRCLE_WORKING_DIRECTORY/girder', 'girder_clone':false, 'girder_update':false, 'girder_web':false, 'mongodb_version':'3.2.17'}"
           environment:
             ANSIBLE_ROLES_PATH: girder/devops/ansible/roles:girder/devops/ansible/examples/girder-dev-environment/roles
       - run:
@@ -268,7 +268,7 @@ jobs:
   py2_coverage:
     docker:
       - image: girder/girder_test:latest-py2
-      - image: mongo:2.6
+      - image: circleci/mongo:3.2-ram
     working_directory: /home/circleci/project # as $CIRCLE_WORKING_DIRECTORY
     steps:
       - attach_workspace:

--- a/docs/prerequisites.rst
+++ b/docs/prerequisites.rst
@@ -58,12 +58,12 @@ the APT key with the following: ::
 
     sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
 
-For Debian, create the following configuration file for the MongoDB APT repository: ::
+For Debian 8, create the following configuration file for the MongoDB APT repository: ::
 
     echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/3.2 main" \
         | sudo tee /etc/apt/sources.list.d/mongodb-org-3.2.list
 
-For Ubuntu, instead create the following configuration file: ::
+For Ubuntu 16.04, instead create the following configuration file: ::
 
     echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse" \
         | sudo tee /etc/apt/sources.list.d/mongodb-org-3.2.list

--- a/docs/prerequisites.rst
+++ b/docs/prerequisites.rst
@@ -5,7 +5,7 @@ The following software packages are required to be installed on your system:
 
 * `Python 2.7 or 3.4+ <https://www.python.org>`_
 * `pip <https://pypi.python.org/pypi/pi>`_
-* `MongoDB 2.6+ <http://www.mongodb.org/>`_
+* `MongoDB 3.2+ <http://www.mongodb.org/>`_
 * `Node.js 6.5+ <http://nodejs.org/>`_
 * `curl <http://curl.haxx.se/>`_
 * `zlib <http://www.zlib.net/>`_
@@ -53,20 +53,20 @@ Install the prerequisites using APT: ::
 
     sudo apt-get install curl g++ git libffi-dev libjpeg-dev libldap2-dev libsasl2-dev libssl-dev make python-dev python-pip zlib1g-dev
 
-MongoDB 2.6 requires a special incantation to install at this time. Install
+MongoDB 3.2 requires a special incantation to install at this time. Install
 the APT key with the following: ::
 
-    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
 
 For Debian, create the following configuration file for the MongoDB APT repository: ::
 
-    echo 'deb http://downloads-distro.mongodb.org/repo/debian-sysvinit dist 10gen' \
-        | sudo tee /etc/apt/sources.list.d/mongodb.list
+    echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/3.2 main" \
+        | sudo tee /etc/apt/sources.list.d/mongodb-org-3.2.list
 
 For Ubuntu, instead create the following configuration file: ::
 
-    echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' \
-        | sudo tee /etc/apt/sources.list.d/mongodb.list
+    echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse" \
+        | sudo tee /etc/apt/sources.list.d/mongodb-org-3.2.list
 
 Reload the package database and install MongoDB server using APT: ::
 
@@ -125,9 +125,10 @@ configuration information for the MongoDB YUM repository:
 
     [mongodb]
     name=MongoDB Repository
-    baseurl=http://downloads-distro.mongodb.org/repo/redhat/os/x86_64/
-    gpgcheck=0
+    baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.2/x86_64/
+    gpgcheck=1
     enabled=1
+    gpgkey=https://www.mongodb.org/static/pgp/server-3.2.asc
 
 Install MongoDB server using YUM: ::
 


### PR DESCRIPTION
* Make MongoDB 3.2 the minimum supported version
* Run CI with MongoDB's ephemeralForTest storage engine
  * There is significant variability in the time taken by the "serverTest" CI steps, but running with this flag on should be theoretically faster, and has empirically been 0.5-2 minutes faster.

Part of #2516