### PR TITLE
Pull mongomock package from github instead of pypi

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ flake8-blind-except
 flake8-docstrings>=1.3
 httmock
 mock
-mongomock
+git+https://github.com/mongomock/mongomock.git@5fb1af64a82b83e9713c6bdd8f22cbd665a0cc6e#egg=mongomock
 moto[server]
 pytest
 pytest-cov


### PR DESCRIPTION
Our upstream fixes have been merged, but the release cycle of mongomock is a complete unknown, its last release was almost a year ago.

This will allow developers to use `pytest --mock-db` locally immediately.