### PR TITLE
Run pytest in strict mode, to flag unregistered markers

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-addopts = --verbose --showlocals --cov=girder --cov-config=.coveragerc --cov-report=""
+addopts = --verbose --strict --showlocals --cov=girder --cov-config=.coveragerc --cov-report=""
 cache_dir = build/test/pytest_cache
 testpaths = girder/test

--- a/pytest_girder/pytest_girder/plugin.py
+++ b/pytest_girder/pytest_girder/plugin.py
@@ -19,8 +19,17 @@ def _makeCoverageDirs(config):
             pass
 
 
+def _addCustomMarkers(config):
+    markerDocs = [
+        'testPlugins(pluginList): load a list of test plugins from the test path',
+    ]
+    for markerDoc in markerDocs:
+        config.addinivalue_line('markers', markerDoc)
+
+
 def pytest_configure(config):
     _makeCoverageDirs(config)
+    _addCustomMarkers(config)
 
 
 def pytest_addoption(parser):

--- a/pytest_girder/pytest_girder/plugin.py
+++ b/pytest_girder/pytest_girder/plugin.py
@@ -2,7 +2,7 @@ import os
 from .fixtures import *  # noqa
 
 
-def pytest_configure(config):
+def _makeCoverageDirs(config):
     """
     Create the necessary directories for coverage. This is necessary because neither coverage nor
     pytest-cov have support for making the data_file directory before running.
@@ -17,6 +17,10 @@ def pytest_configure(config):
             os.makedirs(covDataFileDir)
         except OSError:
             pass
+
+
+def pytest_configure(config):
+    _makeCoverageDirs(config)
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
* Modularize the work done by pytest_girder's "pytest_configure" hook
* Register "testPlugins" as a custom pytest_girder marker
* Run pytest in strict mode, to flag unregistered markers