### PR TITLE
Fix an XSS vulnerability from #2504

### DIFF
--- a/girder/utility/webroot.mako
+++ b/girder/utility/webroot.mako
@@ -27,7 +27,7 @@
                 brandName: '${brandName | js}',
                 bannerColor: '${bannerColor | js}',
                 registrationPolicy: '${registrationPolicy | js}',
-                enablePasswordLogin: ${enablePasswordLogin | n,json}
+                enablePasswordLogin: ${enablePasswordLogin | n,json,js}
             }).render();
             girder.events.trigger('g:appload.after', girder.app);
         });


### PR DESCRIPTION
While the browser is parsing an inline Javascript string literal, a `</script>` tag will terminate the Javascript segment and return to HTML parsing. The `json` filter alone does nothing to escape HTML content within strings.

If an attacker managed to bypass validation of the `ENABLE_PASSWORD_LOGIN` setting (which could occur via another vulnerability), it previously would have been possible to inject a malicious string into this setting value.