### PR TITLE
Add item and folder hrefs.

### DIFF
--- a/clients/web/src/templates/widgets/folderList.pug
+++ b/clients/web/src/templates/widgets/folderList.pug
@@ -3,7 +3,7 @@ ul.g-folder-list
     li.g-folder-list-entry(public=(folder.get('public') ? 'true' : 'false'))
       if checkboxes
         input.g-list-checkbox(type="checkbox", g-folder-cid=folder.cid)
-      a.g-folder-list-link(g-folder-cid=folder.cid, href='#folder/' + folder.id)
+      a.g-folder-list-link(g-folder-cid=folder.cid, href=`#folder/${folder.id}`)
         i.icon-folder
         = folder.get('name')
         i.icon-right-dir

--- a/clients/web/src/templates/widgets/folderList.pug
+++ b/clients/web/src/templates/widgets/folderList.pug
@@ -3,7 +3,7 @@ ul.g-folder-list
     li.g-folder-list-entry(public=(folder.get('public') ? 'true' : 'false'))
       if checkboxes
         input.g-list-checkbox(type="checkbox", g-folder-cid=folder.cid)
-      a.g-folder-list-link(g-folder-cid=folder.cid)
+      a.g-folder-list-link(g-folder-cid=folder.cid, href='#folder/' + folder.id)
         i.icon-folder
         = folder.get('name')
         i.icon-right-dir

--- a/clients/web/src/templates/widgets/itemList.pug
+++ b/clients/web/src/templates/widgets/itemList.pug
@@ -4,11 +4,11 @@ ul.g-item-list
       if checkboxes
         input.g-list-checkbox(type="checkbox", g-item-cid=item.cid)
       if downloadLinks || viewLinks
-        a.g-item-list-link.g-right-border(g-item-cid=item.cid)
+        a.g-item-list-link.g-right-border(g-item-cid=item.cid, href='#item/' + item.id)
           i.icon-doc-text-inv
           = item.name()
       else
-        a.g-item-list-link(g-item-cid=item.cid)
+        a.g-item-list-link(g-item-cid=item.cid, href='#item/' + item.id)
           i.icon-doc-text-inv
           = item.name()
       if downloadLinks

--- a/clients/web/src/templates/widgets/itemList.pug
+++ b/clients/web/src/templates/widgets/itemList.pug
@@ -4,7 +4,7 @@ ul.g-item-list
       if checkboxes
         input.g-list-checkbox(type="checkbox", g-item-cid=item.cid)
       if downloadLinks || viewLinks
-        a.g-item-list-link.g-right-border(g-item-cid=item.cid, href='#item/' + item.id)
+        a.g-item-list-link.g-right-border(g-item-cid=item.cid, href=`#item/${item.id}`)
           i.icon-doc-text-inv
           = item.name()
       else

--- a/clients/web/src/views/widgets/FolderListWidget.js
+++ b/clients/web/src/views/widgets/FolderListWidget.js
@@ -15,6 +15,7 @@ import FolderListTemplate from 'girder/templates/widgets/folderList.pug';
 var FolderListWidget = View.extend({
     events: {
         'click a.g-folder-list-link': function (event) {
+            event.preventDefault();
             var cid = $(event.currentTarget).attr('g-folder-cid');
             this.trigger('g:folderClicked', this.collection.get(cid));
         },

--- a/clients/web/src/views/widgets/ItemListWidget.js
+++ b/clients/web/src/views/widgets/ItemListWidget.js
@@ -14,6 +14,7 @@ import ItemListTemplate from 'girder/templates/widgets/itemList.pug';
 var ItemListWidget = View.extend({
     events: {
         'click a.g-item-list-link': function (event) {
+            event.preventDefault();
             var cid = $(event.currentTarget).attr('g-item-cid');
             this.trigger('g:itemClicked', this.collection.get(cid), event);
         },


### PR DESCRIPTION
This adds hrefs in the item and folder lists.  By preventing defaults on the links, these won't affect the existing hierarchy widget behavior.

Note that this neither depends on nor changes PR #2489 in any way.

We tried to do this in PR #1434, but in a much heavier way.  This doesn't use the href to do routing.