### PR TITLE
Fix where testing.min.css is loaded from.

### DIFF
--- a/grunt_tasks/test.js
+++ b/grunt_tasks/test.js
@@ -52,8 +52,7 @@ module.exports = function (grunt) {
                             '/static/built/fontello/css/fontello.css',
                             '/static/built/fontello/css/animation.css',
                             '/static/built/girder_lib.min.css',
-                            '/static/built/girder_app.min.css',
-                            '/static/built/testing.min.css'
+                            '/static/built/testing/testing.min.css'
                         ],
                         jsFiles: [
                             '/static/built/girder_lib.min.js',


### PR DESCRIPTION
Also, we don't generate girder_app.min.css, so don't try to load it.