### PR TITLE
Upgrade some npm dependencies

### DIFF
--- a/.esdoc.json
+++ b/.esdoc.json
@@ -1,4 +1,19 @@
 {
-    "source": "./clients/web/src",
-    "destination": "./docs/_build/esdoc"
+    "source": "clients/web/src",
+    "destination": "build/docs/web",
+    "index": "README.rst",
+    "plugins": [
+        {
+            "name": "esdoc-standard-plugin",
+            "option": {
+                "brand": {
+                    "title": "Girder",
+                    "description": "Web-based data management platform",
+                    "repository": "https://github.com/girder/girder",
+                    "author": "Kitware, Inc.",
+                    "image": "clients/web/src/assets/Girder_Mark.png"
+                }
+            }
+        }
+    ]
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -86,7 +86,6 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-contrib-pug');
     grunt.loadNpmTasks('grunt-contrib-stylus');
-    grunt.loadNpmTasks('grunt-contrib-symlink');
     grunt.loadNpmTasks('grunt-contrib-uglify');
     grunt.loadNpmTasks('grunt-file-creator');
     grunt.loadNpmTasks('grunt-gitinfo');

--- a/clients/web/src/package.json
+++ b/clients/web/src/package.json
@@ -19,9 +19,9 @@
         "eonasdan-bootstrap-datetimepicker": "~4.17",
         "jquery": "~3.2.1",
         "jsoneditor": "~5.9.3",
-        "moment": "~2.18.1",
+        "moment": "~2.20.1",
         "remarkable": "~1.7.1",
-        "sprintf-js": "~1.0.3",
+        "sprintf-js": "~1.1.1",
         "swagger-ui": "~2.2.10",
         "underscore": "~1.8.3"
     },

--- a/grunt_tasks/webpack.config.js
+++ b/grunt_tasks/webpack.config.js
@@ -27,8 +27,7 @@ var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var paths = require('./webpack.paths.js');
 // Resolving the Babel presets here is required to support symlinking plugin directories from
 // outside Girder's file tree
-const es2015BabelPreset = require.resolve('babel-preset-es2015');
-const es2016BabelPreset = require.resolve('babel-preset-es2016');
+const babelPresets = require.resolve('babel-preset-env');
 
 function fileLoader() {
     return {
@@ -69,7 +68,7 @@ module.exports = {
     ],
     module: {
         rules: [
-            // ES2015
+            // ES2015+
             {
                 resource: {
                     test: /\.js$/,
@@ -80,7 +79,8 @@ module.exports = {
                     {
                         loader: 'babel-loader',
                         options: {
-                            presets: [es2015BabelPreset, es2016BabelPreset],
+                            // Without any options, 'preset-env' behavies like 'preset-latest'
+                            presets: [babelPresets],
                             cacheDirectory: true
                         }
                     }
@@ -131,7 +131,7 @@ module.exports = {
                     {
                         loader: 'babel-loader',
                         options: {
-                            presets: [es2015BabelPreset, es2016BabelPreset],
+                            presets: [babelPresets],
                             cacheDirectory: true
                         }
                     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -243,11 +243,22 @@
             "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
             "requires": {
                 "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000787",
+                "caniuse-db": "1.0.30000789",
                 "normalize-range": "0.1.2",
                 "num2fraction": "1.2.2",
                 "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0"
+            },
+            "dependencies": {
+                "browserslist": {
+                    "version": "1.7.7",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+                    "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+                    "requires": {
+                        "caniuse-db": "1.0.30000789",
+                        "electron-to-chromium": "1.3.30"
+                    }
+                }
             }
         },
         "aws-sign2": {
@@ -404,6 +415,18 @@
                 "lodash": "4.17.4"
             }
         },
+        "babel-helper-remap-async-to-generator": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+            "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+            "requires": {
+                "babel-helper-function-name": "6.24.1",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0"
+            }
+        },
         "babel-helper-replace-supers": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
@@ -463,10 +486,30 @@
                 "test-exclude": "4.1.1"
             }
         },
+        "babel-plugin-syntax-async-functions": {
+            "version": "6.13.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+            "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+        },
         "babel-plugin-syntax-exponentiation-operator": {
             "version": "6.13.0",
             "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
             "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+        },
+        "babel-plugin-syntax-trailing-function-commas": {
+            "version": "6.22.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+            "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+        },
+        "babel-plugin-transform-async-to-generator": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+            "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+            "requires": {
+                "babel-helper-remap-async-to-generator": "6.24.1",
+                "babel-plugin-syntax-async-functions": "6.13.0",
+                "babel-runtime": "6.26.0"
+            }
         },
         "babel-plugin-transform-es2015-arrow-functions": {
             "version": "6.22.0",
@@ -707,12 +750,14 @@
                 "babel-types": "6.26.0"
             }
         },
