### PR TITLE
WIP: Use ESDoc2, to fix package security warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@types/node": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-9.3.0.tgz",
+            "integrity": "sha512-wNBfvNjzsJl4tswIZKXCFQY0lss9nKUyJnG6T94X/eqjRgI2jHZ4evdjhQYBSan/vGtF6XVXPApOmNH2rf0KKw==",
+            "dev": true
+        },
         "abab": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -119,6 +125,22 @@
             "requires": {
                 "micromatch": "2.3.11",
                 "normalize-path": "2.1.1"
+            }
+        },
+        "aproba": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+            "dev": true
+        },
+        "are-we-there-yet": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+            "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+            "dev": true,
+            "requires": {
+                "delegates": "1.0.0",
+                "readable-stream": "2.3.3"
             }
         },
         "argparse": {
@@ -882,6 +904,19 @@
                 "tweetnacl": "0.14.5"
             }
         },
+        "big-json": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/big-json/-/big-json-1.2.0.tgz",
+            "integrity": "sha512-LrtyIojw2a3uFv1kuGkpMh1TFhXgeRRcJ57fW+nutySomxc6RmUJmsxYyXDGs9LJlyfq+zkWpGQG94IG4YXCMQ==",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "json-stream-stringify": "1.5.1",
+                "stream-json": "0.5.2",
+                "through2": "2.0.3",
+                "utf8-stream": "0.0.0"
+            }
+        },
         "big.js": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
@@ -1182,27 +1217,17 @@
             "dev": true
         },
         "cheerio": {
-            "version": "0.22.0",
-            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
-            "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+            "version": "1.0.0-rc.2",
+            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
+            "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
             "dev": true,
             "requires": {
                 "css-select": "1.2.0",
                 "dom-serializer": "0.1.0",
                 "entities": "1.1.1",
                 "htmlparser2": "3.9.2",
-                "lodash.assignin": "4.2.0",
-                "lodash.bind": "4.2.1",
-                "lodash.defaults": "4.2.0",
-                "lodash.filter": "4.6.0",
-                "lodash.flatten": "4.4.0",
-                "lodash.foreach": "4.5.0",
-                "lodash.map": "4.6.0",
-                "lodash.merge": "4.6.0",
-                "lodash.pick": "4.4.0",
-                "lodash.reduce": "4.6.0",
-                "lodash.reject": "4.6.0",
-                "lodash.some": "4.6.0"
+                "lodash": "4.17.4",
+                "parse5": "3.0.3"
             }
         },
         "chokidar": {
@@ -1335,9 +1360,9 @@
             }
         },
         "color-logger": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/color-logger/-/color-logger-0.0.3.tgz",
-            "integrity": "sha1-2bIt0dlz4Waxi/MT+fSBu6TfIBg=",
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/color-logger/-/color-logger-0.0.6.tgz",
+            "integrity": "sha1-5WJF7ymCJlcRDHy3WpzXhstp7Rs=",
             "dev": true
         },
         "color-name": {
@@ -1422,6 +1447,12 @@
             "requires": {
                 "date-now": "0.1.4"
             }
+        },
+        "console-control-strings": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+            "dev": true
         },
         "constantinople": {
             "version": "3.1.0",
@@ -1794,6 +1825,12 @@
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
             "dev": true
         },
+        "delegates": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+            "dev": true
+        },
         "des.js": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
@@ -2048,23 +2085,26 @@
                 }
             }
         },
