### PR TITLE
Allow plugins to customize parts of REST API Documentation page

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,8 @@ Added Features
   IDEs. The ``eslint`` tool (including options such as ``--fix``) may now be invoked directly from
   the command line, without necessarily using a CMake test.
   (`#2550 <https://github.com/girder/girder/pull/2550>`_)
+* Plugins can customize the header and description on the Swagger page.
+  (`#2607 <https://github.com/girder/girder/pull/2607>`_)
 
 Web Client
 ^^^^^^^^^^

--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -508,6 +508,41 @@ login via a username and password. This allows alternative authentication
 modes to be used instead of core, or prior to attempting core authentication.
 The event info contains two keys, "login" and "password".
 
+Customizing the Swagger page
+****************************
+
+To customize text on the Swagger page, create a
+`Mako template <http://www.makotemplates.org/>`_ file that inherits from the
+base template and overrides one or more blocks:
+
+.. code-block:: html+mako
+
+    <%inherit file="${context.get('baseTemplateFilename')}"/>
+
+    <%block name="docsHeader">
+      <span>Cat programming interface</span>
+    </%block>
+
+    <%block name="docsBody">
+      <p>Manage your cats using the resources below.</p>
+    </%block>
+
+Install the template by registering its directory and setting its filename on
+``apiRoot``:
+
+.. code-block:: python
+
+    def load(info):
+        # Set base template filename variable
+        info['apiRoot'].updateHtmlVars({
+            'baseTemplateFilename': info['apiRoot'].templateFilename
+        })
+
+        # Set custom API docs template
+        templateDir = os.path.join(info['pluginRootDir'], 'server')
+        info['apiRoot'].addTemplateDirectory(templateDir)
+        info['apiRoot'].templateFilename = 'custom_api_docs.mako'
+
 .. _client-side-plugins:
 
 Extending the Client-Side Application

--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -513,7 +513,8 @@ Customizing the Swagger page
 
 To customize text on the Swagger page, create a
 `Mako template <http://www.makotemplates.org/>`_ file that inherits from the
-base template and overrides one or more blocks:
+base template and overrides one or more blocks. For example,
+``plugins/cats/server/custom_api_docs.mako``:
 
 .. code-block:: html+mako
 
@@ -527,21 +528,30 @@ base template and overrides one or more blocks:
       <p>Manage your cats using the resources below.</p>
     </%block>
 
-Install the template by registering its directory and setting its filename on
-``apiRoot``:
+Install the custom template in the ``load`` function:
 
 .. code-block:: python
 
     def load(info):
-        # Set base template filename variable
+        # Initially, the value of info['apiRoot'].templateFilename is
+        # 'api_docs.mako'. Because custom_api_docs.mako inherits from this
+        # base template, pass 'api_docs.mako' in the variable that the
+        # <%inherit> directive references.
+        baseTemplateFilename = info['apiRoot'].templateFilename
         info['apiRoot'].updateHtmlVars({
-            'baseTemplateFilename': info['apiRoot'].templateFilename
+            'baseTemplateFilename': baseTemplateFilename
         })
 
-        # Set custom API docs template
+        # Set the custom template filename
+        info['apiRoot'].templateFilename = 'custom_api_docs.mako'
+
+        # Initially, the template search path contains only the directory of
+        # api_docs.mako. To ensure that custom_api_docs.mako can be
+        # located, also add its directory to the search path. The <%inherit>
+        # directive in the custom template will still locate the base template
+        # because the path to api_docs.mako remains in the search path.
         templateDir = os.path.join(info['pluginRootDir'], 'server')
         info['apiRoot'].addTemplateDirectory(templateDir)
-        info['apiRoot'].templateFilename = 'custom_api_docs.mako'
 
 .. _client-side-plugins:
 

--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -542,16 +542,9 @@ Install the custom template in the ``load`` function:
             'baseTemplateFilename': baseTemplateFilename
         })
 
-        # Set the custom template filename
-        info['apiRoot'].templateFilename = 'custom_api_docs.mako'
-
-        # Initially, the template search path contains only the directory of
-        # api_docs.mako. To ensure that custom_api_docs.mako can be
-        # located, also add its directory to the search path. The <%inherit>
-        # directive in the custom template will still locate the base template
-        # because the path to api_docs.mako remains in the search path.
-        templateDir = os.path.join(info['pluginRootDir'], 'server')
-        info['apiRoot'].addTemplateDirectory(templateDir)
+        # Set the path to the custom template
+        templatePath = os.path.join(info['pluginRootDir'], 'server', 'custom_api_docs.mako')
+        info['apiRoot'].setTemplatePath(templatePath)
 
 .. _client-side-plugins:
 

--- a/girder/api/api_docs.mako
+++ b/girder/api/api_docs.mako
@@ -20,11 +20,14 @@
   </head>
   <body>
     <div class="docs-header">
