### PR TITLE
Better clean up after a fuse mount error.

### DIFF
--- a/plugins/fuse/server/server_fuse.py
+++ b/plugins/fuse/server/server_fuse.py
@@ -410,10 +410,14 @@ def unmountServerFuse(name):
 
 
 class FUSELogError(fuse.FUSE):
-    def __init__(self, name, operations, mountpoint, *args, **kwargs):
+    def __init__(self, name, onError, operations, mountpoint, *args, **kwargs):
         """
         This wraps fuse.FUSE so that errors are logged rather than raising a
         RuntimeError exception.
+
+        :param name: key for the mount point.
+        :param onError: a function that is called with `name` if initialization
+            fails.
         """
         try:
             super(FUSELogError, self).__init__(operations, mountpoint, *args, **kwargs)
@@ -423,7 +427,18 @@ class FUSELogError(fuse.FUSE):
                 'it empty?  Does the user have permission to create FUSE '
                 'mounts?  It could be another FUSE mount issue, too.' % (
                     mountpoint, ))
-            _fuseMounts.pop(name, None)
+            onError(name)
+
+
+def handleFuseMountFailure(name):
+    """
+    If a FUSE mount fails to initialize inside, remove it from the list of
+    mounts and clean up its thread.
+
+    :param name: key for the mount point.
+    """
+    with _fuseMountsLock:
+        _fuseMounts.pop(name, None)
 
 
 def mountServerFuse(name, path, level=AccessType.ADMIN, user=None, force=False):
@@ -482,12 +497,12 @@ def mountServerFuse(name, path, level=AccessType.ADMIN, user=None, force=False):
             }
             if sys.platform == 'darwin':
                 del options['auto_unmount']
-            fuseThread = threading.Thread(
-                target=FUSELogError, args=(name, opClass, path), kwargs=options)
-            fuseThread.daemon = True
-            fuseThread.start()
+            fuseThread = threading.Thread(target=FUSELogError, args=(
+                name, handleFuseMountFailure, opClass, path), kwargs=options)
             entry['thread'] = fuseThread
             _fuseMounts[name] = entry
+            fuseThread.daemon = True
+            fuseThread.start()
             logprint.info('Mounted %s at %s' % (name, path))
             events.trigger('server_fuse.mount', {'name': name})
             return True


### PR DESCRIPTION
When we fail to make a fuse mount, don't leave the entry in the mount list.