### PR TITLE
Drop support for Python3 <3.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,7 +298,7 @@ jobs:
           command: pip install codecov
       - run:
           name: Upload coverage
-          command: codecov --disable search pycov gcov --file girder/build/test/coverage/py_coverage.xml
+          command: codecov --disable search pycov gcov --root girder --file girder/build/test/coverage/py_coverage.xml
 
   py3_integrationTests:
     machine: true
@@ -413,7 +413,7 @@ jobs:
           command: pip install codecov
       - run:
           name: Upload coverage
-          command: codecov --disable search pycov gcov --file girder/build/test/coverage/py_coverage.xml girder/build/test/coverage/cobertura-coverage.xml
+          command: codecov --disable search pycov gcov --root girder --file girder/build/test/coverage/py_coverage.xml girder/build/test/coverage/cobertura-coverage.xml
   deploy:
     docker:
       - image: girder/girder_test:latest-py3

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ EXPOSE 8080
 RUN mkdir /girder
 RUN mkdir /girder/logs
 
-RUN apt-get update && apt-get install -qy software-properties-common python-software-properties && \
-  apt-get update && apt-get install -qy \
+RUN apt-get update && apt-get install -qy \
     build-essential \
     git \
     libffi-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6
+FROM node:8-stretch
 MAINTAINER Kitware, Inc. <kitware@kitware.com>
 
 EXPOSE 8080
@@ -31,4 +31,4 @@ COPY README.rst /girder/README.rst
 RUN pip install -e .[plugins]
 RUN girder-install web --all-plugins
 
