### PR TITLE
Run npm binaries via "npx"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,7 @@ Security Fixes
 Changes
 -------
 * Exceptions are now all accessible in the ``exceptions`` module and are descended from the ``GirderBaseException`` class.
+* Require npm 5.2+ (with npm 5.6+ strongly recommended) to build the web client
 
 Deprecations
 ------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,23 +28,6 @@ if(PYTHON_STATIC_ANALYSIS)
   find_program(FLAKE8_EXECUTABLE flake8)
 endif()
 
-if(JAVASCRIPT_STYLE_TESTS)
-  find_program(NODEJS_EXECUTABLE NAMES nodejs node)
-  if(NOT NODEJS_EXECUTABLE)
-    message(FATAL_ERROR "'nodejs' executable couldn't be found.\n"
-                        "Consider reconfiguring passing -DNODEJS_EXECUTABLE:FILEPATH=/path/to/nodejs")
-  endif()
-  find_program(ESLINT_EXECUTABLE eslint ${PROJECT_SOURCE_DIR}/node_modules/.bin NO_DEFAULT_PATH)
-  find_program(PUGLINT_EXECUTABLE pug-lint ${PROJECT_SOURCE_DIR}/node_modules/.bin NO_DEFAULT_PATH)
-  find_program(STYLINT_EXECUTABLE stylint ${PROJECT_SOURCE_DIR}/node_modules/.bin NO_DEFAULT_PATH)
-endif()
-
-if(BUILD_JAVASCRIPT_TESTS)
-  find_program(NYC_EXECUTABLE nyc
-    PATHS "${PROJECT_SOURCE_DIR}/node_modules/.bin"
-    NO_DEFAULT_PATH)
-endif()
-
 if(BUILD_TESTING)
   include(tests/TestData.cmake)
   include(tests/TestCommon.cmake)

--- a/devops/ansible/examples/girder-dev-environment/site.yml
+++ b/devops/ansible/examples/girder-dev-environment/site.yml
@@ -35,17 +35,6 @@
     - role: girder
 
   post_tasks:
