### PR TITLE
Revert "Workaround broken circleci/mongo:3.2-ram image"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,7 @@ jobs:
         # is likely a free (and poorly documented) analogue to the enterprise-only "inMemory"
         # storage engine. We can pass alternate options to "mongod" by overwriting the default "CMD"
         # used to start the Docker image: https://github.com/circleci/circleci-images/blob/master/mongo/resources/Dockerfile-ram.template
-        command: |
-          /bin/bash -c "mkdir -p /dev/shm/mongo &&
-          mongod --storageEngine ephemeralForTest --dbpath /dev/shm/mongo"
+        command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
 
     working_directory: /home/circleci/project # as $CIRCLE_WORKING_DIRECTORY
 
@@ -115,9 +113,7 @@ jobs:
       - image: girder/girder_test:latest-py3
       # Use the latest MongoDB
       - image: circleci/mongo:3.6-ram
-        command: |
-          /bin/bash -c "mkdir -p /dev/shm/mongo &&
-          mongod --storageEngine ephemeralForTest --dbpath /dev/shm/mongo"
+        command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
 
     working_directory: /home/circleci/project # as $CIRCLE_WORKING_DIRECTORY
 
@@ -154,9 +150,7 @@ jobs:
     docker:
       - image: girder/girder_test:latest-py3
       - image: circleci/mongo:3.6-ram
-        command: |
-          /bin/bash -c "mkdir -p /dev/shm/mongo &&
-          mongod --storageEngine ephemeralForTest --dbpath /dev/shm/mongo"
+        command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
 
     working_directory: /home/circleci/project # as $CIRCLE_WORKING_DIRECTORY
 
@@ -279,9 +273,7 @@ jobs:
     docker:
       - image: girder/girder_test:latest-py2
       - image: circleci/mongo:3.2-ram
-        command: |
-          /bin/bash -c "mkdir -p /dev/shm/mongo &&
-          mongod --storageEngine ephemeralForTest --dbpath /dev/shm/mongo"
+        command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
     working_directory: /home/circleci/project # as $CIRCLE_WORKING_DIRECTORY
     steps:
       - attach_workspace:
@@ -390,9 +382,7 @@ jobs:
     docker:
       - image: girder/girder_test:latest-py3
       - image: circleci/mongo:3.6-ram
-        command: |
-          /bin/bash -c "mkdir -p /dev/shm/mongo &&
-          mongod --storageEngine ephemeralForTest --dbpath /dev/shm/mongo"
+        command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
     working_directory: /home/circleci/project # as $CIRCLE_WORKING_DIRECTORY
     steps:
       - attach_workspace:


### PR DESCRIPTION
This reverts commit ab6450bf39148f011a86eea4c16acbfc7536d681.