### PR TITLE
Add support for --host argument to girder-server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,4 +12,4 @@ girder:
     - "8080:8080"
   links:
     - "mongodb:mongodb"
-  command: -d mongodb://mongodb:27017/girder
+  command: --host 0.0.0.0 --database mongodb://mongodb:27017/girder

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 mongodb:
-  image: mongo:3.0
+  image: mongo:3.2
   ports:
     - "27017"
   volumes:

--- a/girder/__main__.py
+++ b/girder/__main__.py
@@ -40,11 +40,14 @@ def main():
                         action="store_true")
     parser.add_argument("-d", "--database",
                         help="to what database url should Girder connect")
+    parser.add_argument("-H", "--host", help="on what host should Girder serve")
     parser.add_argument("-p", "--port",
                         help="on what port should Girder serve")
     args = parser.parse_args()
     if args.database:
         cherrypy.config['database']['uri'] = args.database
+    if args.host:
+        cherrypy.config['server.socket_host'] = args.host
     if args.port:
         cherrypy.config['server.socket_port'] = int(args.port)
     server.setup(args.testing)


### PR DESCRIPTION
This will allow certain cases (such as Docker containers) to override the host at the CLI level instead of in configuration files. This should help ease some of the pain introduced by #2565 (@kotfic).

This PR also upgrades the `docker-compose.yml` to use the new argument, and upgrades the version of Mongo to our minimally supported version 3.2 (see #2540).