### PR TITLE
Add a getLocalFilePath method to the File model.

### DIFF
--- a/girder/exceptions.py
+++ b/girder/exceptions.py
@@ -77,3 +77,13 @@ class RestException(GirderBaseException):
         self.message = message
 
         super(RestException, self).__init__(message)
+
+
+class FilePathException(GirderException):
+    """
+    Thrown when a file path is requested and cannot be returned.
+    """
+    identifier = 'girder.utility.assetstore.file-path-not-available'
+
+    def __init__(self, message='No assetstore adapter', identifier=None):
+        super(FilePathException, self).__init__(message, identifier or self.identifier)

--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -473,3 +473,14 @@ class File(acl_mixin.AccessControlMixin, Model):
         :rtype: girder.utility.abstract_assetstore_adapter.FileHandle
         """
         return self.getAssetstoreAdapter(file).open(file)
+
+    def getLocalFilePath(self, file):
+        """
+        If an assetstore adapter supports it, return a path to the file on the
+        local file system.
+
+        :param file: The file document.
+        :returns: a local path to the file or None if no such path is known.
+        """
+        adapter = self.getAssetstoreAdapter(file)
+        return adapter.getLocalFilePath(file)

--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -21,7 +21,7 @@ import six
 
 from girder.api.rest import setResponseHeader, setContentDisposition
 from girder.constants import SettingKey
-from girder.exceptions import GirderException, ValidationException
+from girder.exceptions import GirderException, ValidationException, FilePathException
 from girder.models.setting import Setting
 from girder.utility import progress, RequestBodyStream
 from .model_importer import ModelImporter
@@ -444,9 +444,11 @@ class AbstractAssetstoreAdapter(ModelImporter):
     def getLocalFilePath(self, file):
         """
         If an assetstore adapter supports it, return a path to the file on the
-        local file system.
+        local file system.  Otherwise, raise an exception.
 
         :param file: The file document.
-        :returns: a local path to the file or None if no such path is known.
+        :type file: dict
+        :returns: a local path to the file.
+        :rtype: str
         """
-        return None
+        raise FilePathException('This assetstore does not expose file paths')

--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -440,3 +440,13 @@ class AbstractAssetstoreAdapter(ModelImporter):
         :rtype: FileHandle
         """
         return FileHandle(file, self)
+
+    def getLocalFilePath(self, file):
+        """
+        If an assetstore adapter supports it, return a path to the file on the
+        local file system.
+
+        :param file: The file document.
+        :returns: a local path to the file or None if no such path is known.
+        """
+        return None

--- a/girder/utility/filesystem_assetstore_adapter.py
+++ b/girder/utility/filesystem_assetstore_adapter.py
@@ -476,3 +476,16 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
                     'file': file,
                     'path': path
                 }
+
+    def getLocalFilePath(self, file):
+        """
+        Return a path to the file on the local file system.
+
+        :param file: The file document.
+        :returns: a local path to the file or None if no such path is known.
+        """
+        path = self.fullPath(file)
+        # If an imported file has moved, don't report the path
+        if path and os.path.exists(path):
+            return path
+        return super(FilesystemAssetstoreAdapter, self).getLocalFilePath(file)

--- a/plugins/fuse/plugin_tests/server_fuse_test.py
+++ b/plugins/fuse/plugin_tests/server_fuse_test.py
@@ -226,24 +226,24 @@ class ServerFuseTestCase(base.TestCase):
                 with open(fusepath) as file1:
                     self.assertEqual(file1.read().strip(), self.knownPaths[subpath])
 
-    def testFilePathNoFullPath(self):
+    def testFilePathNoLocalPath(self):
         """
-        Test that if an assetstore adapter doesn't respond to fullPath, we
-        always get the fuse path.
+        Test that if an assetstore adapter doesn't respond to getLocalFilePath,
+        we always get the fuse path.
         """
         from girder.plugins import fuse as girder_fuse
         from girder.utility.filesystem_assetstore_adapter import FilesystemAssetstoreAdapter
 