+      <%block name="docsHeader">
       <span>${brandName | h} REST API Documentation</span>
       <i class="icon-book-alt right"></i>
       <div id="g-global-info-apiroot" style="display: none">${apiRoot}</div>
+      </%block>
     </div>
     <div class="docs-body">
+      <%block name="docsBody">
       <p>Below you will find the list of all of the resource types exposed by
       the ${brandName | h} RESTful Web API. Click any of the resource links to open up a
       list of all available endpoints related to each resource type.</p>
@@ -37,6 +40,7 @@
       this page are the same as calling the API with any other client, so
       update or delete calls that you make will affect the actual data on the
       server.</p>
+      </%block>
     </div>
     <div class="swagger-section">
       <div id="swagger-ui-container"

--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -21,7 +21,6 @@ import bson.json_util
 import dateutil.parser
 import inspect
 import jsonschema
-import mako
 import os
 import six
 import cherrypy
@@ -479,7 +478,7 @@ class ApiDocs(WebrootBase):
         self.vars['apiRoot'] = server.getApiRoot()
         self.vars['staticRoot'] = server.getApiStaticRoot()
         self.vars['brandName'] = Setting().get(SettingKey.BRAND_NAME)
-        return mako.template.Template(self.template).render(**self.vars)
+        return super(ApiDocs, self)._renderHTML()
 
 
 class Describe(Resource):

--- a/girder/utility/webroot.py
+++ b/girder/utility/webroot.py
@@ -42,16 +42,8 @@ class WebrootBase(object):
         self.vars = {}
         self.config = config.getConfig()
 
-        # Parse the default template directory and filename from the template path.
-        # To override the default template later:
-        # - add the new template's directory to the search path with addTemplateDirectory()
-        # - indicate the new template's filename by setting templateFilename
-        templateDir, templateFilename = os.path.split(templatePath)
-        self._templateDirs = [templateDir]
-        self.templateFilename = templateFilename
-
-        # Instantiated lazily on the first GET request
-        self._templateLookup = None
+        self._templateDirs = []
+        self.setTemplatePath(templatePath)
 
     def updateHtmlVars(self, vars):
         """
@@ -60,14 +52,24 @@ class WebrootBase(object):
         """
         self.vars.update(vars)
 
-    def addTemplateDirectory(self, templateDir):
+    def setTemplatePath(self, templatePath):
         """
-        Add a directory in which to search for templates.
-        """
-        self._templateDirs.append(templateDir)
+        Set the path to a template file to render instead of the default template.
 
-        # Reset TemplateLookup instance so that the latest template directories
-        # are used for the next render
+        The default template remains available so that custom templates can
+        inherit from it. To do so, save the default template filename from
+        the templateFilename attribute before calling this function, pass
+        it as a variable to the custom template using updateHtmlVars(), and
+        reference that variable in an <%inherit> directive like:
+
+            <%inherit file="${context.get('defaultTemplateFilename')}"/>
+        """
+        templateDir, templateFilename = os.path.split(templatePath)
+        self._templateDirs.append(templateDir)
+        self.templateFilename = templateFilename
+
+        # Reset TemplateLookup instance so that it will be instantiated lazily,
+        # with the latest template directories, on the next GET request
         self._templateLookup = None
 
     @staticmethod

--- a/girder/utility/webroot.py
+++ b/girder/utility/webroot.py
@@ -39,9 +39,6 @@ class WebrootBase(object):
     exposed = True
 
     def __init__(self, templatePath):
-        # Rendering occurs lazily on the first GET request
-        self.indexHtml = None
-
         self.vars = {}
         self.config = config.getConfig()
 
@@ -54,7 +51,6 @@ class WebrootBase(object):
         with the updated set of variables to render the template with.
         """
         self.vars.update(vars)
