### PR TITLE
Add a findWithPermissions method.

### DIFF
--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -455,7 +455,7 @@ class filtermodel(object):  # noqa: class name
 
             if isinstance(val, _MONGO_CURSOR_TYPES):
                 if callable(getattr(val, 'count', None)):
-                    cherrypy.response.headers['X-Total-Count'] = val.count()
+                    cherrypy.response.headers['Girder-Total-Count'] = val.count()
                 return [model.filter(m, user, self.addFields) for m in val]
             elif isinstance(val, (list, tuple, types.GeneratorType)):
                 return [model.filter(m, user, self.addFields) for m in val]
@@ -605,7 +605,7 @@ def _mongoCursorToList(val):
     # be callable.
     if isinstance(val, _MONGO_CURSOR_TYPES):
         if callable(getattr(val, 'count', None)):
-            cherrypy.response.headers['X-Total-Count'] = val.count()
+            cherrypy.response.headers['Girder-Total-Count'] = val.count()
         val = list(val)
     return val
 

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -24,12 +24,16 @@ import datetime
 import inspect
 import json
 import posixpath
+import pymongo
 import six
 import sys
 import traceback
+import types
 import unicodedata
 
 from dogpile.cache.util import kwarg_function_key_generator
+from girder.external.mongodb_proxy import MongoProxy
+
 from . import docs
 from girder import auditLogger, events, logger, logprint
 from girder.constants import SettingKey, TokenScope, SortDir
@@ -44,6 +48,8 @@ from six.moves import range, urllib
 
 # Arbitrary buffer length for stream-reading request bodies
 READ_BUFFER_LEN = 65536
+
+_MONGO_CURSOR_TYPES = (MongoProxy, pymongo.cursor.Cursor, pymongo.command_cursor.CommandCursor)
 
 
 def getUrlParts(url=None):
@@ -447,7 +453,11 @@ class filtermodel(object):  # noqa: class name
 
             user = getCurrentUser()
 
-            if isinstance(val, (list, tuple)):
+            if isinstance(val, _MONGO_CURSOR_TYPES):
+                if callable(getattr(val, 'count', None)):
+                    cherrypy.response.headers['X-Total-Count'] = val.count()
+                return [model.filter(m, user, self.addFields) for m in val]
+            elif isinstance(val, (list, tuple, types.GeneratorType)):
                 return [model.filter(m, user, self.addFields) for m in val]
             elif isinstance(val, dict):
                 return model.filter(val, user, self.addFields)
@@ -583,6 +593,23 @@ def _logRestRequest(resource, path, params):
     })
 
 
+def _mongoCursorToList(val):
+    """
+    If the specified value is a Monog cursor, convert it to a list.
+    Otherwise, just return the passed values.
+
+    :param val: a value that might be a Mongo cursor.
+    :returns: a list if val was a Mongo cursor, otherwise the original val.
+    """
+    # This needs to be before the callable check, as mongo cursors can
+    # be callable.
+    if isinstance(val, _MONGO_CURSOR_TYPES):
+        if callable(getattr(val, 'count', None)):
+            cherrypy.response.headers['X-Total-Count'] = val.count()
+        val = list(val)
+    return val
+
+
 def endpoint(fun):
     """
     REST HTTP method endpoints should use this decorator. It converts the return
@@ -606,6 +633,8 @@ def endpoint(fun):
             if 'Content-Range' in cherrypy.response.headers:
                 cherrypy.response.status = 206
 
+            val = _mongoCursorToList(val)
+
             if callable(val):
                 # If the endpoint returned anything callable (function,
                 # lambda, functools.partial), we assume it's a generator
@@ -617,6 +646,9 @@ def endpoint(fun):
             if isinstance(val, cherrypy.lib.file_generator):
                 # Don't do any post-processing of static files
                 return val
+
+            if isinstance(val, types.GeneratorType):
+                val = list(val)
 
         except RestException as e:
             val = _handleRestException(e)

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -595,7 +595,7 @@ def _logRestRequest(resource, path, params):
 
 def _mongoCursorToList(val):
     """
-    If the specified value is a Monog cursor, convert it to a list.
+    If the specified value is a Mongo cursor, convert it to a list.
     Otherwise, just return the passed values.
 
     :param val: a value that might be a Mongo cursor.

--- a/girder/api/v1/assetstore.py
+++ b/girder/api/v1/assetstore.py
@@ -65,7 +65,7 @@ class Assetstore(Resource):
         .errorResponse('You are not an administrator.', 403)
     )
     def find(self, limit, offset, sort):
-        return list(self._model.list(offset=offset, limit=limit, sort=sort))
+        return self._model.list(offset=offset, limit=limit, sort=sort)
 
     @access.admin
     @autoDescribeRoute(
@@ -265,5 +265,5 @@ class Assetstore(Resource):
         .errorResponse('You are not an administrator.', 403)
     )
     def getAssetstoreFiles(self, assetstore, limit, offset, sort):