-        "esdoc": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/esdoc/-/esdoc-1.0.4.tgz",
-            "integrity": "sha512-Hy5sg0Lec4EDHVem3gFqNi+o6ZptivmaiHYacZhmn3hzLnHSMg2C1L0XTsDIcb4Cxd9aUnWdLAu6a6ghH/LLug==",
+        "esdoc2": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/esdoc2/-/esdoc2-2.1.3.tgz",
+            "integrity": "sha1-xhZBJXa9HIB834Bwy368HZbwxAY=",
             "dev": true,
             "requires": {
                 "babel-generator": "6.26.0",
                 "babel-traverse": "6.26.0",
                 "babylon": "6.18.0",
-                "cheerio": "0.22.0",
-                "color-logger": "0.0.3",
+                "big-json": "1.2.0",
+                "cheerio": "1.0.0-rc.2",
+                "color-logger": "0.0.6",
                 "escape-html": "1.0.3",
-                "fs-extra": "1.0.0",
+                "fs-extra": "4.0.2",
                 "ice-cap": "0.0.4",
                 "marked": "0.3.6",
                 "minimist": "1.2.0",
-                "taffydb": "2.7.2"
+                "mkdirp": "0.5.1",
+                "npmlog": "4.1.2",
+                "taffydb": "2.7.3"
             },
             "dependencies": {
                 "minimist": {
@@ -2075,58 +2115,125 @@
                 }
             }
         },
-        "esdoc-accessor-plugin": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/esdoc-accessor-plugin/-/esdoc-accessor-plugin-1.0.0.tgz",
-            "integrity": "sha1-eRukhy5sQDUVznSbE0jW8Ck62es=",
+        "esdoc2-accessor-plugin": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/esdoc2-accessor-plugin/-/esdoc2-accessor-plugin-2.0.0.tgz",
+            "integrity": "sha512-agzJs6OmtCBgww1IncTvxknCD47X9JnXeXM9H18zea3Tllm2yvatXDQnx/1OWGP9RKBVlHFNOJ/HPppI3SeRpw==",
             "dev": true
         },
-        "esdoc-brand-plugin": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/esdoc-brand-plugin/-/esdoc-brand-plugin-1.0.0.tgz",
-            "integrity": "sha1-niFtc15i/OxJ96M5u0Eh2mfMYDM=",
+        "esdoc2-brand-plugin": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/esdoc2-brand-plugin/-/esdoc2-brand-plugin-2.0.0.tgz",
+            "integrity": "sha512-X7GWtSRK/xX60L1P6p1FcJtq/RWCtDW0Q6PdxGFWMCq+e1//MUi61NV0zSr7L+xklXtWl0pJCxSc6ib1s49MKg==",
             "dev": true,
             "requires": {
                 "cheerio": "0.22.0"
+            },
+            "dependencies": {
+                "cheerio": {
+                    "version": "0.22.0",
+                    "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+                    "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+                    "dev": true,
+                    "requires": {
+                        "css-select": "1.2.0",
+                        "dom-serializer": "0.1.0",
+                        "entities": "1.1.1",
+                        "htmlparser2": "3.9.2",
+                        "lodash.assignin": "4.2.0",
+                        "lodash.bind": "4.2.1",
+                        "lodash.defaults": "4.2.0",
+                        "lodash.filter": "4.6.0",
+                        "lodash.flatten": "4.4.0",
+                        "lodash.foreach": "4.5.0",
+                        "lodash.map": "4.6.0",
+                        "lodash.merge": "4.6.0",
+                        "lodash.pick": "4.4.0",
+                        "lodash.reduce": "4.6.0",
+                        "lodash.reject": "4.6.0",
+                        "lodash.some": "4.6.0"
+                    }
+                }
             }
         },
-        "esdoc-coverage-plugin": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/esdoc-coverage-plugin/-/esdoc-coverage-plugin-1.1.0.tgz",
-            "integrity": "sha1-OGmGnNf4eJH5cmJXh2laKZrs5Fw=",
+        "esdoc2-coverage-plugin": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/esdoc2-coverage-plugin/-/esdoc2-coverage-plugin-2.0.0.tgz",
+            "integrity": "sha512-4QP7XxzpUK8DCi55UA3H+mHzK7YVN0LfM6ombsKmRNpRgK6qz/C7wgsjjnQ6pMpT73anCx72EbDB9ZLQWJ+1xg==",
             "dev": true
         },