-        "babel-preset-es2015": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
-            "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+        "babel-preset-env": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
+            "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
             "requires": {
                 "babel-plugin-check-es2015-constants": "6.22.0",
+                "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+                "babel-plugin-transform-async-to-generator": "6.24.1",
                 "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
                 "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
                 "babel-plugin-transform-es2015-block-scoping": "6.26.0",
@@ -735,15 +780,11 @@
                 "babel-plugin-transform-es2015-template-literals": "6.22.0",
                 "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
                 "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-                "babel-plugin-transform-regenerator": "6.26.0"
-            }
-        },
-        "babel-preset-es2016": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-preset-es2016/-/babel-preset-es2016-6.24.1.tgz",
-            "integrity": "sha1-+QC/k+LrwNJ235uKtZck6/2Vn4s=",
-            "requires": {
-                "babel-plugin-transform-exponentiation-operator": "6.24.1"
+                "babel-plugin-transform-exponentiation-operator": "6.24.1",
+                "babel-plugin-transform-regenerator": "6.26.0",
+                "browserslist": "2.11.0",
+                "invariant": "2.2.2",
+                "semver": "5.4.1"
             }
         },
         "babel-register": {
@@ -987,11 +1028,11 @@
             }
         },
         "browserslist": {
-            "version": "1.7.7",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-            "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.0.tgz",
+            "integrity": "sha512-mNYp0RNeu1xueGuJFSXkU+K0nH+dBE/gcjtyhtNKfU8hwdrVIfoA7i5iFSjOmzkGdL2QaO7YX9ExiVPE7AY9JA==",
             "requires": {
-                "caniuse-db": "1.0.30000787",
+                "caniuse-lite": "1.0.30000789",
                 "electron-to-chromium": "1.3.30"
             }
         },
@@ -1065,15 +1106,31 @@
             "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
             "requires": {
                 "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000787",
+                "caniuse-db": "1.0.30000789",
                 "lodash.memoize": "4.1.2",
                 "lodash.uniq": "4.5.0"
+            },
+            "dependencies": {
+                "browserslist": {
+                    "version": "1.7.7",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+                    "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+                    "requires": {
+                        "caniuse-db": "1.0.30000789",
+                        "electron-to-chromium": "1.3.30"
+                    }
+                }
             }
         },
         "caniuse-db": {
-            "version": "1.0.30000787",
-            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000787.tgz",
-            "integrity": "sha1-ygeigb5Taoi9f6yWuolfPPU/gRs="
+            "version": "1.0.30000789",
+            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000789.tgz",
+            "integrity": "sha1-XPP+x1SABBqxYsoGQTFTFB4jQyU="
+        },
+        "caniuse-lite": {
+            "version": "1.0.30000789",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000789.tgz",
+            "integrity": "sha1-Lj2TeyZxM/Y2Ne9/RB+sZjYPyIk="
         },
         "caseless": {
             "version": "0.12.0",
@@ -1765,9 +1822,9 @@
             }
         },
         "doctrine": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
-            "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+            "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
             "dev": true,
             "requires": {
                 "esutils": "2.0.2"
@@ -1900,7 +1957,7 @@
             "requires": {
                 "bootstrap": "3.3.7",
                 "jquery": "3.2.1",
-                "moment": "2.18.1",
+                "moment": "2.20.1",
                 "moment-timezone": "0.4.1"
             }
         },
@@ -1992,14 +2049,14 @@
             }
         },
         "esdoc": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/esdoc/-/esdoc-0.5.2.tgz",