-        return list(File().find(
-            query={'assetstoreId': assetstore['_id']}, offset=offset, limit=limit, sort=sort))
+        return File().find(
+            query={'assetstoreId': assetstore['_id']}, offset=offset, limit=limit, sort=sort)

--- a/girder/api/v1/collection.py
+++ b/girder/api/v1/collection.py
@@ -56,9 +56,9 @@ class Collection(Resource):
         user = self.getCurrentUser()
 
         if text is not None:
-            return list(self._model.textSearch(text, user=user, limit=limit, offset=offset))
+            return self._model.textSearch(text, user=user, limit=limit, offset=offset)
 
-        return list(self._model.list(user=user, offset=offset, limit=limit, sort=sort))
+        return self._model.list(user=user, offset=offset, limit=limit, sort=sort)
 
     @access.user(scope=TokenScope.DATA_WRITE)
     @filtermodel(model=CollectionModel)

--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -94,12 +94,12 @@ class Folder(Resource):
             if name:
                 filters['name'] = name
 
-            return list(self._model.childFolders(
+            return self._model.childFolders(
                 parentType=parentType, parent=parent, user=user,
-                offset=offset, limit=limit, sort=sort, filters=filters))
+                offset=offset, limit=limit, sort=sort, filters=filters)
         elif text:
-            return list(self._model.textSearch(
-                text, user=user, limit=limit, offset=offset, sort=sort))
+            return self._model.textSearch(
+                text, user=user, limit=limit, offset=offset, sort=sort)
         else:
             raise RestException('Invalid search mode.')
 

--- a/girder/api/v1/group.py
+++ b/girder/api/v1/group.py
@@ -73,7 +73,7 @@ class Group(Resource):
         else:
             groupList = self._model.list(
                 user=user, offset=offset, limit=limit, sort=sort)
-        return list(groupList)
+        return groupList
 
     @access.user
     @filtermodel(model=GroupModel)
@@ -133,7 +133,7 @@ class Group(Resource):
         .errorResponse('Read access was denied for the group.', 403)
     )
     def getGroupInvitations(self, group, limit, offset, sort):
-        return list(self._model.getInvites(group, limit, offset, sort))
+        return self._model.getInvites(group, limit, offset, sort)
 
     @access.user
     @filtermodel(model=GroupModel)
@@ -192,7 +192,7 @@ class Group(Resource):
         .errorResponse('Read access was denied for the group.', 403)
     )
     def listMembers(self, group, limit, offset, sort):
-        return list(self._model.listMembers(group, offset=offset, limit=limit, sort=sort))
+        return self._model.listMembers(group, offset=offset, limit=limit, sort=sort)
 
     @access.user
     @filtermodel(model=GroupModel, addFields={'access', 'requests'})

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -91,11 +91,11 @@ class Item(Resource):
             if name:
                 filters['name'] = name
 
-            return list(Folder().childItems(
-                folder=folder, limit=limit, offset=offset, sort=sort, filters=filters))
+            return Folder().childItems(
+                folder=folder, limit=limit, offset=offset, sort=sort, filters=filters)
         elif text is not None:
-            return list(self._model.textSearch(
-                text, user=user, limit=limit, offset=offset, sort=sort))
+            return self._model.textSearch(
+                text, user=user, limit=limit, offset=offset, sort=sort)
         else:
             raise RestException('Invalid search mode.')
 
@@ -232,7 +232,7 @@ class Item(Resource):
         .errorResponse('Read access was denied for the item.', 403)
     )
     def getFiles(self, item, limit, offset, sort):
-        return list(self._model.childFiles(item=item, limit=limit, offset=offset, sort=sort))
+        return self._model.childFiles(item=item, limit=limit, offset=offset, sort=sort)
 
     @access.cookie
     @access.public(scope=TokenScope.DATA_READ)

--- a/girder/external/mongodb_proxy.py
+++ b/girder/external/mongodb_proxy.py
@@ -35,6 +35,7 @@ except ImportError:
 EXECUTABLE_MONGO_METHODS = get_methods(pymongo.collection.Collection,
                                        pymongo.database.Database,
                                        pymongo.cursor.Cursor,
+                                       pymongo.command_cursor.CommandCursor,
                                        MongoClient, MongoReplicaSetClient,
                                        pymongo)
 
@@ -65,7 +66,7 @@ class Executable(object):
 
                 # If we get back a cursor, we need to also make sure it tries
                 # to auto-reconnect on failure.
-                if isinstance(val, pymongo.cursor.Cursor):
+                if isinstance(val, (pymongo.cursor.Cursor, pymongo.command_cursor.CommandCursor)):
                     return MongoProxy(val, self.logger, self.wait_time)
                 else:
                     return val

