### PR TITLE
Add a pytest marker to enable plugins

### DIFF
--- a/pytest_girder/pytest_girder/fixtures.py
+++ b/pytest_girder/pytest_girder/fixtures.py
@@ -96,8 +96,20 @@ def server(db, request):
     girder.events.daemon = girder.events.AsyncEventsThread()
 
     enabledPlugins = []
+    installedPluginMarkers = request.node.get_marker('plugin')
     testPluginMarkers = request.node.get_marker('testPlugin')
-    if testPluginMarkers is not None:
+
+    if installedPluginMarkers is not None and testPluginMarkers is not None:
+        raise Exception(
+            'The "testPlugin" and "plugin" markers cannot both be used on a single test'
+        )
+
+    elif installedPluginMarkers is not None:
+        for installedPluginMarker in installedPluginMarkers:
+            pluginName = installedPluginMarker.args[0]
+            enabledPlugins.append(pluginName)
+
+    elif testPluginMarkers is not None:
         for testPluginMarker in testPluginMarkers:
             pluginName = testPluginMarker.args[0]
             enabledPlugins.append(pluginName)

--- a/pytest_girder/pytest_girder/plugin.py
+++ b/pytest_girder/pytest_girder/plugin.py
@@ -21,7 +21,12 @@ def _makeCoverageDirs(config):
 
 def _addCustomMarkers(config):
     markerDocs = [
-        'testPlugin(pluginName): load a test plugin (may be marked multiple times)',
+        ('testPlugin(pluginName): load and enable a test plugin from girder/test/test_plugins.  '
+         'this marker can be provided multiple times to enable more than one test plugin, '
+         'and is incompatible with "@pytest.mark.plugin".'),
+        ('plugin(pluginName): enable an installed plugin.  this marker cannot be used with '
+         'this marker can be provided multiple times to enable more than one installed plugin, '
+         'and is incompatible with "@pytest.mark.testPlugin".'),
     ]
     for markerDoc in markerDocs:
         config.addinivalue_line('markers', markerDoc)

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,9 @@ parallel = True
 # Include sources from installed package in Tox's {envsitepackagesdir}
 girder =
     girder/
+    plugins/*/server/
     build/test/tox/*/lib/*/site-packages/girder/
+    build/test/tox/*/lib/*/site-packages/girder/plugins/*/server/
 [coverage:html]
 directory = build/test/artifacts/python_coverage
 title = Girder Coverage Report
@@ -77,6 +79,6 @@ exclude: girder/external/*
 ignore: D100,D101,D102,D103,D104,D105,D106,D107,D200,D201,D202,D203,D204,D205,D400,D401,D402,E123,E226,E241,N802,N803,N806,N812,W503
 
 [tool:pytest]
-addopts = --verbose --strict --showlocals --cov=girder --cov-report=""
+addopts = --verbose --strict --showlocals --cov=girder --cov=plugins/jobs/server --cov-report=""
 cache_dir = build/test/pytest_cache
 testpaths = test

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,14 +4,20 @@ branch = True
 omit =
     girder/external/*
     test/*
+include =
+    girder/*
+    plugins/*/server/*
+    build/test/tox/*/lib/*/site-packages/girder/*
+    build/test/tox/*/lib/*/site-packages/girder/plugins/*/server/*
 parallel = True
 [coverage:paths]
 # Include sources from installed package in Tox's {envsitepackagesdir}
 girder =
     girder/
-    plugins/*/server/
     build/test/tox/*/lib/*/site-packages/girder/
-    build/test/tox/*/lib/*/site-packages/girder/plugins/*/server/
+plugins =
+    plugins/
+    build/test/tox/*/lib/*/site-packages/girder/plugins/
 [coverage:html]
 directory = build/test/artifacts/python_coverage
 title = Girder Coverage Report
@@ -79,6 +85,6 @@ exclude: girder/external/*
 ignore: D100,D101,D102,D103,D104,D105,D106,D107,D200,D201,D202,D203,D204,D205,D400,D401,D402,E123,E226,E241,N802,N803,N806,N812,W503
 
 [tool:pytest]
-addopts = --verbose --strict --showlocals --cov=girder --cov=plugins/jobs/server --cov-report=""
+addopts = --verbose --strict --showlocals --cov-report="" --cov
 cache_dir = build/test/pytest_cache
 testpaths = test

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,12 +12,16 @@ include =
 parallel = True
 [coverage:paths]
 # Include sources from installed package in Tox's {envsitepackagesdir}
+# The `_` here is a hack to make sure the plugins are matched first,
+# otherwise, installed plugins (those in `girder/plugins/*`) are matched
+# and aliased into the girder package.
+_plugins =
+    plugins/
+    girder/plugins/
+    build/test/tox/*/lib/*/site-packages/girder/plugins/
 girder =
     girder/
     build/test/tox/*/lib/*/site-packages/girder/
-plugins =
-    plugins/
-    build/test/tox/*/lib/*/site-packages/girder/plugins/
 [coverage:html]
 directory = build/test/artifacts/python_coverage
 title = Girder Coverage Report

--- a/test/jobs/test_constants.py
+++ b/test/jobs/test_constants.py
@@ -1,0 +1,23 @@
+###############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+import pytest
+
+
+@pytest.mark.plugin('jobs')
+def testConstantsIsDefined(server):
+    from girder.plugins.jobs import constants
+    assert constants.JobStatus.isValid(constants.JobStatus.SUCCESS) is True

--- a/tox.ini
+++ b/tox.ini
@@ -6,17 +6,13 @@ toxworkdir = {toxinidir}/build/test/tox
 [testenv]
 deps = -rrequirements-dev.txt
 install_command = pip install --upgrade {opts} {packages}
-commands = pytest \
-           # Augment the coverage sources to include installed package
-           --cov={envsitepackagesdir}/girder \
-           {posargs}
+commands = pytest {posargs}
 
 [testenv:circleci-py27]
 basepython = python2.7
 commands = pytest \
            --tb=long \
            --junit-xml="build/test/results/pytest-2.7.xml" \
-           --cov={envsitepackagesdir}/girder \
            --cov-append \
            --keep-db \
            {posargs}
@@ -26,7 +22,6 @@ basepython = python3.5
 commands = pytest \
            --tb=long \
            --junit-xml="build/test/results/pytest-3.5.xml" \
-           --cov={envsitepackagesdir}/girder \
            --cov-append \
            --keep-db \
             {posargs}


### PR DESCRIPTION
This commit makes it possible to write pytest style tests for girder plugins.  It is based on the interface that will be provided by pip installable plugins in girder 3.  The new marker is incompatible with the "testPlugin" marker, which mocks the normal plugin load mechanism.  This could in theory be fixed, but it isn't clear there is a use case for enabling both "test plugins" and "real plugins" in a single test.

I added a new test to the jobs plugin as a proof-of-concept.  For the moment, each plugin with pytest tests needs to be added to the flags in `setup.cfg`.  I didn't check if globbing works in these flags. Maybe @danlamanna or @brianhelba could suggest an alternative configuration.