### PR TITLE
Allow cancellation of raw Celery

### DIFF
--- a/plugins/worker/server/__init__.py
+++ b/plugins/worker/server/__init__.py
@@ -63,7 +63,7 @@ class CustomJobStatus(object):
 
     # valid transitions for celery scheduled jobs
     # N.B. We have the extra worker input/output states defined here for when
-    # we are running girder_worker.run as a regualar celery task
+    # we are running girder_worker.run as a regular celery task
     valid_celery_transitions = {
         JobStatus.QUEUED: [JobStatus.INACTIVE],
         # Note celery tasks can jump straight from INACTIVE to RUNNING

--- a/plugins/worker/web_client/JobStatus.js
+++ b/plugins/worker/web_client/JobStatus.js
@@ -36,12 +36,8 @@ JobStatus.registerStatus({
 const jobPluginIsCancelable = JobStatus.isCancelable;
 JobStatus.isCancelable = function (job) {
     const handler = job.get('handler');
-    if (handler === 'worker_handler') {
+    if (handler === 'worker_handler' || handler === 'celery_handler') {
         return [JobStatus.CANCELED, JobStatus.WORKER_CANCELING,
-            JobStatus.SUCCESS, JobStatus.ERROR].indexOf(job.get('status')) === -1;
-    } else if (handler === 'celery_handler') {
-        // Currently celery_handler jobs can't be cancelled in the running state
-        return [JobStatus.RUNNING, JobStatus.CANCELED, JobStatus.WORKER_CANCELING,
             JobStatus.SUCCESS, JobStatus.ERROR].indexOf(job.get('status')) === -1;
     }
 


### PR DESCRIPTION
Fixes girder/girder_worker#254. It appear that then the UI component was written there was no support for cancelling RUNNING celery jobs. 