### PR TITLE
Move CLI commands to a "cli" module

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -63,7 +63,7 @@ def _safeMakedirs(path):
         os.makedirs(path)
     except OSError as exception:
         if exception.errno != errno.EEXIST:
-            raise  # pragma: no cover
+            raise
 
 
 class AuthenticationError(RuntimeError):

--- a/clients/python/girder_client/__main__.py
+++ b/clients/python/girder_client/__main__.py
@@ -18,8 +18,8 @@
 ###############################################################################
 
 import warnings
-from girder_client import cli  # pragma: no cover
+from girder_client import cli
 
 if __name__ == '__main__':
     warnings.warn('Deprecation notice: Use "girder-client" to run the CLI.', DeprecationWarning)
-    cli.main()  # pragma: no cover
+    cli.main()

--- a/clients/python/girder_client/__main__.py
+++ b/clients/python/girder_client/__main__.py
@@ -17,9 +17,9 @@
 #  limitations under the License.
 ###############################################################################
 
-import warnings
+import click
 from girder_client import cli
 
 if __name__ == '__main__':
-    warnings.warn('Deprecation notice: Use "girder-client" to run the CLI.', DeprecationWarning)
+    click.echo('Deprecation notice: Use "girder-client" to run the CLI.', err=True)
     cli.main()

--- a/clients/python/girder_client/__main__.py
+++ b/clients/python/girder_client/__main__.py
@@ -17,7 +17,9 @@
 #  limitations under the License.
 ###############################################################################
 
+import warnings
 from girder_client import cli  # pragma: no cover
 
-
-cli.main()  # pragma: no cover
+if __name__ == '__main__':
+    warnings.warn('Deprecation notice: Use "girder-client" to run the CLI.', DeprecationWarning)
+    cli.main()  # pragma: no cover

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -20,6 +20,7 @@ import click
 import requests
 import sys
 import types
+import warnings
 from girder_client import GirderClient, __version__
 
 
