### PR TITLE
Adding a method that gets metadata.

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -1168,6 +1168,19 @@ class GirderClient(object):
         path = 'folder/' + folderId + '/metadata'
         obj = self.put(path, json=metadata)
         return obj
+    
+    def getMetadata(self, resourceType, Id):
+        """
+        Takes in a resource type and an id to get the metadata. 
+
+        :param resourceType: The type of resource being: 'collection', 'user',
+            'folder', 'file', or 'item'.
+        :type resourceType: str
+        :param id: resourceType associated ID.
+        :type id: int
+        """
+        path = resourceType + "/" + Id
+        return self.get(path)
 
     def transformFilename(self, name):
         """


### PR DESCRIPTION
This PR is for adding a method to the Python Client for retrieving metadata. After looking through the source code of the python client for some time, I think getting the metadata of files, items, folders, and collections would be useful. There are options to add metadata but not getting it. 