### PR TITLE
Alter girder_user to only control the system daemon

### DIFF
--- a/devops/ansible/roles/girder/tasks/main.yml
+++ b/devops/ansible/roles/girder/tasks/main.yml
@@ -18,11 +18,7 @@
   file:
     path: "{{ girder_path }}"
     state: directory
-    group: "{{ girder_user|default(ansible_user_id) }}"
-    owner: "{{ girder_user|default(ansible_user_id) }}"
     mode: 0755
-  become: yes
-  become_user: root
 
 - include: npm-RedHat.yml
   when:


### PR DESCRIPTION
This PR changes `girder_user` to only be in control of the daemon 
which Girder runs under. This means that users deploying with a 
sudo-user (necessary due to system packages, system daemons, etc) 
can now run Girder under an unprivileged system user.

This is part of an effort to remove all unnecessary usage of escalating 
to root in our ansible roles.