### PR TITLE
Make build type available to front-end code

### DIFF
--- a/grunt_tasks/build.js
+++ b/grunt_tasks/build.js
@@ -119,6 +119,15 @@ module.exports = function (grunt) {
         });
     }
 
+    // Define global constants
+    updateWebpackConfig({
+        plugins: [
+            new webpack.DefinePlugin({
+                'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+            })
+        ]
+    });
+
     // Add extra config options for grunt-webpack
     updateWebpackConfig({
         progress: progress


### PR DESCRIPTION
Use DefinePlugin to set `process.env.NODE_ENV` to `"development"` or `"production"`. This allows writing debug code that can be eliminated when building for production. Frameworks such as Vue.js use this variable to decide whether to build in production mode.