### PR TITLE
Unify girder-* commands into top level girder command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,8 @@ Added Features
   ``girder.utility._cache.requestCache``. (`#2274 <https://github.com/girder/girder/pull/2274>`_)
 * Plugins can customize the header and description on the Swagger page.
   (`#2607 <https://github.com/girder/girder/pull/2607>`_)
+* Common Girder operations can now be executed with a top level ``girder`` command.
+  (`#2596 <https://github.com/girder/girder/pull/2596>`_)
 
 Web Client
 ^^^^^^^^^^

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ COPY README.rst /girder/README.rst
 RUN pip install --upgrade --editable .[plugins]
 RUN girder-install web --all-plugins
 
-ENTRYPOINT ["python2", "-m", "girder"]
+ENTRYPOINT ["girder", "serve"]

--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -31,4 +31,9 @@ COPY README.rst /girder/README.rst
 RUN pip install --upgrade --editable .[plugins]
 RUN girder-install web --all-plugins
 
-ENTRYPOINT ["python3", "-m", "girder"]
+# See http://click.pocoo.org/5/python3/#python-3-surrogate-handling for more detail on
+# why this is necessary.
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+ENTRYPOINT ["girder", "serve"]

--- a/clients/web/test/testUtils.js
+++ b/clients/web/test/testUtils.js
@@ -1220,7 +1220,7 @@ girderTest.anonymousLoadPage = function (logoutFirst, fragment, hasLoginDialog, 
 /*
  * Provide an alternate path to injecting a test spec as a url query parameter.
  *
- * To use, start girder in testing mode: `python -m girder --testing` and
+ * To use, start girder in testing mode: `girder serve --testing` and
  * browse to the test html with a spec provided:
  *
  *   http://localhost:8080/static/built/testing/testEnv.html?spec=%2Fclients%2Fweb%2Ftest%2Fspec%2FversionSpec.js

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -42,7 +42,7 @@ documentation on how to set this up, see `Developer Installation <dev-installati
 During Development
 ------------------
 
-Once Girder is started via ``girder-server``, the server
+Once Girder is started via ``girder serve``, the server
 will reload itself whenever a Python file is modified.
 
 If you are doing front-end development, it's much faster to use a *watch* process to perform
@@ -69,7 +69,7 @@ are actually bound but requests can still be performed via Python. Bootstrapping
 involves running ``girder.utility.server.configureServer`` with the plugins to be enabled.
 
 Girder provides a utility script for entering into a shell with the server preconfigured. Once
-Girder is installed the script can be run using ``girder-shell`` which optionally takes a comma
+Girder is installed the script can be run using ``girder shell`` which optionally takes a comma
 separated list of plugins to enable.
 
 Utilities
@@ -340,7 +340,7 @@ you should point girder to an empty database ::
 
 You can browse the result in Girder by running ::
 
-    GIRDER_MONGO_URI='mongodb://127.0.0.1:27017/mytest' girder-server
+    GIRDER_MONGO_URI='mongodb://127.0.0.1:27017/mytest' girder serve
 
 .. note::
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -562,7 +562,7 @@ The process for releasing the python client is as follows:
         python setup.py sdist --dist-dir .
 
 3.  That should have created the package tarball as ``girder-client-<version>.tar.gz``.
-    Install it locally in a virtualenv and ensure that you can call the ``girder-cli``
+    Install it locally in a virtualenv and ensure that you can call the ``girder-client``
     executable.
 
     .. code-block:: bash
@@ -571,7 +571,7 @@ The process for releasing the python client is as follows:
         virtualenv release
         source release/bin/activate
         pip install ../girder-client-<version>.tar.gz
-        girder-cli
+        girder-client
 
 4.  Go back to the ``clients/python`` directory and upload the package to pypi:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -151,7 +151,7 @@ To run the server, first make sure the Mongo daemon is running. To manually star
 
 Then to run Girder itself, just use the following command: ::
 
-    girder-server
+    girder serve
 
 Then open http://localhost:8080/ in your web browser, and you should see the application.
 

--- a/docs/python-client.rst
+++ b/docs/python-client.rst
@@ -35,7 +35,7 @@ auto-completion can easily be enabled executing:
 
 ::
 
-    eval "$(_GIRDER_CLI_COMPLETE=source girder-cli)"
+    eval "$(_GIRDER_CLI_COMPLETE=source girder-client)"
 
 For convenience, adding this line at the end of ``.bashrc`` will make sure
 auto-completion is always available.
@@ -48,21 +48,17 @@ The Command Line Interface
 The girder_client package ships with a command-line utility that wraps some of
 its common functionality to make it easy to invoke operations without having
 to write any custom python scripts. If you have installed girder_client via
-pip, you can use the special ``girder-cli`` executable: ::
+pip, you can use the ``girder-client`` executable: ::
 
-    girder-cli <arguments>
-
-Otherwise you can equivalently just invoke the module directly: ::
-
-    python -m girder_client <command> <arguments>
+    girder-client <arguments>
 
 To see all available commands, run: ::
 
-    girder-cli --help
+    girder-client --help
 
 For help with a specific command, run: ::
 
-    girder-cli <command> --help
+    girder-client <command> --help
 
 Specifying the Girder Instance
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -70,9 +66,9 @@ Specifying the Girder Instance
 When constructing a Girder client, you must declare what instance of Girder
 you wish to connect to. The easiest way to do so is to pass the full URL to the
 REST API of the Girder instance you wish to connect to using the ``api-url``
-argument to ``girder-cli``. For example: ::
+argument to ``girder-client``. For example: ::
 
-    girder-cli --api-url http://localhost:8080/api/v1 <command> ...
+    girder-client --api-url http://localhost:8080/api/v1 <command> ...
 
 
 Instead of using ``api-url`` argument, you may also specify the URL in parts, using the
@@ -84,12 +80,12 @@ Specifying credentials
 The recommended way is to generate an :ref:`API key <api_keys>` and specify
 the ``api-key`` argument. ::
 
-    girder-cli --api-url https://girder.example.com:443/api/v1  --api-key abcdefghijklmopqrstuvwxyz012345678901234 ...
+    girder-client --api-url https://girder.example.com:443/api/v1  --api-key abcdefghijklmopqrstuvwxyz012345678901234 ...
 
 Setting the ``GIRDER_API_KEY`` environment variable is also supported: ::
 
     export GIRDER_API_KEY=abcdefghijklmopqrstuvwxyz012345678901234
-    girder-cli --api-url https://girder.example.com:443/api/v1 ...
+    girder-client --api-url https://girder.example.com:443/api/v1 ...
 
 The client also supports ``username`` and ``password`` args. If only the
 ``username`` is specified, the client will prompt the user to interactively
@@ -109,7 +105,7 @@ Specifying ``--certificate /path/to/custom_bundle.pem`` allows to use a custom "
 Certificate Authority (CA) public keys (CA certs) for performing the SSL verification
 applied when the ``https`` scheme is associated with the API url.
 
-By default, the carefully curated collection of Root Certificates from Mozilla is used. 
+By default, the carefully curated collection of Root Certificates from Mozilla is used.
 See https://pypi.python.org/pypi/certifi
 
 Upload a local file hierarchy
@@ -119,31 +115,31 @@ To upload a folder hierarchy rooted at `test_folder` to the Girder Folder with
 id `54b6d41a8926486c0cbca367` ::
 
 
-    girder-cli upload 54b6d41a8926486c0cbca367 test_folder
+    girder-client upload 54b6d41a8926486c0cbca367 test_folder
 
 When using the upload command, the default ``--parent-type``, meaning the type
 of resource the local folder will be created under in Girder, is Folder, so the
 following are equivalent ::
 
-    girder-cli upload 54b6d41a8926486c0cbca367 test_folder
-    girder-cli upload 54b6d41a8926486c0cbca367 test_folder --parent-type folder
+    girder-client upload 54b6d41a8926486c0cbca367 test_folder
+    girder-client upload 54b6d41a8926486c0cbca367 test_folder --parent-type folder
 
 To upload that same local folder to a Collection or User, specify the parent
 type as follows ::
 
-    girder-cli upload 54b6d41a8926486c0cbca459 test_folder --parent-type user
+    girder-client upload 54b6d41a8926486c0cbca459 test_folder --parent-type user
 
 To see what local folders and files on disk would be uploaded without actually
 uploading anything, add the ``--dry-run`` flag ::
 
-    girder-cli upload 54b6d41a8926486c0cbca367 test_folder --dry-run
+    girder-client upload 54b6d41a8926486c0cbca367 test_folder --dry-run
 
 To have leaf folders (those folders with no subfolders, only containing files)
 be uploaded to Girder as single Items with multiple Files, i.e. those leaf
 folders will be created as Items and all files within the leaf folders will be
 Files within those Items, add the ``--leaf-folders-as-items`` flag ::
 
-    girder-cli upload 54b6d41a8926486c0cbca367 test_folder --leaf-folders-as-items
+    girder-client upload 54b6d41a8926486c0cbca367 test_folder --leaf-folders-as-items
 
 If you already have an existing Folder hierarchy in Girder which you have a
 superset of on your local disk (e.g. you previously uploaded a hierarchy to
@@ -153,12 +149,12 @@ Items for those that match folders and files on disk, by using the ``--reuse`` f
 
 ::
 
-    girder-cli upload 54b6d41a8926486c0cbca367 test_folder --reuse
+    girder-client upload 54b6d41a8926486c0cbca367 test_folder --reuse
 
 To include a blacklist of file patterns that will not be uploaded, pass a comma
 separated list to the ``--blacklist`` arg ::
 
-    girder-cli upload 54b6d41a8926486c0cbca367 test_folder --blacklist .DS_Store
+    girder-client upload 54b6d41a8926486c0cbca367 test_folder --blacklist .DS_Store
 
 .. note: The girder_client can upload to an S3 Assetstore when uploading to a Girder server
          that is version 1.3.0 or later.
@@ -172,7 +168,7 @@ Folder
 To download a Girder Folder hierarchy rooted at Folder id
 `54b6d40b8926486c0cbca364` under the local folder `download_folder` ::
 
-    girder-cli download 54b6d40b8926486c0cbca364 download_folder
+    girder-client download 54b6d40b8926486c0cbca364 download_folder
 
 
 Collection
@@ -181,7 +177,7 @@ Collection
 To download the Girder Folder hierarchies associated with a Girder Collection
 with id `57b5c9e58d777f126827f5a1` under the local folder `download_folder` ::
 
-    girder-cli download --parent-type collection 57b5c9e58d777f126827f5a1 download_folder
+    girder-client download --parent-type collection 57b5c9e58d777f126827f5a1 download_folder
 
 User
 """"
@@ -189,7 +185,7 @@ User
 To download the Girder Folder hierarchies associated with a Girder User
 with id `54f8ac238d777f69813604af` under the local folder `download_folder` ::
 
-    girder-cli download --parent-type user 54b6d40b8926486c0cbca364 download_folder
+    girder-client download --parent-type user 54b6d40b8926486c0cbca364 download_folder
 
 Item
 """"
@@ -197,7 +193,7 @@ Item
 To download the file(s) associated with a Girder Item with if `58b8eb798d777f0aef5d0f78` under
 the local folder `download_folder`::
 
-    girder-cli download --parent-type item 8b8eb798d777f0aef5d0f78 download_folder
+    girder-client download --parent-type item 8b8eb798d777f0aef5d0f78 download_folder
 
 File
 """"
@@ -205,7 +201,7 @@ File
 To download a specific file from girder with id `58b8eb798d777f0aef5d0f78` to
 the local file `local_file` ::
 
-    girder-cli download --parent-type file 8b8eb798d777f0aef5d0f78  local_file
+    girder-client download --parent-type file 8b8eb798d777f0aef5d0f78  local_file
 
 
 Auto-detecting parent-type
@@ -229,13 +225,13 @@ If the `download_folder` is a local copy of a Girder Folder hierarchy rooted at
 Folder id `54b6d40b8926486c0cbca364`, any change made to the Girder Folder remotely
 can be synchronized locally by ::
 
-    girder-cli localsync 54b6d40b8926486c0cbca364 download_folder
+    girder-client localsync 54b6d40b8926486c0cbca364 download_folder
 
 This will only download new Items or Items that have been modified since the
 last download/localsync. Local files that are no longer present in the remote
 Girder Folder will not be removed. This command relies on a presence of
 metadata file `.metadata-girder` within `download_folder`, which is created
-upon `girder-cli download`. If `.metadata-girder` is not present,
+upon `girder-client download`. If `.metadata-girder` is not present,
 `localsync` will fallback to `download`.
 
 The Python Client Library

--- a/docs/sftp.rst
+++ b/docs/sftp.rst
@@ -10,16 +10,16 @@ with their Girder login name and password. This protocol can make it much easier
 nested datasets with many individual files, and is tolerant to network failure since it supports
 resuming interrupted downloads of entire data hierarchies.
 
-After installing the Girder package via pip, you should now see the ``girder-sftpd`` executable
-in your PATH. Running it will start the SFTP server using the same database configuration as the
-main Girder HTTP server.
+After installing the Girder package via pip, you should now see the ``girder`` executable
+in your PATH. Running ``girder sftpd`` will start the SFTP server using the same database configuration
+as the main Girder HTTP server.
 
 The SFTP server requires a private key file for secure communication with clients. If you do
 not pass an explicit path to an RSA private key file, the service will look for one at
 ``~/.ssh/id_rsa``. It's recommended to make a special key just for the SFTP service, e.g.::
 
     ssh-keygen -t rsa -b 2048 -f my_key.rsa -N ''
-    girder-sftpd -i my_key.rsa
+    girder sftpd -i my_key.rsa
 
 You can control the port on which the server binds by passing a ``-p <port>`` argument to the
 server CLI. The default port is 8022.

--- a/girder/__main__.py
+++ b/girder/__main__.py
@@ -18,7 +18,7 @@
 ###############################################################################
 
 import cherrypy  # pragma: no cover
-import argparse  # pragma: no cover
+import click
 import os  # pragma: no cover
 
 try:  # pragma: no cover
@@ -33,24 +33,22 @@ except ImportError:
     from girder.utility import server
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description='Girder: data management platform for the web.')
-    parser.add_argument("-t", "--testing", help="run in testing mode",
-                        action="store_true")
-    parser.add_argument("-d", "--database",
-                        help="to what database url should Girder connect")
-    parser.add_argument("-H", "--host", help="on what host should Girder serve")
-    parser.add_argument("-p", "--port",
-                        help="on what port should Girder serve")
-    args = parser.parse_args()
-    if args.database:
-        cherrypy.config['database']['uri'] = args.database
-    if args.host:
-        cherrypy.config['server.socket_host'] = args.host
-    if args.port:
-        cherrypy.config['server.socket_port'] = int(args.port)
-    server.setup(args.testing)
+@click.command(name='serve', short_help='Run the Girder server.', help='Run the Girder server.')
+@click.option('-t', '--testing', is_flag=True, help='Run in testing mode')
+@click.option('-d', '--database', default=cherrypy.config['database']['uri'],
+              show_default=True, help='The database URI to connect to')
+@click.option('-H', '--host', default=cherrypy.config['server.socket_host'],
+              show_default=True, help='The interface to bind to')
+@click.option('-p', '--port', type=int, default=cherrypy.config['server.socket_port'],
+              show_default=True, help='The port to bind to')
+def main(testing, database, host, port):
+    if database:
+        cherrypy.config['database']['uri'] = database
+    if host:
+        cherrypy.config['server.socket_host'] = host
+    if port:
+        cherrypy.config['server.socket_port'] = port
+    server.setup(testing)
 
     cherrypy.engine.start()
     cherrypy.engine.block()

--- a/girder/api/sftp.py
+++ b/girder/api/sftp.py
@@ -273,7 +273,7 @@ class SftpServer(socketserver.ThreadingTCPServer):
               help='The port to bind to')
 def main(identity_file, port, host):  # pragma: no cover
     """
-    This is the entrypoint of the girder-sftpd program. It should not be
+    This is the entrypoint of the girder sftpd program. It should not be
     called from python code.
     """
     try:

--- a/girder/api/sftp.py
+++ b/girder/api/sftp.py
@@ -19,6 +19,7 @@
 
 from __future__ import print_function
 
+import click
 import os
 import paramiko
 import six
@@ -261,32 +262,29 @@ class SftpServer(socketserver.ThreadingTCPServer):
         pass
 
 
-def _main():  # pragma: no cover
+@click.command(name='sftpd', short_help='Run the Girder SFTP service.',
+               help='Run the Girder SFTP service.')
+@click.option('-i', '--identity-file', show_default=True,
+              default=os.path.expanduser(os.path.join('~', '.ssh', 'id_rsa')),
+              help='The identity (private key) file to use')
+@click.option('-H', '--host', show_default=True, default='localhost',
+              help='The interface to bind to')
+@click.option('-p', '--port', show_default=True, default=DEFAULT_PORT, type=int,
+              help='The port to bind to')
+def main(identity_file, port, host):  # pragma: no cover
     """
     This is the entrypoint of the girder-sftpd program. It should not be
     called from python code.
     """
-    import argparse
-
-    parser = argparse.ArgumentParser(
-        prog='girder-sftpd', description='Run the Girder SFTP service.')
-    parser.add_argument(
-        '-i', '--identity-file', required=False, help='path to identity (private key) file')
-    parser.add_argument('-p', '--port', required=False, default=DEFAULT_PORT, type=int)
-    parser.add_argument('-H', '--host', required=False, default='localhost')
-
-    args = parser.parse_args()
-
-    keyFile = args.identity_file or os.path.expanduser(os.path.join('~', '.ssh', 'id_rsa'))
     try:
-        hostKey = paramiko.RSAKey.from_private_key_file(keyFile)
+        hostKey = paramiko.RSAKey.from_private_key_file(identity_file)
     except paramiko.ssh_exception.PasswordRequiredException:
         logprint.error(
-            'Error: encrypted key files are not supported (%s).' % keyFile, file=sys.stderr)
+            'Error: encrypted key files are not supported (%s).' % identity_file, file=sys.stderr)
         sys.exit(1)
 
-    server = SftpServer((args.host, args.port), hostKey)
-    logprint.info('Girder SFTP service listening on %s:%d.' % (args.host, args.port))
+    server = SftpServer((host, port), hostKey)
+    logprint.info('Girder SFTP service listening on %s:%d.' % (host, port))
 
     try:
         server.serve_forever()
@@ -295,4 +293,4 @@ def _main():  # pragma: no cover
 
 
 if __name__ == '__main__':  # pragma: no cover
-    _main()
+    main()

--- a/girder/cli.py
+++ b/girder/cli.py
@@ -1,0 +1,15 @@
+from click_plugins import with_plugins
+from pkg_resources import iter_entry_points
+import click
+
+
+@with_plugins(iter_entry_points('girder.cli_plugins'))
+@click.group(help='Girder: data management platform for the web.',
+             context_settings=dict(help_option_names=['-h', '--help']))
+@click.version_option(message='%(version)s')
+def cli():
+    pass
+
+
+def main():
+    cli()

--- a/girder/utility/shell.py
+++ b/girder/utility/shell.py
@@ -42,7 +42,7 @@ def _launchShell(context):
         return code.interact(banner=header, local=context)
 
 
-@click.command(context_settings=dict(help_option_names=['-h', '--help']))
+@click.command('shell', short_help='Run a Girder shell.', help='Run a Girder shell.')
 @click.option('--plugins', default=None, help='Comma separated list of plugins to import.')
 def main(plugins):
     if plugins is not None:

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ installReqs = [
     # https://github.com/cherrypy/cherrypy/issues/1662
     'CherryPy<11.1',
     'click',
+    'click-plugins',
     'dogpile.cache',
     'filelock',
     'funcsigs ; python_version < \'3\'',
@@ -165,7 +166,9 @@ setup(
             'girder-server = girder.__main__:main',
             'girder-install = girder.utility.install:main',
             'girder-sftpd = girder.api.sftp:_main',
-            'girder-shell = girder.utility.shell:main'
-        ]
+            'girder-shell = girder.utility.shell:main',
+            'girder = girder.cli:main'
+        ],
+        'girder.cli_plugins': []
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -165,12 +165,14 @@ setup(
         'console_scripts': [
             'girder-server = girder.__main__:main',
             'girder-install = girder.utility.install:main',
-            'girder-sftpd = girder.api.sftp:_main',
+            'girder-sftpd = girder.api.sftp:main',
             'girder-shell = girder.utility.shell:main',
             'girder = girder.cli:main'
         ],
         'girder.cli_plugins': [
-            'serve = girder.__main__:main'
+            'serve = girder.__main__:main',
+            'shell = girder.utility.shell:main',
+            'sftpd = girder.api.sftp:main'
         ]
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -169,6 +169,8 @@ setup(
             'girder-shell = girder.utility.shell:main',
             'girder = girder.cli:main'
         ],
-        'girder.cli_plugins': []
+        'girder.cli_plugins': [
+            'serve = girder.__main__:main'
+        ]
     }
 )

--- a/tests/cases/py_client/cli_test.py
+++ b/tests/cases/py_client/cli_test.py
@@ -209,7 +209,7 @@ class PythonCliTestCase(base.TestCase):
         self.assertNotEqual(ret['exitVal'], 0)
 
         ret = invokeCli(('-h',))
-        self.assertIn('Usage: girder-cli', ret['stdout'])
+        self.assertIn('Usage: girder-client', ret['stdout'])
         self.assertEqual(ret['exitVal'], 0)
 
     def testUploadDownload(self):

--- a/tests/packaging/pip_install_girder.sh
+++ b/tests/packaging/pip_install_girder.sh
@@ -16,11 +16,11 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-# Make sure girder-server entrypoint is on the path
+# Make sure girder entrypoint is on the path
 source "${virtualenv_activate}"
-which girder-server
+which girder
 if [ $? -ne 0 ]; then
-    echo "Error: girder-server not found on the executable path"
+    echo "Error: girder not found on the executable path"
     exit 1
 fi
 
@@ -39,7 +39,7 @@ fi
 
 # Start the server
 export GIRDER_PORT=31200
-python -m girder &> /dev/null &
+girder serve &> /dev/null &
 
 girder_pid=$!
 sleep 1
@@ -97,7 +97,7 @@ fi
 
 # Start Girder server
 export GIRDER_PORT=50202
-python -m girder &> /dev/null &
+girder serve &> /dev/null &
 
 # Ensure the server started
 girder_pid=$!

--- a/tests/setup_database.py
+++ b/tests/setup_database.py
@@ -387,7 +387,7 @@ def main(file):
 # environment variable.  For example:
 #
 #   GIRDER_MONGO_URI='mongodb://127.0.0.1:27017/import_test' python setup_database.py spec.yml
-#   GIRDER_MONGO_URI='mongodb://127.0.0.1:27017/import_test' girder-server
+#   GIRDER_MONGO_URI='mongodb://127.0.0.1:27017/import_test' girder serve
 if __name__ == '__main__':
     import sys
     main(sys.argv[1])


### PR DESCRIPTION
The primary objective of this PR is to add a top level `girder` console script which can be used to centralize the various scripts housed in Girder (`girder-install`, `girder-server`, `girder-shell`, `girder-sftpd`, etc). Note that all existing console scripts continue to function as they did before.

This will provide:
1) A unified CLI interface
    As flags need to get added or modified, we can add them to the top level `girder` command rather than reimplementing them in each subcommand's parser.
2) A centralized index for users
    With this PR, typing `girder` or `girder --help` shows an index of subcommands and descriptions that can be executed:
```
Usage: girder [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  serve  Run the Girder server.
  sftpd  Run the Girder SFTP service.
  shell  Run a Girder shell.
```

`girder-install` has been left out due to it's likely significant changes in Girder 3

Future work:
- It would be nice to move the console scripts to a `bin` or `cli` module, rather than having some in `utility`, some in `api`, and some in the main `girder` package.
- There has been discussion about new commands for config file modification and schema migrations.
- Other pip installable packages could (if they want) use an entrypoint to create their own subcommands to the `girder` command.
