### PR TITLE
Upgrade UglifyJS plugin to latest version

### DIFF
--- a/grunt_tasks/build.js
+++ b/grunt_tasks/build.js
@@ -22,6 +22,7 @@ const extendify = require('extendify');
 const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const GoogleFontsPlugin = require('google-fonts-webpack-plugin');
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 
 const isTrue = (str) => !!str && !['false', 'off', '0'].includes(str.toString().toLowerCase());
 
@@ -109,12 +110,9 @@ module.exports = function (grunt) {
                     minimize: true,
                     debug: false
                 }),
-                new webpack.optimize.UglifyJsPlugin({
-                    compress: {
-                        warnings: false
-                    },
-                    output: {
-                        comments: false
+                new UglifyJsPlugin({
+                    uglifyOptions: {
+                        ecma: 6
                     }
                 })
             ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -121,6 +121,11 @@
                 "normalize-path": "2.1.1"
             }
         },
+        "aproba": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+        },
         "argparse": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
@@ -901,6 +906,11 @@
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
             "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
         },
+        "bluebird": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+            "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+        },
         "bn.js": {
             "version": "4.11.8",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
@@ -1071,6 +1081,49 @@
             "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
             "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
         },
+        "cacache": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.2.tgz",
+            "integrity": "sha512-dljb7dk1jqO5ogE+dRpoR9tpHYv5xz9vPSNunh1+0wRuNdYxmzp9WmsyokgW/DUF1FDRVA/TMsmxt027R8djbQ==",
+            "requires": {
+                "bluebird": "3.5.1",
+                "chownr": "1.0.1",
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "lru-cache": "4.1.1",
+                "mississippi": "1.3.1",
+                "mkdirp": "0.5.1",
+                "move-concurrently": "1.0.1",
+                "promise-inflight": "1.0.1",
+                "rimraf": "2.6.2",
+                "ssri": "5.1.0",
+                "unique-filename": "1.1.0",
+                "y18n": "3.2.1"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+                    "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+                    "requires": {
+                        "glob": "7.1.2"
+                    }
+                }
+            }
+        },
         "caller-path": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
@@ -1220,6 +1273,11 @@
                 "path-is-absolute": "1.0.1",
                 "readdirp": "2.1.0"
             }
+        },
+        "chownr": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+            "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
         },
         "cipher-base": {
             "version": "1.0.4",
@@ -1447,6 +1505,29 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
             "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+        },
+        "copy-concurrently": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+            "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+            "requires": {
+                "aproba": "1.2.0",
+                "fs-write-stream-atomic": "1.0.10",
+                "iferr": "0.1.5",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "run-queue": "1.0.3"
+            },
+            "dependencies": {
+                "rimraf": {
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+                    "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+                    "requires": {
+                        "glob": "7.0.6"
+                    }
+                }
+            }
         },
         "core-js": {
             "version": "2.5.3",
@@ -1692,6 +1773,11 @@
                 "array-find-index": "1.0.2"
             }
         },
+        "cyclist": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+            "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
+        },
         "d": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
@@ -1883,6 +1969,17 @@
                 "domelementtype": "1.3.0"
             }
         },
+        "duplexify": {
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz",
+            "integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
+            "requires": {
+                "end-of-stream": "1.4.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3",
+                "stream-shift": "1.0.0"
+            }
+        },
         "ecc-jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
@@ -1931,6 +2028,14 @@
             "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
             "requires": {
                 "iconv-lite": "0.4.19"
+            }
+        },
+        "end-of-stream": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+            "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+            "requires": {
+                "once": "1.4.0"
             }
         },
         "enhanced-resolve": {
@@ -2944,6 +3049,15 @@
             "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
             "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
         },
+        "flush-write-stream": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
+            "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
+            "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3"
+            }
+        },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2974,6 +3088,15 @@
                 "mime-types": "2.1.17"
             }
         },
+        "from2": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+            "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+            "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3"
+            }
+        },
         "fs-extra": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
@@ -2983,6 +3106,17 @@
                 "graceful-fs": "4.1.11",
                 "jsonfile": "2.4.0",
                 "klaw": "1.3.1"
+            }
+        },
+        "fs-write-stream-atomic": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+            "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "iferr": "0.1.5",
+                "imurmurhash": "0.1.4",
+                "readable-stream": "2.3.3"
             }
         },
         "fs.realpath": {
@@ -4475,6 +4609,11 @@
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
             "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
         },