-            "integrity": "sha1-y/0LIOPRyswjyTwyju2YfiG6AGc=",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/esdoc/-/esdoc-1.0.4.tgz",
+            "integrity": "sha512-Hy5sg0Lec4EDHVem3gFqNi+o6ZptivmaiHYacZhmn3hzLnHSMg2C1L0XTsDIcb4Cxd9aUnWdLAu6a6ghH/LLug==",
             "dev": true,
             "requires": {
-                "babel-generator": "6.11.4",
-                "babel-traverse": "6.12.0",
-                "babylon": "6.14.1",
+                "babel-generator": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babylon": "6.18.0",
                 "cheerio": "0.22.0",
                 "color-logger": "0.0.3",
                 "escape-html": "1.0.3",
@@ -2007,6 +2064,77 @@
                 "ice-cap": "0.0.4",
                 "marked": "0.3.6",
                 "minimist": "1.2.0",
+                "taffydb": "2.7.2"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                }
+            }
+        },
+        "esdoc-accessor-plugin": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/esdoc-accessor-plugin/-/esdoc-accessor-plugin-1.0.0.tgz",
+            "integrity": "sha1-eRukhy5sQDUVznSbE0jW8Ck62es=",
+            "dev": true
+        },
+        "esdoc-brand-plugin": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/esdoc-brand-plugin/-/esdoc-brand-plugin-1.0.0.tgz",
+            "integrity": "sha1-niFtc15i/OxJ96M5u0Eh2mfMYDM=",
+            "dev": true,
+            "requires": {
+                "cheerio": "0.22.0"
+            }
+        },
+        "esdoc-coverage-plugin": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/esdoc-coverage-plugin/-/esdoc-coverage-plugin-1.1.0.tgz",
+            "integrity": "sha1-OGmGnNf4eJH5cmJXh2laKZrs5Fw=",
+            "dev": true
+        },
+        "esdoc-external-ecmascript-plugin": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/esdoc-external-ecmascript-plugin/-/esdoc-external-ecmascript-plugin-1.0.0.tgz",
+            "integrity": "sha1-ePVl1KDFGFrGMVJhTc4f4ahmiNs=",
+            "dev": true,
+            "requires": {
+                "fs-extra": "1.0.0"
+            }
+        },
+        "esdoc-integrate-manual-plugin": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/esdoc-integrate-manual-plugin/-/esdoc-integrate-manual-plugin-1.0.0.tgz",
+            "integrity": "sha1-GFSmqhwIEDXXyMUeO91PtlqkcRw=",
+            "dev": true
+        },
+        "esdoc-integrate-test-plugin": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/esdoc-integrate-test-plugin/-/esdoc-integrate-test-plugin-1.0.0.tgz",
+            "integrity": "sha1-4tDQAJD38MNeXS8sAzMnp55T5Ak=",
+            "dev": true
+        },
+        "esdoc-lint-plugin": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/esdoc-lint-plugin/-/esdoc-lint-plugin-1.0.1.tgz",
+            "integrity": "sha1-h77mQD5nbAh/Yb6SxFLWDyxqcOU=",
+            "dev": true
+        },
+        "esdoc-publish-html-plugin": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/esdoc-publish-html-plugin/-/esdoc-publish-html-plugin-1.1.0.tgz",
+            "integrity": "sha1-CT+DN6yhaQIlcss4f/zD9HCwJRM=",
+            "dev": true,
+            "requires": {
+                "babel-generator": "6.11.4",
+                "cheerio": "0.22.0",
+                "escape-html": "1.0.3",
+                "fs-extra": "1.0.0",
+                "ice-cap": "0.0.4",
+                "marked": "0.3.6",
                 "taffydb": "2.7.2"
             },
             "dependencies": {
@@ -2024,29 +2152,6 @@
                         "source-map": "0.5.7"
                     }
                 },
-                "babel-traverse": {
-                    "version": "6.12.0",
-                    "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.12.0.tgz",
-                    "integrity": "sha1-8i9U+g1u639jWFJGurbmN4WPXZQ=",
-                    "dev": true,
-                    "requires": {
-                        "babel-code-frame": "6.26.0",
-                        "babel-messages": "6.23.0",
-                        "babel-runtime": "6.26.0",
-                        "babel-types": "6.26.0",
-                        "babylon": "6.14.1",
-                        "debug": "2.6.9",
-                        "globals": "8.18.0",
-                        "invariant": "2.2.2",
-                        "lodash": "4.17.4"
-                    }
-                },
-                "babylon": {
-                    "version": "6.14.1",
-                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                    "integrity": "sha1-lWJ1+rcnU62bNDXXr+WPi/CimBU=",
-                    "dev": true
-                },
                 "detect-indent": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