-        "esdoc-external-ecmascript-plugin": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/esdoc-external-ecmascript-plugin/-/esdoc-external-ecmascript-plugin-1.0.0.tgz",
-            "integrity": "sha1-ePVl1KDFGFrGMVJhTc4f4ahmiNs=",
+        "esdoc2-external-ecmascript-plugin": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/esdoc2-external-ecmascript-plugin/-/esdoc2-external-ecmascript-plugin-2.0.0.tgz",
+            "integrity": "sha512-04bKYi4Ix0kpiQUqhKIztHIBkGS4JZJhVw9uSc9h9kIKrgWraTrEffeIt/StCdPsgoxQcLhmuTyTK6r49mv3Ow==",
             "dev": true,
             "requires": {
                 "fs-extra": "1.0.0"
+            },
+            "dependencies": {
+                "fs-extra": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+                    "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "jsonfile": "2.4.0",
+                        "klaw": "1.3.1"
+                    }
+                },
+                "jsonfile": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+                    "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11"
+                    }
+                }
             }
         },
-        "esdoc-integrate-manual-plugin": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/esdoc-integrate-manual-plugin/-/esdoc-integrate-manual-plugin-1.0.0.tgz",
-            "integrity": "sha1-GFSmqhwIEDXXyMUeO91PtlqkcRw=",
+        "esdoc2-integrate-manual-plugin": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/esdoc2-integrate-manual-plugin/-/esdoc2-integrate-manual-plugin-2.1.0.tgz",
+            "integrity": "sha512-3mrTAxqAtnDJL9+oynX65Mi9cPD3lTUXTdEMbZpVHZ7nYZCZVDnfWirjDNZZH259x7xfgGTQ0VVY0l5lxzZQaA==",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                }
+            }
+        },
+        "esdoc2-integrate-test-plugin": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/esdoc2-integrate-test-plugin/-/esdoc2-integrate-test-plugin-2.0.0.tgz",
+            "integrity": "sha512-oFldzJMseaIbNHND1+cRAXXeObYoxJCuGjwNGVqSm8HTUsVNh/7EeFVnGYg91QN5spu6etGJFURADzoxGsoqCA==",
             "dev": true
         },
-        "esdoc-integrate-test-plugin": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/esdoc-integrate-test-plugin/-/esdoc-integrate-test-plugin-1.0.0.tgz",
-            "integrity": "sha1-4tDQAJD38MNeXS8sAzMnp55T5Ak=",
+        "esdoc2-lint-plugin": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/esdoc2-lint-plugin/-/esdoc2-lint-plugin-2.0.0.tgz",
+            "integrity": "sha512-3nycNtGv8yUo8VrphNgvT5OakdjgjzgeUHnF+NXJ6wO4yOsUeoh9hEC831N0e4gVTs0mkSJ1Q7levK+w1nQbSA==",
             "dev": true
         },
-        "esdoc-lint-plugin": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/esdoc-lint-plugin/-/esdoc-lint-plugin-1.0.1.tgz",
-            "integrity": "sha1-h77mQD5nbAh/Yb6SxFLWDyxqcOU=",
-            "dev": true
-        },
-        "esdoc-publish-html-plugin": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/esdoc-publish-html-plugin/-/esdoc-publish-html-plugin-1.1.0.tgz",
-            "integrity": "sha1-CT+DN6yhaQIlcss4f/zD9HCwJRM=",
+        "esdoc2-publish-html-plugin": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/esdoc2-publish-html-plugin/-/esdoc2-publish-html-plugin-2.0.1.tgz",
+            "integrity": "sha512-yzmE94/vvGFx2DU9JqfInFGZFBAHFCoEQGNhl0mmc+NRB9iJ+9KMhqz9VdxP7M9S/YOxDrRJlG2v1UtR+UqeNg==",
             "dev": true,
             "requires": {
                 "babel-generator": "6.11.4",
@@ -2152,6 +2259,30 @@
                         "source-map": "0.5.7"
                     }
                 },
+                "cheerio": {
+                    "version": "0.22.0",
+                    "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+                    "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+                    "dev": true,
+                    "requires": {
+                        "css-select": "1.2.0",
+                        "dom-serializer": "0.1.0",
+                        "entities": "1.1.1",
+                        "htmlparser2": "3.9.2",
+                        "lodash.assignin": "4.2.0",
+                        "lodash.bind": "4.2.1",
+                        "lodash.defaults": "4.2.0",
+                        "lodash.filter": "4.6.0",
+                        "lodash.flatten": "4.4.0",
+                        "lodash.foreach": "4.5.0",
+                        "lodash.map": "4.6.0",
+                        "lodash.merge": "4.6.0",
+                        "lodash.pick": "4.4.0",
+                        "lodash.reduce": "4.6.0",
+                        "lodash.reject": "4.6.0",
+                        "lodash.some": "4.6.0"
+                    }
+                },
                 "detect-indent": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