-    - name: Install Grunt globally
-      npm:
-        name: "{{ item }}"
-        global: yes
-      with_items:
-        - grunt
-        - grunt-cli
-      become: yes
-      become_user: root
-      when: girder_web
-
     - name: Install Girder Python development requirements
       pip:
         requirements: "requirements-dev.txt"

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -448,12 +448,11 @@ Web client libraries in Girder core are managed via `npm <https://www.npmjs.com/
 When a new npm package is required, or an existing package is upgraded, the following
 should be done:
 
-1. Ensure that you are using a Linux development environment (macOS causes npm to produce slightly
-   different outputs) with version >=5.3 of npm installed:
+1. Ensure that you are using a development environment with version >=5.6 of npm installed:
 
    .. code-block:: bash
 
-       npm install -g 'npm@>=5.3'
+       npm install -g 'npm@>=5.6'
 
 2. Update ``dependencies`` or ``devDependencies`` in ``package.json`` to add a new
    *abstract* specifier for the package:

--- a/docs/prerequisites.rst
+++ b/docs/prerequisites.rst
@@ -28,7 +28,7 @@ See the specific instructions for your platform below.
    Metadata Extractor plugin will only be available in a Python 2.7 environment.
 
 .. note:: It's recommended to get the latest version of the npm package manager, and Girder currently
-   requires at least version 3.10 of npm. To upgrade to the latest npm, after installing Node.js,
+   requires at least version 5.2 of npm. To upgrade to the latest npm, after installing Node.js,
    run:
 
    .. code-block:: bash

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     },
     "engines": {
         "node": ">=6.5",
-        "npm": ">=3.10"
+        "npm": ">=5.2"
     },
     "dependencies": {
         "babel-core": "^6.25.0",

--- a/tests/DocumentationTests.cmake
+++ b/tests/DocumentationTests.cmake
@@ -1,7 +1,7 @@
 add_test(
   NAME documentation_generate
   WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-  COMMAND "${PROJECT_SOURCE_DIR}/node_modules/.bin/grunt" docs:clean
+  COMMAND npx grunt docs:clean
 )
 
 set_property(TEST documentation_generate

--- a/tests/JavascriptTests.cmake
+++ b/tests/JavascriptTests.cmake
@@ -12,7 +12,7 @@ function(javascript_tests_init)
   add_test(
     NAME js_coverage_combine_report
     WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-    COMMAND "${NYC_EXECUTABLE}" report
+    COMMAND npx nyc report
   )
   set_property(TEST js_coverage_reset PROPERTY LABELS girder_browser girder_integration)
   set_property(TEST js_coverage_combine_report PROPERTY LABELS girder_coverage)
@@ -21,10 +21,6 @@ endfunction()
 function(add_eslint_test name input)
   if (NOT JAVASCRIPT_STYLE_TESTS)
     return()
-  endif()
-
-  if (NOT ESLINT_EXECUTABLE)
-    message(FATAL_ERROR "CMake variable ESLINT_EXECUTABLE is not set. Run 'girder-install web --dev' or disable JAVASCRIPT_STYLE_TESTS.")
   endif()
 
   set(_args ESLINT_IGNORE_FILE ESLINT_CONFIG_FILE)
@@ -45,7 +41,7 @@ function(add_eslint_test name input)
   add_test(
     NAME "eslint_${name}"
     WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-    COMMAND "${ESLINT_EXECUTABLE}" --ignore-path "${ignore_file}" --config "${config_file}" "${input}"
+    COMMAND npx eslint --ignore-path "${ignore_file}" --config "${config_file}" "${input}"
   )
   set_property(TEST "eslint_${name}" PROPERTY LABELS girder_browser)
 endfunction()
@@ -55,14 +51,10 @@ function(add_puglint_test name path)
     return()
   endif()
 
-  if (NOT PUGLINT_EXECUTABLE)
-    message(FATAL_ERROR "CMake variable PUGLINT_EXECUTABLE is not set. Run 'girder-install web --dev' or disable JAVASCRIPT_STYLE_TESTS.")
-  endif()
-
   add_test(
     NAME "puglint_${name}"
     WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-    COMMAND "${PUGLINT_EXECUTABLE}" -c "${PROJECT_SOURCE_DIR}/.pug-lintrc" "${path}"
+    COMMAND npx pug-lint -c "${PROJECT_SOURCE_DIR}/.pug-lintrc" "${path}"
   )
   set_property(TEST "puglint_${name}" PROPERTY LABELS girder_browser)
 endfunction()
@@ -72,14 +64,10 @@ function(add_stylint_test name path)
     return()
   endif()
 
-  if (NOT STYLINT_EXECUTABLE)
-    message(FATAL_ERROR "CMake variable STYLINT_EXECUTABLE is not set. Run 'girder-install web --dev' or disable JAVASCRIPT_STYLE_TESTS.")
-  endif()
-
   add_test(
     NAME "stylint_${name}"
     WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-    COMMAND "${STYLINT_EXECUTABLE}" --config "${PROJECT_SOURCE_DIR}/.stylintrc" "${path}"
+    COMMAND npx stylint --config "${PROJECT_SOURCE_DIR}/.stylintrc" "${path}"
   )
   set_property(TEST "stylint_${name}" PROPERTY LABELS girder_browser)
 endfunction()

--- a/tests/packaging/CMakeLists.txt
+++ b/tests/packaging/CMakeLists.txt
@@ -25,7 +25,7 @@ add_custom_target(
 add_test(
   NAME packaging_generate
   WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-  COMMAND "${PROJECT_SOURCE_DIR}/node_modules/.bin/grunt" package
+  COMMAND npx grunt package
 )
 
 set_property(TEST packaging_generate

--- a/tests/web_client_test.py
+++ b/tests/web_client_test.py
@@ -171,7 +171,7 @@ class WebClientTestCase(base.TestCase):
             baseUrl = os.environ['BASEURL']
 
         cmd = (
-            os.path.join(ROOT_DIR, 'node_modules', '.bin', 'phantomjs'),
+            'npx', 'phantomjs',
             '--web-security=%s' % self.webSecurity,
             os.path.join(ROOT_DIR, 'clients', 'web', 'test', 'specRunner.js'),
             'http://localhost:%s%s' % (os.environ['GIRDER_PORT'], baseUrl),
@@ -188,7 +188,8 @@ class WebClientTestCase(base.TestCase):
         retry_count = os.environ.get('PHANTOMJS_RETRY', 3)
         for _ in range(int(retry_count)):
             retry = False
-            task = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            task = subprocess.Popen(
+                cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=ROOT_DIR)
             jasmineFinished = False
             for line in iter(task.stdout.readline, b''):
                 if isinstance(line, six.binary_type):


### PR DESCRIPTION
* Run npm binaries via "npx"
* Document the required version of npm
  * 5.2 is needed for the "npx" command
  * 5.6 is needed to generate platform-independent package-lock.json files
* Don't install Grunt globally, since npx can be used instead