### PR TITLE
Pin parts of vega.

### DIFF
--- a/plugins/candela/package.json
+++ b/plugins/candela/package.json
@@ -2,6 +2,10 @@
     "name": "candela-plugin",
     "version": "0.1.0",
     "dependencies": {
+        "vega": "3.0.9",
+        "vega-scenegraph": "2.1",
+        "vega-wordcloud": "2.0.2",
+
         "candela": "~0.16.0",
         "datalib": "~1.7"
     }


### PR DESCRIPTION
The most recent version of vega depends on vega-canvas, but that doesn't build with webpack.  See https://github.com/vega/vega-canvas/issues/1. This pins enough of vega to avoid the problem.

This can be reverted when candela publishes a work around or the problem is fixed in vega-canvas.