### PR TITLE
Use Girder's custom JsonEncoder to serialize JSON

### DIFF
--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -28,6 +28,7 @@ from .model_base import AccessControlledModel
 from girder import events
 from girder.constants import AccessType
 from girder.exceptions import ValidationException, GirderException
+from girder.utility import JsonEncoder
 from girder.utility.progress import noProgress, setResponseTimeLimit
 
 
@@ -708,7 +709,7 @@ class Folder(AccessControlledModel):
                 yield (filepath, file)
         if includeMetadata and metadataFile and doc.get('meta', {}):
             def stream():
-                yield json.dumps(doc['meta'], default=str)
+                yield json.dumps(doc['meta'], cls=JsonEncoder)
             yield (os.path.join(path, metadataFile), stream)
 
     def copyFolder(self, srcFolder, parent=None, name=None, description=None,

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -29,7 +29,7 @@ from girder import events
 from girder import logger
 from girder.constants import AccessType
 from girder.exceptions import ValidationException, GirderException
-from girder.utility import acl_mixin
+from girder.utility import acl_mixin, JsonEncoder
 
 
 class Item(acl_mixin.AccessControlMixin, Model):
@@ -504,7 +504,7 @@ class Item(acl_mixin.AccessControlMixin, Model):
             yield (os.path.join(path, file['name']), val)
         if includeMetadata and metadataFile and len(doc.get('meta', {})):
             def stream():
-                yield json.dumps(doc['meta'], default=str)
+                yield json.dumps(doc['meta'], cls=JsonEncoder)
             yield (os.path.join(path, metadataFile), stream)
 
     def _mimeFilter(self, file, mimeFilter):

--- a/girder/utility/__init__.py
+++ b/girder/utility/__init__.py
@@ -137,15 +137,22 @@ class JsonEncoder(json.JSONEncoder):
     """
     def default(self, obj):
         event = girder.events.trigger('rest.json_encode', obj)
-        if len(event.responses):
+        if event.responses:
             return event.responses[-1]
 
-        if isinstance(obj, set):
-            return tuple(obj)
-        elif isinstance(obj, datetime.datetime):
+        try:
+            iter(obj)
+        except TypeError:
+            pass
+        else:
+            return list(obj)
+
+        if isinstance(obj, datetime.datetime):
             return obj.replace(tzinfo=pytz.UTC).isoformat()
-        elif isinstance(obj, bson.ObjectId):
+
+        if isinstance(obj, bson.ObjectId):
             return str(obj)
+
         return str(obj)
 
 

--- a/girder/utility/__init__.py
+++ b/girder/utility/__init__.py
@@ -153,7 +153,9 @@ class JsonEncoder(json.JSONEncoder):
         if isinstance(obj, bson.ObjectId):
             return str(obj)
 
-        return str(obj)
+        # Fail if an object can't be meaningfully serialized, to prevent inaccurate data from
+        # silently being passed on
+        return super(JsonEncoder, self).default(obj)
 
 
 class RequestBodyStream(object):

--- a/girder/utility/__init__.py
+++ b/girder/utility/__init__.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 ###############################################################################
 
+import bson
 import cherrypy
 import datetime
 import dateutil.parser
@@ -143,6 +144,8 @@ class JsonEncoder(json.JSONEncoder):
             return tuple(obj)
         elif isinstance(obj, datetime.datetime):
             return obj.replace(tzinfo=pytz.UTC).isoformat()
+        elif isinstance(obj, bson.ObjectId):
+            return str(obj)
         return str(obj)
 
 

--- a/girder/utility/webroot.py
+++ b/girder/utility/webroot.py
@@ -18,6 +18,7 @@
 ###############################################################################
 
 import json
+import functools
 import os
 import re
 
@@ -27,7 +28,7 @@ import mako
 from girder import constants, events
 from girder.constants import CoreEventHandler, SettingKey
 from girder.models.setting import Setting
-from girder.utility import config
+from girder.utility import config, JsonEncoder
 
 
 class WebrootBase(object):
@@ -71,7 +72,10 @@ class WebrootBase(object):
 
     def _renderHTML(self):
         return mako.template.Template(self.template).render(
-            js=self._escapeJavascript, json=json.dumps, **self.vars)
+            js=self._escapeJavascript,
+            json=functools.partial(json.dumps, cls=JsonEncoder),
+            **self.vars
+        )
 
     def GET(self, **params):
         if self.indexHtml is None or self.config['server']['mode'] == 'development':

--- a/plugins/item_tasks/server/rest.py
+++ b/plugins/item_tasks/server/rest.py
@@ -11,6 +11,7 @@ from girder.models.item import Item
 from girder.models.token import Token
 from girder.plugins.jobs.models.job import Job
 from girder.plugins.worker import utils
+from girder.utility import JsonEncoder
 from . import constants
 from .json_tasks import createItemTasksFromJson, runJsonTasksDescriptionForFolder
 from .slicer_cli_tasks import configureItemTaskFromSlicerCliXml, runSlicerCliTasksDescriptionForItem
@@ -164,9 +165,9 @@ class ItemTask(Resource):
                     reference=json.dumps({
                         'type': 'item_tasks.output',
                         'id': k,
-                        'jobId': str(job['_id']),
-                        'taskId': str(taskId)
-                    }))
+                        'jobId': job['_id'],
+                        'taskId': taskId
+                    }, cls=JsonEncoder))
             else:
                 raise ValidationException('Invalid output mode: %s.' % v['mode'])
 

--- a/plugins/item_tasks/server/slicer_cli_tasks.py
+++ b/plugins/item_tasks/server/slicer_cli_tasks.py
@@ -11,6 +11,7 @@ from girder.models.token import Token
 from girder.models.user import User
 from girder.plugins.jobs.models.job import Job
 from girder.plugins.worker import utils
+from girder.utility import JsonEncoder
 from . import cli_parser, constants
 
 
@@ -195,7 +196,7 @@ def runSlicerCliTasksDescriptionForFolder(self, folder, image, args, pullImage, 
                     'headers': {'Girder-Token': token['_id']},
                     'params': {
                         'image': image,
-                        'args': json.dumps(args),
+                        'args': json.dumps(args, cls=JsonEncoder),
                         'pullImage': pullImage
                     }
                 }

--- a/tests/cases/resource_test.py
+++ b/tests/cases/resource_test.py
@@ -32,6 +32,7 @@ from girder.models.collection import Collection
 from girder.models.item import Item
 from girder.models.folder import Folder
 from girder.models.user import User
+from girder.utility import JsonEncoder
 from six.moves import range, urllib
 
 
@@ -229,7 +230,7 @@ class ResourceTestCase(base.TestCase):
             expected = self.expectedZip[name]
             if isinstance(expected, dict):
                 self.assertEqual(json.loads(zip.read(name).decode('utf8')),
-                                 json.loads(json.dumps(expected, default=str)))
+                                 json.loads(json.dumps(expected, cls=JsonEncoder)))
             else:
                 if not isinstance(expected, six.binary_type):
                     expected = expected.encode('utf8')


### PR DESCRIPTION
* Use Girder's custom JsonEncoder to serialize JSON
* Explicitly add support for JSON serialization of ObjectIds
* Add support for JSON serialization of general iterables
* Fail if an object can't be meaningfully JSON serialized