### PR TITLE
Add some new client Model methods

### DIFF
--- a/clients/web/src/models/FolderModel.js
+++ b/clients/web/src/models/FolderModel.js
@@ -11,6 +11,20 @@ var FolderModel = AccessControlledModel.extend({
         return restRequest({
             url: `${this.resourceName}/${this.id}/rootpath`
         });
+    },
+
+    /**
+     * Remove the contents of the folder.
+     */
+    removeContents: function () {
+        return restRequest({
+            url: `${this.resourceName}/${this.id}/contents`,
+            method: 'DELETE'
+        }).done((resp) => {
+            this.trigger('g:success');
+        }).fail((err) => {
+            this.trigger('g:error', err);
+        });
     }
 });
 

--- a/clients/web/src/models/ItemModel.js
+++ b/clients/web/src/models/ItemModel.js
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
+import FileCollection from 'girder/collections/FileCollection';
 import FolderModel from 'girder/models/FolderModel';
 import MetadataMixin from 'girder/models/MetadataMixin';
 import Model from 'girder/models/Model';
@@ -45,6 +46,21 @@ var ItemModel = Model.extend({
             url: `${this.resourceName}/${this.id}/rootpath`
         }).done((resp) => {
             callback(resp);
+        }).fail((err) => {
+            this.trigger('g:error', err);
+        });
+    },
+
+    /**
+     * Get the files within the item.
+     */
+    getFiles: function () {
+        return restRequest({
+            url: `${this.resourceName}/${this.id}/files`
+        }).then((resp) => {
+            let fileCollection = new FileCollection(resp);
+            this.trigger('g:files', fileCollection);
+            return fileCollection;
         }).fail((err) => {
             this.trigger('g:error', err);
         });

--- a/clients/web/src/routes.js
+++ b/clients/web/src/routes.js
@@ -146,25 +146,16 @@ router.route('useraccount/:id/:tab', 'accountTab', function (id, tab) {
     UserAccountView.fetchAndInit(id, tab);
 });
 router.route('useraccount/:id/token/:token', 'accountToken', function (id, token) {
-    restRequest({
-        url: `user/password/temporary/${id}`,
-        method: 'GET',
-        data: {token: token},
-        error: null
-    }).done((resp) => {
-        resp.user.token = resp.authToken.token;
-        eventStream.close();
-        setCurrentUser(new UserModel(resp.user));
-        eventStream.open();
-        events.trigger('g:login-changed');
-        events.trigger('g:navigateTo', UserAccountView, {
-            user: getCurrentUser(),
-            tab: 'password',
-            temporary: token
+    UserModel.fromTemporaryToken(id, token)
+        .done(() => {
+            events.trigger('g:navigateTo', UserAccountView, {
+                user: getCurrentUser(),
+                tab: 'password',
+                temporary: token
+            });
+        }).fail(() => {
+            router.navigate('users', {trigger: true});
         });
-    }).fail(() => {
-        router.navigate('users', {trigger: true});
-    });
 });
 
 router.route('useraccount/:id/verification/:token', 'accountVerify', function (id, token) {

--- a/clients/web/src/views/body/UserAccountView.js
+++ b/clients/web/src/views/body/UserAccountView.js
@@ -7,9 +7,8 @@ import UserModel from 'girder/models/UserModel';
 import View from 'girder/views/View';
 import { AccessType } from 'girder/constants';
 import events from 'girder/events';
-import eventStream from 'girder/utilities/EventStream';
-import { getCurrentUser, setCurrentUser } from 'girder/auth';
-import { restRequest, cancelRestRequests } from 'girder/rest';
+import { getCurrentUser } from 'girder/auth';
+import { cancelRestRequests } from 'girder/rest';
 
 import UserAccountTemplate from 'girder/templates/body/userAccount.pug';
 
@@ -164,28 +163,6 @@ var UserAccountView = View.extend({
         }, this).on('g:error', function () {
             router.navigate('users', {trigger: true});
         }, this).fetch();
-    },
-
-    temporaryPassword: function (id, token) {
-        restRequest({
-            url: `user/password/temporary/${id}`,
-            method: 'GET',
-            data: {token: token},
-            error: null
-        }).done((resp) => {
-            resp.user.token = resp.authToken.token;
-            eventStream.close();
-            setCurrentUser(new UserModel(resp.user));
-            eventStream.open();
-            events.trigger('g:login-changed');
-            events.trigger('g:navigateTo', UserAccountView, {
-                user: getCurrentUser(),
-                tab: 'password',
-                temporary: token
-            });
-        }).fail(() => {
-            router.navigate('users', {trigger: true});
-        });
     }
 });
 


### PR DESCRIPTION
* Add a `FolderModel.removeContents` method to the client library
* Add an `ItemModel.getFiles` method to the client library
* Move an unused utility method to a more appropriate place
  * This moves the method from `UserAccountView.temporaryPassword` to `UserModel.fromTemporaryToken`, and updates the logic to return a promise and no longer perform global routing.
* Start using `UserModel.fromTemporaryToken`, reducing code duplication