### PR TITLE
Mock exception printing in tests to silence expected error message

### DIFF
--- a/tests/cases/find_entry_point_plugins_test.py
+++ b/tests/cases/find_entry_point_plugins_test.py
@@ -104,7 +104,9 @@ class FindEntryPointPluginsTestCase(unittest.TestCase):
         resource_stream.return_value = resource_stream_json_value()
 
         plugins = {}
-        findEntryPointPlugins(plugins)
+        with mock.patch('girder.utility.plugin_utilities.logprint.exception') as logprint:
+            findEntryPointPlugins(plugins)
+            logprint.assert_called_once()
 
         iter_entry_points.assert_called_once_with(group='girder.plugin')
 
@@ -159,7 +161,9 @@ class FindEntryPointPluginsTestCase(unittest.TestCase):
         resource_stream.return_value = resource_stream_yaml_value()
 
         plugins = {}
-        findEntryPointPlugins(plugins)
+        with mock.patch('girder.utility.plugin_utilities.logprint.exception') as logprint:
+            findEntryPointPlugins(plugins)
+            logprint.assert_called_once()
 
         iter_entry_points.assert_called_once_with(group='girder.plugin')
 
@@ -182,7 +186,9 @@ class FindEntryPointPluginsTestCase(unittest.TestCase):
         _clearPluginFailureInfo.return_value = None
 
         plugins = {}
-        findEntryPointPlugins(plugins)
+        with mock.patch('girder.utility.plugin_utilities.logprint.exception') as logprint:
+            findEntryPointPlugins(plugins)
+            logprint.assert_called_once()
 
         iter_entry_points.assert_called_once_with(group='girder.plugin')
 

--- a/tests/cases/plugin_load_failure_test.py
+++ b/tests/cases/plugin_load_failure_test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 ###############################################################################
 
+import mock
 import os
 
 from .. import base
@@ -35,7 +36,8 @@ class PluginLoadFailureTestCase(base.TestCase):
         self.mockPluginDir(testPluginPath)
         base.enabledPlugins.append('bad_server')
 
-        base.startServer()
+        with mock.patch('girder.utility.plugin_utilities.logprint.exception'):
+            base.startServer()
 
     def tearDown(self):
         base.stopServer()

--- a/tests/cases/rest_decorator_test.py
+++ b/tests/cases/rest_decorator_test.py
@@ -18,6 +18,7 @@
 ###############################################################################
 
 import json
+import mock
 import os
 import requests
 
@@ -36,7 +37,8 @@ def setUpModule():
     base.mockPluginDir(testPluginPath)
     base.enabledPlugins = ['test_plugin']
 
-    base.startServer(mock=False)
+    with mock.patch('girder.utility.plugin_utilities.logprint.exception'):
+        base.startServer(mock=False)
 
 
 def tearDownModule():
@@ -45,6 +47,10 @@ def tearDownModule():
 
 class TestEndpointDecoratorException(base.TestCase):
     """Tests the endpoint decorator exception handling."""
+
+    def setUp(self):
+        with mock.patch('girder.utility.plugin_utilities.logprint.exception'):
+            super(TestEndpointDecoratorException, self).setUp()
 
     @endpoint
     def pointlessEndpointAscii(self, path, params):

--- a/tests/cases/system_test.py
+++ b/tests/cases/system_test.py
@@ -18,6 +18,7 @@
 ###############################################################################
 
 import json
+import mock
 import os
 import time
 import six
@@ -251,7 +252,8 @@ class SystemTestCase(base.TestCase):
             }, user=users[0])
             self.assertStatusOk(resp)
 
-    def testPlugins(self):
+    @mock.patch('girder.utility.plugin_utilities.logprint.exception')
+    def testPlugins(self, logprint):
         resp = self.request(path='/system/plugins', user=self.users[0])
         self.assertStatusOk(resp)
         self.assertIn('all', resp.json)
@@ -294,7 +296,8 @@ class SystemTestCase(base.TestCase):
         self.assertTrue('plugin_yaml' in enabled)
         self.unmockPluginDir()
 
-    def testBadPlugin(self):
+    @mock.patch('girder.utility.plugin_utilities.logprint.exception')
+    def testBadPlugin(self, logprint):
         pluginRoot = os.path.normpath(os.path.join(
             os.path.dirname(os.path.abspath(__file__)), '..', '..', 'test', 'test_plugins'
         ))

--- a/tests/web_client_test.py
+++ b/tests/web_client_test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 ###############################################################################
 
+import mock
 import os
 import six
 import subprocess
@@ -38,10 +39,12 @@ from six.moves import range
 os.environ['GIRDER_PORT'] = os.environ.get('GIRDER_PORT', '30001')
 config.loadConfig()  # Reload config to pick up correct port
 testServer = None
+logprintMock = None
 
 
 def setUpModule():
     global testServer
+    global logprintMock
     mockS3 = False
     if 's3' in os.environ['ASSETSTORE_TYPE']:
         mockS3 = True
@@ -54,11 +57,15 @@ def setUpModule():
     plugins = os.environ.get('ENABLED_PLUGINS', '')
     if plugins:
         base.enabledPlugins.extend(plugins.split())
+
+    logprintMock = mock.patch('girder.utility.plugin_utilities.logprint')
+    logprintMock.start()
     testServer = base.startServer(False, mockS3=mockS3)
 
 
 def tearDownModule():
     base.stopServer()
+    logprintMock.stop()
 
 
 class WebClientTestEndpoints(Resource):


### PR DESCRIPTION
Many tests include the "test_plugins" directory, which contains several invalid plugins.  When loading these, it causes girder print tracebacks that are confusing when trying to find actual errors.  This commit simply mocks the `logprint.exception` call inside plugin_utilities to silence these errors.

The way I'm mocking some of these cases is a bit ham-handed, but I didn't want to bother building up more infrastructure to solve this problem given that `test_plugins` will hopefully be [going away](https://github.com/girder/girder/pull/2552/commits/05a08174d59862cbbd31e2995c2a9a56e860b94d) soon.