-        self.indexHtml = None
 
     def addTemplateDirectory(self, templateDir):
         """
@@ -73,7 +69,6 @@ class WebrootBase(object):
     @templateFilename.setter
     def templateFilename(self, value):
         self._templateFilename = value
-        self.indexHtml = None
 
     @staticmethod
     def _escapeJavascript(string):

--- a/test/test_api_docs.py
+++ b/test/test_api_docs.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+import pytest
+from pytest_girder.assertions import assertStatusOk
+from pytest_girder.utils import getResponseBody
+
+
+def testApiDocsContent(server):
+    """
+    Test content of API documentation page.
+    """
+    resp = server.request(path='/api/v1', method='GET', isJson=False, prefix='')
+    assertStatusOk(resp)
+    body = getResponseBody(resp)
+
+    assert 'Girder REST API Documentation' in body
+    assert 'This is not a sandbox' in body
+    assert 'id="swagger-ui-container"' in body
+
+
+@pytest.mark.testPlugin('custom_api_docs_test')
+def testApiDocsCustomContent(server):
+    """
+    Test content of API documentation page that's customized by a plugin.
+    """
+    resp = server.request(path='/api/v1', method='GET', isJson=False, prefix='')
+    assertStatusOk(resp)
+    body = getResponseBody(resp)
+
+    assert 'Girder REST API Documentation' not in body
+    assert 'This is not a sandbox' not in body
+
+    assert 'Girder Web Application Programming Interface' in body
+    assert '<p>Custom API description</p>' in body
+    assert 'id="swagger-ui-container"' in body

--- a/test/test_plugins/custom_api_docs_test/server/__init__.py
+++ b/test/test_plugins/custom_api_docs_test/server/__init__.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+import os
+
+
+def load(info):
+    # Set base template filename variable
+    info['apiRoot'].updateHtmlVars({
+        'baseTemplateFilename': info['apiRoot'].templateFilename
+    })
+
+    # Set custom API docs template
+    templateDir = os.path.join(info['pluginRootDir'], 'server')
+    info['apiRoot'].addTemplateDirectory(templateDir)
+    info['apiRoot'].templateFilename = 'custom_api_docs.mako'

--- a/test/test_plugins/custom_api_docs_test/server/__init__.py
+++ b/test/test_plugins/custom_api_docs_test/server/__init__.py
@@ -21,12 +21,11 @@ import os
 
 
 def load(info):
-    # Set base template filename variable
     info['apiRoot'].updateHtmlVars({
         'baseTemplateFilename': info['apiRoot'].templateFilename
     })
 
-    # Set custom API docs template
+    info['apiRoot'].templateFilename = 'custom_api_docs.mako'
+
     templateDir = os.path.join(info['pluginRootDir'], 'server')
     info['apiRoot'].addTemplateDirectory(templateDir)
-    info['apiRoot'].templateFilename = 'custom_api_docs.mako'

--- a/test/test_plugins/custom_api_docs_test/server/__init__.py
+++ b/test/test_plugins/custom_api_docs_test/server/__init__.py
@@ -25,7 +25,5 @@ def load(info):
         'baseTemplateFilename': info['apiRoot'].templateFilename
     })
 
-    info['apiRoot'].templateFilename = 'custom_api_docs.mako'
-
-    templateDir = os.path.join(info['pluginRootDir'], 'server')
-    info['apiRoot'].addTemplateDirectory(templateDir)
+    templatePath = os.path.join(info['pluginRootDir'], 'server', 'custom_api_docs.mako')
+    info['apiRoot'].setTemplatePath(templatePath)

--- a/test/test_plugins/custom_api_docs_test/server/custom_api_docs.mako
+++ b/test/test_plugins/custom_api_docs_test/server/custom_api_docs.mako
@@ -1,0 +1,9 @@
+<%inherit file="${context.get('baseTemplateFilename')}"/>
+
+<%block name="docsHeader">
+  <span>${brandName | h} Web Application Programming Interface</span>
+</%block>
+
+<%block name="docsBody">
+  <p>Custom API description</p>
+</%block>

--- a/test/test_webroot.py
+++ b/test/test_webroot.py
@@ -89,3 +89,14 @@ def testWebRootProperlyHandlesStaticRouteUrls(server, db):
     body = getResponseBody(resp)
 
     assert 'href="http://my-cdn-url.com/static/img/Girder_Favicon.png"' in body
+
+def testWebRootTemplateFilename():
+    """
+    Test WebrootBase.templateFilename attribute after initialization
+    and after setting a custom template path.
+    """
+    webroot = WebrootBase(templatePath='/girder/base_template.mako')
+    assert webroot.templateFilename == 'base_template.mako'
+
+    webroot.setTemplatePath('/plugin/custom_template.mako')
+    assert webroot.templateFilename == 'custom_template.mako'


### PR DESCRIPTION
Allow plugins to customize parts of the REST API Documentation (aka Swagger) page using Mako template inheritance [1]. The Mako template defines two named blocks—"docsHeader" and "docsBody"—that may be overridden in an inheriting template.

For example, a plugin can add its own template directory and specify a template filename in its `load` function:

    templateDir = os.path.join(getPluginDir(), 'cats', 'server')
    info['apiRoot'].addTemplateDirectory(templateDir)
    info['apiRoot'].templateFilename = 'cats_api_docs.mako'

The plugin template can inherit from the default template and override the blocks:

    <%inherit file="api_docs.mako"/>

    <%block name="docsBody">
    <p>Warning: This API is not a sandbox; don't get scratched.</p>
    </%block>

To avoid hardcoding the default template filename, pass it as a variable:

    baseTemplateFilename = info['apiRoot'].templateFilename
    info['apiRoot'].updateHtmlVars({
        'baseTemplateFilename': baseTemplateFilename
    })

and get the value in the template like:

    <%inherit file="${context.get('baseTemplateFilename')}"/>

[1] http://docs.makotemplates.org/en/latest/inheritance.html