### PR TITLE
Add support for one-time passwords (two-factor authentication)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,9 @@ Added Features
   list when the remote worker plugin is enabled and also from the worker plugin configuration page.
   (`#2678 <https://github.com/girder/girder/pull/2678>`_)
 
+* Allow users to login with two-factor authentication via TOTP on a mobile authenticator app.
+  (`#2655 <https://github.com/girder/girder/pull/2655>`_).
+
 Python Client
 ^^^^^^^^^^^^^
 * Added a ``--token`` option to the girder-client command line interface to allow users to specify

--- a/clients/web/src/auth.js
+++ b/clients/web/src/auth.js
@@ -79,18 +79,19 @@ function fetchCurrentUser() {
  *        to "true" to save the auth cookie on the current domain. Alternatively,
  *        you may set the global option "girder.corsAuth = true".
  */
-function login(username, password, cors) {
+function login(username, password, cors = corsAuth, otpToken = null) {
     var auth = 'Basic ' + window.btoa(username + ':' + password);
-    if (cors === undefined) {
-        cors = corsAuth;
-    }
 
+    const headers = {
+        'Girder-Authorization': auth
+    };
+    if (otpToken) {
+        headers['Girder-OTP'] = otpToken;
+    }
     return restRequest({
         method: 'GET',
         url: '/user/authentication',
-        headers: {
-            'Girder-Authorization': auth
-        },
+        headers: headers,
         error: null
     }).then(function (response) {
         response.user.token = response.authToken;

--- a/clients/web/src/auth.js
+++ b/clients/web/src/auth.js
@@ -78,6 +78,7 @@ function fetchCurrentUser() {
  * @param cors If the girder server is on a different origin, set this
  *        to "true" to save the auth cookie on the current domain. Alternatively,
  *        you may set the global option "girder.corsAuth = true".
+ * @param otpToken An optional one-time password to include with the login.
  */
 function login(username, password, cors = corsAuth, otpToken = null) {
     var auth = 'Basic ' + window.btoa(username + ':' + password);
@@ -85,7 +86,8 @@ function login(username, password, cors = corsAuth, otpToken = null) {
     const headers = {
         'Girder-Authorization': auth
     };
-    if (otpToken) {
+    if (_.isString(otpToken)) {
+        // Use _.isString to send header with empty string
         headers['Girder-OTP'] = otpToken;
     }
     return restRequest({

--- a/clients/web/src/models/UserModel.js
+++ b/clients/web/src/models/UserModel.js
@@ -120,6 +120,42 @@ var UserModel = Model.extend({
         }).fail((err) => {
             this.trigger('g:error', err);
         });
+    },
+
+    initializeOtp: function () {
+        return restRequest({
+            url: `user/${this.id}/otp`,
+            method: 'POST',
+            error: null
+        })
+            .then((resp) => {
+                return resp.otpUri;
+            });
+    },
+
+    finializeOtp: function (otpToken) {
+        return restRequest({
+            url: `user/${this.id}/otp`,
+            method: 'PUT',
+            headers: {
+                'Girder-OTP': otpToken
+            },
+            error: null
+        })
+            .done(() => {
+                // TODO: update user model
+            });
+    },
+
+    removeOtp: function () {
+        return restRequest({
+            url: `user/${this.id}/otp`,
+            method: 'DELETE',
+            error: null
+        })
+            .done(() => {
+                // TODO: update user model
+            });
     }
 }, {
     fromTemporaryToken: function (userId, token) {

--- a/clients/web/src/models/UserModel.js
+++ b/clients/web/src/models/UserModel.js
@@ -122,7 +122,7 @@ var UserModel = Model.extend({
         });
     },
 
-    initializeOtp: function () {
+    initializeEnableOtp: function () {
         return restRequest({
             url: `user/${this.id}/otp`,
             method: 'POST',
@@ -133,7 +133,7 @@ var UserModel = Model.extend({
             });
     },
 
-    finializeOtp: function (otpToken) {
+    finializeEnableOtp: function (otpToken) {
         return restRequest({
             url: `user/${this.id}/otp`,
             method: 'PUT',
@@ -147,7 +147,7 @@ var UserModel = Model.extend({
             });
     },
 
-    removeOtp: function () {
+    disableOtp: function () {
         return restRequest({
             url: `user/${this.id}/otp`,
             method: 'DELETE',

--- a/clients/web/src/models/UserModel.js
+++ b/clients/web/src/models/UserModel.js
@@ -129,7 +129,7 @@ var UserModel = Model.extend({
             error: null
         })
             .then((resp) => {
-                return resp.otpUri;
+                return resp.totpUri;
             });
     },
 

--- a/clients/web/src/models/UserModel.js
+++ b/clients/web/src/models/UserModel.js
@@ -143,7 +143,7 @@ var UserModel = Model.extend({
             error: null
         })
             .done(() => {
-                // TODO: update user model
+                this.set('otp', true);
             });
     },
 
@@ -154,7 +154,7 @@ var UserModel = Model.extend({
             error: null
         })
             .done(() => {
-                // TODO: update user model
+                this.set('otp', false);
             });
     }
 }, {

--- a/clients/web/src/package.json
+++ b/clients/web/src/package.json
@@ -20,10 +20,12 @@
         "jquery": "~3.2.1",
         "jsoneditor": "~5.9.3",
         "moment": "~2.20.1",
+        "qrcode": "~1.2.0",
         "remarkable": "~1.7.1",
         "sprintf-js": "~1.1.1",
         "swagger-ui": "~2.2.10",
-        "underscore": "~1.8.3"
+        "underscore": "~1.8.3",
+        "url-otpauth": "~2.0.0"
     },
     "main": "./index.js",
     "scripts": {

--- a/clients/web/src/stylesheets/widgets/userOtpManagementWidget.styl
+++ b/clients/web/src/stylesheets/widgets/userOtpManagementWidget.styl
@@ -12,13 +12,29 @@
   h2
     margin 0 20px 10px 0
     display inline-block
+    &.g-user-otp-heading-enable
+      background #EFFFF0
+      border 1px solid #4CAF50
+      border-radius 5px
+      color #4CAF50
+      font-size 26px
+      padding 20px 26px
+      &:before
+        display inline-block
+        content "\e830"
+        font-family "fontello"
+        margin-right 10px
   h3
     color #333
     font-size 20px
     font-weight bold
     margin 0 0 5px
+    &.g-user-otp-heading-disable
+      margin-bottom 5px
+      margin-top 25px
   #g-user-otp-initialize-enable
-    margin-top -12px
+    display block
+    margin-top 6px
   .g-account-otp-steps
     background-color #fafafa
     border 1px solid #e3e3e3

--- a/clients/web/src/stylesheets/widgets/userOtpManagementWidget.styl
+++ b/clients/web/src/stylesheets/widgets/userOtpManagementWidget.styl
@@ -1,0 +1,62 @@
+#g-account-tab-otp
+// Included parent ID to avoid using !important for style overrides
+    .g-user-settings-container
+        background none
+        border none
+.g-account-otp-info-text
+    border-bottom 1px solid #cccccc
+    padding-bottom 25px
+.g-account-otp-container
+    padding-top 25px
+    h2
+        margin 0 20px 10px 0
+        display inline-block
+    h3
+        color #333
+        font-size 20px
+        font-weight bold
+        margin-bottom 5px
+    #g-user-otp-initialize
+        margin-top -12px
+    .g-account-otp-steps
+        background-color #fafafa
+        border 1px solid #e3e3e3
+        border-radius 4px
+        margin-top 10px
+        overflow visible
+        padding-right 25px
+        .g-account-otp-step
+            border-bottom 1px solid #e3e3e3
+            color #bbb
+            font-size 20px
+            font-weight 600
+            padding-bottom 25px
+            // clearfix
+            &:after
+                clear both
+                content ''
+                display table
+            div
+                color #333
+                font-size 14px
+                font-weight normal
+            // Styles for only step 2
+            &:nth-child(2)
+                div
+                    float left
+                    width 26%
+                    &:first-of-type
+                        margin-right 4%
+                        width 70%
+
+// Responsive Goodness
+@media screen and (max-width:960px)
+    .g-account-otp-container
+        .g-account-otp-steps
+            .g-account-otp-step
+                &:nth-child(2)
+                    div
+                        float none
+                        width 100%
+                        &.g-account-otp-scan-qr
+                            margin-right 0

--- a/clients/web/src/stylesheets/widgets/userOtpManagementWidget.styl
+++ b/clients/web/src/stylesheets/widgets/userOtpManagementWidget.styl
@@ -5,9 +5,10 @@
         border none
 .g-account-otp-info-text
     border-bottom 1px solid #cccccc
-    padding-bottom 25px
+    margin-top 10px
+    padding-bottom 35px
 .g-account-otp-container
-    padding-top 25px
+    padding-top 35px
     h2
         margin 0 20px 10px 0
         display inline-block
@@ -15,41 +16,120 @@
         color #333
         font-size 20px
         font-weight bold
-        margin-bottom 5px
+        margin 0 0 5px
     #g-user-otp-initialize
         margin-top -12px
     .g-account-otp-steps
         background-color #fafafa
         border 1px solid #e3e3e3
-        border-radius 4px
+        border-radius 4px 4px 0 0
+        margin-bottom 0
         margin-top 10px
         overflow visible
-        padding-right 25px
+        padding-right 40px
+        position relative
+        &:before
+            background-color #337ab7
+            border 1px solid #2e6da4
+            border-radius 4px 4px 0 0
+            content ''
+            display block
+            height 6px
+            position absolute
+            left -1px
+            right -1px
+            top -1px
         .g-account-otp-step
             border-bottom 1px solid #e3e3e3
             color #bbb
             font-size 20px
             font-weight 600
-            padding-bottom 25px
+            padding 35px 0
             // clearfix
             &:after
                 clear both
                 content ''
                 display table
+            &:first-of-type
+                padding-top 30px
+            &:last-of-type
+                border-bottom none
             div
                 color #333
                 font-size 14px
                 font-weight normal
+                padding-top 5px
+                h4
+                    font-size 16px
+                    font-weight bold
+                    color #666
+                    margin-bottom 20px
             // Styles for only step 2
             &:nth-child(2)
                 div
                     float left
-                    width 26%
-                    &:first-of-type
+                    padding-top 20px
+                    width 45%
+                    &.g-account-otp-scan-qr
                         margin-right 4%
-                        width 70%
+                        width 51%
+                        // Mobile Phone Icon
+                        &:before
+                            color rgba(51, 122, 183, .25)
+                            content '\e8fd'
+                            display block
+                            float left
+                            font-family  "fontello"
+                            font-size 26em
+                            font-style normal
+                            font-weight normal
+                            line-height 280px
+                            margin-right 40px
+                    &.g-account-otp-enter-manual
+                        background #fff
+                        border 1px solid #e3e3e3
+                        border-radius 4px
+                        margin-top 26px
+                        padding 20px
+                        h4
+                            margin-top 0
+                            span
+                                font-weight normal
+                                display block
+                                padding-top 10px
+                        table
+                            tr
+                                th
+                                    min-width 80px
+            #g-user-otp-token
+                padding: 16px 20px;
+                margin-top: 12px;
+    .g-user-otp-footer
+        background-color #3F3B3B
+        border-radius 0 0 4px 4px
+        padding 15px 20px 18px
+        // clearfix
+        &:after
+            clear both
+            content ''
+            display table
+        .btn-default
+            margin 5px 0px 0px 5px
+        .btn-primary
+            float right
+            font-size 20px
 
 // Responsive Goodness
+@media screen and (max-width:1156px)
+    .g-account-otp-container
+        .g-account-otp-steps
+            .g-account-otp-step
+                &:nth-child(2)
+                    div
+                        &.g-account-otp-scan-qr
+                            &:before
+                                display none
+
 @media screen and (max-width:960px)
     .g-account-otp-container
         .g-account-otp-steps
@@ -60,3 +140,4 @@
                         width 100%
                         &.g-account-otp-scan-qr
                             margin-right 0
+                            width 100%

--- a/clients/web/src/stylesheets/widgets/userOtpManagementWidget.styl
+++ b/clients/web/src/stylesheets/widgets/userOtpManagementWidget.styl
@@ -32,7 +32,7 @@
       background-color #337ab7
       border 1px solid #2e6da4
       border-radius 4px 4px 0 0
-      content ''
+      content ""
       display block
       height 6px
       position absolute
@@ -48,7 +48,7 @@
       // clearfix
       &:after
         clear both
-        content ''
+        content ""
         display table
       &:first-of-type
         padding-top 30px
@@ -75,8 +75,8 @@
             width 51%
             // Mobile Phone Icon
             &:before
-              color rgba(51, 122, 183, .25)
-              content '\e8fd'
+              color rgba(51, 122, 183, 0.25)
+              content "\e8fd"
               display block
               float left
               font-family  "fontello"
@@ -102,8 +102,8 @@
                 th
                   min-width 80px
       #g-user-otp-token
-        padding: 16px 20px;
-        margin-top: 12px;
+        padding 16px 20px
+        margin-top 12px
   .g-user-otp-footer
     background-color #3F3B3B
     border-radius 0 0 4px 4px
@@ -111,10 +111,10 @@
     // clearfix
     &:after
       clear both
-      content ''
+      content ""
       display table
     .btn-default
-      margin 5px 0px 0px 5px
+      margin 5px 0 0 5px
     .btn-primary
       float right
       font-size 20px

--- a/clients/web/src/stylesheets/widgets/userOtpManagementWidget.styl
+++ b/clients/web/src/stylesheets/widgets/userOtpManagementWidget.styl
@@ -17,7 +17,7 @@
     font-size 20px
     font-weight bold
     margin 0 0 5px
-  #g-user-otp-initialize
+  #g-user-otp-initialize-enable
     margin-top -12px
   .g-account-otp-steps
     background-color #fafafa

--- a/clients/web/src/stylesheets/widgets/userOtpManagementWidget.styl
+++ b/clients/web/src/stylesheets/widgets/userOtpManagementWidget.styl
@@ -1,143 +1,143 @@
 #g-account-tab-otp
 // Included parent ID to avoid using !important for style overrides
-    .g-user-settings-container
-        background none
-        border none
+  .g-user-settings-container
+    background none
+    border none
 .g-account-otp-info-text
-    border-bottom 1px solid #cccccc
-    margin-top 10px
-    padding-bottom 35px
+  border-bottom 1px solid #cccccc
+  margin-top 10px
+  padding-bottom 35px
 .g-account-otp-container
-    padding-top 35px
-    h2
-        margin 0 20px 10px 0
-        display inline-block
-    h3
+  padding-top 35px
+  h2
+    margin 0 20px 10px 0
+    display inline-block
+  h3
+    color #333
+    font-size 20px
+    font-weight bold
+    margin 0 0 5px
+  #g-user-otp-initialize
+    margin-top -12px
+  .g-account-otp-steps
+    background-color #fafafa
+    border 1px solid #e3e3e3
+    border-radius 4px 4px 0 0
+    margin-bottom 0
+    margin-top 10px
+    overflow visible
+    padding-right 40px
+    position relative
+    &:before
+      background-color #337ab7
+      border 1px solid #2e6da4
+      border-radius 4px 4px 0 0
+      content ''
+      display block
+      height 6px
+      position absolute
+      left -1px
+      right -1px
+      top -1px
+    .g-account-otp-step
+      border-bottom 1px solid #e3e3e3
+      color #bbb
+      font-size 20px
+      font-weight 600
+      padding 35px 0
+      // clearfix
+      &:after
+        clear both
+        content ''
+        display table
+      &:first-of-type
+        padding-top 30px
+      &:last-of-type
+        border-bottom none
+      div
         color #333
-        font-size 20px
-        font-weight bold
-        margin 0 0 5px
-    #g-user-otp-initialize
-        margin-top -12px
-    .g-account-otp-steps
-        background-color #fafafa
-        border 1px solid #e3e3e3
-        border-radius 4px 4px 0 0
-        margin-bottom 0
-        margin-top 10px
-        overflow visible
-        padding-right 40px
-        position relative
-        &:before
-            background-color #337ab7
-            border 1px solid #2e6da4
-            border-radius 4px 4px 0 0
-            content ''
-            display block
-            height 6px
-            position absolute
-            left -1px
-            right -1px
-            top -1px
-        .g-account-otp-step
-            border-bottom 1px solid #e3e3e3
-            color #bbb
-            font-size 20px
-            font-weight 600
-            padding 35px 0
-            // clearfix
-            &:after
-                clear both
-                content ''
-                display table
-            &:first-of-type
-                padding-top 30px
-            &:last-of-type
-                border-bottom none
-            div
-                color #333
-                font-size 14px
+        font-size 14px
+        font-weight normal
+        padding-top 5px
+        h4
+          font-size 16px
+          font-weight bold
+          color #666
+          margin-bottom 20px
+      // Styles for only step 2
+      &:nth-child(2)
+        div
+          float left
+          padding-top 20px
+          width 45%
+          &.g-account-otp-scan-qr
+            margin-right 4%
+            width 51%
+            // Mobile Phone Icon
+            &:before
+              color rgba(51, 122, 183, .25)
+              content '\e8fd'
+              display block
+              float left
+              font-family  "fontello"
+              font-size 26em
+              font-style normal
+              font-weight normal
+              line-height 280px
+              margin-right 40px
+          &.g-account-otp-enter-manual
+            background #fff
+            border 1px solid #e3e3e3
+            border-radius 4px
+            margin-top 26px
+            padding 20px
+            h4
+              margin-top 0
+              span
                 font-weight normal
-                padding-top 5px
-                h4
-                    font-size 16px
-                    font-weight bold
-                    color #666
-                    margin-bottom 20px
-            // Styles for only step 2
-            &:nth-child(2)
-                div
-                    float left
-                    padding-top 20px
-                    width 45%
-                    &.g-account-otp-scan-qr
-                        margin-right 4%
-                        width 51%
-                        // Mobile Phone Icon
-                        &:before
-                            color rgba(51, 122, 183, .25)
-                            content '\e8fd'
-                            display block
-                            float left
-                            font-family  "fontello"
-                            font-size 26em
-                            font-style normal
-                            font-weight normal
-                            line-height 280px
-                            margin-right 40px
-                    &.g-account-otp-enter-manual
-                        background #fff
-                        border 1px solid #e3e3e3
-                        border-radius 4px
-                        margin-top 26px
-                        padding 20px
-                        h4
-                            margin-top 0
-                            span
-                                font-weight normal
-                                display block
-                                padding-top 10px
-                        table
-                            tr
-                                th
-                                    min-width 80px
-            #g-user-otp-token
-                padding: 16px 20px;
-                margin-top: 12px;
-    .g-user-otp-footer
-        background-color #3F3B3B
-        border-radius 0 0 4px 4px
-        padding 15px 20px 18px
-        // clearfix
-        &:after
-            clear both
-            content ''
-            display table
-        .btn-default
-            margin 5px 0px 0px 5px
-        .btn-primary
-            float right
-            font-size 20px
+                display block
+                padding-top 10px
+            table
+              tr
+                th
+                  min-width 80px
+      #g-user-otp-token
+        padding: 16px 20px;
+        margin-top: 12px;
+  .g-user-otp-footer
+    background-color #3F3B3B
+    border-radius 0 0 4px 4px
+    padding 15px 20px 18px
+    // clearfix
+    &:after
+      clear both
+      content ''
+      display table
+    .btn-default
+      margin 5px 0px 0px 5px
+    .btn-primary
+      float right
+      font-size 20px
 
 // Responsive Goodness
 @media screen and (max-width:1156px)
-    .g-account-otp-container
-        .g-account-otp-steps
-            .g-account-otp-step
-                &:nth-child(2)
-                    div
-                        &.g-account-otp-scan-qr
-                            &:before
-                                display none
+  .g-account-otp-container
+    .g-account-otp-steps
+      .g-account-otp-step
+        &:nth-child(2)
+          div
+            &.g-account-otp-scan-qr
+              &:before
+                display none
 
 @media screen and (max-width:960px)
-    .g-account-otp-container
-        .g-account-otp-steps
-            .g-account-otp-step
-                &:nth-child(2)
-                    div
-                        float none
-                        width 100%
-                        &.g-account-otp-scan-qr
-                            margin-right 0
-                            width 100%
+  .g-account-otp-container
+    .g-account-otp-steps
+      .g-account-otp-step
+        &:nth-child(2)
+          div
+            float none
+            width 100%
+            &.g-account-otp-scan-qr
+              margin-right 0
+              width 100%

--- a/clients/web/src/templates/body/userAccount.pug
+++ b/clients/web/src/templates/body/userAccount.pug
@@ -15,6 +15,10 @@ ul.g-account-tabs.nav.nav-tabs
     a(href="#g-account-tab-api-keys", data-toggle="tab", name="apikeys")
       i.icon-key-inv
       | API keys
+  li
+    a(href="#g-account-tab-otp", data-toggle="tab", name="otp")
+      i.icon-mobile
+      | Two-factor authentication
 
 .tab-content
   #g-account-tab-info.tab-pane.active
@@ -71,3 +75,9 @@ ul.g-account-tabs.nav.nav-tabs
         the default expiration for user login sessions will be used.
 
       .g-api-keys-list-container
+  #g-account-tab-otp.tab-pane
+    .g-user-settings-container
+      .g-account-otp-info-text.
+        Two factor authentication...
+
+      .g-account-otp-container

--- a/clients/web/src/templates/body/userAccount.pug
+++ b/clients/web/src/templates/body/userAccount.pug
@@ -78,6 +78,6 @@ ul.g-account-tabs.nav.nav-tabs
   #g-account-tab-otp.tab-pane
     .g-user-settings-container
       .g-account-otp-info-text.
-        Two-factor authentication adds another level of authentication to your account log-in. Click "begin" if you wish to set it up.
+        Two-factor authentication adds another level of authentication to your account log-in.
 
       .g-account-otp-container

--- a/clients/web/src/templates/body/userAccount.pug
+++ b/clients/web/src/templates/body/userAccount.pug
@@ -78,6 +78,6 @@ ul.g-account-tabs.nav.nav-tabs
   #g-account-tab-otp.tab-pane
     .g-user-settings-container
       .g-account-otp-info-text.
-        Two factor authentication...
+        Two-factor authentication adds another level of authentication to your account log-in. Click "begin" if you wish to set it up.
 
       .g-account-otp-container

--- a/clients/web/src/templates/layout/loginDialog.pug
+++ b/clients/web/src/templates/layout/loginDialog.pug
@@ -12,6 +12,11 @@
           .form-group
             label.control-label(for="g-password") Password
             input#g-password.input-sm.form-control(type="password", placeholder="Enter password")
+          .form-group
+            label.control-label(for="g-login-otp") Two-factor code
+            input#g-login-otp.input-sm.form-control(
+              type='text', minlength=6, maxlength=6,
+              placeholder="Your 6-digit two-factor authentication code, if enabled")
           .g-validation-failed-message
           .g-bottom-message
             if registrationPolicy !== 'closed'

--- a/clients/web/src/templates/layout/loginDialog.pug
+++ b/clients/web/src/templates/layout/loginDialog.pug
@@ -12,11 +12,10 @@
           .form-group
             label.control-label(for="g-password") Password
             input#g-password.input-sm.form-control(type="password", placeholder="Enter password")
-          .form-group
+          #g-login-otp-group.form-group.hidden
             label.control-label(for="g-login-otp") Two-factor code
             input#g-login-otp.input-sm.form-control(
-              type='text', minlength=6, maxlength=6,
-              placeholder="Your 6-digit two-factor authentication code, if enabled")
+              type='text', minlength=6, maxlength=6, placeholder="Your 6-digit two-factor authentication code, if enabled")
           .g-validation-failed-message
           .g-bottom-message
             if registrationPolicy !== 'closed'

--- a/clients/web/src/templates/widgets/userOtpBegin.pug
+++ b/clients/web/src/templates/widgets/userOtpBegin.pug
@@ -1,0 +1,4 @@
+h2 Enable 2-factor authentication
+
+button#g-user-otp-initialize.btn.btn-primary(type="submit")
+  |  Begin

--- a/clients/web/src/templates/widgets/userOtpBegin.pug
+++ b/clients/web/src/templates/widgets/userOtpBegin.pug
@@ -1,4 +1,4 @@
 h2 Enable Two-factor authentication
 
-button#g-user-otp-initialize.btn.btn-primary(type="submit")
+button#g-user-otp-initialize-enable.btn.btn-primary(type="submit")
   |  Begin

--- a/clients/web/src/templates/widgets/userOtpBegin.pug
+++ b/clients/web/src/templates/widgets/userOtpBegin.pug
@@ -1,4 +1,4 @@
-h2 Enable 2-factor authentication
+h2 Enable Two-factor authentication
 
 button#g-user-otp-initialize.btn.btn-primary(type="submit")
   |  Begin

--- a/clients/web/src/templates/widgets/userOtpConfirmation.pug
+++ b/clients/web/src/templates/widgets/userOtpConfirmation.pug
@@ -1,0 +1,38 @@
+h2 Enable 2-factor authentication
+
+h3 1. Install an authenticator app on your mobile device.
+div.
+  There are many compatible apps, but
+  #[a(href='https://support.google.com/accounts/answer/1066447?hl=en', target='_blank', rel='noopener') Google Authenticator],
+  #[a(href='https://guide.duo.com/third-party-accounts', target='_blank', rel='noopener') Duo Mobile], and
+  #[a(href='https://freeotp.github.io/', target='_blank', rel='noopener') FreeOTP],
+  are some options.
+
+h3 2. Enter the code in the authenticator app
+h4 Scan with your mobile device's camera (easiest):
+canvas#g-user-otp-qr
+h4 Or enter the information manually (advanced):
+  table
+    tr
+      th Service
+      td
+        code= otpInfo.issuer
+    tr
+      th Account
+      td
+        code= otpInfo.account
+    tr
+      th Key
+      td
+        // Split into 4-character chunks for human readability
+        code= otpInfo.key.match(/.{1,4}/g).join('-')
+    tr
+      th Type
+      td
+        span #[code Time-based] / #[code TOTP]
+
+h3 3. Enter a new authentication code from the app
+input#g-user-otp-token(type='text', minlength=6, maxlength=6, placeholder='Your 6-digit code')
+div
+  a#g-user-otp-cancel.btn.btn-default Cancel
+  button#g-user-otp-finalize.btn.btn-primary(type="submit") Enable

--- a/clients/web/src/templates/widgets/userOtpConfirmation.pug
+++ b/clients/web/src/templates/widgets/userOtpConfirmation.pug
@@ -1,38 +1,42 @@
 h2 Enable 2-factor authentication
 
-h3 1. Install an authenticator app on your mobile device.
-div.
-  There are many compatible apps, but
-  #[a(href='https://support.google.com/accounts/answer/1066447?hl=en', target='_blank', rel='noopener') Google Authenticator],
-  #[a(href='https://guide.duo.com/third-party-accounts', target='_blank', rel='noopener') Duo Mobile], and
-  #[a(href='https://freeotp.github.io/', target='_blank', rel='noopener') FreeOTP],
-  are some options.
-
-h3 2. Enter the code in the authenticator app
-h4 Scan with your mobile device's camera (easiest):
-canvas#g-user-otp-qr
-h4 Or enter the information manually (advanced):
-  table
-    tr
-      th Service
-      td
-        code= otpInfo.issuer
-    tr
-      th Account
-      td
-        code= otpInfo.account
-    tr
-      th Key
-      td
-        // Split into 4-character chunks for human readability
-        code= otpInfo.key.match(/.{1,4}/g).join('-')
-    tr
-      th Type
-      td
-        span #[code Time-based] / #[code TOTP]
-
-h3 3. Enter a new authentication code from the app
-input#g-user-otp-token(type='text', minlength=6, maxlength=6, placeholder='Your 6-digit code')
-div
-  a#g-user-otp-cancel.btn.btn-default Cancel
-  button#g-user-otp-finalize.btn.btn-primary(type="submit") Enable
+ol.g-account-otp-steps
+  li.g-account-otp-step
+    h3 Install an authenticator app on your mobile device.
+    div.
+      There are many compatible apps, but
+      #[a(href='https://support.google.com/accounts/answer/1066447?hl=en', target='_blank', rel='noopener') Google Authenticator],
+      #[a(href='https://guide.duo.com/third-party-accounts', target='_blank', rel='noopener') Duo Mobile], and
+      #[a(href='https://freeotp.github.io/', target='_blank', rel='noopener') FreeOTP],
+      are some options.
+  li.g-account-otp-step
+    h3 Enter the code in the authenticator app
+    div.g-account-otp-scan-qr
+      h4 Scan with your mobile device's camera (easiest):
+      canvas#g-user-otp-qr
+    div.g-account-otp-enter-manual
+      h4 Or enter the information manually (advanced):
+        table
+          tr
+            th Service
+            td
+              code= otpInfo.issuer
+          tr
+            th Account
+            td
+              code= otpInfo.account
+          tr
+            th Key
+            td
+              // Split into 4-character chunks for human readability
+              code= otpInfo.key.match(/.{1,4}/g).join('-')
+          tr
+            th Type
+            td
+              span #[code Time-based] / #[code TOTP]
+  li.g-account-otp-step
+    h3 Enter a new authentication code from the app
+    input#g-user-otp-token(type='text', minlength=6, maxlength=6, placeholder='Your 6-digit code')
+    div
+      a#g-user-otp-cancel.btn.btn-default Cancel
+      button#g-user-otp-finalize.btn.btn-primary(type="submit") Enable

--- a/clients/web/src/templates/widgets/userOtpConfirmation.pug
+++ b/clients/web/src/templates/widgets/userOtpConfirmation.pug
@@ -10,10 +10,10 @@ ol.g-account-otp-steps
       #[a(href='https://freeotp.github.io/', target='_blank', rel='noopener') FreeOTP].
   li.g-account-otp-step
     h3 Enter your key into the authenticator app
-    div.g-account-otp-scan-qr
+    .g-account-otp-scan-qr
       h4 Scan with your mobile device's camera:
       canvas#g-user-otp-qr
-    div.g-account-otp-enter-manual
+    .g-account-otp-enter-manual
       h4 Advanced Users:
         span You may enter your information manually, instead:
       table
@@ -37,6 +37,6 @@ ol.g-account-otp-steps
   li.g-account-otp-step
     h3 Enter the authentication code from your app
     input#g-user-otp-token(type='text', minlength=6, maxlength=6, placeholder='Your 6-digit code')
-div.g-user-otp-footer
-    a#g-user-otp-cancel.btn.btn-default Cancel
-    button#g-user-otp-finalize.btn.btn-primary.btn-success(type="submit") Enable Two-Factor
+.g-user-otp-footer
+  a#g-user-otp-cancel.btn.btn-default Cancel
+  button#g-user-otp-finalize.btn.btn-primary.btn-success(type="submit") Enable Two-Factor

--- a/clients/web/src/templates/widgets/userOtpConfirmation.pug
+++ b/clients/web/src/templates/widgets/userOtpConfirmation.pug
@@ -1,42 +1,42 @@
-h2 Enable 2-factor authentication
+h2 Enable Two-factor authentication
 
 ol.g-account-otp-steps
   li.g-account-otp-step
     h3 Install an authenticator app on your mobile device.
     div.
-      There are many compatible apps, but
+      There are many compatible apps, including, but not limited to
       #[a(href='https://support.google.com/accounts/answer/1066447?hl=en', target='_blank', rel='noopener') Google Authenticator],
       #[a(href='https://guide.duo.com/third-party-accounts', target='_blank', rel='noopener') Duo Mobile], and
-      #[a(href='https://freeotp.github.io/', target='_blank', rel='noopener') FreeOTP],
-      are some options.
+      #[a(href='https://freeotp.github.io/', target='_blank', rel='noopener') FreeOTP].
   li.g-account-otp-step
-    h3 Enter the code in the authenticator app
+    h3 Enter your key into the authenticator app
     div.g-account-otp-scan-qr
-      h4 Scan with your mobile device's camera (easiest):
+      h4 Scan with your mobile device's camera:
       canvas#g-user-otp-qr
     div.g-account-otp-enter-manual
-      h4 Or enter the information manually (advanced):
-        table
-          tr
-            th Service
-            td
-              code= otpInfo.issuer
-          tr
-            th Account
-            td
-              code= otpInfo.account
-          tr
-            th Key
-            td
-              // Split into 4-character chunks for human readability
-              code= otpInfo.key.match(/.{1,4}/g).join('-')
-          tr
-            th Type
-            td
-              span #[code Time-based] / #[code TOTP]
+      h4 Advanced Users:
+        span You may enter your information manually, instead:
+      table
+        tr
+          th Service
+          td
+            code= otpInfo.issuer
+        tr
+          th Account
+          td
+            code= otpInfo.account
+        tr
+          th Key
+          td
+            // Split into 4-character chunks for human readability
+            code= otpInfo.key.match(/.{1,4}/g).join('-')
+        tr
+          th Type
+          td
+            span #[code Time-based] / #[code TOTP]
   li.g-account-otp-step
-    h3 Enter a new authentication code from the app
+    h3 Enter the authentication code from your app
     input#g-user-otp-token(type='text', minlength=6, maxlength=6, placeholder='Your 6-digit code')
-    div
-      a#g-user-otp-cancel.btn.btn-default Cancel
-      button#g-user-otp-finalize.btn.btn-primary(type="submit") Enable
+div.g-user-otp-footer
+    a#g-user-otp-cancel.btn.btn-default Cancel
+    button#g-user-otp-finalize.btn.btn-primary.btn-success(type="submit") Enable Two-Factor

--- a/clients/web/src/templates/widgets/userOtpConfirmation.pug
+++ b/clients/web/src/templates/widgets/userOtpConfirmation.pug
@@ -20,16 +20,16 @@ ol.g-account-otp-steps
         tr
           th Service
           td
-            code= otpInfo.issuer
+            code= totpInfo.issuer
         tr
           th Account
           td
-            code= otpInfo.account
+            code= totpInfo.account
         tr
           th Key
           td
             // Split into 4-character chunks for human readability
-            code= otpInfo.key.match(/.{1,4}/g).join('-')
+            code= totpInfo.key.match(/.{1,4}/g).join('-')
         tr
           th Type
           td

--- a/clients/web/src/templates/widgets/userOtpDisable.pug
+++ b/clients/web/src/templates/widgets/userOtpDisable.pug
@@ -1,0 +1,6 @@
+h2 Two-factor authentication is currently enabled
+
+h3 Disable Two-factor authentication
+
+button#g-user-otp-remove.btn.btn-primary(type="submit")
+  |  Disable

--- a/clients/web/src/templates/widgets/userOtpDisable.pug
+++ b/clients/web/src/templates/widgets/userOtpDisable.pug
@@ -2,5 +2,5 @@ h2 Two-factor authentication is currently enabled
 
 h3 Disable Two-factor authentication
 
-button#g-user-otp-remove.btn.btn-primary(type="submit")
+button#g-user-otp-disable.btn.btn-primary(type="submit")
   |  Disable

--- a/clients/web/src/templates/widgets/userOtpDisable.pug
+++ b/clients/web/src/templates/widgets/userOtpDisable.pug
@@ -1,6 +1,6 @@
-h2 Two-factor authentication is currently enabled
+h2.g-user-otp-heading-enable Two-factor authentication is currently enabled
 
-h3 Disable Two-factor authentication
+h3.g-user-otp-heading-disable Disable Two-factor authentication
 
 button#g-user-otp-disable.btn.btn-primary(type="submit")
   |  Disable

--- a/clients/web/src/templates/widgets/userOtpEnable.pug
+++ b/clients/web/src/templates/widgets/userOtpEnable.pug
@@ -37,6 +37,8 @@ ol.g-account-otp-steps
   li.g-account-otp-step
     h3 Enter the authentication code from your app
     input#g-user-otp-token(type='text', minlength=6, maxlength=6, placeholder='Your 6-digit code')
+    div
+      span#g-account-otp-error.g-validation-failed-message
 .g-user-otp-footer
   a#g-user-otp-cancel-enable.btn.btn-default Cancel
   button#g-user-otp-finalize-enable.btn.btn-primary.btn-success(type="submit") Enable Two-Factor

--- a/clients/web/src/templates/widgets/userOtpEnable.pug
+++ b/clients/web/src/templates/widgets/userOtpEnable.pug
@@ -38,5 +38,5 @@ ol.g-account-otp-steps
     h3 Enter the authentication code from your app
     input#g-user-otp-token(type='text', minlength=6, maxlength=6, placeholder='Your 6-digit code')
 .g-user-otp-footer
-  a#g-user-otp-cancel.btn.btn-default Cancel
-  button#g-user-otp-finalize.btn.btn-primary.btn-success(type="submit") Enable Two-Factor
+  a#g-user-otp-cancel-enable.btn.btn-default Cancel
+  button#g-user-otp-finalize-enable.btn.btn-primary.btn-success(type="submit") Enable Two-Factor

--- a/clients/web/src/views/body/UserAccountView.js
+++ b/clients/web/src/views/body/UserAccountView.js
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import _ from 'underscore';
 
 import ApiKeyListWidget from 'girder/views/widgets/ApiKeyListWidget';
+import UserOtpManagementWidget from 'girder/views/widgets/UserOtpManagementWidget';
 import router from 'girder/router';
 import UserModel from 'girder/models/UserModel';
 import View from 'girder/views/View';
@@ -114,6 +115,11 @@ var UserAccountView = View.extend({
             parentView: this
         });
 
+        this.userOtpManagementWidget = new UserOtpManagementWidget({
+            user: this.user,
+            parentView: this
+        });
+
         this.render();
     },
 
@@ -139,6 +145,10 @@ var UserAccountView = View.extend({
                 if (this.tab === 'apikeys') {
                     this.apiKeyListWidget.setElement(
                         this.$('.g-api-keys-list-container')).render();
+                } else if (this.tab === 'otp') {
+                    this.userOtpManagementWidget
+                        .setElement(this.$('.g-account-otp-container'))
+                        .render();
                 }
             });
 

--- a/clients/web/src/views/layout/LoginView.js
+++ b/clients/web/src/views/layout/LoginView.js
@@ -25,7 +25,8 @@ var LoginView = View.extend({
 
             const loginName = this.$('#g-login').val();
             const password = this.$('#g-password').val();
-            login(loginName, password)
+            const otpToken = this.$('#g-login-otp').val() || null;
+            login(loginName, password, otpToken)
                 .done(() => {
                     this.$el.modal('hide');
                 })

--- a/clients/web/src/views/layout/LoginView.js
+++ b/clients/web/src/views/layout/LoginView.js
@@ -25,12 +25,20 @@ var LoginView = View.extend({
 
             const loginName = this.$('#g-login').val();
             const password = this.$('#g-password').val();
-            const otpToken = this.$('#g-login-otp').val() || null;
-            login(loginName, password, otpToken)
+            const otpToken = this.$('#g-login-otp-group').hasClass('hidden') ? null : this.$('#g-login-otp').val();
+            login(loginName, password, undefined, otpToken)
                 .done(() => {
                     this.$el.modal('hide');
                 })
                 .fail((err) => {
+                    if (err.responseJSON.message.indexOf('Girder-OTP') !== -1 &&
+                        this.$('#g-login-otp-group').hasClass('hidden')
+                    ) {
+                        this.$('#g-login-otp-group').removeClass('hidden');
+                        this.$('#g-login-otp').focus();
+                        return;
+                    }
+
                     this.$('.g-validation-failed-message').text(err.responseJSON.message);
 
                     if (err.responseJSON.extra === 'emailVerification') {
@@ -73,7 +81,8 @@ var LoginView = View.extend({
     render: function () {
         this.$el.html(LoginDialogTemplate({
             registrationPolicy: this.registrationPolicy,
-            enablePasswordLogin: this.enablePasswordLogin
+            enablePasswordLogin: this.enablePasswordLogin,
+            showOtp: true
         })).girderModal(this)
             .on('shown.bs.modal', () => {
                 this.$('#g-login').focus();

--- a/clients/web/src/views/widgets/UserOtpManagementWidget.js
+++ b/clients/web/src/views/widgets/UserOtpManagementWidget.js
@@ -1,0 +1,102 @@
+import QRCode from 'qrcode';
+import OTPAuth from 'url-otpauth';
+
+import View from 'girder/views/View';
+import { confirm } from 'girder/dialog';
+import events from 'girder/events';
+
+import UserOtpBeginTemplate from 'girder/templates/widgets/userOtpBegin.pug';
+import UserOtpConfirmationTemplate from 'girder/templates/widgets/userOtpConfirmation.pug';
+
+const UserOtpManagementWidget = View.extend({
+    events: {
+        'click #g-user-otp-initialize': function () {
+            this.model.initializeOtp()
+                .done((otpUri) => {
+                    this.otpUri = otpUri;
+                    this.render();
+                });
+        },
+        'click #g-user-otp-finalize': function () {
+            const otpToken = this.$('#g-user-otp-token').value().trim();
+
+            this.model.finializeOtp(otpToken)
+                .done(() => {
+                    // TODO: show confirmation
+                    this.render();
+                })
+                .fail((err) => {
+                    // TODO: render error message
+                });
+        },
+        'click #g-user-otp-cancel': function () {
+            this.otpUri = undefined;
+            this.render();
+        },
+        'click #g-user-otp-remove': function () {
+            this.model.removeOtp()
+                .done(() => {
+                    this.render();
+                })
+                .fail((err) => {
+                    // TODO: render error message
+                });
+        }
+    },
+
+    /**
+     * A widget for listing and editing API keys for a user.
+     *
+     * @param settings.user {UserModel} The user whose keys to show.
+     */
+    initialize: function (settings) {
+        this.model = settings.user;
+    },
+
+    render: function () {
+        if (!this.model.has('otp')) {
+            // OTP not set up
+            if (!this.otpUri) {
+                // Enablement has not started
+                this._renderBegin();
+            } else {
+                // Enablement is pending
+                this._renderConfirmation();
+            }
+        } else {
+            // OTP already enabled
+            this._renderDisable();
+        }
+
+        return this;
+    },
+
+    _renderBegin: function () {
+        this.$el.html(UserOtpBeginTemplate({
+        }));
+    },
+
+    _renderConfirmation: function () {
+        // The OTP URI format is defined at https://github.com/google/google-authenticator/wiki/Key-Uri-Format
+        const otpInfo = OTPAuth.parse(this.otpUri);
+
+        this.$el.html(UserOtpConfirmationTemplate({
+            otpInfo: otpInfo
+        }));
+
+        // Render the OTP as a QR code
+        QRCode.toCanvas(
+            this.$('#g-user-otp-qr')[0],
+            this.otpUri,
+            {
+                errorCorrectionLevel: 'H',
+            }
+        );
+    },
+
+    _renderDisable: function () {
+        // When OTP is enabled
+    }
+});
+
+export default UserOtpManagementWidget;

--- a/clients/web/src/views/widgets/UserOtpManagementWidget.js
+++ b/clients/web/src/views/widgets/UserOtpManagementWidget.js
@@ -13,8 +13,8 @@ const UserOtpManagementWidget = View.extend({
     events: {
         'click #g-user-otp-initialize': function () {
             this.model.initializeOtp()
-                .done((otpUri) => {
-                    this.otpUri = otpUri;
+                .done((totpUri) => {
+                    this.totpUri = totpUri;
                     this.render();
                 });
         },
@@ -33,7 +33,7 @@ const UserOtpManagementWidget = View.extend({
                 });
         },
         'click #g-user-otp-cancel': function () {
-            this.otpUri = undefined;
+            this.totpUri = undefined;
             this.render();
         },
         'click #g-user-otp-remove': function () {
@@ -60,7 +60,7 @@ const UserOtpManagementWidget = View.extend({
     render: function () {
         if (!this.model.has('otp')) {
             // OTP not set up
-            if (!this.otpUri) {
+            if (!this.totpUri) {
                 // Enablement has not started
                 this._renderBegin();
             } else {
@@ -82,16 +82,16 @@ const UserOtpManagementWidget = View.extend({
 
     _renderConfirmation: function () {
         // The OTP URI format is defined at https://github.com/google/google-authenticator/wiki/Key-Uri-Format
-        const otpInfo = OTPAuth.parse(this.otpUri);
+        const totpInfo = OTPAuth.parse(this.totpUri);
 
         this.$el.html(UserOtpConfirmationTemplate({
-            otpInfo: otpInfo
+            totpInfo: totpInfo
         }));
 
         // Render the OTP as a QR code
         QRCode.toCanvas(
             this.$('#g-user-otp-qr')[0],
-            this.otpUri,
+            this.totpUri,
             {
                 errorCorrectionLevel: 'H',
             }

--- a/clients/web/src/views/widgets/UserOtpManagementWidget.js
+++ b/clients/web/src/views/widgets/UserOtpManagementWidget.js
@@ -18,7 +18,7 @@ const UserOtpManagementWidget = View.extend({
                 });
         },
         'click #g-user-otp-finalize': function () {
-            const otpToken = this.$('#g-user-otp-token').value().trim();
+            const otpToken = this.$('#g-user-otp-token').val().trim();
 
             this.model.finializeOtp(otpToken)
                 .done(() => {

--- a/clients/web/src/views/widgets/UserOtpManagementWidget.js
+++ b/clients/web/src/views/widgets/UserOtpManagementWidget.js
@@ -23,10 +23,12 @@ const UserOtpManagementWidget = View.extend({
             this.model.finializeOtp(otpToken)
                 .done(() => {
                     // TODO: show confirmation
+                    console.log('Confirm success');
                     this.render();
                 })
                 .fail((err) => {
                     // TODO: render error message
+                    console.log('Finalize failed');
                 });
         },
         'click #g-user-otp-cancel': function () {
@@ -40,6 +42,7 @@ const UserOtpManagementWidget = View.extend({
                 })
                 .fail((err) => {
                     // TODO: render error message
+                    console.log('Remove failed');
                 });
         }
     },
@@ -96,6 +99,8 @@ const UserOtpManagementWidget = View.extend({
 
     _renderDisable: function () {
         // When OTP is enabled
+        // TODO: implement
+        console.log('TODO: Show disable view');
     }
 });
 

--- a/clients/web/src/views/widgets/UserOtpManagementWidget.js
+++ b/clients/web/src/views/widgets/UserOtpManagementWidget.js
@@ -7,6 +7,7 @@ import events from 'girder/events';
 
 import UserOtpBeginTemplate from 'girder/templates/widgets/userOtpBegin.pug';
 import UserOtpConfirmationTemplate from 'girder/templates/widgets/userOtpConfirmation.pug';
+import 'girder/stylesheets/widgets/userOTPManagementWidget.styl';
 
 const UserOtpManagementWidget = View.extend({
     events: {

--- a/clients/web/src/views/widgets/UserOtpManagementWidget.js
+++ b/clients/web/src/views/widgets/UserOtpManagementWidget.js
@@ -2,11 +2,10 @@ import QRCode from 'qrcode';
 import OTPAuth from 'url-otpauth';
 
 import View from 'girder/views/View';
-import { confirm } from 'girder/dialog';
-import events from 'girder/events';
 
 import UserOtpBeginTemplate from 'girder/templates/widgets/userOtpBegin.pug';
 import UserOtpConfirmationTemplate from 'girder/templates/widgets/userOtpConfirmation.pug';
+import UserOtpDisableTemplate from 'girder/templates/widgets/userOtpDisable.pug';
 import 'girder/stylesheets/widgets/userOtpManagementWidget.styl';
 
 const UserOtpManagementWidget = View.extend({
@@ -25,11 +24,12 @@ const UserOtpManagementWidget = View.extend({
                 .done(() => {
                     // TODO: show confirmation
                     console.log('Confirm success');
+                    this.totpUri = undefined;
                     this.render();
                 })
                 .fail((err) => {
                     // TODO: render error message
-                    console.log('Finalize failed');
+                    console.log('Finalize failed', err);
                 });
         },
         'click #g-user-otp-cancel': function () {
@@ -43,7 +43,7 @@ const UserOtpManagementWidget = View.extend({
                 })
                 .fail((err) => {
                     // TODO: render error message
-                    console.log('Remove failed');
+                    console.log('Remove failed', err);
                 });
         }
     },
@@ -58,7 +58,7 @@ const UserOtpManagementWidget = View.extend({
     },
 
     render: function () {
-        if (!this.model.has('otp')) {
+        if (!this.model.get('otp')) {
             // OTP not set up
             if (!this.totpUri) {
                 // Enablement has not started
@@ -76,8 +76,7 @@ const UserOtpManagementWidget = View.extend({
     },
 
     _renderBegin: function () {
-        this.$el.html(UserOtpBeginTemplate({
-        }));
+        this.$el.html(UserOtpBeginTemplate());
     },
 
     _renderConfirmation: function () {
@@ -93,15 +92,13 @@ const UserOtpManagementWidget = View.extend({
             this.$('#g-user-otp-qr')[0],
             this.totpUri,
             {
-                errorCorrectionLevel: 'H',
+                errorCorrectionLevel: 'H'
             }
         );
     },
 
     _renderDisable: function () {
-        // When OTP is enabled
-        // TODO: implement
-        console.log('TODO: Show disable view');
+        this.$el.html(UserOtpDisableTemplate());
     }
 });
 

--- a/clients/web/src/views/widgets/UserOtpManagementWidget.js
+++ b/clients/web/src/views/widgets/UserOtpManagementWidget.js
@@ -4,23 +4,23 @@ import OTPAuth from 'url-otpauth';
 import View from 'girder/views/View';
 
 import UserOtpBeginTemplate from 'girder/templates/widgets/userOtpBegin.pug';
-import UserOtpConfirmationTemplate from 'girder/templates/widgets/userOtpConfirmation.pug';
+import UserOtpEnableTemplate from 'girder/templates/widgets/userOtpEnable.pug';
 import UserOtpDisableTemplate from 'girder/templates/widgets/userOtpDisable.pug';
 import 'girder/stylesheets/widgets/userOtpManagementWidget.styl';
 
 const UserOtpManagementWidget = View.extend({
     events: {
-        'click #g-user-otp-initialize': function () {
-            this.model.initializeOtp()
+        'click #g-user-otp-initialize-enable': function () {
+            this.model.initializeEnableOtp()
                 .done((totpUri) => {
                     this.totpUri = totpUri;
                     this.render();
                 });
         },
-        'click #g-user-otp-finalize': function () {
+        'click #g-user-otp-finalize-enable': function () {
             const otpToken = this.$('#g-user-otp-token').val().trim();
 
-            this.model.finializeOtp(otpToken)
+            this.model.finializeEnableOtp(otpToken)
                 .done(() => {
                     // TODO: show confirmation
                     console.log('Confirm success');
@@ -32,12 +32,12 @@ const UserOtpManagementWidget = View.extend({
                     console.log('Finalize failed', err);
                 });
         },
-        'click #g-user-otp-cancel': function () {
+        'click #g-user-otp-cancel-enable': function () {
             this.totpUri = undefined;
             this.render();
         },
-        'click #g-user-otp-remove': function () {
-            this.model.removeOtp()
+        'click #g-user-otp-disable': function () {
+            this.model.disableOtp()
                 .done(() => {
                     this.render();
                 })
@@ -83,7 +83,7 @@ const UserOtpManagementWidget = View.extend({
         // The OTP URI format is defined at https://github.com/google/google-authenticator/wiki/Key-Uri-Format
         const totpInfo = OTPAuth.parse(this.totpUri);
 
-        this.$el.html(UserOtpConfirmationTemplate({
+        this.$el.html(UserOtpEnableTemplate({
             totpInfo: totpInfo
         }));
 

--- a/clients/web/src/views/widgets/UserOtpManagementWidget.js
+++ b/clients/web/src/views/widgets/UserOtpManagementWidget.js
@@ -20,16 +20,20 @@ const UserOtpManagementWidget = View.extend({
         'click #g-user-otp-finalize-enable': function () {
             const otpToken = this.$('#g-user-otp-token').val().trim();
 
+            if (otpToken.length !== 6) {
+                this.$('#g-account-otp-error').text('Enter a 6-digit token.');
+                return;
+            } else {
+                this.$('#g-account-otp-error').text('');
+            }
+
             this.model.finializeEnableOtp(otpToken)
                 .done(() => {
-                    // TODO: show confirmation
-                    console.log('Confirm success');
                     this.totpUri = undefined;
                     this.render();
                 })
                 .fail((err) => {
-                    // TODO: render error message
-                    console.log('Finalize failed', err);
+                    this.$('#g-account-otp-error').text(err.responseJSON.message);
                 });
         },
         'click #g-user-otp-cancel-enable': function () {
@@ -40,10 +44,6 @@ const UserOtpManagementWidget = View.extend({
             this.model.disableOtp()
                 .done(() => {
                     this.render();
-                })
-                .fail((err) => {
-                    // TODO: render error message
-                    console.log('Remove failed', err);
                 });
         }
     },

--- a/clients/web/src/views/widgets/UserOtpManagementWidget.js
+++ b/clients/web/src/views/widgets/UserOtpManagementWidget.js
@@ -7,7 +7,7 @@ import events from 'girder/events';
 
 import UserOtpBeginTemplate from 'girder/templates/widgets/userOtpBegin.pug';
 import UserOtpConfirmationTemplate from 'girder/templates/widgets/userOtpConfirmation.pug';
-import 'girder/stylesheets/widgets/userOTPManagementWidget.styl';
+import 'girder/stylesheets/widgets/userOtpManagementWidget.styl';
 
 const UserOtpManagementWidget = View.extend({
     events: {

--- a/clients/web/test/spec/userSpec.js
+++ b/clients/web/test/spec/userSpec.js
@@ -362,6 +362,29 @@ describe('test the API key management tab', function () {
     });
 });
 
+describe('test the API key management tab', function () {
+    it('go to the two-factor authentication tab', function () {
+        runs(function () {
+            $('.g-account-tabs li>a[name="otp"]').click();
+        });
+        waitsFor(function () {
+            return $('.g-account-otp-info-text').length > 0;
+        }, 'tab to display');
+    });
+
+    it('begin activation of 2FA', function () {
+        runs(function () {
+            $('#g-user-otp-initialize').click();
+        });
+        waitsFor(function () {
+            return $('.g-account-otp-enter-manual').length > 0;
+        }, 'OTP key parameters to display');
+    });
+
+    // Further client testing requires a Javascript TOTP implementation, which is too difficult to provide in the
+    // current testing environment
+});
+
 describe('test email verification', function () {
     it('Turn on email verification', function () {
         girderTest.logout()();

--- a/clients/web/test/spec/userSpec.js
+++ b/clients/web/test/spec/userSpec.js
@@ -374,7 +374,7 @@ describe('test the API key management tab', function () {
 
     it('begin activation of 2FA', function () {
         runs(function () {
-            $('#g-user-otp-initialize').click();
+            $('#g-user-otp-initialize-enable').click();
         });
         waitsFor(function () {
             return $('.g-account-otp-enter-manual').length > 0;

--- a/docs/sftp.rst
+++ b/docs/sftp.rst
@@ -23,3 +23,6 @@ not pass an explicit path to an RSA private key file, the service will look for 
 
 You can control the port on which the server binds by passing a ``-p <port>`` argument to the
 server CLI. The default port is 8022.
+
+.. note:: If SFTP clients are logging in as a user with two-factor authentication (one-time passwords) enabled, they
+   must append the one-time authentication code to the user's basic password.

--- a/girder/__init__.py
+++ b/girder/__init__.py
@@ -28,7 +28,7 @@ import traceback
 
 from girder.constants import LOG_ROOT, MAX_LOG_SIZE, LOG_BACKUP_COUNT, TerminalColor, VERSION
 from girder.utility import config, mkdir
-from girder.utility._cache import cache, requestCache
+from girder.utility._cache import cache, requestCache, rateLimitBuffer
 
 __version__ = '2.5.0'
 __license__ = 'Apache 2.0'
@@ -288,6 +288,10 @@ def _setupCache():
         # Reset caches back to null cache (in the case of server teardown)
         cache.configure(backend='dogpile.cache.null', replace_existing_backend=True)
         requestCache.configure(backend='dogpile.cache.null', replace_existing_backend=True)
+
+    # Although the rateLimitBuffer has no pre-existing backend, this method may be called multiple
+    # times in testing (where caches were already configured)
+    rateLimitBuffer.configure(backend='dogpile.cache.memory', replace_existing_backend=True)
 
 
 # Expose common logging levels and colors as methods of logprint.

--- a/girder/api/sftp.py
+++ b/girder/api/sftp.py
@@ -228,6 +228,7 @@ class _ServerAdapter(paramiko.ServerInterface):
             return paramiko.AUTH_SUCCESSFUL
 
         try:
+            # TODO: otp
             self.girderUser = User().authenticate(username, password)
             return paramiko.AUTH_SUCCESSFUL
         except AccessException:

--- a/girder/api/sftp.py
+++ b/girder/api/sftp.py
@@ -228,8 +228,7 @@ class _ServerAdapter(paramiko.ServerInterface):
             return paramiko.AUTH_SUCCESSFUL
 
         try:
-            # TODO: otp
-            self.girderUser = User().authenticate(username, password)
+            self.girderUser = User().authenticate(username, password, otpToken=True)
             return paramiko.AUTH_SUCCESSFUL
         except AccessException:
             return paramiko.AUTH_FAILED

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -101,7 +101,7 @@ class User(Resource):
         Description('Log in to the system.')
         .notes('Pass your username and password using HTTP Basic Auth. Sends'
                ' a cookie that should be passed back in future requests.')
-        .param('Girder-OTP', 'A one-time-password for this user', paramType='header',
+        .param('Girder-OTP', 'A one-time password for this user', paramType='header',
                required=False)
         .errorResponse('Missing Authorization header.', 401)
         .errorResponse('Invalid login or password.', 403)
@@ -397,7 +397,7 @@ class User(Resource):
     @autoDescribeRoute(
         Description('Finalize the enablement of one-time passwords for this user.')
         .modelParam('id', model=UserModel, level=AccessType.ADMIN)
-        .param('Girder-OTP', 'A one-time-password for this user', paramType='header')
+        .param('Girder-OTP', 'A one-time password for this user', paramType='header')
         .errorResponse()
         .errorResponse('Admin access was denied on the user.', 403)
     )
@@ -428,7 +428,7 @@ class User(Resource):
         if not self._model.hasOtp(user):
             raise RestException('The user has not enabled one-time passwords.')
 
-        del self._model['otp']
+        del user['otp']
         self._model.save(user)
 
     @access.public

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -388,12 +388,10 @@ class User(Resource):
         if self._model.hasOtp(user):
             raise RestException('The user has already enabled one-time passwords.')
 
-        otpUri = self._model.initializeOtp(user)
+        otpUris = self._model.initializeOtp(user)
         self._model.save(user)
 
-        return {
-            'otpUri': otpUri
-        }
+        return otpUris
 
     @access.user
     @autoDescribeRoute(

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -385,7 +385,7 @@ class User(Resource):
         .errorResponse('Admin access was denied on the user.', 403)
     )
     def initializeOtp(self, user):
-        if self._model.hasOtp(user):
+        if self._model.hasOtpEnabled(user):
             raise RestException('The user has already enabled one-time passwords.')
 
         otpUris = self._model.initializeOtp(user)
@@ -408,7 +408,7 @@ class User(Resource):
 
         if 'otp' not in user:
             raise RestException('The user has not initialized one-time passwords.')
-        if self._model.hasOtp(user):
+        if self._model.hasOtpEnabled(user):
             raise RestException('The user has already enabled one-time passwords.')
 
         user['otp']['enabled'] = True
@@ -425,7 +425,7 @@ class User(Resource):
         .errorResponse('Admin access was denied on the user.', 403)
     )
     def removeOtp(self, user):
-        if not self._model.hasOtp(user):
+        if not self._model.hasOtpEnabled(user):
             raise RestException('The user has not enabled one-time passwords.')
 
         del user['otp']

--- a/girder/constants.py
+++ b/girder/constants.py
@@ -209,7 +209,7 @@ class SettingDefault(object):
         # changes to the CORS origin
         SettingKey.CORS_ALLOW_HEADERS:
             'Accept-Encoding, Authorization, Content-Disposition, '
-            'Content-Type, Cookie, Girder-Authorization, Girder-Token',
+            'Content-Type, Cookie, Girder-Authorization, Girder-OTP, Girder-Token',
         # An apache server using reverse proxy would also need
         #  X-Requested-With, X-Forwarded-Server, X-Forwarded-For,
         #  X-Forwarded-Host, Remote-Addr

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -284,8 +284,8 @@ class User(AccessControlledModel):
         This does not save the modified user model.
 
         :param user: The user to modify.
-        :return: The new OTP key, in KeyUriFormat.
-        :rtype: str
+        :return: The new OTP keys, each in KeyUriFormat.
+        :rtype: dict
         """
         totp = self._TotpFactory.new()
 
@@ -294,7 +294,9 @@ class User(AccessControlledModel):
             'totp': totp.to_dict()
         }
 
-        return totp.to_uri(label=user['login'])
+        return {
+            'totpUri': totp.to_uri(label=user['login'])
+        }
 
     def hasOtp(self, user):
         return 'otp' in user and user['otp']['enabled']

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -351,7 +351,6 @@ class User(AccessControlledModel):
             totpMatch = self._TotpFactory.verify(
                 otpToken, user['otp']['totp'], last_counter=lastCounter)
         except TokenError as e:
-            # TODO: implement rate limiting
             raise AccessException('One-time password validation failed: %s' % e)
 
         # The totpMatch.cache_seconds tells us prospectively how long the counter needs to be cached

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -180,7 +180,7 @@ class User(AccessControlledModel):
             raise AccessException('Login failed.')
 
         # Handle OTP token concatenation
-        if otpToken is True and self.hasOtp(user):
+        if otpToken is True and self.hasOtpEnabled(user):
             # Assume the last (typically 6) characters are the OTP, so split at that point
             otpTokenLength = self._TotpFactory.digits
             otpToken = password[-otpTokenLength:]
@@ -191,7 +191,7 @@ class User(AccessControlledModel):
             raise AccessException('Login failed.')
 
         # Verify OTP
-        if self.hasOtp(user):
+        if self.hasOtpEnabled(user):
             if otpToken is None:
                 raise AccessException(
                     'User authentication must include a one-time password '
@@ -324,7 +324,7 @@ class User(AccessControlledModel):
             'totpUri': totp.to_uri(label=user['login'])
         }
 
-    def hasOtp(self, user):
+    def hasOtpEnabled(self, user):
         return 'otp' in user and user['otp']['enabled']
 
     def verifyOtp(self, user, otpToken):

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -138,6 +138,15 @@ class User(AccessControlledModel):
 
         return doc
 
+    def filter(self, doc, user, additionalKeys=None):
+        filteredDoc = super(User, self).filter(doc, user, additionalKeys)
+
+        level = self.getAccessLevel(doc, user)
+        if level >= AccessType.ADMIN:
+            filteredDoc['otp'] = doc.get('otp', {}).get('enabled', False)
+
+        return filteredDoc
+
     def authenticate(self, login, password, otpToken=None):
         """
         Validate a user login via username and password. If authentication fails,

--- a/girder/utility/_cache.py
+++ b/girder/utility/_cache.py
@@ -29,3 +29,8 @@ register_backend('cherrypy_request', 'girder.utility._cache', 'CherrypyRequestBa
 # doesn't occur when using Girder as a library.
 cache = make_region(name='girder.cache').configure(backend='dogpile.cache.null')
 requestCache = make_region(name='girder.request').configure(backend='dogpile.cache.null')
+
+# This cache is not configurable by the user, and will always be configured when the server is.
+# It holds data for rate limiting, which is ephemeral, but must be persisted (i.e. it's not optional
+# or best-effort).
+rateLimitBuffer = make_region(name='girder.rate_limit')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1153,6 +1153,14 @@
                 "map-obj": "1.0.1"
             }
         },
+        "can-promise": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/can-promise/-/can-promise-0.0.1.tgz",
+            "integrity": "sha512-gzVrHyyrvgt0YpDm7pn04MQt8gjh0ZAhN4ZDyCRtGl6YnuuK6b4aiUTD7G52r9l4YNmxfTtEscb92vxtAlL6XQ==",
+            "requires": {
+                "window-or-global": "1.0.1"
+            }
+        },
         "caniuse-api": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
@@ -1576,7 +1584,6 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-            "dev": true,
             "requires": {
                 "lru-cache": "4.1.1",
                 "shebang-command": "1.2.0",
@@ -1906,6 +1913,11 @@
                 "miller-rabin": "4.0.1",
                 "randombytes": "2.0.5"
             }
+        },
+        "dijkstrajs": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.1.tgz",
+            "integrity": "sha1-082BIh4+pAdCz83lVtTpnpjdxxs="
         },
         "doctrine": {
             "version": "2.1.0",
@@ -2788,6 +2800,20 @@
                 "safe-buffer": "5.1.1"
             }
         },
+        "execa": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+            "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+            "requires": {
+                "cross-spawn": "5.1.0",
+                "get-stream": "3.0.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
+            }
+        },
         "exit": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -3130,7 +3156,7 @@
             "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
             "optional": true,
             "requires": {
-                "nan": "2.8.0",
+                "nan": "2.9.2",
                 "node-pre-gyp": "0.6.39"
             },
             "dependencies": {
@@ -3955,6 +3981,11 @@
             "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
             "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
         },
+        "get-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+        },
         "getobject": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
@@ -3980,6 +4011,7 @@
                 "jquery": "3.2.1",
                 "jsoneditor": "5.9.6",
                 "moment": "2.20.1",
+                "qrcode": "1.2.0",
                 "remarkable": "1.7.1",
                 "sprintf-js": "1.1.1",
                 "swagger-ui": "2.2.10",
@@ -5534,6 +5566,14 @@
                 }
             }
         },
+        "mem": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+            "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+            "requires": {
+                "mimic-fn": "1.1.0"
+            }
+        },
         "memory-fs": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -5614,8 +5654,7 @@
         "mimic-fn": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-            "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
-            "dev": true
+            "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
         },
         "minimalistic-assert": {
             "version": "1.0.0",
@@ -5719,9 +5758,9 @@
             "dev": true
         },
         "nan": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-            "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+            "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
             "optional": true
         },
         "natives": {
@@ -5920,7 +5959,8 @@
             "dependencies": {
                 "align-text": {
                     "version": "0.1.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                    "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
                     "dev": true,
                     "requires": {
                         "kind-of": "3.2.2",
@@ -5930,22 +5970,26 @@
                 },
                 "amdefine": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+                    "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
                     "dev": true
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                     "dev": true
                 },
                 "ansi-styles": {
                     "version": "2.2.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
                     "dev": true
                 },
                 "append-transform": {
                     "version": "0.4.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+                    "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
                     "dev": true,
                     "requires": {
                         "default-require-extensions": "1.0.0"
@@ -5953,12 +5997,14 @@
                 },
                 "archy": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+                    "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
                     "dev": true
                 },
                 "arr-diff": {
                     "version": "2.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "dev": true,
                     "requires": {
                         "arr-flatten": "1.1.0"
@@ -5966,27 +6012,32 @@
                 },
                 "arr-flatten": {
                     "version": "1.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+                    "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
                     "dev": true
                 },
                 "array-unique": {
                     "version": "0.2.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
                     "dev": true
                 },
                 "arrify": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+                    "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
                     "dev": true
                 },
                 "async": {
                     "version": "1.5.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
                     "dev": true
                 },
                 "babel-code-frame": {
                     "version": "6.26.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+                    "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
                     "dev": true,
                     "requires": {
                         "chalk": "1.1.3",
@@ -5996,7 +6047,8 @@
                 },
                 "babel-generator": {
                     "version": "6.26.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
+                    "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
                     "dev": true,
                     "requires": {
                         "babel-messages": "6.23.0",
@@ -6011,7 +6063,8 @@
                 },
                 "babel-messages": {
                     "version": "6.23.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+                    "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
                     "dev": true,
                     "requires": {
                         "babel-runtime": "6.26.0"
@@ -6019,7 +6072,8 @@
                 },
                 "babel-runtime": {
                     "version": "6.26.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+                    "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
                     "dev": true,
                     "requires": {
                         "core-js": "2.5.3",
@@ -6028,7 +6082,8 @@
                 },
                 "babel-template": {
                     "version": "6.26.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+                    "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
                     "dev": true,
                     "requires": {
                         "babel-runtime": "6.26.0",
@@ -6040,7 +6095,8 @@
                 },
                 "babel-traverse": {
                     "version": "6.26.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+                    "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
                     "dev": true,
                     "requires": {
                         "babel-code-frame": "6.26.0",
@@ -6056,7 +6112,8 @@
                 },
                 "babel-types": {
                     "version": "6.26.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+                    "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
                     "dev": true,
                     "requires": {
                         "babel-runtime": "6.26.0",
@@ -6067,17 +6124,20 @@
                 },
                 "babylon": {
                     "version": "6.18.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+                    "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
                     "dev": true
                 },
                 "balanced-match": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                     "dev": true
                 },
                 "brace-expansion": {
                     "version": "1.1.8",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                    "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                     "dev": true,
                     "requires": {
                         "balanced-match": "1.0.0",
@@ -6086,7 +6146,8 @@
                 },
                 "braces": {
                     "version": "1.8.5",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
                     "dev": true,
                     "requires": {
                         "expand-range": "1.8.2",
@@ -6096,12 +6157,14 @@
                 },
                 "builtin-modules": {
                     "version": "1.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                    "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
                     "dev": true
                 },
                 "caching-transform": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
+                    "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
                     "dev": true,
                     "requires": {
                         "md5-hex": "1.3.0",
@@ -6111,13 +6174,15 @@
                 },
                 "camelcase": {
                     "version": "1.2.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                    "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
                     "dev": true,
                     "optional": true
                 },
                 "center-align": {
                     "version": "0.1.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                    "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -6127,7 +6192,8 @@
                 },
                 "chalk": {
                     "version": "1.1.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "2.2.1",
@@ -6139,7 +6205,8 @@
                 },
                 "cliui": {
                     "version": "2.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                    "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -6150,7 +6217,8 @@
                     "dependencies": {
                         "wordwrap": {
                             "version": "0.0.2",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                            "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
                             "dev": true,
                             "optional": true
                         }
@@ -6158,32 +6226,38 @@
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                     "dev": true
                 },
                 "commondir": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+                    "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
                     "dev": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                     "dev": true
                 },
                 "convert-source-map": {
                     "version": "1.5.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+                    "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
                     "dev": true
                 },
                 "core-js": {
                     "version": "2.5.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+                    "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
                     "dev": true
                 },
                 "cross-spawn": {
                     "version": "4.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+                    "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
                     "dev": true,
                     "requires": {
                         "lru-cache": "4.1.1",
@@ -6192,7 +6266,8 @@
                 },
                 "debug": {
                     "version": "2.6.9",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
                     "dev": true,
                     "requires": {
                         "ms": "2.0.0"
@@ -6200,17 +6275,20 @@
                 },
                 "debug-log": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+                    "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
                     "dev": true
                 },
                 "decamelize": {
                     "version": "1.2.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                    "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
                     "dev": true
                 },
                 "default-require-extensions": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+                    "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
                     "dev": true,
                     "requires": {
                         "strip-bom": "2.0.0"
@@ -6218,7 +6296,8 @@
                 },
                 "detect-indent": {
                     "version": "4.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+                    "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
                     "dev": true,
                     "requires": {
                         "repeating": "2.0.1"
@@ -6226,7 +6305,8 @@
                 },
                 "error-ex": {
                     "version": "1.3.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+                    "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
                     "dev": true,
                     "requires": {
                         "is-arrayish": "0.2.1"
@@ -6234,17 +6314,20 @@
                 },
                 "escape-string-regexp": {
                     "version": "1.0.5",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
                     "dev": true
                 },
                 "esutils": {
                     "version": "2.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                    "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
                     "dev": true
                 },
                 "execa": {
                     "version": "0.7.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+                    "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                     "dev": true,
                     "requires": {
                         "cross-spawn": "5.1.0",
@@ -6258,7 +6341,8 @@
                     "dependencies": {
                         "cross-spawn": {
                             "version": "5.1.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                            "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                             "dev": true,
                             "requires": {
                                 "lru-cache": "4.1.1",
@@ -6270,7 +6354,8 @@
                 },
                 "expand-brackets": {
                     "version": "0.1.5",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
                     "dev": true,
                     "requires": {
                         "is-posix-bracket": "0.1.1"
@@ -6278,7 +6363,8 @@
                 },
                 "expand-range": {
                     "version": "1.8.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                    "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
                     "dev": true,
                     "requires": {
                         "fill-range": "2.2.3"
@@ -6286,7 +6372,8 @@
                 },
                 "extglob": {
                     "version": "0.3.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
                     "dev": true,
                     "requires": {
                         "is-extglob": "1.0.0"
@@ -6294,12 +6381,14 @@
                 },
                 "filename-regex": {
                     "version": "2.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+                    "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
                     "dev": true
                 },
                 "fill-range": {
                     "version": "2.2.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                    "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
                     "dev": true,
                     "requires": {
                         "is-number": "2.1.0",
@@ -6311,7 +6400,8 @@
                 },
                 "find-cache-dir": {
                     "version": "0.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+                    "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
                     "dev": true,
                     "requires": {
                         "commondir": "1.0.1",
@@ -6321,7 +6411,8 @@
                 },
                 "find-up": {
                     "version": "2.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                     "dev": true,
                     "requires": {
                         "locate-path": "2.0.0"
@@ -6329,12 +6420,14 @@
                 },
                 "for-in": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+                    "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
                     "dev": true
                 },
                 "for-own": {
                     "version": "0.1.5",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                    "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
                     "dev": true,
                     "requires": {
                         "for-in": "1.0.2"
@@ -6342,7 +6435,8 @@
                 },
                 "foreground-child": {
                     "version": "1.5.6",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+                    "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
                     "dev": true,
                     "requires": {
                         "cross-spawn": "4.0.2",
@@ -6351,22 +6445,26 @@
                 },
                 "fs.realpath": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                    "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                     "dev": true
                 },
                 "get-caller-file": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+                    "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
                     "dev": true
                 },
                 "get-stream": {
                     "version": "3.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                    "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
                     "dev": true
                 },
                 "glob": {
                     "version": "7.1.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "1.0.0",
@@ -6379,7 +6477,8 @@
                 },
                 "glob-base": {
                     "version": "0.3.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+                    "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
                     "dev": true,
                     "requires": {
                         "glob-parent": "2.0.0",
@@ -6388,7 +6487,8 @@
                 },
                 "glob-parent": {
                     "version": "2.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "dev": true,
                     "requires": {
                         "is-glob": "2.0.1"
@@ -6396,17 +6496,20 @@
                 },
                 "globals": {
                     "version": "9.18.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+                    "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
                     "dev": true
                 },
                 "graceful-fs": {
                     "version": "4.1.11",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
                     "dev": true
                 },
                 "handlebars": {
                     "version": "4.0.11",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+                    "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
                     "dev": true,
                     "requires": {
                         "async": "1.5.2",
@@ -6417,7 +6520,8 @@
                     "dependencies": {
                         "source-map": {
                             "version": "0.4.4",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                            "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                             "dev": true,
                             "requires": {
                                 "amdefine": "1.0.1"
@@ -6427,7 +6531,8 @@
                 },
                 "has-ansi": {
                     "version": "2.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                    "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                     "dev": true,
                     "requires": {
                         "ansi-regex": "2.1.1"
@@ -6435,22 +6540,26 @@
                 },
                 "has-flag": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
                     "dev": true
                 },
                 "hosted-git-info": {
                     "version": "2.5.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+                    "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
                     "dev": true
                 },
                 "imurmurhash": {
                     "version": "0.1.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+                    "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
                     "dev": true
                 },
                 "inflight": {
                     "version": "1.0.6",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                    "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                     "dev": true,
                     "requires": {
                         "once": "1.4.0",
@@ -6459,12 +6568,14 @@
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
                     "dev": true
                 },
                 "invariant": {
                     "version": "2.2.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                    "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
                     "dev": true,
                     "requires": {
                         "loose-envify": "1.3.1"
@@ -6472,22 +6583,26 @@
                 },
                 "invert-kv": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                    "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
                     "dev": true
                 },
                 "is-arrayish": {
                     "version": "0.2.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                    "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
                     "dev": true
                 },
                 "is-buffer": {
                     "version": "1.1.6",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+                    "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
                     "dev": true
                 },
                 "is-builtin-module": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                    "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
                     "dev": true,
                     "requires": {
                         "builtin-modules": "1.1.1"
@@ -6495,12 +6610,14 @@
                 },
                 "is-dotfile": {
                     "version": "1.0.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+                    "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
                     "dev": true
                 },
                 "is-equal-shallow": {
                     "version": "0.1.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+                    "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
                     "dev": true,
                     "requires": {
                         "is-primitive": "2.0.0"
@@ -6508,17 +6625,20 @@
                 },
                 "is-extendable": {
                     "version": "0.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+                    "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
                     "dev": true
                 },
                 "is-extglob": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
                     "dev": true
                 },
                 "is-finite": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                    "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
                     "dev": true,
                     "requires": {
                         "number-is-nan": "1.0.1"
@@ -6526,7 +6646,8 @@
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "dev": true,
                     "requires": {
                         "number-is-nan": "1.0.1"
@@ -6534,7 +6655,8 @@
                 },
                 "is-glob": {
                     "version": "2.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
                         "is-extglob": "1.0.0"
@@ -6542,7 +6664,8 @@
                 },
                 "is-number": {
                     "version": "2.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+                    "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
                     "dev": true,
                     "requires": {
                         "kind-of": "3.2.2"
@@ -6550,37 +6673,44 @@
                 },
                 "is-posix-bracket": {
                     "version": "0.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+                    "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
                     "dev": true
                 },
                 "is-primitive": {
                     "version": "2.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+                    "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
                     "dev": true
                 },
                 "is-stream": {
                     "version": "1.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                    "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
                     "dev": true
                 },
                 "is-utf8": {
                     "version": "0.2.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+                    "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
                     "dev": true
                 },
                 "isarray": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                     "dev": true
                 },
                 "isexe": {
                     "version": "2.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+                    "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
                     "dev": true
                 },
                 "isobject": {
                     "version": "2.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                    "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
                     "dev": true,
                     "requires": {
                         "isarray": "1.0.0"
@@ -6588,12 +6718,14 @@
                 },
                 "istanbul-lib-coverage": {
                     "version": "1.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+                    "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
                     "dev": true
                 },
                 "istanbul-lib-hook": {
                     "version": "1.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
+                    "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
                     "dev": true,
                     "requires": {
                         "append-transform": "0.4.0"
@@ -6601,7 +6733,8 @@
                 },
                 "istanbul-lib-instrument": {
                     "version": "1.9.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz",
+                    "integrity": "sha512-RQmXeQ7sphar7k7O1wTNzVczF9igKpaeGQAG9qR2L+BS4DCJNTI9nytRmIVYevwO0bbq+2CXvJmYDuz0gMrywA==",
                     "dev": true,
                     "requires": {
                         "babel-generator": "6.26.0",
@@ -6615,7 +6748,8 @@
                 },
                 "istanbul-lib-report": {
                     "version": "1.1.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz",
+                    "integrity": "sha512-UTv4VGx+HZivJQwAo1wnRwe1KTvFpfi/NYwN7DcsrdzMXwpRT/Yb6r4SBPoHWj4VuQPakR32g4PUUeyKkdDkBA==",
                     "dev": true,
                     "requires": {
                         "istanbul-lib-coverage": "1.1.1",
@@ -6626,7 +6760,8 @@
                     "dependencies": {
                         "supports-color": {
                             "version": "3.2.3",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                            "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                             "dev": true,
                             "requires": {
                                 "has-flag": "1.0.0"
@@ -6636,7 +6771,8 @@
                 },
                 "istanbul-lib-source-maps": {
                     "version": "1.2.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz",
+                    "integrity": "sha512-8BfdqSfEdtip7/wo1RnrvLpHVEd8zMZEDmOFEnpC6dg0vXflHt9nvoAyQUzig2uMSXfF2OBEYBV3CVjIL9JvaQ==",
                     "dev": true,
                     "requires": {
                         "debug": "3.1.0",
@@ -6648,7 +6784,8 @@
                     "dependencies": {
                         "debug": {
                             "version": "3.1.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
                             "dev": true,
                             "requires": {
                                 "ms": "2.0.0"
@@ -6658,7 +6795,8 @@
                 },
                 "istanbul-reports": {
                     "version": "1.1.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.3.tgz",
+                    "integrity": "sha512-ZEelkHh8hrZNI5xDaKwPMFwDsUf5wIEI2bXAFGp1e6deR2mnEKBPhLJEgr4ZBt8Gi6Mj38E/C8kcy9XLggVO2Q==",
                     "dev": true,
                     "requires": {
                         "handlebars": "4.0.11"
@@ -6666,17 +6804,20 @@
                 },
                 "js-tokens": {
                     "version": "3.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+                    "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
                     "dev": true
                 },
                 "jsesc": {
                     "version": "1.3.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+                    "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
                     "dev": true
                 },
                 "kind-of": {
                     "version": "3.2.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
                         "is-buffer": "1.1.6"
@@ -6684,13 +6825,15 @@
                 },
                 "lazy-cache": {
                     "version": "1.0.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+                    "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
                     "dev": true,
                     "optional": true
                 },
                 "lcid": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                    "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
                     "dev": true,
                     "requires": {
                         "invert-kv": "1.0.0"
@@ -6698,7 +6841,8 @@
                 },
                 "load-json-file": {
                     "version": "1.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                    "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                     "dev": true,
                     "requires": {
                         "graceful-fs": "4.1.11",
@@ -6710,7 +6854,8 @@
                 },
                 "locate-path": {
                     "version": "2.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
                     "dev": true,
                     "requires": {
                         "p-locate": "2.0.0",
@@ -6719,24 +6864,28 @@
                     "dependencies": {
                         "path-exists": {
                             "version": "3.0.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
                             "dev": true
                         }
                     }
                 },
                 "lodash": {
                     "version": "4.17.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+                    "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
                     "dev": true
                 },
                 "longest": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                    "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
                     "dev": true
                 },
                 "loose-envify": {
                     "version": "1.3.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                    "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
                     "dev": true,
                     "requires": {
                         "js-tokens": "3.0.2"
@@ -6744,7 +6893,8 @@
                 },
                 "lru-cache": {
                     "version": "4.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+                    "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
                     "dev": true,
                     "requires": {
                         "pseudomap": "1.0.2",
@@ -6753,7 +6903,8 @@
                 },
                 "md5-hex": {
                     "version": "1.3.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+                    "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
                     "dev": true,
                     "requires": {
                         "md5-o-matic": "0.1.1"
@@ -6761,12 +6912,14 @@
                 },
                 "md5-o-matic": {
                     "version": "0.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+                    "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
                     "dev": true
                 },
                 "mem": {
                     "version": "1.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+                    "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
                     "dev": true,
                     "requires": {
                         "mimic-fn": "1.1.0"
@@ -6774,7 +6927,8 @@
                 },
                 "merge-source-map": {
                     "version": "1.0.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
+                    "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
                     "dev": true,
                     "requires": {
                         "source-map": "0.5.7"
@@ -6782,7 +6936,8 @@
                 },
                 "micromatch": {
                     "version": "2.3.11",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
                     "dev": true,
                     "requires": {
                         "arr-diff": "2.0.0",
@@ -6802,12 +6957,14 @@
                 },
                 "mimic-fn": {
                     "version": "1.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+                    "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
                     "dev": true
                 },
                 "minimatch": {
                     "version": "3.0.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                     "dev": true,
                     "requires": {
                         "brace-expansion": "1.1.8"
@@ -6815,12 +6972,14 @@
                 },
                 "minimist": {
                     "version": "0.0.8",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                     "dev": true
                 },
                 "mkdirp": {
                     "version": "0.5.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                    "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                     "dev": true,
                     "requires": {
                         "minimist": "0.0.8"
@@ -6828,12 +6987,14 @@
                 },
                 "ms": {
                     "version": "2.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                     "dev": true
                 },
                 "normalize-package-data": {
                     "version": "2.4.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+                    "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
                     "dev": true,
                     "requires": {
                         "hosted-git-info": "2.5.0",
@@ -6844,7 +7005,8 @@
                 },
                 "normalize-path": {
                     "version": "2.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                    "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
                     "dev": true,
                     "requires": {
                         "remove-trailing-separator": "1.1.0"
@@ -6852,7 +7014,8 @@
                 },
                 "npm-run-path": {
                     "version": "2.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+                    "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
                     "dev": true,
                     "requires": {
                         "path-key": "2.0.1"
@@ -6860,17 +7023,20 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                     "dev": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                     "dev": true
                 },
                 "object.omit": {
                     "version": "2.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+                    "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
                     "dev": true,
                     "requires": {
                         "for-own": "0.1.5",
@@ -6879,7 +7045,8 @@
                 },
                 "once": {
                     "version": "1.4.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                     "dev": true,
                     "requires": {
                         "wrappy": "1.0.2"
@@ -6887,7 +7054,8 @@
                 },
                 "optimist": {
                     "version": "0.6.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                    "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
                     "dev": true,
                     "requires": {
                         "minimist": "0.0.8",
@@ -6896,12 +7064,14 @@
                 },
                 "os-homedir": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                    "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                     "dev": true
                 },
                 "os-locale": {
                     "version": "2.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+                    "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
                     "dev": true,
                     "requires": {
                         "execa": "0.7.0",
@@ -6911,17 +7081,20 @@
                 },
                 "p-finally": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+                    "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
                     "dev": true
                 },
                 "p-limit": {
                     "version": "1.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+                    "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
                     "dev": true
                 },
                 "p-locate": {
                     "version": "2.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
                     "dev": true,
                     "requires": {
                         "p-limit": "1.1.0"
@@ -6929,7 +7102,8 @@
                 },
                 "parse-glob": {
                     "version": "3.0.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                    "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
                     "dev": true,
                     "requires": {
                         "glob-base": "0.3.0",
@@ -6940,7 +7114,8 @@
                 },
                 "parse-json": {
                     "version": "2.2.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                    "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                     "dev": true,
                     "requires": {
                         "error-ex": "1.3.1"
@@ -6948,7 +7123,8 @@
                 },
                 "path-exists": {
                     "version": "2.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "dev": true,
                     "requires": {
                         "pinkie-promise": "2.0.1"
@@ -6956,22 +7132,26 @@
                 },
                 "path-is-absolute": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                    "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                     "dev": true
                 },
                 "path-key": {
                     "version": "2.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+                    "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
                     "dev": true
                 },
                 "path-parse": {
                     "version": "1.0.5",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+                    "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
                     "dev": true
                 },
                 "path-type": {
                     "version": "1.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                    "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                     "dev": true,
                     "requires": {
                         "graceful-fs": "4.1.11",
@@ -6981,17 +7161,20 @@
                 },
                 "pify": {
                     "version": "2.3.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                     "dev": true
                 },
                 "pinkie": {
                     "version": "2.0.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                    "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
                     "dev": true
                 },
                 "pinkie-promise": {
                     "version": "2.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                    "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                     "dev": true,
                     "requires": {
                         "pinkie": "2.0.4"
@@ -6999,7 +7182,8 @@
                 },
                 "pkg-dir": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+                    "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
                     "dev": true,
                     "requires": {
                         "find-up": "1.1.2"
@@ -7007,7 +7191,8 @@
                     "dependencies": {
                         "find-up": {
                             "version": "1.1.2",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                            "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                             "dev": true,
                             "requires": {
                                 "path-exists": "2.1.0",
@@ -7018,17 +7203,20 @@
                 },
                 "preserve": {
                     "version": "0.2.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+                    "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
                     "dev": true
                 },
                 "pseudomap": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+                    "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
                     "dev": true
                 },
                 "randomatic": {
                     "version": "1.1.7",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+                    "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
                     "dev": true,
                     "requires": {
                         "is-number": "3.0.0",
@@ -7037,7 +7225,8 @@
                     "dependencies": {
                         "is-number": {
                             "version": "3.0.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                            "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                             "dev": true,
                             "requires": {
                                 "kind-of": "3.2.2"
@@ -7045,7 +7234,8 @@
                             "dependencies": {
                                 "kind-of": {
                                     "version": "3.2.2",
-                                    "bundled": true,
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
                                         "is-buffer": "1.1.6"
@@ -7055,7 +7245,8 @@
                         },
                         "kind-of": {
                             "version": "4.0.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                            "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                             "dev": true,
                             "requires": {
                                 "is-buffer": "1.1.6"
@@ -7065,7 +7256,8 @@
                 },
                 "read-pkg": {
                     "version": "1.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                    "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                     "dev": true,
                     "requires": {
                         "load-json-file": "1.1.0",
@@ -7075,7 +7267,8 @@
                 },
                 "read-pkg-up": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                    "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
                     "dev": true,
                     "requires": {
                         "find-up": "1.1.2",
@@ -7084,7 +7277,8 @@
                     "dependencies": {
                         "find-up": {
                             "version": "1.1.2",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                            "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                             "dev": true,
                             "requires": {
                                 "path-exists": "2.1.0",
@@ -7095,12 +7289,14 @@
                 },
                 "regenerator-runtime": {
                     "version": "0.11.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+                    "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
                     "dev": true
                 },
                 "regex-cache": {
                     "version": "0.4.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+                    "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
                     "dev": true,
                     "requires": {
                         "is-equal-shallow": "0.1.3"
@@ -7108,22 +7304,26 @@
                 },
                 "remove-trailing-separator": {
                     "version": "1.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+                    "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
                     "dev": true
                 },
                 "repeat-element": {
                     "version": "1.1.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+                    "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
                     "dev": true
                 },
                 "repeat-string": {
                     "version": "1.6.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                    "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
                     "dev": true
                 },
                 "repeating": {
                     "version": "2.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+                    "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
                     "dev": true,
                     "requires": {
                         "is-finite": "1.0.2"
@@ -7131,22 +7331,26 @@
                 },
                 "require-directory": {
                     "version": "2.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+                    "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
                     "dev": true
                 },
                 "require-main-filename": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+                    "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
                     "dev": true
                 },
                 "resolve-from": {
                     "version": "2.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+                    "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
                     "dev": true
                 },
                 "right-align": {
                     "version": "0.1.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                    "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -7155,7 +7359,8 @@
                 },
                 "rimraf": {
                     "version": "2.6.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+                    "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
                     "dev": true,
                     "requires": {
                         "glob": "7.1.2"
@@ -7163,17 +7368,20 @@
                 },
                 "semver": {
                     "version": "5.4.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+                    "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
                     "dev": true
                 },
                 "set-blocking": {
                     "version": "2.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+                    "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                     "dev": true
                 },
                 "shebang-command": {
                     "version": "1.2.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+                    "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
                     "dev": true,
                     "requires": {
                         "shebang-regex": "1.0.0"
@@ -7181,27 +7389,32 @@
                 },
                 "shebang-regex": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                    "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
                     "dev": true
                 },
                 "signal-exit": {
                     "version": "3.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                    "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                     "dev": true
                 },
                 "slide": {
                     "version": "1.1.6",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+                    "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
                     "dev": true
                 },
                 "source-map": {
                     "version": "0.5.7",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
                     "dev": true
                 },
                 "spawn-wrap": {
                     "version": "1.4.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
+                    "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
                     "dev": true,
                     "requires": {
                         "foreground-child": "1.5.6",
@@ -7214,7 +7427,8 @@
                 },
                 "spdx-correct": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                    "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
                     "dev": true,
                     "requires": {
                         "spdx-license-ids": "1.2.2"
@@ -7222,17 +7436,20 @@
                 },
                 "spdx-expression-parse": {
                     "version": "1.0.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+                    "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
                     "dev": true
                 },
                 "spdx-license-ids": {
                     "version": "1.2.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+                    "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
                     "dev": true
                 },
                 "string-width": {
                     "version": "2.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
                         "is-fullwidth-code-point": "2.0.0",
@@ -7241,17 +7458,20 @@
                     "dependencies": {
                         "ansi-regex": {
                             "version": "3.0.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                            "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                             "dev": true
                         },
                         "is-fullwidth-code-point": {
                             "version": "2.0.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                             "dev": true
                         },
                         "strip-ansi": {
                             "version": "4.0.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                             "dev": true,
                             "requires": {
                                 "ansi-regex": "3.0.0"
@@ -7261,7 +7481,8 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
                         "ansi-regex": "2.1.1"
@@ -7269,7 +7490,8 @@
                 },
                 "strip-bom": {
                     "version": "2.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
                         "is-utf8": "0.2.1"
@@ -7277,17 +7499,20 @@
                 },
                 "strip-eof": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+                    "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
                     "dev": true
                 },
                 "supports-color": {
                     "version": "2.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
                     "dev": true
                 },
                 "test-exclude": {
                     "version": "4.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
+                    "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
                     "dev": true,
                     "requires": {
                         "arrify": "1.0.1",
@@ -7299,17 +7524,20 @@
                 },
                 "to-fast-properties": {
                     "version": "1.0.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                    "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
                     "dev": true
                 },
                 "trim-right": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+                    "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
                     "dev": true
                 },
                 "uglify-js": {
                     "version": "2.8.29",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+                    "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -7320,7 +7548,8 @@
                     "dependencies": {
                         "yargs": {
                             "version": "3.10.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                            "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -7334,13 +7563,15 @@
                 },
                 "uglify-to-browserify": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                    "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
                     "dev": true,
                     "optional": true
                 },
                 "validate-npm-package-license": {
                     "version": "3.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                    "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
                     "dev": true,
                     "requires": {
                         "spdx-correct": "1.0.2",
@@ -7349,7 +7580,8 @@
                 },
                 "which": {
                     "version": "1.3.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+                    "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
                     "dev": true,
                     "requires": {
                         "isexe": "2.0.0"
@@ -7357,23 +7589,27 @@
                 },
                 "which-module": {
                     "version": "2.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
                     "dev": true
                 },
                 "window-size": {
                     "version": "0.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                    "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
                     "dev": true,
                     "optional": true
                 },
                 "wordwrap": {
                     "version": "0.0.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                    "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
                     "dev": true
                 },
                 "wrap-ansi": {
                     "version": "2.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+                    "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
                     "dev": true,
                     "requires": {
                         "string-width": "1.0.2",
@@ -7382,7 +7618,8 @@
                     "dependencies": {
                         "string-width": {
                             "version": "1.0.2",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                             "dev": true,
                             "requires": {
                                 "code-point-at": "1.1.0",
@@ -7394,12 +7631,14 @@
                 },
                 "wrappy": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                     "dev": true
                 },
                 "write-file-atomic": {
                     "version": "1.3.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+                    "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
                     "dev": true,
                     "requires": {
                         "graceful-fs": "4.1.11",
@@ -7409,17 +7648,20 @@
                 },
                 "y18n": {
                     "version": "3.2.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+                    "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
                     "dev": true
                 },
                 "yallist": {
                     "version": "2.1.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                    "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
                     "dev": true
                 },
                 "yargs": {
                     "version": "10.0.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+                    "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
                     "dev": true,
                     "requires": {
                         "cliui": "3.2.0",
@@ -7438,7 +7680,8 @@
                     "dependencies": {
                         "cliui": {
                             "version": "3.2.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                            "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                             "dev": true,
                             "requires": {
                                 "string-width": "1.0.2",
@@ -7448,7 +7691,8 @@
                             "dependencies": {
                                 "string-width": {
                                     "version": "1.0.2",
-                                    "bundled": true,
+                                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                                     "dev": true,
                                     "requires": {
                                         "code-point-at": "1.1.0",
@@ -7462,7 +7706,8 @@
                 },
                 "yargs-parser": {
                     "version": "8.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
+                    "integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
                     "dev": true,
                     "requires": {
                         "camelcase": "4.1.0"
@@ -7470,7 +7715,8 @@
                     "dependencies": {
                         "camelcase": {
                             "version": "4.1.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                            "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
                             "dev": true
                         }
                     }
@@ -7563,6 +7809,11 @@
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/over/-/over-0.0.5.tgz",
             "integrity": "sha1-8phS5w/X4l82DgE6jsRMgq7bVwg="
+        },
+        "p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
         },
         "p-limit": {
             "version": "1.2.0",
@@ -7799,6 +8050,11 @@
             "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
             "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
             "dev": true
+        },
+        "pngjs": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.3.2.tgz",
+            "integrity": "sha512-bVNd3LMXRzdo6s4ehr4XW2wFMu9cb40nPgHEjSSppm8/++Xc+g0b2QQb+SeDesgfANXbjydOr1or9YQ+pcCZPQ=="
         },
         "postcss": {
             "version": "5.2.18",
@@ -8719,6 +8975,172 @@
             "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
             "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
         },
+        "qrcode": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.2.0.tgz",
+            "integrity": "sha512-wZK0Z0eYmOUDP2tOGzmLdeBn5Npa+4wms9GdvzH7HrywvGUq/Stz0BKUhW4DfmBf1PSrm9dNfdnVDq683Zxvag==",
+            "requires": {
+                "can-promise": "0.0.1",
+                "dijkstrajs": "1.0.1",
+                "isarray": "2.0.4",
+                "pngjs": "3.3.2",
+                "yargs": "8.0.2"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+                },
+                "camelcase": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+                },
+                "cliui": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                    "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                    "requires": {
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wrap-ansi": "2.1.0"
+                    },
+                    "dependencies": {
+                        "string-width": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                            "requires": {
+                                "code-point-at": "1.1.0",
+                                "is-fullwidth-code-point": "1.0.0",
+                                "strip-ansi": "3.0.1"
+                            }
+                        }
+                    }
+                },
+                "isarray": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.4.tgz",
+                    "integrity": "sha512-GMxXOiUirWg1xTKRipM0Ek07rX+ubx4nNVElTJdNLYmNO/2YrDkgJGw9CljXn+r4EWiDQg/8lsRdHyg2PJuUaA=="
+                },
+                "load-json-file": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+                    "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "strip-bom": "3.0.0"
+                    }
+                },
+                "os-locale": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+                    "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+                    "requires": {
+                        "execa": "0.7.0",
+                        "lcid": "1.0.0",
+                        "mem": "1.1.0"
+                    }
+                },
+                "path-type": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+                    "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+                    "requires": {
+                        "pify": "2.3.0"
+                    }
+                },
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                },
+                "read-pkg": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+                    "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+                    "requires": {
+                        "load-json-file": "2.0.0",
+                        "normalize-package-data": "2.4.0",
+                        "path-type": "2.0.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+                    "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+                    "requires": {
+                        "find-up": "2.1.0",
+                        "read-pkg": "2.0.0"
+                    }
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "requires": {
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
+                    },
+                    "dependencies": {
+                        "is-fullwidth-code-point": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+                        },
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                            "requires": {
+                                "ansi-regex": "3.0.0"
+                            }
+                        }
+                    }
+                },
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+                },
+                "which-module": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+                },
+                "yargs": {
+                    "version": "8.0.2",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+                    "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+                    "requires": {
+                        "camelcase": "4.1.0",
+                        "cliui": "3.2.0",
+                        "decamelize": "1.2.0",
+                        "get-caller-file": "1.0.2",
+                        "os-locale": "2.1.0",
+                        "read-pkg-up": "2.0.0",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "2.1.1",
+                        "which-module": "2.0.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "7.0.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+                    "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+                    "requires": {
+                        "camelcase": "4.1.0"
+                    }
+                }
+            }
+        },
         "qs": {
             "version": "6.5.1",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
@@ -9198,7 +9620,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-            "dev": true,
             "requires": {
                 "shebang-regex": "1.0.0"
             }
@@ -9206,8 +9627,7 @@
         "shebang-regex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-            "dev": true
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
         },
         "signal-exit": {
             "version": "3.0.2",
@@ -9437,6 +9857,11 @@
             "requires": {
                 "is-utf8": "0.2.1"
             }
+        },
+        "strip-eof": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
         },
         "strip-indent": {
             "version": "1.0.1",
@@ -10333,6 +10758,11 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
             "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+        },
+        "window-or-global": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/window-or-global/-/window-or-global-1.0.1.tgz",
+            "integrity": "sha1-2+RboqKRqrxW1iz2bEW3+jIpRt4="
         },
         "window-size": {
             "version": "0.1.0",

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ with open('README.rst') as f:
     readme = f.read()
 
 installReqs = [
-    'bcrypt',
     'boto3',
     # CherryPy version is restricted due to a bug in versions >=11.1
     # https://github.com/cherrypy/cherrypy/issues/1662
@@ -71,6 +70,7 @@ installReqs = [
     'funcsigs ; python_version < \'3\'',
     'jsonschema',
     'Mako',
+    'passlib [bcrypt,totp]',
     'pymongo>=3.5',
     'PyYAML',
     'psutil',

--- a/test/test_user_otp.py
+++ b/test/test_user_otp.py
@@ -40,17 +40,17 @@ def testInitializeOtp(user):
     assert 'totp' in user['otp']
 
 
-def testHasOtp(user):
-    assert User().hasOtp(user) is False
+def testHasOtpEnabled(user):
+    assert User().hasOtpEnabled(user) is False
 
     User().initializeOtp(user)
 
     # OTP is not yet enabled
-    assert User().hasOtp(user) is False
+    assert User().hasOtpEnabled(user) is False
 
     user['otp']['enabled'] = True
 
-    assert User().hasOtp(user) is True
+    assert User().hasOtpEnabled(user) is True
 
 
 def _tokenFromTotpUri(totpUri, valid=True):

--- a/test/test_user_otp.py
+++ b/test/test_user_otp.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+import re
+
+import pytest
+
+from girder.exceptions import AccessException
+from girder.models.user import User
+from pytest_girder.assertions import assertStatus, assertStatusOk
+
+
+def testInitializeOtp(user):
+    otpUris = User().initializeOtp(user)
+
+    # A URI for TOTP should be returned
+    assert re.match(r'', otpUris['totpUri'])
+
+    # OTP should not be enabled yet, since it's not finalized
+    assert user['otp']['enabled'] is False
+    # TOTP parameters should be generated
+    assert 'totp' in user['otp']
+
+
+def testHasOtp(user):
+    assert User().hasOtp(user) is False
+
+    User().initializeOtp(user)
+
+    # OTP is not yet enabled
+    assert User().hasOtp(user) is False
+
+    user['otp']['enabled'] = True
+
+    assert User().hasOtp(user) is True
+
+
+def _tokenFromTotpUri(totpUri, valid=True):
+    # Create an external TOTP instance
+    from passlib.totp import TOTP
+    totp = TOTP.from_uri(totpUri)
+
+    # Generate a valid token
+    otpToken = totp.generate().token
+
+    if not valid:
+        # Increment the token by 1 to invalidate it
+        otpToken = str((int(otpToken) + 1) % int(1e6))
+
+    return otpToken
+
+
+def testVerifyOtp(user):
+    # Enable OTP
+    otpUris = User().initializeOtp(user)
+    user['otp']['enabled'] = True
+
+    # Generate an invalid token
+    otpToken = _tokenFromTotpUri(otpUris['totpUri'], False)
+
+    with pytest.raises(AccessException):
+        User().verifyOtp(user, otpToken)
+
+    # Generate a valid token
+    otpToken = _tokenFromTotpUri(otpUris['totpUri'])
+    # Verify the token, which should succeed without raising an exception
+    User().verifyOtp(user, otpToken)
+
+    # Re-verify the same token, which should fail
+    with pytest.raises(AccessException):
+        User().verifyOtp(user, otpToken)
+
+
+def testAuthenticateWithOtp(user):
+    # Providing an unnecessary token should fail
+    with pytest.raises(AccessException):
+        User().authenticate('user', 'password', '123456')
+
+    # Enable OTP and save user
+    otpUris = User().initializeOtp(user)
+    user['otp']['enabled'] = True
+    User().save(user)
+
+    # Providing no token should now fail
+    with pytest.raises(AccessException):
+        User().authenticate('user', 'password')
+
+    # Generate a valid token
+    otpToken = _tokenFromTotpUri(otpUris['totpUri'])
+
+    # Authenticate successfully with the valid token
+    User().authenticate('user', 'password', otpToken)
+
+
+def testOtpAPIWorkflow(server, user):
+    # Try to finalize OTP before it's been initialized
+    resp = server.request(
+        path='/user/%s/otp' % user['_id'], method='PUT', user=user,
+        additionalHeaders=[('Girder-OTP', '123456')])
+    # This should fail cleanly
+    assertStatus(resp, 400)
+    assert 'not initialized' in resp.json['message']
+
+    # Initialize OTP
+    resp = server.request(path='/user/%s/otp' % user['_id'], method='POST', user=user)
+    assertStatusOk(resp)
+    # Save the URI
+    totpUri = resp.json['totpUri']
+
+    # Login without an OTP
+    resp = server.request(path='/user/authentication', method='GET', basicAuth='user:password')
+    # Since OTP has not been finalized, this should still succeed
+    assertStatusOk(resp)
+
+    # Finalize without an OTP
+    resp = server.request(
+        path='/user/%s/otp' % user['_id'], method='PUT', user=user)
+    assertStatus(resp, 400)
+    assert 'Girder-OTP' in resp.json['message']
+
+    # Finalize with an invalid OTP
+    resp = server.request(
+        path='/user/%s/otp' % user['_id'], method='PUT', user=user,
+        additionalHeaders=[('Girder-OTP', _tokenFromTotpUri(totpUri, False))])
+    assertStatus(resp, 403)
+    assert 'validation failed' in resp.json['message']
+
+    # Finalize with a valid OTP
+    resp = server.request(
+        path='/user/%s/otp' % user['_id'], method='PUT', user=user,
+        additionalHeaders=[('Girder-OTP', _tokenFromTotpUri(totpUri))])
+    assertStatusOk(resp)
+
+    # Login without an OTP
+    resp = server.request(path='/user/authentication', method='GET', basicAuth='user:password')
+    assertStatus(resp, 401)
+    assert 'Girder-OTP' in resp.json['message']
+
+    # Login with an invalid OTP
+    resp = server.request(
+        path='/user/authentication', method='GET', basicAuth='user:password',
+        additionalHeaders=[('Girder-OTP', _tokenFromTotpUri(totpUri, False))])
+    assertStatus(resp, 401)
+    assert 'validation failed' in resp.json['message']
+
+    # Login with a valid OTP
+    resp = server.request(
+        path='/user/authentication', method='GET', basicAuth='user:password',
+        additionalHeaders=[('Girder-OTP', _tokenFromTotpUri(totpUri))])
+    assertStatusOk(resp)

--- a/test/test_user_otp.py
+++ b/test/test_user_otp.py
@@ -17,11 +17,11 @@
 #  limitations under the License.
 ###############################################################################
 
-import re
-
 import pytest
 
+from girder.constants import SettingKey
 from girder.exceptions import AccessException
+from girder.models.setting import Setting
 from girder.models.user import User
 from pytest_girder.assertions import assertStatus, assertStatusOk
 
@@ -30,7 +30,9 @@ def testInitializeOtp(user):
     otpUris = User().initializeOtp(user)
 
     # A URI for TOTP should be returned
-    assert re.match(r'', otpUris['totpUri'])
+    assert otpUris['totpUri'].startswith('otpauth://')
+    assert user['login'] in otpUris['totpUri']
+    assert Setting().get(SettingKey.BRAND_NAME) in otpUris['totpUri']
 
     # OTP should not be enabled yet, since it's not finalized
     assert user['otp']['enabled'] is False

--- a/test/test_user_otp.py
+++ b/test/test_user_otp.py
@@ -67,7 +67,7 @@ def _tokenFromTotpUri(totpUri, valid=True):
 
     if not valid:
         # Increment the token by 1 to invalidate it
-        otpToken = str((int(otpToken) + 1) % int(1e6))
+        otpToken = '%06d' % ((int(otpToken) + 1) % int(1e6))
 
     return otpToken
 

--- a/test/test_user_otp.py
+++ b/test/test_user_otp.py
@@ -189,7 +189,7 @@ def testOtpApiWorkflow(server, user):
         path='/user/authentication', method='GET', basicAuth='user:password',
         additionalHeaders=[('Girder-OTP', _tokenFromTotpUri(totpUri, False))])
     assertStatus(resp, 401)
-    assert 'Login failed' in resp.json['message']
+    assert 'Token did not match' in resp.json['message']
 
     # Login with a valid OTP
     resp = server.request(


### PR DESCRIPTION
This now has basic functionality. Still TODO:
* [x] Allow OTP to be sent when logging into the SFTP server
* [x] Only prompt for an OTP on the login dialog if necessary
* [x] Refactor some logic out of the API layer and into the User model
* [x] Add `Girder-OTP` to default CORS headers
* [x] Server testing
* [x] Client testing
* [x] Resolve #2724
* [x] Add client confirmation / error message dialogs
* [x] Final styling pass
* [x] Resolve #2730

Additional work that may be out of scope for this initial PR:
* [ ] Rate limit login requests
* [ ] Switch caching of the last-used token to be stored in MongoDB ([see here](https://docs.openstack.org/keystone/pike/contributor/caching-layer.html) for possibly-helpful resources)
* [ ] Option to mandate use of 2FA by all users
* [ ] Allow user to recover account access with HOTP-based codes (currently, a site admin must disable a user's OTP to recover access)
* [ ] Use application secrets (once they exist) when generating TOTP keys
* [ ] Set OTP issuer when `User._TotpFactory` is created (requires more robust server hostname detection)

Technical reference: http://passlib.readthedocs.io/en/stable/narr/totp-tutorial.html

---

Current login dialog:
![image](https://user-images.githubusercontent.com/1282879/37310968-0b42eb04-261c-11e8-90cb-e51bb422555d.png)

Before 2FA enrollment:
![image](https://user-images.githubusercontent.com/1282879/37310987-18b2cb56-261c-11e8-868d-d6147657358e.png)

2FA enrollment process:
![image](https://user-images.githubusercontent.com/1282879/37310927-f27fb4a8-261b-11e8-8bbb-4dbfdb752fe1.png)