@@ -2057,12 +2162,6 @@
                         "minimist": "1.2.0",
                         "repeating": "1.1.3"
                     }
-                },
-                "globals": {
-                    "version": "8.18.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-                    "integrity": "sha1-k9SmK9ysOM+vr8R9awNHaMsP/LQ=",
-                    "dev": true
                 },
                 "minimist": {
                     "version": "1.2.0",
@@ -2081,10 +2180,47 @@
                 }
             }
         },
+        "esdoc-standard-plugin": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/esdoc-standard-plugin/-/esdoc-standard-plugin-1.0.0.tgz",
+            "integrity": "sha1-ZhIBysfvhokkkCRG/awVJyU8XU0=",
+            "dev": true,
+            "requires": {
+                "esdoc-accessor-plugin": "1.0.0",
+                "esdoc-brand-plugin": "1.0.0",
+                "esdoc-coverage-plugin": "1.1.0",
+                "esdoc-external-ecmascript-plugin": "1.0.0",
+                "esdoc-integrate-manual-plugin": "1.0.0",
+                "esdoc-integrate-test-plugin": "1.0.0",
+                "esdoc-lint-plugin": "1.0.1",
+                "esdoc-publish-html-plugin": "1.1.0",
+                "esdoc-type-inference-plugin": "1.0.1",
+                "esdoc-undocumented-identifier-plugin": "1.0.0",
+                "esdoc-unexported-identifier-plugin": "1.0.0"
+            }
+        },
+        "esdoc-type-inference-plugin": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/esdoc-type-inference-plugin/-/esdoc-type-inference-plugin-1.0.1.tgz",
+            "integrity": "sha1-qrynhkH5m9Hs5vMC8EW71jG+cvU=",
+            "dev": true
+        },
+        "esdoc-undocumented-identifier-plugin": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/esdoc-undocumented-identifier-plugin/-/esdoc-undocumented-identifier-plugin-1.0.0.tgz",
+            "integrity": "sha1-guBdNxwy0ShxFA8dXIHsmf2cwsg=",
+            "dev": true
+        },
+        "esdoc-unexported-identifier-plugin": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/esdoc-unexported-identifier-plugin/-/esdoc-unexported-identifier-plugin-1.0.0.tgz",
+            "integrity": "sha1-H5h0xqfCvr+a05fDzrdcnGnaurE=",
+            "dev": true
+        },
         "eslint": {
-            "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.14.0.tgz",
-            "integrity": "sha512-Ul6CSGRjKscEyg0X/EeNs7o2XdnbTEOD1OM8cTjmx85RPcBJQrEhZLevhuJZNAE/vS2iVl5Uhgiqf3h5uLMCJQ==",
+            "version": "4.15.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.15.0.tgz",
+            "integrity": "sha512-zEO/Z1ZUxIQ+MhDVKkVTUYpIPDTEJLXGMrkID+5v1NeQHtCz6FZikWuFRgxE1Q/RV2V4zVl1u3xmpPADHhMZ6A==",
             "dev": true,
             "requires": {
                 "ajv": "5.5.2",
@@ -2093,7 +2229,7 @@
                 "concat-stream": "1.6.0",
                 "cross-spawn": "5.1.0",
                 "debug": "3.1.0",
-                "doctrine": "2.0.2",
+                "doctrine": "2.1.0",
                 "eslint-scope": "3.7.1",
                 "eslint-visitor-keys": "1.0.0",
                 "espree": "3.5.2",
@@ -2242,9 +2378,9 @@
             "dev": true
         },
         "eslint-import-resolver-node": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
-            "integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+            "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
@@ -2318,7 +2454,7 @@
                 "contains-path": "0.1.0",
                 "debug": "2.6.9",
                 "doctrine": "1.5.0",
-                "eslint-import-resolver-node": "0.3.1",
+                "eslint-import-resolver-node": "0.3.2",
                 "eslint-module-utils": "2.1.1",
                 "has": "1.0.1",
                 "lodash.cond": "4.5.2",
@@ -3709,11 +3845,17 @@
                 "eonasdan-bootstrap-datetimepicker": "4.17.47",
                 "jquery": "3.2.1",
                 "jsoneditor": "5.9.6",
-                "moment": "2.18.1",
+                "moment": "2.20.1",
                 "remarkable": "1.7.1",
-                "sprintf-js": "1.0.3",
+                "sprintf-js": "1.1.1",
                 "swagger-ui": "2.2.10",
                 "underscore": "1.8.3"
+            },
+            "dependencies": {
+                "sprintf-js": {
+                    "version": "1.1.1",
+                    "bundled": true
+                }
             }
         },
         "glob": {
@@ -3892,11 +4034,6 @@
                 }
             }
         },
