### PR TITLE
Swagger doesn't recognize application/zip as binary data.

### DIFF
--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -28,6 +28,7 @@ import jsonschema
 import os
 import six
 import cherrypy
+from collections import OrderedDict
 
 from girder import constants, events, logprint
 from girder.api.rest import getCurrentUser, getBodyJson
@@ -135,7 +136,17 @@ class Description(object):
             resp['consumes'] = self._consumes
 
         if self._produces:
-            resp['produces'] = self._produces
+            # swagger has a bug where not all appropriate mime types are
+            # considered to be binary (see
+            # https://github.com/swagger-api/swagger-ui/issues/1605).  If we
+            # have specified zip format, replace it with
+            # application/octet-stream
+            #   Reduce the list of produces values to unique values,
+            # maintaining the order.
+            produces = list(OrderedDict.fromkeys([
+                'application/octet-stream' if item in ('application/zip', )
+                else item for item in self._produces]))
+            resp['produces'] = produces
 
         if self._deprecated:
             resp['deprecated'] = True


### PR DESCRIPTION
Swagger injects BOM markers to non-binary data when it buffers it for downloading.  Since Swagger 2.x only recognizes images, pdfs, and application/octet-stream as binary, any other content dispositions can be corrupted by this process.  Change the value stored in the `produces` field for Swagger so that any data that might be binary (notably zip files) is specified as application/octet-stream.

Fixes #2561.