-        def altFullPath(self, file):
-            return None
+        def getLocalFilePath(self, file):
+            return super(FilesystemAssetstoreAdapter, self).getLocalFilePath(file)
 
         file = File().findOne()
 
-        origFullPath = FilesystemAssetstoreAdapter.fullPath
-        FilesystemAssetstoreAdapter.fullPath = altFullPath
+        origGetLocalFilePath = FilesystemAssetstoreAdapter.getLocalFilePath
+        FilesystemAssetstoreAdapter.getLocalFilePath = getLocalFilePath
         filepath = girder_fuse.getFilePath(file)
         fusepath = girder_fuse.getFuseFilePath(file)
-        FilesystemAssetstoreAdapter.fullPath = origFullPath
+        FilesystemAssetstoreAdapter.getLocalFilePath = origGetLocalFilePath
         self.assertTrue(os.path.exists(filepath))
         self.assertTrue(os.path.exists(fusepath))
         self.assertEqual(filepath, fusepath)

--- a/plugins/fuse/plugin_tests/server_fuse_test.py
+++ b/plugins/fuse/plugin_tests/server_fuse_test.py
@@ -234,10 +234,13 @@ class ServerFuseTestCase(base.TestCase):
         from girder.plugins import fuse as girder_fuse
         from girder.utility.filesystem_assetstore_adapter import FilesystemAssetstoreAdapter
 
+        def altFullPath(self, file):
+            return None
+
         file = File().findOne()
 
         origFullPath = FilesystemAssetstoreAdapter.fullPath
-        FilesystemAssetstoreAdapter.fullPath = None
+        FilesystemAssetstoreAdapter.fullPath = altFullPath
         filepath = girder_fuse.getFilePath(file)
         fusepath = girder_fuse.getFuseFilePath(file)
         FilesystemAssetstoreAdapter.fullPath = origFullPath

--- a/plugins/metadata_extractor/server/__init__.py
+++ b/plugins/metadata_extractor/server/__init__.py
@@ -18,13 +18,12 @@
 ###############################################################################
 
 from girder import events
-from girder.constants import AssetstoreType
 
 from . metadata_extractor import ServerMetadataExtractor
 
 
 def handler(event):
-    if event.info['assetstore']['type'] == AssetstoreType.FILESYSTEM:
+    if event.info['file'].get('itemId'):
         metadataExtractor = ServerMetadataExtractor(event.info['assetstore'],
                                                     event.info['file'])
         metadataExtractor.extractMetadata()

--- a/plugins/metadata_extractor/server/metadata_extractor.py
+++ b/plugins/metadata_extractor/server/metadata_extractor.py
@@ -22,6 +22,7 @@ import six
 from hachoir_core.error import HachoirError
 from hachoir_metadata import extractMetadata
 from hachoir_parser import createParser
+from girder.exceptions import FilePathException
 from girder.models.file import File
 from girder.models.item import Item
 
@@ -114,7 +115,10 @@ class ServerMetadataExtractor(MetadataExtractor):
         :param assetstore: asset store containing file
         :param uploadedFile: file from which to extract metadata
         """
-        path = File().getLocalFilePath(uploadedFile)
+        try:
+            path = File().getLocalFilePath(uploadedFile)
+        except FilePathException:
+            path = None
         super(ServerMetadataExtractor, self).__init__(path, uploadedFile['itemId'])
         self.userId = uploadedFile['creatorId']
 

--- a/plugins/metadata_extractor/server/metadata_extractor.py
+++ b/plugins/metadata_extractor/server/metadata_extractor.py
@@ -17,12 +17,12 @@
 #  limitations under the License.
 ###############################################################################
 
-import os
 import six
 
 from hachoir_core.error import HachoirError
 from hachoir_metadata import extractMetadata
 from hachoir_parser import createParser
+from girder.models.file import File
 from girder.models.item import Item
 
 
@@ -44,7 +44,8 @@ class MetadataExtractor(object):
         Extract metadata from file on client or server and attach to item on
         server.
         """
