### PR TITLE
Restrict python-dateutil to <2.7 for botocore 1.9.8

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,5 +10,6 @@ moto[server]
 pytest
 pytest-cov
 pytest-xdist
+python-dateutil<2.7 # required for botocore=1.9.8
 tox
 virtualenv

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ installReqs = [
     'pymongo>=3.5',
     'PyYAML',
     'psutil',
-    'python-dateutil',
+    'python-dateutil<2.7',  # required for compatibility with botocore=1.9.8
     'pytz',
     'requests',
     'shutilwhich ; python_version < \'3\'',


### PR DESCRIPTION
The dev requirement botocore=1.9.8 restricts the version of
python-dateutil to <2.7 to maintain support for python 2.6[1].  This is
breaking how we do development installs on CI because pip doesn't fully
resolve package dependencies.  I also had to add the restriction to
setup.py because we use the `-U` flag in the install command in
`tox.ini`.  It's ugly, but hopefully will go away with future updates to
botocore.

An alternative solution would be to pin botocore to 1.9.7 (as well as
boto which requires botocore>=1.9.8) because we don't actually care
about python 2.6 support.  I chose to do this because it is more likely
that botocore will make important changes.

[1] https://github.com/boto/botocore/pull/1402