+        "iferr": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+            "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
+        },
         "ignore": {
             "version": "3.3.7",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
@@ -4484,8 +4623,7 @@
         "imurmurhash": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-            "dev": true
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
         },
         "indent-string": {
             "version": "2.1.0",
@@ -5299,7 +5437,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
             "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-            "dev": true,
             "requires": {
                 "pseudomap": "1.0.2",
                 "yallist": "2.1.2"
@@ -5503,6 +5640,23 @@
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
             "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
+        "mississippi": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.1.tgz",
+            "integrity": "sha512-/6rB8YXFbAtsUVRphIRQqB0+9c7VaPHCjVtvto+JqwVxgz8Zz+I+f68/JgQ+Pb4VlZb2svA9OtdXnHHsZz7ltg==",
+            "requires": {
+                "concat-stream": "1.6.0",
+                "duplexify": "3.5.3",
+                "end-of-stream": "1.4.1",
+                "flush-write-stream": "1.0.2",
+                "from2": "2.3.0",
+                "parallel-transform": "1.1.0",
+                "pump": "1.0.3",
+                "pumpify": "1.4.0",
+                "stream-each": "1.2.2",
+                "through2": "2.0.3"
+            }
+        },
         "mkdirp": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -5529,6 +5683,29 @@
             "resolved": "https://registry.npmjs.org/mout/-/mout-0.5.0.tgz",
             "integrity": "sha1-/5Z1ZqkPKVlenLi254AKW1ZjVYM=",
             "dev": true
+        },
+        "move-concurrently": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+            "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+            "requires": {
+                "aproba": "1.2.0",
+                "copy-concurrently": "1.0.5",
+                "fs-write-stream-atomic": "1.0.10",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "run-queue": "1.0.3"
+            },
+            "dependencies": {
+                "rimraf": {
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+                    "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+                    "requires": {
+                        "glob": "7.0.6"
+                    }
+                }
+            }
         },
         "ms": {
             "version": "2.0.0",
@@ -7413,6 +7590,16 @@
             "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
             "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
         },
+        "parallel-transform": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+            "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+            "requires": {
+                "cyclist": "0.2.2",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3"
+            }
+        },
         "parse-asn1": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
@@ -8222,6 +8409,11 @@
                 "asap": "2.0.6"
             }
         },
+        "promise-inflight": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+            "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+        },
         "prr": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -8230,8 +8422,7 @@
         "pseudomap": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-            "dev": true
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
         },
         "public-encrypt": {
             "version": "4.0.0",
@@ -8485,6 +8676,36 @@
                     "version": "0.10.31",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                     "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                }
+            }
+        },
+        "pump": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+            "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+            "requires": {
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
+            }
+        },
+        "pumpify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
+            "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
+            "requires": {
+                "duplexify": "3.5.3",
+                "inherits": "2.0.3",
+                "pump": "2.0.1"
+            },
+            "dependencies": {
+                "pump": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+                    "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+                    "requires": {
+                        "end-of-stream": "1.4.1",
+                        "once": "1.4.0"
+                    }
                 }
             }
         },
@@ -8898,6 +9119,14 @@
                 "is-promise": "2.1.0"
             }
         },
+        "run-queue": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+            "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+            "requires": {
+                "aproba": "1.2.0"
+            }
+        },
         "rx-lite": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
@@ -8935,6 +9164,11 @@
             "version": "5.4.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
             "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+        },
+        "serialize-javascript": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.4.0.tgz",
+            "integrity": "sha1-fJWFFNtqwkQ6irwGLcn3iGp/YAU="
         },
         "set-blocking": {
             "version": "2.0.0",
@@ -9107,6 +9341,14 @@
                 "tweetnacl": "0.14.5"
             }
         },
+        "ssri": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.1.0.tgz",
+            "integrity": "sha512-TevC8fgxQKTfQ1nWtM9GNzr3q5rrHNntG9CDMH1k3QhSZI6Kb+NbjLRs8oPFZa2Hgo7zoekL+UTvoEk7tsbjQg==",
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
+        },
         "stampit": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/stampit/-/stampit-1.2.0.tgz",
@@ -9125,6 +9367,15 @@
                 "readable-stream": "2.3.3"
             }
         },
