### PR TITLE
Girder client: The size is not required to upload data

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -118,7 +118,7 @@ class _ProgressBytesIO(six.BytesIO):
         self.reporter = kwargs.pop('reporter')
         six.BytesIO.__init__(self, *args, **kwargs)
 
-    def read(self, _size):
+    def read(self, _size=-1):
         _chunk = six.BytesIO.read(self, _size)
         self.reporter.update(len(_chunk))
         return _chunk
@@ -130,7 +130,7 @@ class _ProgressMultiPartEncoder(MultipartEncoder):
         self.reporter = kwargs.pop('reporter')
         MultipartEncoder.__init__(self, *args, **kwargs)
 
-    def read(self, _size):
+    def read(self, _size=-1):
         _chunk = MultipartEncoder.read(self, _size)
         self.reporter.update(len(_chunk))
         return _chunk


### PR DESCRIPTION
This small changes on the girder client will fix an issue when recording cassettes with [pyvcr](https://github.com/kevin1024/vcrpy) in external girder plugin.

```
    def __init__(self, method, uri, body, headers):
        self.method = method
        self.uri = uri
        self._was_file = hasattr(body, 'read')
        if self._was_file:
>           self.body = body.read()
E           TypeError: read() takes exactly 2 arguments (1 given)

body       = <girder_client._ProgressBytesIO instance at 0x7f9614e0a488>
headers    = {'Content-Length': '28', 'Girder-Token': u'BQS7ZcGCTEU9X9k8Cz7GThGiaGzprpmyfaF...pt': '*/*', 'User-Agent': 'python-requests/2.18.4', 'Connection': 'keep-alive'}
method     = 'POST'
self       = <Request (POST) http://localhost:8080/api/v1/file/chunk?offset=0&uploadId=5abaae3dbf0ca6a01ff9198e>
uri        = 'http://localhost:8080/api/v1/file/chunk?offset=0&uploadId=5abaae3dbf0ca6a01ff9198e'

../../../../../venv/lib/python2.7/site-packages/vcr/request.py:17: TypeError
```

In fact, during external plugin testing with pytest, the use of pyvrc to record server behavior is very convenient. But when some of the tests use the girder-client upload, the record doesn't succeed because of the `_size` argument which is missing. But allowing the size to be none set (with a default value), this fix the issue and lead to correctly record the upload request response.