### PR TITLE
Do not specify default service for S3 assetstore type

### DIFF
--- a/devops/ansible/roles/girder/library/girder.py
+++ b/devops/ansible/roles/girder/library/girder.py
@@ -257,9 +257,10 @@ options:
 
                    service:
                        required: false
-                       default: s3.amazonaws.com
+                       default: ''
                        description:
                            - The S3 service host (for S3 type)
+                           - Only set this if you're not using AWS S3.
                            - This can be used to specify a protocol and port
                              -  use the form [http[s]://](host domain)[:(port)]
                            - Do not include the bucket name here
@@ -1709,7 +1710,7 @@ class GirderClientModule(GirderClient):
 
     def assetstore(self, name, type, root=None, db=None, mongohost=None,
                    replicaset='', bucket=None, prefix='', accessKeyId=None,
-                   secret=None, service='s3.amazonaws.com', host=None,
+                   secret=None, service='', host=None,
                    port=None, path=None, user=None, webHdfsPort=None,
                    dbtype=None, dburi=None, readOnly=False, current=False,
                    region=DEFAULT_REGION, inferCredentials=False):


### PR DESCRIPTION
@mgrauer this is the correct fix for the S3 issue you encountered.

Connecting to buckets in non-default regions requires either virtual addressing style i.e. `bucketname.s3.amazonaws.com` or using the region-specific endpoint with path-style addressing e.g. `s3-eu-west-1.amazonaws.com/bucketname`.

If you explicitly pass `s3.amazonaws.com` as the service, it overrides the intelligent behavior of botocore that would otherwise handle this for you and use the region-specific endpoint.

In your case, you could have also solved this problem by setting your service to `s3-us-west-1.amazonaws.com` in your configuration, but that would be redundant since we have a region field.

TLDR: we should never set service explicitly to `s3.amazonaws.com`. The service field of an assetstore should only be set if you're using something other than AWS S3.