### PR TITLE
Remove unused flake8 config option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,8 +30,6 @@ output = build/test/coverage/py_coverage.xml
 
 [flake8]
 max-line-length: 100
-# Whether to display the pep8 instructions on failure (can be quite verbose)
-show-pep8: False
 # Whether to show source code for each failure
 show-source: True
 # Maximum cyclomatic complexity allowed


### PR DESCRIPTION
Remove the 'show-pep8' option from the flake8 config. This option is left over from when the pep8 (now pycodestyle) tool was used for style checking.