-ENTRYPOINT ["python", "-m", "girder"]
+ENTRYPOINT ["python2", "-m", "girder"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -qy \
     libffi-dev \
     libsasl2-dev \
     libldap2-dev \
-    libpython-dev && \
+    libpython2.7-dev && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN wget https://bootstrap.pypa.io/get-pip.py && python get-pip.py
@@ -28,7 +28,7 @@ COPY setup.py /girder/setup.py
 COPY package.json /girder/package.json
 COPY README.rst /girder/README.rst
 
-RUN pip install -e .[plugins]
+RUN pip install --upgrade --editable .[plugins]
 RUN girder-install web --all-plugins
 
 ENTRYPOINT ["python2", "-m", "girder"]

--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -28,7 +28,7 @@ COPY setup.py /girder/setup.py
 COPY package.json /girder/package.json
 COPY README.rst /girder/README.rst
 
-RUN pip install -e .[plugins]
+RUN pip install --upgrade --editable .[plugins]
 RUN girder-install web --all-plugins
 
 ENTRYPOINT ["python3", "-m", "girder"]

--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -6,8 +6,7 @@ EXPOSE 8080
 RUN mkdir /girder
 RUN mkdir /girder/logs
 
-RUN apt-get update && apt-get install -qy software-properties-common python-software-properties && \
-  apt-get update && apt-get install -qy \
+RUN apt-get update && apt-get install -qy \
     build-essential \
     git \
     libffi-dev \

--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -1,4 +1,4 @@
-FROM node:6
+FROM node:8-stretch
 MAINTAINER Kitware, Inc. <kitware@kitware.com>
 
 EXPOSE 8080

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -244,7 +244,7 @@ Elastic Beanstalk
 
 Girder comes with pre-packaged configurations for deploying onto Elastic Beanstalk's
 `Python platform <http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/concepts.platforms.html#concepts.platforms.python>`_
-(both 2.7 and 3.4).
+(both 2.7 and 3.6).
 
 The configurations live within ``devops/beanstalk`` and are designed to be copied into your working Girder directory
 at deploy time.

--- a/docs/prerequisites.rst
+++ b/docs/prerequisites.rst
@@ -19,7 +19,7 @@ recommend setting up `Postfix <http://www.postfix.org/documentation.html>`_.
 See the specific instructions for your platform below.
 
 .. note:: We perform continuous integration testing using Python 2.7 and Python 3.5.
-   The system *should* work on other versions of Python 3 as well, but we do not
+   The system *should* work on newer versions of Python 3 as well, but we do not
    verify that support in our automated testing at this time, so use at your own
    risk.
 

--- a/docs/prerequisites.rst
+++ b/docs/prerequisites.rst
@@ -3,7 +3,7 @@ System Prerequisites
 
 The following software packages are required to be installed on your system:
 
-* `Python 2.7 or 3.4+ <https://www.python.org>`_
+* `Python 2.7 or 3.5+ <https://www.python.org>`_
 * `pip <https://pypi.python.org/pypi/pi>`_
 * `MongoDB 3.2+ <http://www.mongodb.org/>`_
 * `Node.js 6.5+ <http://nodejs.org/>`_

--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -19,10 +19,6 @@
 
 import bson.json_util
 import dateutil.parser
-try:
-    from inspect import signature, Parameter
-except ImportError:
-    from funcsigs import signature, Parameter
 import inspect
 import jsonschema
 import os
@@ -41,6 +37,11 @@ from girder.utility.webroot import WebrootBase
 from girder.utility.resource import _apiRouteMap
 from . import docs, access
 from .rest import Resource, getApiUrl, getUrlParts
+
+if six.PY3:
+    from inspect import signature, Parameter
+else:
+    from funcsigs import signature, Parameter
 
 """
 Whenever we add new return values or new options we should increment the

--- a/girder/utility/install.py
+++ b/girder/utility/install.py
@@ -40,7 +40,7 @@ version = constants.VERSION['apiVersion']
 webRoot = os.path.join(constants.STATIC_ROOT_DIR, 'clients', 'web')
 
 # monkey patch shutil for python < 3
-if sys.version_info[0] == 2:
+if not six.PY3:
     import shutilwhich  # noqa
 
 

--- a/pytest_girder/pytest_girder/utils.py
+++ b/pytest_girder/pytest_girder/utils.py
@@ -8,7 +8,6 @@ import os
 import six
 import smtpd
 import socket
-import sys
 import threading
 import time
 
@@ -24,7 +23,7 @@ class MockSmtpServer(smtpd.SMTPServer):
 
     def __init__(self, localaddr, remoteaddr, decode_data=False):
         kwargs = {}
-        if sys.version_info >= (3, 5):
+        if six.PY3:
             # Python 3.5+ prints a warning if 'decode_data' isn't explicitly
             # specified, but earlier versions don't accept the argument at all
             kwargs['decode_data'] = decode_data

--- a/setup.py
+++ b/setup.py
@@ -152,6 +152,7 @@ setup(
             'api/api_docs.mako'
         ]
     },
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     install_requires=installReqs,
     extras_require=extrasReqs,
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4'
+        'Programming Language :: Python :: 3.5'
     ],
     packages=find_packages(
         exclude=('girder.test', 'tests.*', 'tests', '*.plugin_tests.*', '*.plugin_tests')

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ installReqs = [
     'CherryPy<11.1',
     'click',
     'filelock',
-    'funcsigs ; python_version < \'3.5\'',
+    'funcsigs ; python_version < \'3\'',
     'jsonschema',
     'Mako',
     'pymongo>=3.5',
@@ -75,7 +75,7 @@ installReqs = [
     'python-dateutil',
     'pytz',
     'requests',
-    'shutilwhich ; python_version < \'3.3\'',
+    'shutilwhich ; python_version < \'3\'',
     'six>=1.9',
 ]
 

--- a/test/test_hash_state.py
+++ b/test/test_hash_state.py
@@ -38,21 +38,21 @@ def iterableBytes():
     yield iterable
 
 
-@pytest.mark.parametrize('algorithm', [
-    hashlib.md5,
-    hashlib.sha1,
-    hashlib.sha224,
-    hashlib.sha256,
-    hashlib.sha384,
-    hashlib.sha512
+@pytest.mark.parametrize('algorithmName', [
+    'md5',
+    'sha1',
+    'sha224',
+    'sha256',
+    'sha384',
+    'sha512'
 ])
-def testSimpleHashing(iterableBytes, algorithm):
-    canonicalHash = algorithm()
-    runningState = hash_state.serializeHex(algorithm())
-    hashName = canonicalHash.name
+def testSimpleHashing(iterableBytes, algorithmName):
+    canonicalHash = hashlib.new(algorithmName)
+    runningHash = hashlib.new(algorithmName)
+    runningState = hash_state.serializeHex(runningHash)
 
     for chunk in iterableBytes:
-        runningHash = hash_state.restoreHex(runningState, hashName)
+        runningHash = hash_state.restoreHex(runningState, algorithmName)
         assert canonicalHash.hexdigest() == runningHash.hexdigest()
         assert canonicalHash.digest() == runningHash.digest()
 
@@ -60,6 +60,6 @@ def testSimpleHashing(iterableBytes, algorithm):
         runningHash.update(chunk)
         runningState = hash_state.serializeHex(runningHash)
 
-    runningHash = hash_state.restoreHex(runningState, hashName)
+    runningHash = hash_state.restoreHex(runningState, algorithmName)
     assert canonicalHash.hexdigest() == runningHash.hexdigest()
     assert canonicalHash.digest() == runningHash.digest()

--- a/tests/cases/find_entry_point_plugins_test.py
+++ b/tests/cases/find_entry_point_plugins_test.py
@@ -18,7 +18,7 @@
 ###############################################################################
 
 import mock
-import sys
+import six
 import unittest
 
 from contextlib import contextmanager
@@ -114,7 +114,7 @@ class FindEntryPointPluginsTestCase(unittest.TestCase):
         self.assertIn('entry_point_plugin_bad_json', failures)
         self.assertIn('traceback', failures['entry_point_plugin_bad_json'])
         self.assertIn(
-            'JSONDecodeError' if sys.version_info >= (3, 5) else 'ValueError',
+            'JSONDecodeError' if six.PY3 else 'ValueError',
             failures['entry_point_plugin_bad_json']['traceback'])
 
     @mock.patch('pkg_resources.resource_stream')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36}
+envlist = py{27,35,36}
 skip_missing_interpreters = true
 toxworkdir = {toxinidir}/build/test/tox
 


### PR DESCRIPTION
Per the rationale in #2516, this makes Python 3.5 the minimum version of Python3 for Girder.

* Remove documentation references to Python 3.4
* Remove Python 3.4 from Tox
* Add package metadata to specify compatible Python versions
* Simplify code checks for Python versions <3.5
* Fix test_hash_state to work on Python 3.6
* Prevent test_hash_state from printing to stdout on import
* Identify the repo root for Codecov client, to silence warnings
* Improve variable naming in test_hash_state
* Clarify docs on supported Python 3 versions
* Do not install "software-properties" packages in Docker
  * It's unknown what these packages do, but their absence does not prevent Girder from building and running in Docker.
* Upgrade to Node 8 and Debian Stretch for the Docker base image
  * This makes the Docker "py3" image use Python 3.5.
* Fix a Pip version conflict in the Docker base image

Fixes #2516 