### PR TITLE
Improvements to SearchResultsView 

### DIFF
--- a/clients/web/src/stylesheets/body/searchResultsList.styl
+++ b/clients/web/src/stylesheets/body/searchResultsList.styl
@@ -1,6 +1,6 @@
 .g-search-results-title-container
   display block
-  padding 0.5% 0 0.5% 2%
+  padding 0.5% 0 0.5% 0.5%
   font-size 20px
   background-color #eaebea
   border-bottom 1px solid #ddd
@@ -46,6 +46,6 @@
   font-size 30px
 
 .g-search-no-results
-    padding 0.5% 0 0.5% 1%
-    border 1px solid #efefef
-    font-size 15px
+  padding 0.5% 0 0.5% 1%
+  border 1px solid #efefef
+  font-size 15px

--- a/clients/web/src/stylesheets/body/searchResultsList.styl
+++ b/clients/web/src/stylesheets/body/searchResultsList.styl
@@ -41,6 +41,10 @@
     ul.pagination
       margin 5px 15px
 
+.g-search-pending
+  padding 10px
+  font-size 30px
+
 .g-search-no-results
     padding 0.5% 0 0.5% 1%
     border 1px solid #efefef

--- a/clients/web/src/templates/body/searchResults.pug
+++ b/clients/web/src/templates/body/searchResults.pug
@@ -1,16 +1,15 @@
 .g-search-results-header-container
   .g-search-results-title-container
     i.g-search-results-title-element.icon-search
-    if length === 1
-      span.g-search-results-title.g-search-results-title-element Result : #{query}
-    else
-      span.g-search-results-title.g-search-results-title-element Results : #{query}
+    span.g-search-results-title.g-search-results-title-element Results : #{query}
   .g-search-results-header
     .g-search-results-advance-search
 
 .g-search-results-container
 
-if !length
-  .g-search-no-results.disabled
-    i.icon-block
-    |  No results found
+.g-search-pending
+  i.icon-spin4.animate-spin
+
+.g-search-no-results(style='display: none;')
+  i.icon-block
+  |  No results found

--- a/clients/web/src/templates/body/searchResultsType.pug
+++ b/clients/web/src/templates/body/searchResultsType.pug
@@ -5,10 +5,9 @@
 ul.g-search-results-type
   each element in results
     li.g-search-result
-      if type === 'user'
-        a(data-resource-id=element._id, data-resource-type=type, data-resource-icon=icon, tabindex="-1")
+      a(href=`#${type}/${element._id}`)
+        if type === 'user'
           | #{element.firstName} #{element.lastName} (#{element.login})
-      else
-        a(data-resource-id=element._id, data-resource-type=type, data-resource-icon=icon, tabindex="-1")
+        else
           | #{element.name}
 .g-search-results-paginate(id=`${type}Paginate`)