-        "grunt-contrib-symlink": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/grunt-contrib-symlink/-/grunt-contrib-symlink-1.0.0.tgz",
-            "integrity": "sha1-yDYWwDVxGmwAYqKBDPHHf/xr7Ss="
-        },
         "grunt-contrib-uglify": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-3.3.0.tgz",
@@ -3904,7 +4041,7 @@
             "requires": {
                 "chalk": "1.1.3",
                 "maxmin": "1.1.0",
-                "uglify-js": "3.3.4",
+                "uglify-js": "3.3.5",
                 "uri-path": "1.0.0"
             },
             "dependencies": {
@@ -3919,9 +4056,9 @@
                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
                 },
                 "uglify-js": {
-                    "version": "3.3.4",
-                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.4.tgz",
-                    "integrity": "sha512-hfIwuAQI5dlXP30UtdmWoYF9k+ypVqBXIdmd6ZKBiaNHHvA8ty7ZloMe3+7S5AEKVkxHbjByl4DfRHQ7QpZquw==",
+                    "version": "3.3.5",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.5.tgz",
+                    "integrity": "sha512-ZebM2kgBL/UI9rKeAbsS2J0UPPv7SBy5hJNZml/YxB1zC6JK8IztcPs+cxilE4pu0li6vadVSFqiO7xFTKuSrg==",
                     "requires": {
                         "commander": "2.12.2",
                         "source-map": "0.6.1"
@@ -5322,11 +5459,6 @@
                 "brorand": "1.1.0"
             }
         },
