### PR TITLE
Garbage collect before unmounting fuse.

### DIFF
--- a/plugins/fuse/plugin_tests/server_fuse_test.py
+++ b/plugins/fuse/plugin_tests/server_fuse_test.py
@@ -524,6 +524,7 @@ class ServerFuseTestCase(base.TestCase):
         fh = op.open(self.publicFileName, os.O_RDONLY)
         self.assertTrue(isinstance(fh, int))
         self.assertIn(fh, op.openFiles)
+        op.release(self.publicFileName, fh)
         path = os.path.dirname(self.publicFileName)
         fh = op.open(path, os.O_RDONLY)
         self.assertTrue(isinstance(fh, int))

--- a/plugins/fuse/plugin_tests/server_fuse_test.py
+++ b/plugins/fuse/plugin_tests/server_fuse_test.py
@@ -30,14 +30,7 @@ def tearDownModule():
     curConfig = config.getConfig()
     tempdir = curConfig['server_fuse']['path']
     base.stopServer()
-    retries = 0
-    while retries < 50:
-        try:
-            os.rmdir(tempdir)
-            break
-        except OSError:
-            retries += 1
-            time.sleep(0.1)
+    os.rmdir(tempdir)
 
 
 class ServerFuseTestCase(base.TestCase):
@@ -70,14 +63,7 @@ class ServerFuseTestCase(base.TestCase):
         super(ServerFuseTestCase, self).tearDown()
         if self.extraMount:
             server_fuse.unmountServerFuse(self.extraMount)
-        retries = 0
-        while retries < 100:
-            try:
-                os.rmdir(self.extraMountPath)
-                break
-            except OSError:
-                retries += 1
-                time.sleep(0.1)
+        os.rmdir(self.extraMountPath)
 
     def testMainMount(self):
         """

--- a/plugins/fuse/server/server_fuse.py
+++ b/plugins/fuse/server/server_fuse.py
@@ -1,6 +1,7 @@
 import atexit
 import errno
 import fuse
+import gc
 import os
 import shutil
 import six
@@ -388,6 +389,9 @@ def unmountServerFuse(name):
 
     :param name: a key within the list of known mounts.
     """
+    # Have python do a garbage collection.  This ensures any file handle that
+    # could be closed really is closed, and therefore won't block unmounting.
+    gc.collect()
     with _fuseMountsLock:
         entry = _fuseMounts.pop(name, None)
         if entry:


### PR DESCRIPTION
If a file has been placed in the queue for garbage collection, it can still be open until python actually does the garbage collection.  If the file is on a fuse mount, fuse can't unmount the file system due to the open file.  By running `gc.collect()` prior to the unmount call, files that should be closed don't prevent the unmounting.

Prior to this change, there were some wait loops in the tests to try to clean up that still sometimes could fail due to the file being open and the mount not closing.