@@ -2161,6 +2292,26 @@
                         "get-stdin": "4.0.1",
                         "minimist": "1.2.0",
                         "repeating": "1.1.3"
+                    }
+                },
+                "fs-extra": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+                    "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "jsonfile": "2.4.0",
+                        "klaw": "1.3.1"
+                    }
+                },
+                "jsonfile": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+                    "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11"
                     }
                 },
                 "minimist": {
@@ -2177,44 +2328,50 @@
                     "requires": {
                         "is-finite": "1.0.2"
                     }
+                },
+                "taffydb": {
+                    "version": "2.7.2",
+                    "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.7.2.tgz",
+                    "integrity": "sha1-e/gQalwaSCUbPjvAoOFzJIn9Dcg=",
+                    "dev": true
                 }
             }
         },
-        "esdoc-standard-plugin": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/esdoc-standard-plugin/-/esdoc-standard-plugin-1.0.0.tgz",
-            "integrity": "sha1-ZhIBysfvhokkkCRG/awVJyU8XU0=",
+        "esdoc2-standard-plugin": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/esdoc2-standard-plugin/-/esdoc2-standard-plugin-2.1.0.tgz",
+            "integrity": "sha512-sX/10o8qm/9+zKEpH4LdcZeEkO+cKdfupDo3562x5lyNxnQe5p50RO2kVMwwxRu31Fo+vheamQYXsQuEr90MXg==",
             "dev": true,
             "requires": {
-                "esdoc-accessor-plugin": "1.0.0",
-                "esdoc-brand-plugin": "1.0.0",
-                "esdoc-coverage-plugin": "1.1.0",
-                "esdoc-external-ecmascript-plugin": "1.0.0",
-                "esdoc-integrate-manual-plugin": "1.0.0",
-                "esdoc-integrate-test-plugin": "1.0.0",
-                "esdoc-lint-plugin": "1.0.1",
-                "esdoc-publish-html-plugin": "1.1.0",
-                "esdoc-type-inference-plugin": "1.0.1",
-                "esdoc-undocumented-identifier-plugin": "1.0.0",
-                "esdoc-unexported-identifier-plugin": "1.0.0"
+                "esdoc2-accessor-plugin": "2.0.0",
+                "esdoc2-brand-plugin": "2.0.0",
+                "esdoc2-coverage-plugin": "2.0.0",
+                "esdoc2-external-ecmascript-plugin": "2.0.0",
+                "esdoc2-integrate-manual-plugin": "2.1.0",
+                "esdoc2-integrate-test-plugin": "2.0.0",
+                "esdoc2-lint-plugin": "2.0.0",
+                "esdoc2-publish-html-plugin": "2.0.1",
+                "esdoc2-type-inference-plugin": "2.0.1",
+                "esdoc2-undocumented-identifier-plugin": "2.0.0",
+                "esdoc2-unexported-identifier-plugin": "2.0.0"
             }
         },
-        "esdoc-type-inference-plugin": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/esdoc-type-inference-plugin/-/esdoc-type-inference-plugin-1.0.1.tgz",
-            "integrity": "sha1-qrynhkH5m9Hs5vMC8EW71jG+cvU=",
+        "esdoc2-type-inference-plugin": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/esdoc2-type-inference-plugin/-/esdoc2-type-inference-plugin-2.0.1.tgz",
+            "integrity": "sha512-YfXpCe8ZWCvTOqml5s8LidnBPd2WM0cMvy6XCk9MYILqvEbDWaAhS+z0Mqu7m2EvuEBckgyZK/EyF8WxedsoRw==",
             "dev": true
         },
