### PR TITLE
Add --upgrade-strategy eager to all uses of pip install -U

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           command: pip install --upgrade pip setuptools virtualenv
       - run:
           name: Install Girder
-          command: pip install --upgrade --editable .[plugins,sftp] clients/python --requirement requirements-dev.txt
+          command: pip install --upgrade  --upgrade-strategy eager --editable .[plugins,sftp] clients/python --requirement requirements-dev.txt
           # Until https://github.com/pypa/pip/pull/4208 is available in pip 10, the install of
           # "requirements-dev.txt" must be run from the "girder" working directory
           working_directory: girder
@@ -92,7 +92,7 @@ jobs:
           command: pip install --upgrade pip setuptools
       - run:
           name: Install Girder
-          command: pip install --upgrade --editable .[plugins,sftp] clients/python --requirement requirements-dev.txt
+          command: pip install --upgrade --upgrade-strategy eager --editable .[plugins,sftp] clients/python --requirement requirements-dev.txt
           working_directory: girder
       - run:
           name: Reduce workspace size
@@ -248,7 +248,7 @@ jobs:
       - run:
           name: Install all pip modules
           # sftp and python client aren't installed by the ansible example
-          command: pip install --upgrade --editable .[plugins,sftp] clients/python --requirement requirements-dev.txt
+          command: pip install --upgrade --upgrade-strategy eager --editable .[plugins,sftp] clients/python --requirement requirements-dev.txt
           working_directory: girder
       - run:
           name: Create Girder build directory
@@ -369,7 +369,7 @@ jobs:
       - run:
           name: Install all pip modules
           # sftp and python client aren't installed by the ansible example
-          command: pip install --upgrade --editable .[plugins,sftp] clients/python --requirement requirements-dev.txt
+          command: pip install --upgrade --upgrade-strategy eager --editable .[plugins,sftp] clients/python --requirement requirements-dev.txt
           working_directory: girder
       - run:
           name: Create Girder build directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY setup.py /girder/setup.py
 COPY package.json /girder/package.json
 COPY README.rst /girder/README.rst
 
-RUN pip install --upgrade --editable .[plugins]
+RUN pip install --upgrade --upgrade-strategy eager --editable .[plugins]
 RUN girder-install web --all-plugins
 
 ENTRYPOINT ["girder", "serve"]

--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -28,7 +28,7 @@ COPY setup.py /girder/setup.py
 COPY package.json /girder/package.json
 COPY README.rst /girder/README.rst
 
-RUN pip install --upgrade --editable .[plugins]
+RUN pip install --upgrade --upgrade-strategy eager --editable .[plugins]
 RUN girder-install web --all-plugins
 
 # See http://click.pocoo.org/5/python3/#python-3-surrogate-handling for more detail on

--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -8,7 +8,7 @@ between major versions of Girder. Major version bumps contain breaking changes
 to the Girder core library, which are enumerated in this guide along with
 instructions on how to update your plugin code to work in the newer version.
 
-Existing installations may be upgraded by running ``pip install -U girder`` and
+Existing installations may be upgraded by running ``pip install --upgrade --upgrade-strategy eager girder`` and
 re-running ``girder-install web``. You may need to remove ``node_modules`` directory
 from the installed girder package if you encounter problems while re-running
 ``girder-install web``. Note that the prerequisites may have changed in the latest

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ toxworkdir = {toxinidir}/build/test/tox
 
 [testenv]
 deps = -rrequirements-dev.txt
-install_command = pip install --upgrade {opts} {packages}
+install_command = pip install --upgrade --upgrade-strategy eager {opts} {packages}
 commands = pytest {posargs}
 
 [testenv:docs]


### PR DESCRIPTION
The default behavior of `pip install -U` has changed as of version 10.
The default only-if-needed strategy only upgrades direct dependencies of
the packages being installed.  This is likely to break automated
upgrades such as ansible and CI deployments that use a previously
generated virtual environment.

Both upgrade strategies can lead to invalid virtual environment states because 
One could argue that the new behavior is superior because it makes
minimal changes to the environment; however, my guess is that the eager
strategy will cause less confusion and is identical to what pip had done
prior to version 10 with no flag.

See also:

https://github.com/pypa/pip/issues/5274