### PR TITLE
Support virtual domain syntax in s3 assetstore test

### DIFF
--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -496,7 +496,8 @@ class AssetstoreTestCase(base.TestCase):
     def testS3AssetstoreAdapter(self):
         # Delete the default assetstore
         Assetstore().remove(self.assetstore)
-        s3Regex = r'^https://s3.amazonaws.com(:443)?/bucketname/foo/bar'
+        s3Regex = (r'^(https://s3.amazonaws.com(:443)?/bucketname/foo/bar|'
+                   'https://bucketname.s3.amazonaws.com(:443)?/foo/bar)')
 
         params = {
             'name': 'S3 Assetstore',
@@ -675,7 +676,7 @@ class AssetstoreTestCase(base.TestCase):
         # Test download as part of a streaming zip
         @httmock.all_requests
         def s3_pipe_mock(url, request):
-            if url.netloc.startswith('s3.amazonaws.com') and url.scheme == 'https':
+            if 's3.amazonaws.com' in url.netloc and url.scheme == 'https':
                 return 'dummy file contents'
             else:
                 raise Exception('Unexpected url %s' % url)


### PR DESCRIPTION
Something changed with a recent change to boto (or moto) that broke our test assertion in `assetstore_test.py`.  Since S3 supports both URL's, this just modifies the regex to pass if it finds either.  Alternatively, we could modify the assertion to expect only the new URL, but that would require finding exactly what upstream release changed the behavior.