-        "esdoc-undocumented-identifier-plugin": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/esdoc-undocumented-identifier-plugin/-/esdoc-undocumented-identifier-plugin-1.0.0.tgz",
-            "integrity": "sha1-guBdNxwy0ShxFA8dXIHsmf2cwsg=",
+        "esdoc2-undocumented-identifier-plugin": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/esdoc2-undocumented-identifier-plugin/-/esdoc2-undocumented-identifier-plugin-2.0.0.tgz",
+            "integrity": "sha512-JRM9VJLcBINJ+XF+yZGbBLa3rFET2rtpc5ksto1wwum6FnxkWLEPLoRjkWlOMxrUyW6sdIxzvGVIyNgWMT44GA==",
             "dev": true
         },
-        "esdoc-unexported-identifier-plugin": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/esdoc-unexported-identifier-plugin/-/esdoc-unexported-identifier-plugin-1.0.0.tgz",
-            "integrity": "sha1-H5h0xqfCvr+a05fDzrdcnGnaurE=",
+        "esdoc2-unexported-identifier-plugin": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/esdoc2-unexported-identifier-plugin/-/esdoc2-unexported-identifier-plugin-2.0.0.tgz",
+            "integrity": "sha512-WWCZwKCZf6otdjvgiOBxz6ESPZxbZFW+IZnSQ9WLAus8M9RUUXMCeuQ2mYWpDAJLrN4PZmEnkMWhJH4riPvdRg==",
             "dev": true
         },
         "eslint": {
@@ -2975,14 +3132,14 @@
             }
         },
         "fs-extra": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
-            "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
+            "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
             "dev": true,
             "requires": {
                 "graceful-fs": "4.1.11",
-                "jsonfile": "2.4.0",
-                "klaw": "1.3.1"
+                "jsonfile": "4.0.0",
+                "universalify": "0.1.1"
             }
         },
         "fs.realpath": {
@@ -3811,6 +3968,22 @@
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
             "dev": true
         },
+        "gauge": {
+            "version": "2.7.4",
+            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+            "dev": true,
+            "requires": {
+                "aproba": "1.2.0",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.2"
+            }
+        },
         "get-caller-file": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
@@ -4271,6 +4444,12 @@
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
             "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
+        "has-unicode": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+            "dev": true
+        },
         "hash-base": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
@@ -4403,6 +4582,12 @@
                         "jsdom": "7.2.2",
                         "lodash": "4.17.4"
                     }
+                },
+                "color-logger": {
+                    "version": "0.0.3",
+                    "resolved": "https://registry.npmjs.org/color-logger/-/color-logger-0.0.3.tgz",
+                    "integrity": "sha1-2bIt0dlz4Waxi/MT+fSBu6TfIBg=",
+                    "dev": true
                 },
                 "domhandler": {
                     "version": "2.3.0",
@@ -4943,6 +5128,13 @@
                     "requires": {
                         "acorn": "2.7.0"
                     }
+                },
+                "parse5": {
+                    "version": "1.5.1",
+                    "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+                    "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -4979,6 +5171,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
+        },
+        "json-stream-stringify": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/json-stream-stringify/-/json-stream-stringify-1.5.1.tgz",
+            "integrity": "sha1-urkFrqkqLxMKThQreOZsg2ehBk4=",
             "dev": true
         },
         "json-stringify-safe": {
@@ -5021,9 +5219,9 @@
             }
         },
         "jsonfile": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-            "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "dev": true,
             "requires": {
                 "graceful-fs": "4.1.11"
@@ -5678,6 +5876,18 @@
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "requires": {
                 "path-key": "2.0.1"
+            }
+        },
+        "npmlog": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+            "dev": true,
+            "requires": {
+                "are-we-there-yet": "1.1.4",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.7.4",
+                "set-blocking": "2.0.0"
             }
         },
         "nth-check": {
@@ -7445,11 +7655,19 @@
             }
         },
         "parse5": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-            "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+            "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
             "dev": true,
