### PR TITLE
Improve exceptions when no token.

### DIFF
--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -645,10 +645,10 @@ def ensureTokenScopes(token, scope):
     :type scope: `str or list of str`
     """
     tokenModel = Token()
-    if tokenModel.hasScope(token, TokenScope.USER_AUTH):
+    if token is not None and tokenModel.hasScope(token, TokenScope.USER_AUTH):
         return
 
-    if not tokenModel.hasScope(token, scope):
+    if token is None or not tokenModel.hasScope(token, scope):
         setCurrentUser(None)
         if isinstance(scope, six.string_types):
             scope = (scope,)
@@ -656,7 +656,8 @@ def ensureTokenScopes(token, scope):
             'Invalid token scope.\n'
             'Required: %s.\n'
             'Allowed: %s' % (
-                ' '.join(scope), ' '.join(tokenModel.getAllowedScopes(token))))
+                ' '.join(scope),
+                '' if token is None else ' '.join(tokenModel.getAllowedScopes(token))))
 
 
 def _setCommonCORSHeaders():

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -645,10 +645,10 @@ def ensureTokenScopes(token, scope):
     :type scope: `str or list of str`
     """
     tokenModel = Token()
-    if token is not None and tokenModel.hasScope(token, TokenScope.USER_AUTH):
+    if tokenModel.hasScope(token, TokenScope.USER_AUTH):
         return
 
-    if token is None or not tokenModel.hasScope(token, scope):
+    if not tokenModel.hasScope(token, scope):
         setCurrentUser(None)
         if isinstance(scope, six.string_types):
             scope = (scope,)

--- a/plugins/jobs/plugin_tests/jobs_test.py
+++ b/plugins/jobs/plugin_tests/jobs_test.py
@@ -89,6 +89,10 @@ class JobsTestCase(base.TestCase):
         resp = self.request(path, user=self.users[2], method='DELETE')
         self.assertStatus(resp, 403)
 
+        # If no user is specified, we should get a 401 error
+        resp = self.request(path, user=None)
+        self.assertStatus(resp, 401)
+
         # Make sure user who created the job can see it
         resp = self.request(path, user=self.users[1])
         self.assertStatusOk(resp)


### PR DESCRIPTION
Querying an endpoint that needs a token should throw an `AccessException` if there is no token.  Before, this would throw an `AttributeError` (and the rest call would return a 500 error).

You can see this behavior by calling the GET `/job/:id` endpoint without an auth token.