-        "mime": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
-            "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA="
-        },
         "mime-db": {
             "version": "1.30.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
@@ -5380,16 +5512,16 @@
             }
         },
         "moment": {
-            "version": "2.18.1",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-            "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
+            "version": "2.20.1",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
+            "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
         },
         "moment-timezone": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.1.tgz",
             "integrity": "sha1-gfWYw61eIs2teWtn7NjYjQ9bqgY=",
             "requires": {
-                "moment": "2.18.1"
+                "moment": "2.20.1"
             }
         },
         "mout": {
@@ -7609,6 +7741,17 @@
                 "postcss": "5.2.18",
                 "postcss-selector-parser": "2.2.3",
                 "vendors": "1.0.1"
+            },
+            "dependencies": {
+                "browserslist": {
+                    "version": "1.7.7",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+                    "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+                    "requires": {
+                        "caniuse-db": "1.0.30000789",
+                        "electron-to-chromium": "1.3.30"
+                    }
+                }
             }
         },
         "postcss-message-helpers": {
@@ -7662,7 +7805,7 @@
             "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
             "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
             "requires": {
-                "postcss": "6.0.15"
+                "postcss": "6.0.16"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -7699,9 +7842,9 @@
                     "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                 },
                 "postcss": {
-                    "version": "6.0.15",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
-                    "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
+                    "version": "6.0.16",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+                    "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
                     "requires": {
                         "chalk": "2.3.0",
                         "source-map": "0.6.1",
@@ -7729,7 +7872,7 @@
             "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
             "requires": {
                 "css-selector-tokenizer": "0.7.0",
-                "postcss": "6.0.15"
+                "postcss": "6.0.16"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -7766,9 +7909,9 @@
                     "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                 },
                 "postcss": {
-                    "version": "6.0.15",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
-                    "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
+                    "version": "6.0.16",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+                    "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
                     "requires": {
                         "chalk": "2.3.0",
                         "source-map": "0.6.1",
@@ -7796,7 +7939,7 @@
             "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
             "requires": {
                 "css-selector-tokenizer": "0.7.0",
-                "postcss": "6.0.15"
+                "postcss": "6.0.16"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -7833,9 +7976,9 @@
                     "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                 },
                 "postcss": {
-                    "version": "6.0.15",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
-                    "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
+                    "version": "6.0.16",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+                    "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
                     "requires": {
                         "chalk": "2.3.0",
                         "source-map": "0.6.1",
@@ -7863,7 +8006,7 @@
             "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
             "requires": {
                 "icss-replace-symbols": "1.1.0",
-                "postcss": "6.0.15"
+                "postcss": "6.0.16"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -7900,9 +8043,9 @@
                     "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                 },
                 "postcss": {
-                    "version": "6.0.15",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
-                    "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
+                    "version": "6.0.16",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+                    "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
                     "requires": {
                         "chalk": "2.3.0",
                         "source-map": "0.6.1",
@@ -9602,15 +9745,6 @@
                     "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
                     "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
                 }
-            }
-        },
-        "url-loader": {
-            "version": "0.5.9",
-            "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.9.tgz",
-            "integrity": "sha512-B7QYFyvv+fOBqBVeefsxv6koWWtjmHaMFT6KZWti4KRw8YUD/hOU+3AECvXuzyVawIBx3z7zQRejXCDSO5kk1Q==",
-            "requires": {
-                "loader-utils": "1.1.0",
-                "mime": "1.3.6"
             }
         },
         "user-home": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "devDependencies": {
         "babel-plugin-istanbul": "^4.1.5",
         "core-js": "^2.4.1",
-        "esdoc": "^0.5.2",
+        "esdoc": "^1.0.4",
+        "esdoc-standard-plugin": "^1.0.0",
         "eslint": "^4.13.1",
         "eslint-config-girder": "^4.0.1",
         "eslint-config-semistandard": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
         "grunt-contrib-copy": "^1.0.0",
         "grunt-contrib-pug": "^1.0.0",
         "grunt-contrib-stylus": "^1.2.0",
-        "grunt-contrib-symlink": "^1.0.0",
         "grunt-contrib-uglify": "^3.0.1",
         "grunt-file-creator": "^0.1.3",
         "grunt-fontello": "^0.3.4",
@@ -49,7 +48,6 @@
         "swagger-ui": "~2.2.10",
         "toposort": "^1.0.3",
         "underscore": "^1.8.3",
-        "url-loader": "^0.5.9",
         "webpack": "^2.7.0"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "dependencies": {
         "babel-core": "^6.25.0",
         "babel-loader": "^7.1.1",
-        "babel-preset-es2015": "^6.24.1",
-        "babel-preset-es2016": "^6.24.1",
+        "babel-preset-env": "^1.6.1",
         "colors": "^1.1.2",
         "css-loader": "^0.26.1",
         "extendify": "^1.0.0",

--- a/plugins/candela/webpack.helper.js
+++ b/plugins/candela/webpack.helper.js
@@ -1,8 +1,5 @@
 var path = require('path');
 
-const es2015BabelPreset = require.resolve('babel-preset-es2015');
-const es2016BabelPreset = require.resolve('babel-preset-es2016');
-
 module.exports = function (config, data) {
     var candelaDir = path.resolve(data.nodeDir, 'candela');
 
@@ -15,7 +12,7 @@ module.exports = function (config, data) {
             {
                 loader: 'babel-loader',
                 options: {
-                    presets: [es2015BabelPreset, es2016BabelPreset]
+                    presets: ['env']
                 }
             }
         ]

--- a/plugins/dicom_viewer/plugin.json
+++ b/plugins/dicom_viewer/plugin.json
@@ -7,7 +7,7 @@
         "dependencies": {
             "daikon": "^1.2.15",
             "shader-loader": "1.3.0",
-            "vtk.js": "2.24.1"
+            "vtk.js": "5.10.3"
         }
     }
 }

--- a/plugins/dicom_viewer/webpack.helper.js
+++ b/plugins/dicom_viewer/webpack.helper.js
@@ -17,7 +17,7 @@ module.exports = function (config) {
             {
                 loader: 'babel-loader',
                 options: {
-                    presets: ['es2015', 'es2016']
+                    presets: ['env']
                 }
             }
         ]


### PR DESCRIPTION
This fixes some security warnings for npm packages, and should fix some build problems at https://doc.esdoc.org/github.com/girder/girder

* Remove unused npm dependencies
* Use "babel-preset-env" for Babel presets
* Upgrade vtk.js, to use a version with more modern bundling
* Upgrade and fix issues with ESDoc
* Upgrade some client npm dependencies with security patches
* Update package-lock.json
  
Fixes #1540