-            "optional": true
+            "requires": {
+                "@types/node": "9.3.0"
+            }
+        },
+        "parser-toolkit": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/parser-toolkit/-/parser-toolkit-0.0.5.tgz",
+            "integrity": "sha1-7EthcpyGMYtW6pcb+6azxnLWLAE=",
+            "dev": true
         },
         "path-browserify": {
             "version": "0.0.0",
@@ -7540,6 +7758,26 @@
                 "which": "1.2.14"
             },
             "dependencies": {
+                "fs-extra": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+                    "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "jsonfile": "2.4.0",
+                        "klaw": "1.3.1"
+                    }
+                },
+                "jsonfile": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+                    "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11"
+                    }
+                },
                 "progress": {
                     "version": "1.1.8",
                     "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
@@ -9137,6 +9375,15 @@
                 "xtend": "4.0.1"
             }
         },
+        "stream-json": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-0.5.2.tgz",
+            "integrity": "sha512-/QlOLybrc6LkH/oVgXo1lJ8oemRIze/grdpfssLn1Pm8nZVhW4VMOqDDYGaORPodQFxiDEUquQJER5LiBu8Ehg==",
+            "dev": true,
+            "requires": {
+                "parser-toolkit": "0.0.5"
+            }
+        },
         "strict-uri-encode": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
@@ -9502,9 +9749,9 @@
             }
         },
         "taffydb": {
-            "version": "2.7.2",
-            "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.7.2.tgz",
-            "integrity": "sha1-e/gQalwaSCUbPjvAoOFzJIn9Dcg=",
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.7.3.tgz",
+            "integrity": "sha1-KtNxaWKUmPylvIQkMJbTzeDsOjQ=",
             "dev": true
         },
         "tapable": {
@@ -9542,6 +9789,16 @@
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
             "dev": true
+        },
+        "through2": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+            "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.3",
+                "xtend": "4.0.1"
+            }
         },
         "timers-browserify": {
             "version": "2.0.4",
@@ -9690,6 +9947,12 @@
             "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
             "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
         },
+        "universalify": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+            "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+            "dev": true
+        },
         "unzip": {
             "version": "0.1.11",
             "resolved": "https://registry.npmjs.org/unzip/-/unzip-0.1.11.tgz",
@@ -9754,6 +10017,41 @@
             "dev": true,
             "requires": {
                 "os-homedir": "1.0.2"
+            }
+        },
+        "utf8-stream": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/utf8-stream/-/utf8-stream-0.0.0.tgz",
+            "integrity": "sha1-Bc5BB/zq+JOiyDj+Y6HUI0VcH8Q=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "1.0.34"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "1.0.34",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                }
             }
         },
         "util": {
@@ -10002,6 +10300,15 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
             "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+        },
+        "wide-align": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+            "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+            "dev": true,
+            "requires": {
+                "string-width": "1.0.2"
+            }
         },
         "window-size": {
             "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "devDependencies": {
         "babel-plugin-istanbul": "^4.1.5",
         "core-js": "^2.4.1",
-        "esdoc": "^1.0.4",
-        "esdoc-standard-plugin": "^1.0.0",
+        "esdoc2": "^2.1.3",
+        "esdoc2-standard-plugin": "^2.1.0",
         "eslint": "^4.13.1",
         "eslint-config-girder": "^4.0.1",
         "eslint-config-semistandard": "^12.0.0",
@@ -106,7 +106,10 @@
         "rules": {
             "for-direction": "error",
             "getter-return": "error",
-            "multiline-ternary": ["error", "always-multiline"],
+            "multiline-ternary": [
+                "error",
+                "always-multiline"
+            ],
             "no-alert": "error",
             "switch-colon-spacing": "error",
             "import/exports-last": "error",
@@ -252,11 +255,16 @@
             "error": true
         },
         "reporterOptions": {
-              "columns": ["lineData", "severity", "description", "rule"],
-              "columnSplitter": "  ",
-              "showHeaders": false,
-              "truncate": true
-          },
+            "columns": [
+                "lineData",
+                "severity",
+                "description",
+                "rule"
+            ],
+            "columnSplitter": "  ",
+            "showHeaders": false,
+            "truncate": true
+        },
         "semicolons": {
             "expect": "never",
             "error": true


### PR DESCRIPTION
ESDoc2 is a fork of ESDoc with more updated dependencies, including the "marked" package, which is causing security warnings.