-        self._extractMetadata()
+        if self.path:
+            self._extractMetadata()
 
         if self.metadata is not None:
             self._setMetadata()
@@ -113,7 +114,7 @@ class ServerMetadataExtractor(MetadataExtractor):
         :param assetstore: asset store containing file
         :param uploadedFile: file from which to extract metadata
         """
-        path = os.path.join(assetstore['root'], uploadedFile['path'])
+        path = File().getLocalFilePath(uploadedFile)
         super(ServerMetadataExtractor, self).__init__(path, uploadedFile['itemId'])
         self.userId = uploadedFile['creatorId']
 

--- a/plugins/worker/server/utils.py
+++ b/plugins/worker/server/utils.py
@@ -79,9 +79,9 @@ def girderInputSpec(resource, resourceType='file', name=None, token=None,
         # If we are adding a file and it exists on the local filesystem include
         # that location.  This can permit the user of the specification to
         # access the file directly instead of downloading the file.
-        adapter = File().getAssetstoreAdapter(resource)
-        if callable(getattr(adapter, 'fullPath', None)):
-            result['direct_path'] = adapter.fullPath(resource)
+        direct_path = File().getLocalFilePath(resource)
+        if direct_path is not None:
+            result['direct_path'] = direct_path
     return result
 
 

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -32,7 +32,7 @@ from .. import base, mock_s3
 from girder import events
 from girder.constants import SettingKey
 from girder.models import getDbConnection
-from girder.exceptions import AccessException, GirderException
+from girder.exceptions import AccessException, GirderException, FilePathException
 from girder.models.assetstore import Assetstore
 from girder.models.collection import Collection
 from girder.models.file import File
@@ -841,7 +841,7 @@ class FileTestCase(base.TestCase):
         self.assertEqual(hash, file['sha512'])
 
         # The file should have no local path
-        self.assertIsNone(File().getLocalFilePath(file))
+        self.assertRaises(FilePathException, File().getLocalFilePath, file)
 
         # We should have two chunks in the database
         self.assertEqual(chunkColl.find({'uuid': file['chunkUuid']}).count(), 2)

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -690,6 +690,10 @@ class FileTestCase(base.TestCase):
         self.assertEqual(os.stat(abspath).st_size, file['size'])
         self.assertEqual(os.stat(abspath).st_mode & 0o777, DEFAULT_PERMS)
 
+        # Make sure the file reports the same path as we have
+        self.assertEqual(File().getAssetstoreAdapter(file).fullPath(file), abspath)
+        self.assertEqual(File().getLocalFilePath(file), abspath)
+
         # Make sure access control is enforced on download
         resp = self.request(
             path='/file/%s/download' % file['_id'], method='GET')
@@ -835,6 +839,9 @@ class FileTestCase(base.TestCase):
         hash = sha512(chunkData).hexdigest()
         file = File().load(file['_id'], force=True)
         self.assertEqual(hash, file['sha512'])
+
+        # The file should have no local path
+        self.assertIsNone(File().getLocalFilePath(file))
 
         # We should have two chunks in the database
         self.assertEqual(chunkColl.find({'uuid': file['chunkUuid']}).count(), 2)


### PR DESCRIPTION
The method `getLocalFilePath` is added to the File model, and will return `None` if there is no such path.

The same method name is used in the AbstractAssetstoreAdapter and inherited by the other adapters.  The filesystem assetstore adapter overrides this to provide a path.  The Fuse plugin overrides the AbstractAssetstoreAdapter to report a fuse path if one exists.

This allows any consumer (such as the worker or metadata extractor plugins) to ask for `File().getLocalFilePath(file)`, and, if it isn't `None`, to use that path.

If the Fuse plugin is enabled, the metadata extractor will now work on any file.  This also fixes a bug where a file that was attached to a resource (rather than on an Item) would throw an exception in the metadata extractor.