### PR TITLE
Add support for alternative assetstore models

### DIFF
--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -161,6 +161,13 @@ class File(acl_mixin.AccessControlMixin, Model):
                 raise ValidationException(
                     'Linked file URL must start with http: or https:.',
                     'linkUrl')
+        if doc.get('assetstoreModel'):
+            # If assetstore model is overridden, make sure it's a valid model
+            try:
+                self.model(doc['assetstoreModel'], plugin=doc.get('assetstoreModelPlugin'))
+            except Exception:
+                raise ValidationException('Invalid assetstore model: %s (plugin=%s).' % (
+                    doc['assetstoreModel'], doc.get('assetstoreModelPlugin')))
         if 'name' not in doc or not doc['name']:
             raise ValidationException('File name must not be empty.', 'name')
 

--- a/girder/utility/assetstore_utilities.py
+++ b/girder/utility/assetstore_utilities.py
@@ -74,6 +74,10 @@ def setAssetstoreAdapter(storeType, cls):
     _assetstoreTable[storeType] = cls
 
 
+def removeAssetstoreAdapter(storeType):
+    del _assetstoreTable[storeType]
+
+
 def fileIndexFields():
     """
     This will return a set of all required index fields from all of the

--- a/girder/utility/model_importer.py
+++ b/girder/utility/model_importer.py
@@ -106,4 +106,10 @@ class ModelImporter(object):
         :param instance: The model singleton instance.
         :type instance: subclass of Model
         """
+        if plugin not in _modelInstances:
+            _modelInstances[plugin] = {}
         _modelInstances[plugin][model] = instance
+
+    @staticmethod
+    def unregisterModel(model, plugin='_core'):
+        del _modelInstances[plugin][model]

--- a/test/test_assetstore_model_override.py
+++ b/test/test_assetstore_model_override.py
@@ -1,0 +1,49 @@
+import pytest
+from girder.models.file import File
+from girder.models.model_base import Model
+from girder.utility import assetstore_utilities
+from girder.utility.model_importer import ModelImporter
+from girder.utility.abstract_assetstore_adapter import AbstractAssetstoreAdapter
+
+
+class Fake(Model):
+    def initialize(self):
+        self.name = 'fake_collection'
+
+    def validate(self, doc):
+        return doc
+
+
+class FakeAdapter(AbstractAssetstoreAdapter):
+    def __init__(self, assetstore):
+        self.the_assetstore = assetstore
+
+
+@pytest.fixture
+def fakeModel(db):
+    ModelImporter.registerModel('fake', Fake(), plugin='fake_plugin')
+
+    yield Fake().save({
+        'foo': 'bar',
+        'type': 'fake'
+    })
+
+    ModelImporter.unregisterModel('fake', plugin='fake_plugin')
+
+
+@pytest.fixture
+def fakeAdapter(db):
+    assetstore_utilities.setAssetstoreAdapter('fake', FakeAdapter)
+
+    yield
+
+    assetstore_utilities.removeAssetstoreAdapter('fake')
+
+
+def testAssetstoreModelOverride(fakeModel, fakeAdapter, admin):
+    file = File().createFile(
+        creator=admin, item=None, name='a.out', size=0, assetstore=fakeModel,
+        assetstoreModel='fake', assetstoreModelPlugin='fake_plugin')
+
+    adapter = File().getAssetstoreAdapter(file)
+    assert adapter.the_assetstore == fakeModel

--- a/test/test_assetstore_model_override.py
+++ b/test/test_assetstore_model_override.py
@@ -45,7 +45,7 @@ def testAssetstoreModelOverride(fakeModel, fakeAdapter, admin):
     })
     file = File().createFile(
         creator=admin, item=None, name='a.out', size=0, assetstore=fakeAssetstore,
-        assetstoreModel='fake', assetstoreModelPlugin='fake_plugin')
+        assetstoreType=('fake', 'fake_plugin'))
 
     adapter = File().getAssetstoreAdapter(file)
     assert isinstance(adapter, FakeAdapter)
@@ -56,5 +56,5 @@ def testAssetstoreModelIsValidated(fakeModel, admin):
     fake = fakeModel().save({})
     with pytest.raises(ValidationException) as exc:
         File().createFile(
-            creator=admin, item=None, name='foo', size=0, assetstore=fake, assetstoreModel='bad')
-    assert str(exc.value) == 'Invalid assetstore model: bad (plugin=None).'
+            creator=admin, item=None, name='foo', size=0, assetstore=fake, assetstoreType='bad')
+    assert str(exc.value) == 'Invalid assetstore type: bad.'

--- a/test/test_assetstore_model_override.py
+++ b/test/test_assetstore_model_override.py
@@ -1,4 +1,5 @@
 import pytest
+from girder.exceptions import ValidationException
 from girder.models.file import File
 from girder.models.model_base import Model
 from girder.utility import assetstore_utilities
@@ -49,3 +50,11 @@ def testAssetstoreModelOverride(fakeModel, fakeAdapter, admin):
     adapter = File().getAssetstoreAdapter(file)
     assert isinstance(adapter, FakeAdapter)
     assert adapter.the_assetstore == fakeAssetstore
+
+
+def testAssetstoreModelIsValidated(fakeModel, admin):
+    fake = fakeModel().save({})
+    with pytest.raises(ValidationException) as exc:
+        File().createFile(
+            creator=admin, item=None, name='foo', size=0, assetstore=fake, assetstoreModel='bad')
+    assert str(exc.value) == 'Invalid assetstore model: bad (plugin=None).'

--- a/test/test_assetstore_model_override.py
+++ b/test/test_assetstore_model_override.py
@@ -23,10 +23,7 @@ class FakeAdapter(AbstractAssetstoreAdapter):
 def fakeModel(db):
     ModelImporter.registerModel('fake', Fake(), plugin='fake_plugin')
 
-    yield Fake().save({
-        'foo': 'bar',
-        'type': 'fake'
-    })
+    yield Fake
 
     ModelImporter.unregisterModel('fake', plugin='fake_plugin')
 
@@ -41,9 +38,14 @@ def fakeAdapter(db):
 
 
 def testAssetstoreModelOverride(fakeModel, fakeAdapter, admin):
+    fakeAssetstore = fakeModel().save({
+        'foo': 'bar',
+        'type': 'fake'
+    })
     file = File().createFile(
-        creator=admin, item=None, name='a.out', size=0, assetstore=fakeModel,
+        creator=admin, item=None, name='a.out', size=0, assetstore=fakeAssetstore,
         assetstoreModel='fake', assetstoreModelPlugin='fake_plugin')
 
     adapter = File().getAssetstoreAdapter(file)
-    assert adapter.the_assetstore == fakeModel
+    assert isinstance(adapter, FakeAdapter)
+    assert adapter.the_assetstore == fakeAssetstore


### PR DESCRIPTION
This change allows models besides the core assetstore model to be used to initialize assetstore adapters. This is desirable because it decouples assetstore *management* (an explicitly admin-only capability) from the actual service provided by the assetstore adapter. This will allow us to have user-managed "Database" models with their own custom UI and set of REST endpoints in the downstream database_assetstore plugin.

@manthey @jeffbaumes  PTAL