### PR TITLE
add server specific searchField to search attributes

### DIFF
--- a/plugins/ldap/server/__init__.py
+++ b/plugins/ldap/server/__init__.py
@@ -146,9 +146,7 @@ def _ldapAuth(event):
 
             searchStr = '%s=%s' % (server['searchField'], login)
             # Add the searchStr to the attributes, keep local scope.
-            temp_attr = [server['searchField']]
-            temp_attr.extend(_LDAP_ATTRS)
-            lattr = tuple(temp_attr)
+            lattr = _LDAP_ATTRS + (server['searchField'],)
             results = conn.search_s(server['baseDn'], ldap.SCOPE_SUBTREE, searchStr, lattr)
             if results:
                 entry, attrs = results[0]

--- a/plugins/ldap/server/__init__.py
+++ b/plugins/ldap/server/__init__.py
@@ -145,8 +145,11 @@ def _ldapAuth(event):
             conn.bind_s(server['bindName'], server['password'], ldap.AUTH_SIMPLE)
 
             searchStr = '%s=%s' % (server['searchField'], login)
-            results = conn.search_s(server['baseDn'], ldap.SCOPE_ONELEVEL, searchStr, _LDAP_ATTRS)
-
+            # Add the searchStr to the attributes, keep local scope.
+            temp_attr = [server['searchField']]
+            temp_attr.extend(_LDAP_ATTRS)
+            lattr = tuple(temp_attr)
+            results = conn.search_s(server['baseDn'], ldap.SCOPE_SUBTREE, searchStr, lattr)
             if results:
                 entry, attrs = results[0]
                 dn = attrs['distinguishedName'][0].decode('utf8')


### PR DESCRIPTION
For the search to succeed, i needed to add in the server specific `searchField` to the function `_ldapAuth`:

```
# Add the searchStr to the attributes, keep local scope.
temp_attr = [server['searchField']]
temp_attr.extend(_LDAP_ATTRS)
lattr = tuple(temp_attr)
results = conn.search_s(server['baseDn'], ldap.SCOPE_SUBTREE, searchStr, lattr)
```