### PR TITLE
Add a registry for loading and querying plugins

### DIFF
--- a/girder/_plugin.py
+++ b/girder/_plugin.py
@@ -1,0 +1,266 @@
+###############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+"""
+This module defines functions for registering, loading, and querying girder plugins.
+"""
+
+import abc
+import traceback
+
+from pkg_resources import iter_entry_points
+import six
+
+from girder import logprint
+
+NAMESPACE = 'girder.plugin'
+_pluginRegistry = None
+_pluginFailureInfo = {}
+
+
+@six.add_metaclass(abc.ABCMeta)
+class GirderPlugin(object):
+    """
+    This is a base class for describing a girder plugin.  A plugin is registered by adding
+    an entrypoint under the namespace ``girder.plugin``.  This entrypoint should return a
+    class derived from this class.
+
+    Example ::
+        class Cats(GirderPlugin):
+            '''
+            This string will be displayed to the user as a plugin description.
+            '''
+            URL = 'https://girder-cats.com'
+            DEPENDENCIES = ['animals']
+
+            def load(self, info):
+                super(Cats, self).load()
+                import rest  # register new rest endpoints
+    """
+    URL = ''
+    DEPENDENCIES = []
+    WEB_DEPENDENCIES = []
+
+    def __init__(self, entryPoint):
+        self._entryPoint = entryPoint
+        self._loaded = False
+
+    @property
+    def name(self):
+        """Return the plugin name defaulting to the entrypoint name."""
+        return self._entryPoint.name
+
+    @property
+    def description(self):
+        """Return the plugin description defaulting to the classes docstring."""
+        return self.__class__.__doc__ or ''
+
+    @property
+    def url(self):
+        """Return a url reference to the plugin (usually a readthedocs page)."""
+        return self.URL
+
+    @property
+    def version(self):
+        """Return the version of the plugin automatically determined from setup.py."""
+        return self._entryPoint.dist.version
+
+    @property
+    def dependencies(self):
+        """Return a list of plugins that this plugin requires."""
+        return list(self.DEPENDENCIES)
+
+    @property
+    def webDependencies(self):
+        """Return a list of plugins containing web client assets this plugin uses."""
+        return list(self.WEB_DEPENDENCIES)
+
+    @property
+    def loaded(self):
+        """Return true if this plugin has been loaded."""
+        return self._loaded
+
+    @abc.abstractmethod
+    def load(self, info):
+        """Execute any code necessary to load the plugin.
+
+        This method must be overridden by derived classes and call the superclass method.
+        """
+        self._loaded = True
+
+
+def _findPlugins():
+    """Iterate through entrypoints to discover installed plugins."""
+    global _pluginRegistry
+    if _pluginRegistry is not None:
+        return
+
+    _pluginRegistry = {}
+    for entryPoint in iter_entry_points(NAMESPACE):
+        pluginClass = entryPoint.load()
+        plugin = pluginClass(entryPoint)
+        _pluginRegistry[plugin.name] = plugin
+
+
+def _walkPluginTree(func, plugins, dependencyGetter, handled, nodes):
+    """Walk through the plugin dependency tree depth first.
+
+    This is a recursive function performing a specialized topological sorting of the
+    plugin dependency tree.  Each time a new plugin is encountered the provided function
+    is called on the plugin config object.  This function will be called at most once
+    for each plugin and if it raises any exception, an error message will be recorded and
+    the walk cancelled.
+
+    :param func: A function taking the plugin configuration object.
+    :param plugins: A list of plugin names to traverse.
+    :param dependencyGetter: A function that returns a list of dependencies of a plugin.
+    :param handled: A set of plugin names that have already been handled.
+    :param nodes: A set of plugin names in the current tree traversal.  This is used
+                  to detect cycles in the dependency graph.
+    """
+    # loop over a sorted list of plugins to ensure a consistent traversal order
+    for pluginName in sorted(plugins):
+        if pluginName in handled:
+            continue
+
+        # handle dependency cycles
+        if pluginName in nodes:
+            logprint.error('Cyclic dependencies encountered while processing plugins')
+            raise Exception('Cyclic dependencies encountered while processing plugins')
+
+        # generate a set of nodes traversed up to the root for cycle detection
+        pluginNodes = {pluginName}
+        pluginNodes.update(nodes)
+
+        plugin = getPlugin(pluginName)
+
+        # handle missing dependencies
+        if plugin is None:
+            logprint.error('ERROR: Plugin %s not found', pluginName)
+            raise Exception('Required plugin missing')
+
+        # traverse into sub-dependencies
+        try:
+            _walkPluginTree(func, dependencyGetter(plugin), dependencyGetter, handled, pluginNodes)
+        except Exception:
+            logprint.error('ERROR: Dependency failure while processing %s', pluginName)
+            _pluginFailureInfo[pluginName] = {
+                'traceback': '',
+                'message': 'Dependency error'
+            }
+            handled.add(pluginName)
+            raise
+
+        # call the handler function and record it
+        func(plugin)
+        handled.add(pluginName)
+
+
+def _getToposortedPlugins(plugins=None, dependencyGetter=None):
+    """Return a toposorted list of plugins with a custom child-node accessor.
+
+    :param plugins: A list of plugins to include (defaults to all plugins)
+    :param dependencyGetter: A function taking a plugin object and returning a list of dependencies
+    """
+    dependencyGetter = dependencyGetter or (lambda p: p.dependencies)
+    pluginNames = []
+    if plugins is None:
+        plugins = allPlugins()
+
+    def appendPluginName(plugin):
+        pluginNames.append(plugin.name)
+
+    _walkPluginTree(appendPluginName, plugins, dependencyGetter, set(), set())
+    return pluginNames
+
+
+def getToposortedPlugins(plugins=None):
+    """Return a toposorted list of plugins.
+
+    By default this function will return a toposorted list of all detected plugins.  If a list of
+    plugin names is provided, it will only return a minimal list of plugins required for the
+    given top-level plugins.
+    """
+    return _getToposortedPlugins(plugins)
+
+
+def getToposortedWebDependencies(plugins=None):
+    """Return a toposorted list of plugin web dependencies.
+
+    By default this function will return a toposorted list of all detected plugins.  If a list of
+    plugin names is provided, it will only return a minimal list of plugins required for the
+    given top-level plugins.
+    """
+    return _getToposortedPlugins(
+        plugins,
+        dependencyGetter=lambda p: p.webDependencies
+    )
+
+
+def getPlugin(name):
+    """Return a plugin configuration object or None if the plugin is not found."""
+    _findPlugins()
+    if name not in _pluginRegistry:
+        return None
+    return _pluginRegistry[name]
+
+
+def getPluginFailureInfo():
+    """Return an object containing plugin failure information."""
+    return _pluginFailureInfo
+
+
+def loadPlugin(name, root, appconf, apiRoot=None):
+    """Load a plugin and all of its dependencies in topological order."""
+    def callPluginLoad(plugin):
+        if not plugin or plugin.loaded:
+            return
+        info['dependencies'] = list(plugin.dependencies)
+        try:
+            plugin.load(info)
+        except Exception:
+            logprint.exception('ERROR: Failed to execute load method for %s', plugin.name)
+            _pluginFailureInfo[plugin.name] = {
+                'traceback': traceback.format_exc()
+            }
+            raise
+
+    info = {
+        'config': appconf,
+        'serverRoot': root,
+        'apiRoot': apiRoot
+    }
+    try:
+        _walkPluginTree(callPluginLoad, [name], lambda p: p.dependencies, set(), set())
+    except Exception:
+        return None
+    return getPlugin(name)
+
+
+def loadPlugins(names, root, appconf, apiRoot=None):
+    """Load a list of plugins and their dependencies in topological order."""
+    loadedPlugins = {}
+    for name in names:
+        pluginObject = loadPlugin(name, root, appconf, apiRoot)
+        if pluginObject:
+            loadedPlugins[name] = pluginObject
+    return loadedPlugins
+
+
+def allPlugins():
+    """Return a list of all detected plugins."""
+    _findPlugins()
+    return list(_pluginRegistry.keys())

--- a/girder/test/test_plugin_registry.py
+++ b/girder/test/test_plugin_registry.py
@@ -1,0 +1,315 @@
+###############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+import re
+
+import mock
+import pytest
+
+from girder import _plugin as plugin
+
+
+@pytest.fixture
+def logprint():
+    with mock.patch.object(plugin, 'logprint') as logprintMock:
+        yield logprintMock
+
+
+def assertNoDuplicates(loadOrder):
+    __tracebackhide__ = True
+    assert len(loadOrder) == len(set(loadOrder))
+
+
+def assertPluginLoadOrder(plugin, loadOrder):
+    __tracebackhide__ = True
+
+    assertNoDuplicates(loadOrder)
+    pluginIndex = loadOrder.index(plugin.name)
+    for dep in plugin.dependencies:
+        depIndex = loadOrder.index(dep)
+        assert depIndex < pluginIndex
+
+
+def assertAllPluginsLoadOrder(loadOrder):
+    __tracebackhide__ = True
+
+    assertNoDuplicates(loadOrder)
+    for pluginName in loadOrder:
+        assertPluginLoadOrder(plugin.getPlugin(pluginName), loadOrder)
+
+
+class MockedPlugin(plugin.GirderPlugin):
+    _side_effect = None
+
+    def __init__(self, *args, **kwargs):
+        self._mockLoad = mock.Mock()
+        super(MockedPlugin, self).__init__(*args, **kwargs)
+
+    def load(self, *args, **kwargs):
+        super(MockedPlugin, self).load(*args, **kwargs)
+        self._mockLoad(*args, **kwargs)
+        if self._side_effect:
+            raise self._side_effect
+
+
+def mockPluginGenerator(deps, webDeps, url, doc, side_effect=None):
+    class GeneratedMockPlugin(MockedPlugin):
+        DEPENDENCIES = deps
+        WEB_DEPENDENCIES = webDeps
+        URL = url
+        _side_effect = side_effect
+        __doc__ = doc
+
+    return GeneratedMockPlugin
+
+
+class MockEntryPoint(object):
+    def __init__(self, name, version, pluginClass):
+        self.name = name
+        self.dist = mock.Mock()
+        self.dist.version = version
+        self.load = mock.Mock(return_value=pluginClass)
+        self.pluginClass = pluginClass
+
+
+def mockEntryPointGenerator(name, version='0.1.0', deps=None, webDeps=None, side_effect=None):
+    if deps is None:
+        deps = []
+    if webDeps is None:
+        webDeps = []
+
+    url = 'url for %s' % name
+    doc = 'doc for %s' % name
+    pluginClass = mockPluginGenerator(deps, webDeps, url, doc, side_effect)
+    return MockEntryPoint(name, version, pluginClass)
+
+
+@pytest.fixture
+def pluginRegistry():
+    yield plugin._pluginRegistry
+    plugin._pluginRegistry = None
+    plugin._pluginFailureInfo = {}
+
+
+@pytest.fixture
+def registerPlugin(pluginRegistry):
+    entry_points = []
+
+    def iter_entry_points(*args, **kwargs):
+        for ep in entry_points:
+            yield ep
+
+    def register(*args):
+        entry_points.extend(args)
+
+    with mock.patch.object(plugin, 'iter_entry_points', side_effect=iter_entry_points):
+        yield register
+
+
+validPluginTree = [
+    mockEntryPointGenerator('withdeps4', deps=['withdeps3'], webDeps=['leaf1', 'leaf4']),
+    mockEntryPointGenerator('withdeps1', deps=['leaf1']),
+    mockEntryPointGenerator('leaf1'),
+    mockEntryPointGenerator('leaf2'),
+    mockEntryPointGenerator('leaf3'),
+    mockEntryPointGenerator('leaf4'),
+    mockEntryPointGenerator('withdeps2', deps=['withdeps1', 'leaf1', 'leaf2']),
+    mockEntryPointGenerator('withdeps3', deps=['withdeps2', 'withdeps1'], webDeps=['leaf3'])
+]
+validPluginList = [
+    [],
+    [mockEntryPointGenerator('nodeps')],
+    [
+        mockEntryPointGenerator('withdeps', '1.0.0', ['depa', 'depb']),
+        mockEntryPointGenerator('depa'),
+        mockEntryPointGenerator('depb')
+    ],
+    [
+        mockEntryPointGenerator('withwebdeps', webDeps=['depa', 'depb']),
+        mockEntryPointGenerator('depa'),
+        mockEntryPointGenerator('depb')
+    ],
+    [
+        mockEntryPointGenerator('withmultideps', deps=['depa', 'depb'], webDeps=['depb', 'depc']),
+        mockEntryPointGenerator('depa'),
+        mockEntryPointGenerator('depb'),
+        mockEntryPointGenerator('depc')
+    ],
+    validPluginTree
+]
+pluginTreeWithCycle = [
+    mockEntryPointGenerator('plugin1', deps=['plugin2']),
+    mockEntryPointGenerator('plugin2', deps=['plugin3']),
+    mockEntryPointGenerator('plugin3', deps=['plugin1'])
+]
+pluginTreeWithLoadFailure = [
+    mockEntryPointGenerator('loadfailurea', side_effect=Exception('failure a')),
+    mockEntryPointGenerator('loadfailureb', side_effect=Exception('failure b')),
+    mockEntryPointGenerator('dependsonfailure', deps=['loadfailurea']),
+    mockEntryPointGenerator('leafa'),
+    mockEntryPointGenerator('leafb'),
+    mockEntryPointGenerator('withdeps', deps=['leafa', 'leafb']),
+    mockEntryPointGenerator('multipledepends', deps=['leafa', 'loadfailureb']),
+    mockEntryPointGenerator('rootdepends', deps=['leafb', 'withdeps', 'dependsonfailure'])
+]
+
+
+@pytest.mark.parametrize('pluginList', validPluginList)
+def testAllPlugins(registerPlugin, pluginList):
+    registerPlugin(*pluginList)
+    allPlugins = plugin.allPlugins()
+    assert len(allPlugins) == len(pluginList)
+    for pluginClass in pluginList:
+        assert pluginClass.name in allPlugins
+
+
+@pytest.mark.parametrize('pluginList', validPluginList)
+def testPluginGetMetadata(registerPlugin, pluginList):
+    registerPlugin(*pluginList)
+    for pluginEntryPoint in pluginList:
+        pluginDefinition = plugin.getPlugin(pluginEntryPoint.name)
+        assert pluginDefinition.name == pluginEntryPoint.name
+        assert pluginDefinition.version == pluginEntryPoint.dist.version
+        assert pluginDefinition.description == pluginEntryPoint.pluginClass.__doc__
+        assert pluginDefinition.url == pluginEntryPoint.pluginClass.URL
+
+
+@pytest.mark.parametrize('pluginList', validPluginList)
+def testPluginLoad(registerPlugin, pluginList):
+    registerPlugin(*pluginList)
+    for pluginEntryPoint in pluginList:
+        pluginDefinition = plugin.loadPlugin(pluginEntryPoint.name, 'root', 'appconf')
+        assert pluginDefinition.loaded is True
+
+
+def testPluginLoadOnlyOnce(registerPlugin):
+    registerPlugin(mockEntryPointGenerator('nodeps'))
+    pluginDefinition = plugin.getPlugin('nodeps')
+    assert pluginDefinition.loaded is False
+    pluginDefinition._mockLoad.assert_not_called()
+
+    plugin.loadPlugin('nodeps', 'root', 'appconf')
+    assert pluginDefinition.loaded is True
+    pluginDefinition._mockLoad.assert_called_once()
+
+    plugin.loadPlugin('nodeps', 'root', 'appconf')
+    assert pluginDefinition.loaded is True
+    pluginDefinition._mockLoad.assert_called_once()
+
+
+def testPluginLoadOrder(registerPlugin):
+    registerPlugin(*validPluginTree)
+    manager = mock.Mock()
+    allPlugins = plugin.allPlugins()
+    assert len(allPlugins) == len(validPluginTree)
+
+    for pluginName in plugin.allPlugins():
+        pluginClass = plugin.getPlugin(pluginName)
+        manager.attach_mock(pluginClass._mockLoad, pluginName)
+    plugin.loadPlugin('withdeps4', 'root', 'appconf')
+
+    loadOrder = []
+    for call in manager.mock_calls:
+        loadOrder.append(re.search(r'call\.(.+)\(', str(call)).groups()[0])
+
+    assertAllPluginsLoadOrder(loadOrder)
+
+
+def testMissingDependencyHandler(registerPlugin, logprint):
+    registerPlugin(
+        mockEntryPointGenerator('hasmissingdeps', deps=['missing'])
+    )
+    assert plugin.getPlugin('hasmissingdeps')
+    assert plugin.loadPlugin('hasmissingdeps', 'root', 'appconf') is None
+
+    logprint.error.assert_any_call('ERROR: Plugin %s not found', 'missing')
+    logprint.error.assert_any_call('ERROR: Dependency failure while processing %s',
+                                   'hasmissingdeps')
+
+
+def testListAllPluginsToposorted(registerPlugin):
+    registerPlugin(*validPluginTree)
+    plugins = plugin.getToposortedPlugins()
+    assertAllPluginsLoadOrder(plugins)
+
+
+def testListPluginsToposortedFromList(registerPlugin):
+    registerPlugin(*validPluginTree)
+    plugins = plugin.getToposortedPlugins(['withdeps4', 'withdeps2'])
+    assert plugins == ['leaf1', 'leaf2', 'withdeps1', 'withdeps2', 'withdeps3', 'withdeps4']
+
+
+def testListPluginWebDependenciesFromList(registerPlugin):
+    registerPlugin(*validPluginTree)
+    plugins = plugin.getToposortedWebDependencies(['withdeps4', 'withdeps2'])
+    assert plugins == ['withdeps2', 'leaf1', 'leaf4', 'withdeps4']
+
+
+def testListAllPluginsToposortedFromRoot(registerPlugin):
+    registerPlugin(*validPluginTree)
+    plugins = plugin.getToposortedPlugins(['withdeps4'])
+    assert 'withdeps4' in plugins
+    assertAllPluginsLoadOrder(plugins)
+
+
+def testLoadPluginList(registerPlugin):
+    registerPlugin(*validPluginTree)
+    loaded = plugin.loadPlugins(['withdeps1', 'leaf4', 'withdeps2'], 'root', 'appconf')
+    assert set(loaded.keys()) == {'withdeps1', 'leaf4', 'withdeps2'}
+    assert plugin.getPlugin('leaf1').loaded is True
+
+
+def testLoadPluginListWithMissingDependency(registerPlugin, logprint):
+    registerPlugin(*validPluginTree)
+    loaded = plugin.loadPlugins(
+        ['withdeps1', 'notaplugin', 'leaf4', 'withdeps2'], 'root', 'appconf')
+    assert set(loaded.keys()) == {'withdeps1', 'leaf4', 'withdeps2'}
+    logprint.error.assert_any_call('ERROR: Plugin %s not found', 'notaplugin')
+    assert plugin.getPlugin('leaf1').loaded is True
+
+
+def testLoadPluginCyclicDepencencyHandler(registerPlugin, logprint):
+    registerPlugin(*pluginTreeWithCycle)
+    with pytest.raises(Exception, match='Cyclic dependencies encountered'):
+        plugin.getToposortedPlugins()
+    logprint.error.assert_any_call('Cyclic dependencies encountered while processing plugins')
+
+
+def testSuccessfulLoadWithBadPlugin(registerPlugin):
+    registerPlugin(*pluginTreeWithLoadFailure)
+    plugin.loadPlugin('leafa', 'root', 'appconf')
+
+
+def testLoadPluginWithException(registerPlugin, logprint):
+    registerPlugin(*pluginTreeWithLoadFailure)
+    assert plugin.loadPlugin('loadfailurea', 'root', 'appconf') is None
+    assert set(plugin.getPluginFailureInfo().keys()) == {'loadfailurea'}
+    logprint.exception.assert_called_with(
+        'ERROR: Failed to execute load method for %s', 'loadfailurea')
+
+
+def testLoadPluginTreeWithException(registerPlugin, logprint):
+    registerPlugin(*pluginTreeWithLoadFailure)
+    assert plugin.loadPlugin('rootdepends', 'root', 'appconf') is None
+    assert set(plugin.getPluginFailureInfo().keys()) == {
+        'dependsonfailure', 'loadfailurea', 'rootdepends'
+    }
+    logprint.exception.assert_any_call(
+        'ERROR: Failed to execute load method for %s', 'loadfailurea')
+    logprint.error.assert_any_call(
+        'ERROR: Dependency failure while processing %s', 'dependsonfailure')
+    logprint.error.assert_any_call(
+        'ERROR: Dependency failure while processing %s', 'rootdepends')


### PR DESCRIPTION
This adds a module meant to replace the functional contents of `utilities/plugin_utilities.py` for the girder 3.0 migration.  This module is not yet used to maintain backwards compatibility.  I have added it as an independent PR to collect feedback before moving on with the larger effort to replace core girder code with this new module, which will require backwards incompatible changes and migration of existing plugins.

I don't know how useful this is as a standalone PR, but it is the most I can achieve before I start breaking compatibility.  Alternatively, I can make this a WIP and start pushing breaking changes here so others can get a better idea for where this is headed.