### PR TITLE
Revert #2542 and use the latest flake8-docstrings

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,14 +2,11 @@
 coverage
 flake8
 flake8-blind-except
-flake8-docstrings
+flake8-docstrings>=1.3
 httmock
 mock
 mongomock
 moto[server]
-# Restrict version to work around a bug in flake8-docstrings
-# https://gitlab.com/pycqa/flake8-docstrings/issues/23
-pydocstyle<2.1
 pytest
 pytest-cov
 pytest-xdist


### PR DESCRIPTION
There was just a new release of flake8-docstrings that fixes the error
that #2542 addressed.  This reverts that change and requires the latest
release with the fix in place.