### PR TITLE
When using empty layout, all space should be available

### DIFF
--- a/clients/web/src/stylesheets/layout/layout.styl
+++ b/clients/web/src/stylesheets/layout/layout.styl
@@ -12,7 +12,7 @@
 
 #g-app-body-container.g-empty-layout
   margin 0
-  padding 10px
+  padding 0
 
 #g-alerts-container
   position fixed


### PR DESCRIPTION
The Layout.EMPTY feature is quite handy and I'm currently using it to open a view in "full-screen" mode, however there was a 10px padding around the screen that I did not want. Requesting an empty layout should grant *all* available space to the view.