### PR TITLE
Reinstate py34

### DIFF
--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -19,6 +19,10 @@
 
 import bson.json_util
 import dateutil.parser
+try:
+    from inspect import signature, Parameter
+except ImportError:
+    from funcsigs import signature, Parameter
 import inspect
 import jsonschema
 import os
@@ -37,11 +41,6 @@ from girder.utility.webroot import WebrootBase
 from girder.utility.resource import _apiRouteMap
 from . import docs, access
 from .rest import Resource, getApiUrl, getUrlParts
-
-if six.PY3:
-    from inspect import signature, Parameter
-else:
-    from funcsigs import signature, Parameter
 
 """
 Whenever we add new return values or new options we should increment the

--- a/girder/utility/install.py
+++ b/girder/utility/install.py
@@ -40,7 +40,7 @@ version = constants.VERSION['apiVersion']
 webRoot = os.path.join(constants.STATIC_ROOT_DIR, 'clients', 'web')
 
 # monkey patch shutil for python < 3
-if not six.PY3:
+if sys.version_info[0] == 2:
     import shutilwhich  # noqa
 
 

--- a/pytest_girder/pytest_girder/utils.py
+++ b/pytest_girder/pytest_girder/utils.py
@@ -8,6 +8,7 @@ import os
 import six
 import smtpd
 import socket
+import sys
 import threading
 import time
 
@@ -23,7 +24,7 @@ class MockSmtpServer(smtpd.SMTPServer):
 
     def __init__(self, localaddr, remoteaddr, decode_data=False):
         kwargs = {}
-        if six.PY3:
+        if sys.version_info >= (3, 5):
             # Python 3.5+ prints a warning if 'decode_data' isn't explicitly
             # specified, but earlier versions don't accept the argument at all
             kwargs['decode_data'] = decode_data

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ installReqs = [
     'python-dateutil',
     'pytz',
     'requests',
-    'shutilwhich ; python_version < \'3.3\'',
+    'shutilwhich ; python_version < \'3\'',
     'six>=1.9',
 ]
 
@@ -152,7 +152,7 @@ setup(
             'api/api_docs.mako'
         ]
     },
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     install_requires=installReqs,
     extras_require=extrasReqs,
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ installReqs = [
     'click-plugins',
     'dogpile.cache',
     'filelock',
-    'funcsigs ; python_version < \'3\'',
+    'funcsigs ; python_version < \'3.5\'',
     'jsonschema',
     'Mako',
     'pymongo>=3.5',
@@ -77,7 +77,7 @@ installReqs = [
     'python-dateutil',
     'pytz',
     'requests',
-    'shutilwhich ; python_version < \'3\'',
+    'shutilwhich ; python_version < \'3.3\'',
     'six>=1.9',
 ]
 

--- a/tests/cases/find_entry_point_plugins_test.py
+++ b/tests/cases/find_entry_point_plugins_test.py
@@ -18,7 +18,7 @@
 ###############################################################################
 
 import mock
-import six
+import sys
 import unittest
 
 from contextlib import contextmanager
@@ -114,7 +114,7 @@ class FindEntryPointPluginsTestCase(unittest.TestCase):
         self.assertIn('entry_point_plugin_bad_json', failures)
         self.assertIn('traceback', failures['entry_point_plugin_bad_json'])
         self.assertIn(
-            'JSONDecodeError' if six.PY3 else 'ValueError',
+            'JSONDecodeError' if sys.version_info >= (3, 5) else 'ValueError',
             failures['entry_point_plugin_bad_json']['traceback'])
 
     @mock.patch('pkg_resources.resource_stream')


### PR DESCRIPTION
@girder/developers I'd like you to consider this PR. I'm not sure if it's a good idea myself, but I think there needs to be a bit more discussion on this topic before we come to a final conclusion about python 3.4.

While I generally approve of the spirit of #2572, I had some trepidation about the parts of the code where we went out of our way to make sure Girder would break if someone tried to install it on python 3.4. I understand why those changes were made, but given that we have downstream users who still would like to use python 3.4, we should reconsider whether that was a good or a bad decision.

Given that we don't strictly need to do anything in our code that will work on python 2.7 and 3.5 but not 3.4, I see no harm in preserving the *present* support for python 3.4, even though we will continue to state in our docs that it is not supported.

@brianhelba @jamiesnape @mgrauer @danlamanna PTAL