@@ -324,4 +325,5 @@ def _upload(gc, parent_type, parent_id, local_folder,
 
 
 if __name__ == '__main__':
+    warnings.warn('Deprecation notice: Use "girder-client" to run the CLI.', DeprecationWarning)
     main()  # pragma: no cover

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -326,4 +326,4 @@ def _upload(gc, parent_type, parent_id, local_folder,
 
 if __name__ == '__main__':
     warnings.warn('Deprecation notice: Use "girder-client" to run the CLI.', DeprecationWarning)
-    main()  # pragma: no cover
+    main()

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -20,7 +20,6 @@ import click
 import requests
 import sys
 import types
-import warnings
 from girder_client import GirderClient, __version__
 
 
@@ -325,5 +324,5 @@ def _upload(gc, parent_type, parent_id, local_folder,
 
 
 if __name__ == '__main__':
-    warnings.warn('Deprecation notice: Use "girder-client" to run the CLI.', DeprecationWarning)
+    click.echo('Deprecation notice: Use "girder-client" to run the CLI.', err=True)
     main()

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -239,6 +239,10 @@ The coverage data will be automatically generated. After the tests are run,
 you can find the HTML output from the coverage tool in the source directory
 under **build/test/artifacts/**.
 
+.. note:: Non-packaged third-party modules in the the ``girder/external`` directory are not included
+          in test coverage tracking.
+
+
 Client Side Testing
 -------------------
 

--- a/girder/__main__.py
+++ b/girder/__main__.py
@@ -17,12 +17,11 @@
 #  limitations under the License.
 ###############################################################################
 
-import cherrypy  # pragma: no cover
-import click
-import os  # pragma: no cover
+import cherrypy
+import os
 
-try:  # pragma: no cover
-    from girder.utility import server
+try:
+    from girder.cli import serve
 except ImportError:
     # Update python path to ensure server respawning works. See #732
     source_root_dir = os.path.dirname(os.path.dirname(__file__))
@@ -30,29 +29,8 @@ except ImportError:
     cherrypy.engine.log("[Girder] Appending source root dir to 'sys.path': %s"
                         % source_root_dir)
     sys.path.append(source_root_dir)
-    from girder.utility import server
+    from girder.cli import serve
 
 
-@click.command(name='serve', short_help='Run the Girder server.', help='Run the Girder server.')
-@click.option('-t', '--testing', is_flag=True, help='Run in testing mode')
-@click.option('-d', '--database', default=cherrypy.config['database']['uri'],
-              show_default=True, help='The database URI to connect to')
-@click.option('-H', '--host', default=cherrypy.config['server.socket_host'],
-              show_default=True, help='The interface to bind to')
-@click.option('-p', '--port', type=int, default=cherrypy.config['server.socket_port'],
-              show_default=True, help='The port to bind to')
-def main(testing, database, host, port):
-    if database:
-        cherrypy.config['database']['uri'] = database
-    if host:
-        cherrypy.config['server.socket_host'] = host
-    if port:
-        cherrypy.config['server.socket_port'] = port
-    server.setup(testing)
-
-    cherrypy.engine.start()
-    cherrypy.engine.block()
-
-
-if __name__ == '__main__':  # pragma: no cover
-    main()
+if __name__ == '__main__':
+    serve.main()

--- a/girder/__main__.py
+++ b/girder/__main__.py
@@ -35,5 +35,5 @@ except ImportError:
 
 
 if __name__ == '__main__':
-    girder.logger.warning('Deprecation notice: Use "girder serve" to start Girder.')
+    girder.logprint.warning('Deprecation notice: Use "girder serve" to start Girder.')
     serve.main()

--- a/girder/__main__.py
+++ b/girder/__main__.py
@@ -22,6 +22,7 @@ import os
 
 try:
     from girder.cli import serve
+    import girder
 except ImportError:
     # Update python path to ensure server respawning works. See #732
     source_root_dir = os.path.dirname(os.path.dirname(__file__))
@@ -30,7 +31,9 @@ except ImportError:
                         % source_root_dir)
     sys.path.append(source_root_dir)
     from girder.cli import serve
+    import girder
 
 
 if __name__ == '__main__':
+    girder.logger.warning('Deprecation notice: Use "girder serve" to start Girder.')
     serve.main()

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -515,7 +515,7 @@ def _createResponse(val):
     for accept in accepts:
         if accept.value == 'application/json':
             break
-        elif accept.value == 'text/html':  # pragma: no cover
+        elif accept.value == 'text/html':
             # Pretty-print and HTML-ify the response for the browser
             setResponseHeader('Content-Type', 'text/html')
             resp = cgi.escape(json.dumps(

--- a/girder/api/sftp.py
+++ b/girder/api/sftp.py
@@ -17,17 +17,12 @@
 #  limitations under the License.
 ###############################################################################
 
-from __future__ import print_function
-
-import click
-import os
 import paramiko
 import six
 import stat
-import sys
 import time
 
-from girder import logger, logprint
+from girder import logger
 from girder.exceptions import AccessException, ValidationException, ResourcePathNotFound
 from girder.models.file import File
 from girder.models.folder import Folder
@@ -37,7 +32,6 @@ from girder.utility.path import lookUpPath
 from girder.utility.model_importer import ModelImporter
 from six.moves import socketserver
 
-DEFAULT_PORT = 8022
 MAX_BUF_LEN = 10 * 1024 * 1024
 
 
@@ -260,37 +254,3 @@ class SftpServer(socketserver.ThreadingTCPServer):
 
     def shutdown_request(self, request):
         pass
-
-
-@click.command(name='sftpd', short_help='Run the Girder SFTP service.',
-               help='Run the Girder SFTP service.')
-@click.option('-i', '--identity-file', show_default=True,
-              default=os.path.expanduser(os.path.join('~', '.ssh', 'id_rsa')),
-              help='The identity (private key) file to use')
-@click.option('-H', '--host', show_default=True, default='localhost',
-              help='The interface to bind to')
-@click.option('-p', '--port', show_default=True, default=DEFAULT_PORT, type=int,
-              help='The port to bind to')
-def main(identity_file, port, host):  # pragma: no cover
-    """
-    This is the entrypoint of the girder sftpd program. It should not be
-    called from python code.
-    """
-    try:
-        hostKey = paramiko.RSAKey.from_private_key_file(identity_file)
-    except paramiko.ssh_exception.PasswordRequiredException:
-        logprint.error(
-            'Error: encrypted key files are not supported (%s).' % identity_file, file=sys.stderr)
-        sys.exit(1)
-
-    server = SftpServer((host, port), hostKey)
-    logprint.info('Girder SFTP service listening on %s:%d.' % (host, port))
-
-    try:
-        server.serve_forever()
-    except (SystemExit, KeyboardInterrupt):
-        server.server_close()
-
-
-if __name__ == '__main__':  # pragma: no cover
-    main()

--- a/girder/cli/__init__.py
+++ b/girder/cli/__init__.py
@@ -7,9 +7,5 @@ import click
 @click.group(help='Girder: data management platform for the web.',
              context_settings=dict(help_option_names=['-h', '--help']))
 @click.version_option(message='%(version)s')
-def cli():
-    pass
-
-
 def main():
-    cli()
+    pass

--- a/girder/cli/serve.py
+++ b/girder/cli/serve.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright 2013 Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+import cherrypy
+import click
+
+from girder.utility import server
+
+
+@click.command(name='serve', short_help='Run the Girder server.', help='Run the Girder server.')
+@click.option('-t', '--testing', is_flag=True, help='Run in testing mode')
+@click.option('-d', '--database', default=cherrypy.config['database']['uri'],
+              show_default=True, help='The database URI to connect to')
+@click.option('-H', '--host', default=cherrypy.config['server.socket_host'],
+              show_default=True, help='The interface to bind to')
+@click.option('-p', '--port', type=int, default=cherrypy.config['server.socket_port'],
+              show_default=True, help='The port to bind to')
+def main(testing, database, host, port):
+    if database:
+        cherrypy.config['database']['uri'] = database
+    if host:
+        cherrypy.config['server.socket_host'] = host
+    if port:
+        cherrypy.config['server.socket_port'] = port
+    server.setup(testing)
+
+    cherrypy.engine.start()
+    cherrypy.engine.block()

--- a/girder/cli/sftpd.py
+++ b/girder/cli/sftpd.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright 2016 Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+import click
+import os
+import paramiko
+import sys
+
+from girder import logprint
+from girder.api.sftp import SftpServer
+
+DEFAULT_PORT = 8022
+
+
+@click.command(name='sftpd', short_help='Run the Girder SFTP service.',
+               help='Run the Girder SFTP service.')
+@click.option('-i', '--identity-file', show_default=True,
+              default=os.path.expanduser(os.path.join('~', '.ssh', 'id_rsa')),
+              help='The identity (private key) file to use')
+@click.option('-H', '--host', show_default=True, default='localhost',
+              help='The interface to bind to')
+@click.option('-p', '--port', show_default=True, default=DEFAULT_PORT, type=int,
+              help='The port to bind to')
+def main(identity_file, port, host):
+    """
+    This is the entrypoint of the girder sftpd program. It should not be
+    called from python code.
+    """
+    try:
+        hostKey = paramiko.RSAKey.from_private_key_file(identity_file)
+    except paramiko.ssh_exception.PasswordRequiredException:
+        logprint.error(
+            'Error: encrypted key files are not supported (%s).' % identity_file, file=sys.stderr)
+        sys.exit(1)
+
+    server = SftpServer((host, port), hostKey)
+    logprint.info('Girder SFTP service listening on %s:%d.' % (host, port))
+
+    try:
+        server.serve_forever()
+    except (SystemExit, KeyboardInterrupt):
+        server.server_close()

--- a/girder/cli/shell.py
+++ b/girder/cli/shell.py
@@ -54,7 +54,3 @@ def main(plugins):
         'webroot': webroot,
         'appconf': appconf
     })
-
-
-if __name__ == '__main__':
-    main()

--- a/girder/constants.py
+++ b/girder/constants.py
@@ -51,7 +51,7 @@ VERSION = {  # Set defaults in case girder-version.json doesn't exist
 try:
     with open(os.path.join(PACKAGE_DIR, 'girder-version.json')) as f:
         VERSION.update(json.load(f))
-except IOError:  # pragma: no cover
+except IOError:
     pass
 
 #: The local directory containing the static content.

--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -146,7 +146,7 @@ class File(acl_mixin.AccessControlMixin, Model):
                             'endByte': endByte,
                             'redirect': False})
                 return stream
-        else:  # pragma: no cover
+        else:
             raise Exception('File has no known download mechanism.')
 
     def validate(self, doc):

--- a/girder/models/group.py
+++ b/girder/models/group.py
@@ -409,7 +409,7 @@ class Group(AccessControlledModel):
             return level
 
     def setGroupAccess(self, doc, group, level, save=False):
-        raise Exception('Not implemented.')  # pragma: no cover
+        raise NotImplementedError('Not implemented.')
 
     def setUserAccess(self, doc, user, level, save=False):
         """

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -223,8 +223,8 @@ class Model(ModelImporter):
         :param doc: The document to validate before saving to the collection.
         :type doc: dict
         """
-        raise Exception('Must override validate() in %s model.'
-                        % self.__class__.__name__)  # pragma: no cover
+        raise NotImplementedError('Must override validate() in %s model.'
+                                  % self.__class__.__name__)
 
     def validateKeys(self, keys):
         """
@@ -251,8 +251,8 @@ class Model(ModelImporter):
         Subclasses should override this and set the name of the collection as
         self.name. Also, they should set any indexed fields that they require.
         """
-        raise Exception('Must override initialize() in %s model'
-                        % self.__class__.__name__)  # pragma: no cover
+        raise NotImplementedError('Must override initialize() in %s model'
+                                  % self.__class__.__name__)
 
     def find(self, query=None, offset=0, limit=0, timeout=None,
              fields=None, sort=None, **kwargs):

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -71,7 +71,7 @@ class User(AccessControlledModel):
 
         cur_config = config.getConfig()
 
-        if 'salt' not in doc:  # pragma: no cover
+        if 'salt' not in doc:
             # Internal error, this should not happen
             raise Exception('Tried to save user document with no salt.')
 

--- a/girder/utility/__init__.py
+++ b/girder/utility/__init__.py
@@ -35,7 +35,7 @@ try:
     from random import SystemRandom
     random = SystemRandom()
     random.random()  # potentially raises NotImplementedError
-except NotImplementedError:  # pragma: no cover
+except NotImplementedError:
     girder.logprint.warning(
         'WARNING: using non-cryptographically secure PRNG.')
     import random

--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -171,7 +171,7 @@ class AbstractAssetstoreAdapter(ModelImporter):
         :param upload: The upload document to optionally augment.
         :type upload: dict
         """
-        return upload  # pragma: no cover
+        return upload
 
     def uploadChunk(self, upload, chunk):
         """
@@ -184,7 +184,7 @@ class AbstractAssetstoreAdapter(ModelImporter):
         :returns: Must return the upload document with any optional changes.
         """
         raise NotImplementedError('Must override processChunk in %s.' %
-                                  self.__class__.__name__)  # pragma: no cover
+                                  self.__class__.__name__)
 
     def finalizeUpload(self, upload, file):
         """
@@ -221,7 +221,7 @@ class AbstractAssetstoreAdapter(ModelImporter):
         :type file: dict
         """
         raise NotImplementedError('Must override deleteFile in %s.' %
-                                  self.__class__.__name__)  # pragma: no cover
+                                  self.__class__.__name__)
 
     def shouldImportFile(self, path, params):
         """
@@ -272,7 +272,7 @@ class AbstractAssetstoreAdapter(ModelImporter):
         :type extraParameters: str or None
         """
         raise NotImplementedError('Must override downloadFile in %s.' %
-                                  self.__class__.__name__)  # pragma: no cover
+                                  self.__class__.__name__)
 
     def findInvalidFiles(self, progress=progress.noProgress, filters=None,
                          checkSize=True, **kwargs):
@@ -291,7 +291,7 @@ class AbstractAssetstoreAdapter(ModelImporter):
         :type checkSize: bool
         """
         raise NotImplementedError('Must override findInvalidFiles in %s.' %
-                                  self.__class__.__name__)  # pragma: no cover
+                                  self.__class__.__name__)
 
     def copyFile(self, srcFile, destFile):
         """
@@ -379,7 +379,7 @@ class AbstractAssetstoreAdapter(ModelImporter):
         information the assetstore contains.
         """
         raise NotImplementedError('Must override cancelUpload in %s.' %
-                                  self.__class__.__name__)  # pragma: no cover
+                                  self.__class__.__name__)
 
     def untrackedUploads(self, knownUploads=(), delete=False):
         """
@@ -415,7 +415,7 @@ class AbstractAssetstoreAdapter(ModelImporter):
         """
         raise NotImplementedError(
             'The %s assetstore type does not support importing existing data.'
-            % self.__class__.__name__)  # pragma: no cover
+            % self.__class__.__name__)
 
     def fileUpdated(self, file):
         """

--- a/girder/utility/filesystem_assetstore_adapter.py
+++ b/girder/utility/filesystem_assetstore_adapter.py
@@ -135,7 +135,7 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
                 'Failed to get disk usage of %s' % self.assetstore['root'])
         # If psutil.disk_usage fails or we can't query the assetstore's root
         # directory, just report nothing regarding disk capacity
-        return {  # pragma: no cover
+        return {
             'free': None,
             'total': None
         }

--- a/girder/utility/install.py
+++ b/girder/utility/install.py
@@ -375,7 +375,3 @@ def main():
 
     parsed = parser.parse_args()
     parsed.func(parsed)
-
-
-if __name__ == '__main__':
-    main()  # pragma: no cover

--- a/girder/utility/model_importer.py
+++ b/girder/utility/model_importer.py
@@ -39,7 +39,7 @@ def _loadModel(model, module, plugin):
 
     try:
         constructor = getattr(imported, className)
-    except AttributeError:  # pragma: no cover
+    except AttributeError:
         raise Exception('Incorrect model class name "%s" for model "%s".' % (
             className, module))
 

--- a/girder/utility/ziputil.py
+++ b/girder/utility/ziputil.py
@@ -41,7 +41,7 @@ import time
 
 try:
     import zlib
-except ImportError:  # pragma: no cover
+except ImportError:
     zlib = None
 
 __all__ = ('STORE', 'DEFLATE', 'ZipGenerator')
@@ -84,7 +84,7 @@ class ZipInfo(object):
         self.timestamp = timestamp
         self.compressType = STORE
         if sys.platform == 'win32':
-            self.createSystem = 0  # pragma: no cover
+            self.createSystem = 0
         else:
             self.createSystem = 3
         self.createVersion = 20
@@ -127,7 +127,7 @@ class ZipGenerator(object):
         :type
         """
         if compression == DEFLATE and not zlib:
-            raise RuntimeError('Missing zlib module')  # pragma: no cover
+            raise RuntimeError('Missing zlib module')
 
         self.files = []
         self.compression = compression

--- a/plugins/hashsum_download/server/__init__.py
+++ b/plugins/hashsum_download/server/__init__.py
@@ -19,8 +19,8 @@
 
 import hashlib
 import six
-import warnings
 
+import girder
 from girder import events
 from girder.api import access
 from girder.api.describe import autoDescribeRoute, Description
@@ -45,9 +45,9 @@ class PluginSettings(object):
 class HashedFile(File):
     @property
     def supportedAlgorithms(self):  # pragma: no cover
-        warnings.warn(
+        girder.logger.warning(
             'HashedFile.supportedAlgorithms is deprecated, use the module-level '
-            'SUPPORTED_ALGORITHMS instead.', DeprecationWarning)
+            'SUPPORTED_ALGORITHMS instead.')
         return SUPPORTED_ALGORITHMS
 
     def __init__(self, node):

--- a/plugins/hashsum_download/server/__init__.py
+++ b/plugins/hashsum_download/server/__init__.py
@@ -44,7 +44,7 @@ class PluginSettings(object):
 
 class HashedFile(File):
     @property
-    def supportedAlgorithms(self):  # pragma: no cover
+    def supportedAlgorithms(self):
         girder.logger.warning(
             'HashedFile.supportedAlgorithms is deprecated, use the module-level '
             'SUPPORTED_ALGORITHMS instead.')

--- a/plugins/provenance/server/resource.py
+++ b/plugins/provenance/server/resource.py
@@ -423,7 +423,7 @@ class ResourceExt(Resource):
         # We should have marked the new object already when it was first
         # created.  If not, exit
         if 'provenance' not in newObj:
-            pass  # pragma: no cover
+            pass
         if 'provenance' in srcObj:
             newProv = newObj['provenance'][-1]
             newObj['provenance'] = copy.deepcopy(srcObj['provenance'])

--- a/setup.py
+++ b/setup.py
@@ -162,16 +162,16 @@ setup(
     },
     entry_points={
         'console_scripts': [
-            'girder-server = girder.__main__:main',
+            'girder-server = girder.cli.serve:main',
             'girder-install = girder.utility.install:main',
-            'girder-sftpd = girder.api.sftp:main',
-            'girder-shell = girder.utility.shell:main',
+            'girder-sftpd = girder.cli.sftpd:main',
+            'girder-shell = girder.cli.shell:main',
             'girder = girder.cli:main'
         ],
         'girder.cli_plugins': [
-            'serve = girder.__main__:main',
-            'shell = girder.utility.shell:main',
-            'sftpd = girder.api.sftp:main'
+            'serve = girder.cli.serve:main',
+            'shell = girder.cli.shell:main',
+            'sftpd = girder.cli.sftpd:main'
         ]
     }
 )


### PR DESCRIPTION
* Move CLI commands to a "cli" module
* Deprecate legacy "python -m ..." methods for starting Girder
  * The CLI console scripts should be used instead.
* Don't use warnings.warn for runtime server code  …
  * The logger should be used directly, to ensure the output is available for all log handlers.
* Document a coverage exclusion policy for Python code