### PR TITLE
Allow save events to modify a job document.

### DIFF
--- a/plugins/jobs/server/models/job.py
+++ b/plugins/jobs/server/models/job.py
@@ -264,10 +264,9 @@ class Job(AccessControlledModel):
         to the database. This will allow kwargs with $ and . characters in the
         keys.
         """
-        deserialized = job['kwargs']
         job['kwargs'] = json_util.dumps(job['kwargs'])
         job = AccessControlledModel.save(self, job, *args, **kwargs)
-        job['kwargs'] = deserialized
+        job['kwargs'] = json_util.loads(job['kwargs'])
         return job
 
     def find(self, *args, **kwargs):


### PR DESCRIPTION
When saving a job, if a save event modifies the `kwargs` parameter, it would not be reflected in the job returned from the save method.