--- a/girder/models/collection.py
+++ b/girder/models/collection.py
@@ -201,14 +201,11 @@ class Collection(AccessControlledModel):
 
         count = 1
         folderModel = Folder()
-        folders = folderModel.find({
+        folders = folderModel.findWithPermissions({
             'parentId': doc['_id'],
             'parentCollection': 'collection'
-        }, fields=('access',))
+        }, fields=('access',), user=user, level=level)
 
-        if level is not None:
-            folders = self.filterResultsByPermission(
-                cursor=folders, user=user, level=level)
         count += sum(folderModel.subtreeCount(
             folder, includeItems=includeItems, user=user, level=level)
             for folder in folders)
@@ -259,13 +256,10 @@ class Collection(AccessControlledModel):
             from .folder import Folder
 
             folderModel = Folder()
-            cursor = folderModel.find({
+            folders = folderModel.findWithPermissions({
                 'parentId': doc['_id'],
                 'parentCollection': 'collection'
-            })
-
-            folders = self.filterResultsByPermission(
-                cursor=cursor, user=user, level=AccessType.ADMIN)
+            }, user=user, level=AccessType.ADMIN)
 
             for folder in folders:
                 folderModel.setAccessList(
@@ -318,16 +312,12 @@ class Collection(AccessControlledModel):
         fields = () if level is None else ('access', 'public')
 
         folderModel = Folder()
-        folders = folderModel.find({
+        folders = folderModel.findWithPermissions({
             'parentId': collection['_id'],
             'parentCollection': 'collection'
-        }, fields=fields)
+        }, fields=fields, user=user, level=level)
 
-        if level is None:
-            return folders.count()
-        else:
-            return sum(1 for _ in folderModel.filterResultsByPermission(
-                cursor=folders, user=user, level=level))
+        return folders.count()
 
     def updateSize(self, doc):
         """

--- a/girder/models/collection.py
+++ b/girder/models/collection.py
@@ -204,7 +204,7 @@ class Collection(AccessControlledModel):
         folders = folderModel.findWithPermissions({
             'parentId': doc['_id'],
             'parentCollection': 'collection'
-        }, fields=('access',), user=user, level=level)
+        }, fields='access', user=user, level=level)
 
         count += sum(folderModel.subtreeCount(
             folder, includeItems=includeItems, user=user, level=level)

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -454,12 +454,10 @@ class Folder(AccessControlledModel):
         }
         q.update(filters)
 
-        # Perform the find; we'll do access-based filtering of the result set
-        # afterward.
-        cursor = self.find(q, sort=sort, **kwargs)
+        cursor = self.findWithPermissions(
+            q, sort=sort, user=user, level=AccessType.READ, limit=limit, offset=offset, **kwargs)
 
-        return self.filterResultsByPermission(
-            cursor=cursor, user=user, level=AccessType.READ, limit=limit, offset=offset)
+        return iter(cursor)
 
     def createFolder(self, parent, name, description='', parentType='folder',
                      public=None, creator=None, allowRename=False, reuseExisting=False):
@@ -617,16 +615,12 @@ class Folder(AccessControlledModel):
         """
         fields = () if level is None else ('access', 'public')
 
-        folders = self.find({
+        folders = self.findWithPermissions({
             'parentId': folder['_id'],
             'parentCollection': 'folder'
-        }, fields=fields)
+        }, fields=fields, user=user, level=level)
 
-        if level is None:
-            return folders.count()
-        else:
-            return sum(1 for _ in self.filterResultsByPermission(
-                cursor=folders, user=user, level=level))
+        return folders.count()
 
     def subtreeCount(self, folder, includeItems=True, user=None, level=None):
         """
@@ -647,14 +641,10 @@ class Folder(AccessControlledModel):
         if includeItems:
             count += self.countItems(folder)
 
-        folders = self.find({
+        folders = self.findWithPermissions({
             'parentId': folder['_id'],
             'parentCollection': 'folder'
-        }, fields=('access',))
-
-        if level is not None:
-            folders = self.filterResultsByPermission(
-                cursor=folders, user=user, level=level)
+        }, fields=('access',), user=user, level=level)
 
         count += sum(self.subtreeCount(subfolder, includeItems=includeItems,
                                        user=user, level=level)
@@ -870,13 +860,10 @@ class Folder(AccessControlledModel):
             self, doc, access, user=user, save=save, force=force)
 
         if recurse:
-            cursor = self.find({
+            subfolders = self.findWithPermissions({
                 'parentId': doc['_id'],
                 'parentCollection': 'folder'
-            })
-
-            subfolders = self.filterResultsByPermission(
-                cursor=cursor, user=user, level=AccessType.ADMIN)
+            }, user=user, level=AccessType.ADMIN)
 
             for folder in subfolders:
                 self.setAccessList(

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -644,7 +644,7 @@ class Folder(AccessControlledModel):
         folders = self.findWithPermissions({
             'parentId': folder['_id'],
             'parentCollection': 'folder'
-        }, fields=('access',), user=user, level=level)
+        }, fields='access', user=user, level=level)
 
         count += sum(self.subtreeCount(subfolder, includeItems=includeItems,
                                        user=user, level=level)

--- a/girder/models/group.py
+++ b/girder/models/group.py
@@ -375,6 +375,16 @@ class Group(AccessControlledModel):
             return self._hasUserAccess(doc.get('access', {}).get('users', []),
                                        user['_id'], level)
 
+    def permissionClauses(self, user=None, level=None, prefix=''):
+        permission = super(Group, self).permissionClauses(user, level, prefix)
+        if user and level == AccessType.READ:
+            permission['$or'].extend([
+                {prefix + '_id': {'$in': user.get('groups', [])}},
+                {prefix + '_id': {'$in': [i['groupId'] for i in
+                                          user.get('groupInvites', [])]}},
+            ])
+        return permission
+
     def getAccessLevel(self, doc, user):
         """
         Return the maximum access level for a given user on the group.

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -64,13 +64,13 @@ def _permissionClauses(user=None, level=None, prefix=''):
     permissionClauses = []
     if level is None or (user and user['admin']):
         # Without a level or with an admin user, match everything.
-        permissionClauses.append({})
-    elif level <= AccessType.READ:
+        return {}
+    if level <= AccessType.READ:
         permissionClauses.append({prefix + 'public': True})
     elif not user:
         # If we have no user and asked for higher than read access, make a
         # query that will fail
-        permissionClauses.append({'__matchnothing': 'nothing'})
+        return {'__matchnothing': 'nothing'}
     if user and not user['admin']:
         permissionClauses.extend([
             {prefix + 'access.users': {'$elemMatch': {

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -55,7 +55,7 @@ def _permissionClauses(user=None, level=None, prefix=''):
     :param level: The access level.  Explicitly passing None skips doing
         permissions checks.
     :type level: AccessType
-    :param prefix: an optional string to append to the keys used in the
+    :param prefix: an optional string to prepend to the keys used in the
         clauses.
     :type prefix: str
     :returns: A query dictionary with an '$or' entry which consists of a list
@@ -154,7 +154,7 @@ class Model(ModelImporter):
         :param level: The required access level for the field.
         :type level: AccessType
         :param fields: A field or list of fields to expose for that level.
-        :type fields: `str, list, or tuple`
+        :type fields: `str, list, set, or tuple`
         """
         if isinstance(fields, six.string_types):
             fields = (fields, )
@@ -171,7 +171,7 @@ class Model(ModelImporter):
         :param level: The access level to remove the fields from.
         :type level: AccessType
         :param fields: The field or fields to remove from the white list.
-        :type fields: `str, list, or tuple`
+        :type fields: `str, list, set, or tuple`
         """
         if isinstance(fields, six.string_types):
             fields = (fields, )
@@ -304,10 +304,12 @@ class Model(ModelImporter):
         :type limit: int
         :param timeout: Cursor timeout in ms. Default is no timeout.
         :type timeout: int
-        :param fields: A mask for filtering result documents by key, or None to return the full
-            document, passed to MongoDB find() as the `projection` param.
-        :type fields: `str, list of strings or tuple of strings for fields to be included from the
-            document, or dict for an inclusion or exclusion projection`.
+        :param fields: A mask for filtering result documents by key, or None to
+            return the full document, passed to MongoDB find() as the
+            `projection` param.  This is a string or iterable of strings to be
+            included from the document, or dict for an inclusion or exclusion
+            projection`.
+        :type fields: `str, list, set, or tuple`
         :param sort: The sort order.
         :type sort: List of (key, order) tuples.
         :returns: A pymongo database cursor.
@@ -331,10 +333,12 @@ class Model(ModelImporter):
 
         :param query: The search query (see general MongoDB docs for "find()")
         :type query: dict
-        :param fields: A mask for filtering result documents by key, or None to return the full
-            document, passed to MongoDB find() as the `projection` param.
-        :type fields: `str, list of strings or tuple of strings for fields to be included from the
-            document, or dict for an inclusion or exclusion projection`.
+        :param fields: A mask for filtering result documents by key, or None to
+            return the full document, passed to MongoDB find() as the
+            `projection` param.  This is a string or iterable of strings to be
+            included from the document, or dict for an inclusion or exclusion
+            projection`.
+        :type fields: `str, list, set, or tuple`
         :param sort: The sort order.
         :type sort: List of (key, order) tuples.
         :returns: the first object that was found, or None if none found.
@@ -351,10 +355,12 @@ class Model(ModelImporter):
         :type query: str
         :param filters: Any additional query operators to apply.
         :type filters: dict
-        :param fields: A mask for filtering result documents by key, or None to return the full
-            document, passed to MongoDB find() as the `projection` param.
-        :type fields: `str, list of strings or tuple of strings for fields to be included from the
-            document, or dict for an inclusion or exclusion projection`.
+        :param fields: A mask for filtering result documents by key, or None to
+            return the full document, passed to MongoDB find() as the
+            `projection` param.  This is a string or iterable of strings to be
+            included from the document, or dict for an inclusion or exclusion
+            projection`.
+        :type fields: `str, list, set, or tuple`
         :returns: (filters, fields) to be passed to the query.
         """
         filters = filters or {}
@@ -377,10 +383,12 @@ class Model(ModelImporter):
         :type limit: int
         :param sort: The sort order.
         :type sort: List of (key, order) tuples.
-        :param fields: A mask for filtering result documents by key, or None to return the full
-            document, passed to MongoDB find() as the `projection` param.
-        :type fields: `str, list of strings or tuple of strings for fields to be included from the
-            document, or dict for an inclusion or exclusion projection`.
+        :param fields: A mask for filtering result documents by key, or None to
+            return the full document, passed to MongoDB find() as the
+            `projection` param.  This is a string or iterable of strings to be
+            included from the document, or dict for an inclusion or exclusion
+            projection`.
+        :type fields: `str, list, set, or tuple`
         :param filters: Any additional query operators to apply.
         :type filters: dict
         :returns: A pymongo cursor. It is left to the caller to build the
@@ -447,10 +455,12 @@ class Model(ModelImporter):
         :type limit: int
         :param sort: The sort order.
         :type sort: List of (key, order) tuples.
-        :param fields: A mask for filtering result documents by key, or None to return the full
-            document, passed to MongoDB find() as the `projection` param.
-        :type fields: `str, list of strings or tuple of strings for fields to be included from the
-            document, or dict for an inclusion or exclusion projection`.
+        :param fields: A mask for filtering result documents by key, or None to
+            return the full document, passed to MongoDB find() as the
+            `projection` param.  This is a string or iterable of strings to be
+            included from the document, or dict for an inclusion or exclusion
+            projection`.
+        :type fields: `str, list, set, or tuple`
         :param filters: Any additional query operators to apply.
         :type filters: dict
         :param prefixSearchFields: To override the model's prefixSearchFields
@@ -596,10 +606,12 @@ class Model(ModelImporter):
         :type id: string or ObjectId
         :param objectId: Whether the id should be coerced to ObjectId type.
         :type objectId: bool
-        :param fields: A mask for filtering result documents by key, or None to return the full
-            document, passed to MongoDB find() as the `projection` param.
-        :type fields: `str, list of strings or tuple of strings for fields to be included from the
-            document, or dict for an inclusion or exclusion projection`.
+        :param fields: A mask for filtering result documents by key, or None to
+            return the full document, passed to MongoDB find() as the
+            `projection` param.  This is a string or iterable of strings to be
+            included from the document, or dict for an inclusion or exclusion
+            projection`.
+        :type fields: `str, list, set, or tuple`
         :param exc: Whether to raise a ValidationException if there is no
                     document with the given id.
         :type exc: bool
@@ -1531,10 +1543,12 @@ class AccessControlledModel(Model):
         :type offset: int
         :param sort: The sort order
         :type sort: List of (key, order) tuples
-        :param fields: A mask for filtering result documents by key, or None to return the full
-            document, passed to MongoDB find() as the `projection` param.
-        :type fields: `str, list of strings or tuple of strings for fields to be included from the
-            document, or dict for an inclusion or exclusion projection`.
+        :param fields: A mask for filtering result documents by key, or None to
+            return the full document, passed to MongoDB find() as the
+            `projection` param.  This is a string or iterable of strings to be
+            included from the document, or dict for an inclusion or exclusion
+            projection`.
+        :type fields: `str, list, set, or tuple`
         :param level: The access level to require.
         :type level: girder.constants.AccessType
         """
@@ -1570,10 +1584,12 @@ class AccessControlledModel(Model):
         :type offset: int
         :param sort: The sort order.
         :type sort: List of (key, order) tuples.
-        :param fields: A mask for filtering result documents by key, or None to return the full
-            document, passed to MongoDB find() as the `projection` param.
-        :type fields: `str, list of strings or tuple of strings for fields to be included from the
-            document, or dict for an inclusion or exclusion projection`.
+        :param fields: A mask for filtering result documents by key, or None to
+            return the full document, passed to MongoDB find() as the
+            `projection` param.  This is a string or iterable of strings to be
+            included from the document, or dict for an inclusion or exclusion
+            projection`.
+        :type fields: `str, list, set, or tuple`
         :param level: The access level to require.
         :type level: girder.constants.AccessType
         :param prefixSearchFields: To override the model's prefixSearchFields
@@ -1606,10 +1622,12 @@ class AccessControlledModel(Model):
         :type limit: int
         :param timeout: Cursor timeout in ms. Default is no timeout.
         :type timeout: int
-        :param fields: A mask for filtering result documents by key, or None to return the full
-            document, passed to MongoDB find() as the `projection` param.
-        :type fields: `str, list of strings or tuple of strings for fields to be included from the
-            document, or dict for an inclusion or exclusion projection`.
+        :param fields: A mask for filtering result documents by key, or None to
+            return the full document, passed to MongoDB find() as the
+            `projection` param.  This is a string or iterable of strings to be
+            included from the document, or dict for an inclusion or exclusion
+            projection`.
+        :type fields: `str, list, set, or tuple`
         :param sort: The sort order.
         :type sort: List of (key, order) tuples.
         :param user: The user to check policies against.

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -556,7 +556,7 @@ class User(AccessControlledModel):
         folders = folderModel.findWithPermissions({
             'parentId': doc['_id'],
             'parentCollection': 'user'
-        }, fields=('access',), user=user, level=level)
+        }, fields='access', user=user, level=level)
 
         count += sum(folderModel.subtreeCount(
             folder, includeItems=includeItems, user=user, level=level)

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -553,14 +553,10 @@ class User(AccessControlledModel):
 
         count = 1
         folderModel = Folder()
-        folders = folderModel.find({
+        folders = folderModel.findWithPermissions({
             'parentId': doc['_id'],
             'parentCollection': 'user'
-        }, fields=('access',))
-
-        if level is not None:
-            folders = self.filterResultsByPermission(
-                cursor=folders, user=user, level=level)
+        }, fields=('access',), user=user, level=level)
 
         count += sum(folderModel.subtreeCount(
             folder, includeItems=includeItems, user=user, level=level)
@@ -585,16 +581,12 @@ class User(AccessControlledModel):
         fields = () if level is None else ('access', 'public')
 
         folderModel = Folder()
-        folders = folderModel.find({
+        folders = folderModel.findWithPermissions({
             'parentId': user['_id'],
             'parentCollection': 'user'
-        }, fields=fields)
+        }, fields=fields, user=filterUser, level=level)
 
-        if level is None:
-            return folders.count()
-        else:
-            return sum(1 for _ in folderModel.filterResultsByPermission(
-                cursor=folders, user=filterUser, level=level))
+        return folders.count()
 
     def updateSize(self, doc):
         """

--- a/girder/utility/acl_mixin.py
+++ b/girder/utility/acl_mixin.py
@@ -17,12 +17,13 @@
 #  limitations under the License.
 ###############################################################################
 
+import collections
 import itertools
 import six
 
-from ..models.model_base import Model
+from ..models.model_base import Model, AccessControlledModel, _permissionClauses
 from ..exceptions import AccessException
-from ..constants import AccessType
+from ..constants import AccessType, TEXT_SCORE_SORT_MAX
 
 
 class AccessControlMixin(object):
@@ -175,15 +176,22 @@ class AccessControlMixin(object):
 
     def textSearch(self, query, user=None, filters=None, limit=0, offset=0,
                    sort=None, fields=None, level=AccessType.READ):
-        filters = filters or {}
-
-        cursor = Model.textSearch(
-            self, query=query, filters=filters, sort=sort, fields=fields)
-        return self.filterResultsByPermission(
-            cursor, user=user, level=level, limit=limit, offset=offset)
+        filters, fields = self._textSearchFilters(query, filters, fields)
+        defaultSort = [('_textScore', {'$meta': 'textScore'})]
+        cursor = self.findWithPermissions(
+            filters, offset=offset, limit=limit, sort=sort, fields=fields,
+            user=user, level=level, aggregateSort=defaultSort)
+        if (sort is None and not getattr(cursor, 'fromAggregate', False) and
+                callable(getattr(cursor, 'count', None)) and
+                cursor.count() < TEXT_SCORE_SORT_MAX):
+            cursor = self.findWithPermissions(
+                filters, offset=offset, limit=limit, sort=defaultSort, fields=fields,
+                user=user, level=level)
+        return cursor
 
     def prefixSearch(self, query, user=None, filters=None, limit=0, offset=0,
-                     sort=None, fields=None, level=AccessType.READ):
+                     sort=None, fields=None, level=AccessType.READ,
+                     prefixSearchFields=None):
         """
         Custom override of Model.prefixSearch to also force permission-based
         filtering. The parameters are the same as Model.prefixSearch.
@@ -193,9 +201,162 @@ class AccessControlMixin(object):
         :param level: The access level to require.
         :type level: girder.constants.AccessType
         """
-        filters = filters or {}
+        filters = self._prefixSearchFilters(query, filters, prefixSearchFields)
 
-        cursor = Model.prefixSearch(
-            self, query=query, filters=filters, sort=sort, fields=fields)
-        return self.filterResultsByPermission(
-            cursor, user=user, level=level, limit=limit, offset=offset)
+        return self.findWithPermissions(
+            filters, offset=offset, limit=limit, sort=sort, fields=fields,
+            user=user, level=level)
+
+    def permissionClauses(self, user=None, level=None, prefix=''):
+        return _permissionClauses(user, level, prefix)
+
+    def _findWithPermissionsFallback(self, query, offset, limit, timeout,
+                                     fields, sort, user, level, **kwargs):
+        """
+        See findWithPermissions.  This is called if Mongo doesn't support
+        appropriate aggregations or find is used on a model that uses an
+        acl-mixin model as its parent and therefore needs multiple steps to
+        reach the owner of the access control list.
+
+        See findWithPermissions for parameters and return.
+        """
+        removeKeys = ()
+        if (fields and any(fields[key] is True for key in fields) and
+                not fields.get(self.resourceParent)):
+            fields = fields.copy()
+            fields[self.resourceParent] = True
+            removeKeys = (self.resourceParent, )
+        cursor = self.find(query, timeout=timeout, fields=fields, sort=sort, **kwargs)
+        result = self.filterResultsByPermission(
+            cursor=cursor, user=user, level=level, limit=limit, offset=offset,
+            removeKeys=removeKeys)
+        if not hasattr(result, 'count'):
+            origResult, origSelf = result, self
+
+            class resultWithCount(object):
+                def count(self):
+                    cursor = origSelf.find(
+                        query, timeout=timeout, fields=fields, sort=sort, **kwargs)
+                    result = origSelf.filterResultsByPermission(
+                        cursor=cursor, user=user, level=level, limit=limit, offset=offset,
+                        removeKeys=removeKeys)
+                    return len(list(result))
+
+                def __iter__(self):
+                    return self
+
+                def __next__(self):
+                    return six.next(origResult)
+
+                next = __next__
+
+            result = resultWithCount()
+        return result
+
+    def findWithPermissions(self, query=None, offset=0, limit=0, timeout=None, fields=None,
+                            sort=None, user=None, level=AccessType.READ, aggregateSort=None,
+                            **kwargs):
+        """
+        Search the collection by a set of parameters, only returning results
+        that the combined user and level have permission to access. Passes any
+        extra kwargs through to the underlying pymongo.collection.find
+        function.
+
+        :param query: The search query (see general MongoDB docs for "find()")
+        :type query: dict
+        :param offset: The offset into the results
+        :type offset: int
+        :param limit: Maximum number of documents to return
+        :type limit: int
+        :param timeout: Cursor timeout in ms. Default is no timeout.
+        :type timeout: int
+        :param fields: A mask for filtering result documents by key, or None to return the full
+            document, passed to MongoDB find() as the `projection` param.
+        :type fields: `str, list of strings or tuple of strings for fields to be included from the
+            document, or dict for an inclusion or exclusion projection`.
+        :param sort: The sort order.
+        :type sort: List of (key, order) tuples.
+        :param user: The user to check policies against.
+        :type user: dict or None
+        :param level: The access level.  Explicitly passing None skips doing
+            permissions checks.
+        :type level: AccessType
+        :param aggregateSort: A sort order to use if `sort` is None and an
+            aggregation is used.
+        :type aggregateSort: List of (key, order) tuples.
+        :returns: A pymongo Cursor, CommandCursor, or an iterable.  If a
+            CommandCursor, it has been augmented with a count function.
+        """
+        # If no user is specified and greater than READ access is requested,
+        # we won't return anything.  So as to always return a cursor for
+        # consistency, we make a query that will return no results
+        if user is None and level is not None and level > AccessType.READ:
+            query = {'__matchnothing': 'nothing'}
+        elif level is not None and (not user or not user['admin']):
+            # If the resourceColl isn't an access controlled model that we
+            # know how to reach, fall back to performing the ordinary query and
+            # then filtering it by permission.  For instance, if a model uses
+            # the acl mixin to get acl from a model that itself uses the acl
+            # mixin, this will return the correct results, but without the
+            # utility of being able perform count().
+            #  Note, this also handles models which use attachedToType and
+            # attachedToId, since self.model(None) will not be an access
+            # controlled model.
+            #  This is also the fall-back for Mongo < 3.4, as those versions do
+            # not support the aggregation steps that are used.
+            if (not isinstance(self.model(self.resourceColl), AccessControlledModel) or
+                    not getattr(self, '_dbserver_version', None) or
+                    getattr(self, '_dbserver_version', None) < (3, 4)):
+                return self._findWithPermissionsFallback(
+                    query, offset, limit, timeout, fields, sort, user, level,
+                    **kwargs)
+
+            query = query or {}
+            initialPipeline = [
+                {'$match': query},
+                {'$lookup': {
+                    'from': self.resourceColl,
+                    'localField': self.resourceParent,
+                    'foreignField': '_id',
+                    'as': '_access'
+                }},
+                {'$match': self.permissionClauses(user, level, '_access.')},
+            ]
+            countPipeline = initialPipeline[:] + [
+                {'$count': 'count'},
+            ]
+            fullPipeline = initialPipeline[:] + [
+                {'$project': {'_access': False}},
+            ]
+            if sort is not None or aggregateSort is not None:
+                fullPipeline.append({'$sort': collections.OrderedDict(sort or aggregateSort)})
+            # limit should immediately follow sort for efficiency
+            if limit:
+                fullPipeline.append({'$limit': limit + (offset or 0)})
+            if offset:
+                fullPipeline.append({'$skip': offset})
+            if fields is not None:
+                if any([isinstance(v, bool) for v in fields.values()]):
+                    fullPipeline.append({'$project': fields})
+                else:
+                    fullPipeline.append({'$addFields': fields})
+            options = {
+                'allowDiskUse': True,
+                'cursor': {'batchSize': 0}
+            }
+            if timeout:
+                options['maxTimeMS'] = timeout
+            result = self.collection.aggregate(fullPipeline, **options)
+
+            def count():
+                try:
+                    return next(iter(self.collection.aggregate(countPipeline, **options)))['count']
+                except StopIteration:
+                    # If there are no values, this won't return the count, in
+                    # which case it is zero.
+                    return 0
+
+            result.count = count
+            result.fromAggregate = True
+            return result
+        return self.find(query, offset, limit, timeout, fields, sort, **kwargs)

--- a/girder/utility/acl_mixin.py
+++ b/girder/utility/acl_mixin.py
@@ -322,10 +322,10 @@ class AccessControlMixin(object):
                 }},
                 {'$match': self.permissionClauses(user, level, '_access.')},
             ]
-            countPipeline = initialPipeline[:] + [
+            countPipeline = initialPipeline + [
                 {'$count': 'count'},
             ]
-            fullPipeline = initialPipeline[:] + [
+            fullPipeline = initialPipeline + [
                 {'$project': {'_access': False}},
             ]
             if sort is not None or aggregateSort is not None:
@@ -336,7 +336,7 @@ class AccessControlMixin(object):
             if offset:
                 fullPipeline.append({'$skip': offset})
             if fields is not None:
-                if any([isinstance(v, bool) for v in fields.values()]):
+                if any(isinstance(v, bool) for v in fields.values()):
                     fullPipeline.append({'$project': fields})
                 else:
                     fullPipeline.append({'$addFields': fields})

--- a/tests/cases/folder_test.py
+++ b/tests/cases/folder_test.py
@@ -149,6 +149,15 @@ class FolderTestCase(base.TestCase):
         self.assertTrue(resp.json['message'].startswith(
             'Write access denied for user'))
 
+    def testFolderTextSearch(self):
+        resp = self.request(
+            path='/folder', method='GET', user=self.admin, params={
+                'text': 'Public',
+                'sortdir': SortDir.DESCENDING
+            })
+        self.assertStatusOk(resp)
+        self.assertEqual(len(resp.json), 2)
+
     def testCreateFolder(self):
         self.ensureRequiredParams(
             path='/folder', method='POST', required=['name', 'parentId'],


### PR DESCRIPTION
For access controlled models and models that use the acl-mixin, add a `findWithPermissions` method that uses mongo to filter by permissions either by extra query parameters (for ac models) or via an aggregate pipeline (for acl-mixin models).  For models that use the acl-mixin and get permissions from a model that itself uses the acl-mixin or use `attachedToType` rather than `resourceColl`, this falls back to using `filterResultsByPermission`.  If an aggregate pipeline is used, augment the resulting CommandCursor with a `count` method that uses a similar pipeline to get the count (but only on demand).

The where clauses used for groups are different than for other models.

For rest endpoints, support returning generators, Mongo Cursors, and Mongo Command Cursors.  For each of these, the result is coerced to a list as part of the standard endpoint handling.  For Cursors and Command Cursors with a count method, a `Girder-Total-Count` header to the response.  Adding this header resolves #1603.

If the Mongo server is less than version 3.4, this falls back to `filterResultsByPermission`.

Things that could be done:

* For models that use the acl-mixin and refer to a model that uses an acl-mixin, we could do multiple joins (`$lookup`) instead of falling back to filtering in python.

* Contribute to the mongo proxy upstream so that we can use it directly.

* When `findWithPermissions` is called without a user and asking for more than READ permission, a special query is constructed that returns an empty result set.  This results in a consistent result type (a Cursor or CommandCursor).  Is there a better way to do this?

Areas that need testing:

* The mongo proxy with a command cursor.

* We may want to test with Mongo version 3.4 (and Python 2 with Mongo >=3.4).