--- a/clients/web/src/views/body/SearchResultsView.js
+++ b/clients/web/src/views/body/SearchResultsView.js
@@ -46,17 +46,6 @@ var SearchResultsView = View.extend({
         return length;
     },
 
-    _getIcon: function (type) {
-        const icons = {
-            'user': 'user',
-            'group': 'users',
-            'collection': 'sitemap',
-            'folder': 'folder',
-            'item': 'doc-text-inv'
-        };
-        return icons[type];
-    },
-
     /**
      * Return a consistent and semantically-meaningful type ordering.
      */
@@ -85,7 +74,6 @@ var SearchResultsView = View.extend({
                     query: this._query,
                     mode: this._mode,
                     type: type,
-                    icon: this._getIcon(type),
                     limit: this.pageLimit,
                     initResults: this._initResults[type],
                     sizeOneElement: this._sizeOneElement
@@ -105,14 +93,12 @@ var SearchResultsView = View.extend({
  * for iterating amongst pages of a list of search results.
  */
 var SearchResultsTypeView = View.extend({
-
     className: 'g-search-results-type-container',
 
     initialize: function (settings) {
         this._query = settings.query;
         this._mode = settings.mode;
         this._type = settings.type;
-        this._icon = settings.icon || 'icon-attention-alt';
         this._initResults = settings.initResults || [];
         this._pageLimit = settings.limit || 10;
         this._sizeOneElement = settings.sizeOneElement || 30;
@@ -132,7 +118,7 @@ var SearchResultsTypeView = View.extend({
         this._results = this._initResults;
     },
 
-    getCollectionName: function (types) {
+    _getTypeName: function (type) {
         const names = {
             'collection': 'Collections',
             'group': 'Groups',
@@ -140,15 +126,26 @@ var SearchResultsTypeView = View.extend({
             'folder': 'Folders',
             'item': 'Items'
         };
-        return names[types];
+        return names[type] || type;
+    },
+
+    _getTypeIcon: function (type) {
+        const icons = {
+            'user': 'user',
+            'group': 'users',
+            'collection': 'sitemap',
+            'folder': 'folder',
+            'item': 'doc-text-inv'
+        };
+        return icons[type] || 'icon-attention-alt';
     },
 
     render: function () {
         this.$el.html(SearchResultsTypeTemplate({
             results: this._results,
-            collectionName: this.getCollectionName(this._type),
+            collectionName: this._getTypeName(this._type),
             type: this._type,
-            icon: this._icon
+            icon: this._getTypeIcon(this._type)
         }));
 
         /* This size of the results list cannot be known until after the fetch completes. And we don't want to set

--- a/clients/web/src/views/body/SearchResultsView.js
+++ b/clients/web/src/views/body/SearchResultsView.js
@@ -1,9 +1,7 @@
-import $ from 'jquery';
 import _ from 'underscore';
 
 import View from 'girder/views/View';
 import { restRequest } from 'girder/rest';
-import router from 'girder/router';
 import SearchPaginateWidget from 'girder/views/widgets/SearchPaginateWidget';
 import SearchFieldWidget from 'girder/views/widgets/SearchFieldWidget';
 
@@ -16,13 +14,6 @@ import 'girder/stylesheets/body/searchResultsList.styl';
  * per each type found.
  */
 var SearchResultsView = View.extend({
-    events: {
-        'click .g-search-result>a': function (e) {
-            var result = $(e.currentTarget);
-            this._resultClicked(result.data('resourceType'), result.data('resourceId'));
-        }
-    },
-
     initialize: function (settings) {
         this._query = settings.query;
         this._mode = settings.mode || 'text';
@@ -110,12 +101,6 @@ var SearchResultsView = View.extend({
         });
 
         return this;
-    },
-
-    _resultClicked: function (type, id) {
-        router.navigate(`${type}/${id}`, {
-            trigger: true
-        });
     }
 });
 

--- a/clients/web/src/views/body/SearchResultsView.js
+++ b/clients/web/src/views/body/SearchResultsView.js
@@ -46,10 +46,6 @@ var SearchResultsView = View.extend({
         return length;
     },
 
-    _parseResults: function (results) {
-        return _.values(results)[0];
-    },
-
     _getIcon: function (type) {
         const icons = {
             'user': 'user',
@@ -86,7 +82,6 @@ var SearchResultsView = View.extend({
             if (this._initResults[type].length) {
                 this._subviews[type] = new SearchResultsTypeView({
                     parentView: this,
-                    name: `${type}ResultsView`,
                     query: this._query,
                     mode: this._mode,
                     type: type,
@@ -114,7 +109,6 @@ var SearchResultsTypeView = View.extend({
     className: 'g-search-results-type-container',
 
     initialize: function (settings) {
-        this._name = settings.name;
         this._query = settings.query;
         this._mode = settings.mode;
         this._type = settings.type;


### PR DESCRIPTION
* Return a stable ordering for unknown search result types
  * This also fixes bugs with custom search modes returning fewer types.
* Use hrefs in the search results page
* Remove unused variables in `SearchResultsView`
* Simplify parameters for `SearchResultsTypeView`
* Refactor `SearchResultsView` to add a pending spinner icon
* Adjust the title position of the search results page