### PR TITLE
Use new-style Python 2 classes.

### DIFF
--- a/girder/__init__.py
+++ b/girder/__init__.py
@@ -78,7 +78,7 @@ class LogFormatter(logging.Formatter):
         return super(LogFormatter, self).format(record, *args, **kwargs)
 
 
-class StreamToLogger:
+class StreamToLogger(object):
     """
     Redirect a file-like stream to a logger.
     """

--- a/girder/constants.py
+++ b/girder/constants.py
@@ -116,7 +116,7 @@ class TerminalColor(object):
         return TerminalColor._color(TerminalColor.INFO, text)
 
 
-class AssetstoreType:
+class AssetstoreType(object):
     """
     All possible assetstore implementation types.
     """
@@ -125,7 +125,7 @@ class AssetstoreType:
     S3 = 2
 
 
-class AccessType:
+class AccessType(object):
     """
     Represents the level of access granted to a user or group on an
     AccessControlledModel. Having a higher access level on a resource also
@@ -154,7 +154,7 @@ class AccessType:
             raise ValueError('Invalid AccessType: %d.' % level)
 
 
-class SettingKey:
+class SettingKey(object):
     """
     Core settings should be enumerated here by a set of constants corresponding
     to sensible strings.
@@ -187,7 +187,7 @@ class SettingKey:
     USER_DEFAULT_FOLDERS = 'core.user_default_folders'
 
 
-class SettingDefault:
+class SettingDefault(object):
     """
     Core settings that have a default should be enumerated here with the
     SettingKey.
@@ -230,7 +230,7 @@ class SortDir(object):
     DESCENDING = -1
 
 
-class TokenScope:
+class TokenScope(object):
     """
     Constants for core token scope strings. Token scopes must not contain
     spaces, since many services accept scope lists as a space-separated list

--- a/plugins/celery_jobs/server/constants.py
+++ b/plugins/celery_jobs/server/constants.py
@@ -18,7 +18,7 @@
 ###############################################################################
 
 
-class PluginSettings:
+class PluginSettings(object):
     BROKER_URL = 'celery_jobs.broker_url'
     APP_MAIN = 'celery_jobs.app_main'
     CELERY_USER_ID = 'celery_jobs.celery_user_id'

--- a/plugins/google_analytics/server/constants.py
+++ b/plugins/google_analytics/server/constants.py
@@ -19,5 +19,5 @@
 
 
 # Constants representing the setting keys for this plugin
-class PluginSettings:
+class PluginSettings(object):
     GOOGLE_ANALYTICS_TRACKING_ID = 'google_analytics.tracking_id'

--- a/plugins/homepage/server/constants.py
+++ b/plugins/homepage/server/constants.py
@@ -28,7 +28,7 @@ from girder.utility import setting_utilities
 COLLECTION_NAME = 'Homepage Assets'
 
 
-class PluginSettings:
+class PluginSettings(object):
     MARKDOWN = 'homepage.markdown'
 
     HEADER = 'homepage.header'

--- a/plugins/item_licenses/server/constants.py
+++ b/plugins/item_licenses/server/constants.py
@@ -18,11 +18,11 @@
 ###############################################################################
 
 
-class PluginSettings:
+class PluginSettings(object):
     LICENSES = 'item_licenses.licenses'
 
 
-class PluginSettingsDefaults:
+class PluginSettingsDefaults(object):
     defaults = {
         PluginSettings.LICENSES: [
             {

--- a/plugins/ldap/server/constants.py
+++ b/plugins/ldap/server/constants.py
@@ -18,5 +18,5 @@
 ###############################################################################
 
 
-class PluginSettings:
+class PluginSettings(object):
     LDAP_SERVERS = 'ldap.servers'

--- a/plugins/oauth/server/constants.py
+++ b/plugins/oauth/server/constants.py
@@ -19,7 +19,7 @@
 
 
 # Constants representing the setting keys for this plugin
-class PluginSettings:
+class PluginSettings(object):
     PROVIDERS_ENABLED = 'oauth.providers_enabled'
     IGNORE_REGISTRATION_POLICY = 'oauth.ignore_registration_policy'
 

--- a/plugins/provenance/server/constants.py
+++ b/plugins/provenance/server/constants.py
@@ -19,5 +19,5 @@
 
 
 # Constants representing the setting keys for this plugin
-class PluginSettings:
+class PluginSettings(object):
     PROVENANCE_RESOURCES = 'provenance.resources'

--- a/plugins/user_quota/server/constants.py
+++ b/plugins/user_quota/server/constants.py
@@ -19,6 +19,6 @@
 
 
 # Constants representing the setting keys for this plugin
-class PluginSettings:
+class PluginSettings(object):
     QUOTA_DEFAULT_USER_QUOTA = 'user_quota.default_user_quota'
     QUOTA_DEFAULT_COLLECTION_QUOTA = 'user_quota.default_collection_quota'

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -24,7 +24,7 @@ import time
 from girder import events
 
 
-class EventsHelper():
+class EventsHelper(object):
     def __init__(self):
         self.ctr = 0
         self.responses = None

--- a/tests/cases/install_test.py
+++ b/tests/cases/install_test.py
@@ -34,7 +34,7 @@ pluginRoot = os.path.normpath(os.path.join(
 ))
 
 
-class PluginOpts():
+class PluginOpts(object):
     def __init__(self, plugin=None, force=False, symlink=False, dev=False, npm='npm',
                  skip_requirements=False, all_plugins=False, plugins=None, watch=False,
                  watch_plugin=None, plugin_prefix='plugin', no_plugins=False):


### PR DESCRIPTION
Code of the form `class <name>:` or `class <name>():` define old-style classes in Python 2.  Use new-style classes instead by using `class <name>(object):`.  In Python 3, this results in no change.