### PR TITLE
Run pip install in a subprocess

### DIFF
--- a/girder/utility/install.py
+++ b/girder/utility/install.py
@@ -21,9 +21,7 @@ This module contains functions to install optional components
 into the current Girder installation.  Note that Girder must
 be restarted for these changes to take effect.
 """
-
 import os
-import pip
 import re
 import select
 import shutil
@@ -42,6 +40,16 @@ webRoot = os.path.join(constants.STATIC_ROOT_DIR, 'clients', 'web')
 # monkey patch shutil for python < 3
 if not six.PY3:
     import shutilwhich  # noqa
+
+
+def _pipMain(*args):
+    """Run `pip *args` in a system independent way.
+
+    This replaces the old method of calling `pip.main` directly which
+    was broken by pip 9.0.2.
+    """
+    pipCommand = (sys.executable, '-m', 'pip') + args
+    subprocess.check_call(pipCommand)
 
 
 def print_version(parser):
@@ -222,20 +230,16 @@ def _install_plugin_reqs(pluginPath, name, dev=False):
     # Install plugin dependencies
     if os.path.isfile(setupPath):
         print(constants.TerminalColor.info('Installing %s as a package.' % name))
-        if pip.main(['install', '-e', pluginPath]) != 0:
-            raise Exception('Failed to install package at %s.' % pluginPath)
+        _pipMain('install', '-e', pluginPath)
     elif os.path.isfile(requirementsPath):
         print(constants.TerminalColor.info('Installing requirements.txt for %s.' % name))
-        if pip.main(['install', '-r', requirementsPath]) != 0:
-            raise Exception('Failed to install requirements file at %s.' % requirementsPath)
+        _pipMain('install', '-r', requirementsPath)
 
     # Install plugin development dependencies
     if dev and os.path.isfile(devRequirementsPath):
         print(constants.TerminalColor.info(
             'Installing requirements-dev.txt for %s.' % name))
-        if pip.main(['install', '-r', devRequirementsPath]) != 0:
-            raise Exception(
-                'Failed to install requirements file at %s.' % devRequirementsPath)
+        _pipMain('install', '-r', devRequirementsPath)
 
 
 def install_plugin(opts):

--- a/plugins/fuse/plugin_tests/server_fuse_test.py
+++ b/plugins/fuse/plugin_tests/server_fuse_test.py
@@ -214,9 +214,10 @@ class ServerFuseTestCase(base.TestCase):
             server_fuse.mountServerFuse(
                 self.extraMount, mountpath, level=AccessType.READ, user=self.user)
             # If can take a short amount of time to trigger an error, so wait
-            # for it
+            # for it.  Also wait for the mount information to be cleaned up.
             for iter in six.moves.range(50):
-                if logprint.call_count:
+                if logprint.call_count and not server_fuse.isServerFuseMounted(
+                        self.extraMount, level=AccessType.READ, user=self.user):
                     break
                 time.sleep(0.1)
             logprint.assert_called_once()

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,21 +4,16 @@ branch = True
 omit =
     girder/external/*
     test/*
+    # We can't collect coverage information for plugins at this time due to
+    # https://bitbucket.org/ned/coveragepy/issues/649/explicit-path-alias-matching-order-for
+    build/test/tox/*/lib/*/site-packages/girder/plugins/*/server/*
 include =
     girder/*
     plugins/*/server/*
     build/test/tox/*/lib/*/site-packages/girder/*
-    build/test/tox/*/lib/*/site-packages/girder/plugins/*/server/*
 parallel = True
 [coverage:paths]
 # Include sources from installed package in Tox's {envsitepackagesdir}
-# The `_` here is a hack to make sure the plugins are matched first,
-# otherwise, installed plugins (those in `girder/plugins/*`) are matched
-# and aliased into the girder package.
-_plugins =
-    plugins/
-    girder/plugins/
-    build/test/tox/*/lib/*/site-packages/girder/plugins/
 girder =
     girder/
     build/test/tox/*/lib/*/site-packages/girder/


### PR DESCRIPTION
This fixes errors running girder in certain environments that arose from the release of pip 9.0.2.  Running pip install in a subprocess is the method recommended by the pip maintainers, and the only way that will be supported post 10.0.

The `server_fuse.server_fuse` test is failing on this branch.  I still haven't been able to track down why.