### PR TITLE
Enforce an older version of pydocstyle

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,9 @@ httmock
 mock
 mongomock
 moto[server]
+# Restrict version to work around a bug in flake8-docstrings
+# https://gitlab.com/pycqa/flake8-docstrings/issues/23
+pydocstyle<2.1
 pytest
 pytest-cov
 pytest-xdist


### PR DESCRIPTION
Fixes a bug present in flake8-docstrings, ref: https://gitlab.com/pycqa/flake8-docstrings/issues/23

The bug doesn't appear with any of girder's code, but the handling of `__all__` in https://github.com/girder/large_image/blob/master/server/tilesource/__init__.py does trigger it.  I'm conflicted on whether to enforce this in girder itself or in the development requirements of large_image. 
 Because this is a legitimate bug flake8-docstrings, I decided to make the change here.  I'm watching the upstream issue, and I'll revert when a fix is in place.