+        "stream-each": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+            "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+            "requires": {
+                "end-of-stream": "1.4.1",
+                "stream-shift": "1.0.0"
+            }
+        },
         "stream-http": {
             "version": "2.7.2",
             "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
@@ -9136,6 +9387,11 @@
                 "to-arraybuffer": "1.0.1",
                 "xtend": "4.0.1"
             }
+        },
+        "stream-shift": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+            "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
         },
         "strict-uri-encode": {
             "version": "1.1.0",
@@ -9543,6 +9799,15 @@
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
             "dev": true
         },
+        "through2": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+            "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+            "requires": {
+                "readable-stream": "2.3.3",
+                "xtend": "4.0.1"
+            }
+        },
         "timers-browserify": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
@@ -9662,6 +9927,56 @@
             "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
             "optional": true
         },
+        "uglifyjs-webpack-plugin": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.1.6.tgz",
+            "integrity": "sha512-VUja+7rYbznEvUaeb8IxOCTUrq4BCb1ml0vffa+mfwKtrAwlqnU0ENF14DtYltV1cxd/HSuK51CCA/D/8kMQVw==",
+            "requires": {
+                "cacache": "10.0.2",
+                "find-cache-dir": "1.0.0",
+                "schema-utils": "0.4.3",
+                "serialize-javascript": "1.4.0",
+                "source-map": "0.6.1",
+                "uglify-es": "3.3.8",
+                "webpack-sources": "1.1.0",
+                "worker-farm": "1.5.2"
+            },
+            "dependencies": {
+                "ajv-keywords": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+                    "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+                },
+                "commander": {
+                    "version": "2.13.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+                    "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+                },
+                "schema-utils": {
+                    "version": "0.4.3",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.3.tgz",
+                    "integrity": "sha512-sgv/iF/T4/SewJkaVpldKC4WjSkz0JsOh2eKtxCPpCO1oR05+7MOF+H476HVRbLArkgA7j5TRJJ4p2jdFkUGQQ==",
+                    "requires": {
+                        "ajv": "5.5.2",
+                        "ajv-keywords": "2.1.1"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                },
+                "uglify-es": {
+                    "version": "3.3.8",
+                    "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.8.tgz",
+                    "integrity": "sha512-j8li0jWcAN6yBuAVYFZEFyYINZAm4WEdMwkA6qXFi4TLrze3Mp0Le7QjW6LR9HQjQJ2zRa9VgnFLs3PatijWOw==",
+                    "requires": {
+                        "commander": "2.13.0",
+                        "source-map": "0.6.1"
+                    }
+                }
+            }
+        },
         "underscore": {
             "version": "1.8.3",
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
@@ -9689,6 +10004,22 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
             "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
+        },
+        "unique-filename": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+            "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
+            "requires": {
+                "unique-slug": "2.0.0"
+            }
+        },
+        "unique-slug": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+            "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+            "requires": {
+                "imurmurhash": "0.1.4"
+            }
         },
         "unzip": {
             "version": "0.1.11",
@@ -10022,6 +10353,15 @@
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
             "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
         },
+        "worker-farm": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.2.tgz",
+            "integrity": "sha512-XxiQ9kZN5n6mmnW+mFJ+wXjNNI/Nx4DIdaAKLX1Bn6LYBWlN/zaBhu34DQYPZ1AJobQuu67S2OfDdNSVULvXkQ==",
+            "requires": {
+                "errno": "0.1.6",
+                "xtend": "4.0.1"
+            }
+        },
         "wrap-ansi": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
@@ -10065,8 +10405,7 @@
         "yallist": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-            "dev": true
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         },
         "yargs": {
             "version": "3.10.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "stylus-loader": "^3.0.1",
         "swagger-ui": "~2.2.10",
         "toposort": "^1.0.3",
+        "uglifyjs-webpack-plugin": "^1.1.6",
         "underscore": "^1.8.3",
         "webpack": "^2.7.0"
     },


### PR DESCRIPTION
The motivation for this is to take advantage of a new feature in the UglifyJsPlugin that is not available in the current major version of webpack that Girder uses. Namely, the ability to handle ES6+ syntax in the output.

This allows me to build my paraviewweb + vtk.js plugin in prod mode, which was otherwise impossible since their upstream build process produces outputs with some ES6 features in the output, such as hex numeric notation.