### PR TITLE
Add a text index to the file model.

### DIFF
--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -31,7 +31,7 @@ from girder.utility import path as path_util
 from girder.utility.progress import ProgressContext
 
 # Plugins can modify this set to allow other types to be searched
-allowedSearchTypes = {'collection', 'folder', 'group', 'item', 'user'}
+allowedSearchTypes = {'collection', 'file', 'folder', 'group', 'item', 'user'}
 allowedDeleteTypes = {'collection', 'file', 'folder', 'group', 'item', 'user'}
 
 

--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -39,6 +39,7 @@ class File(acl_mixin.AccessControlMixin, Model):
         self.ensureIndices(
             ['itemId', 'assetstoreId', 'exts'] +
             assetstore_utilities.fileIndexFields())
+        self.ensureTextIndex({'name': 1})
         self.resourceColl = 'item'
         self.resourceParent = 'itemId'
 

--- a/tests/cases/search_test.py
+++ b/tests/cases/search_test.py
@@ -202,6 +202,40 @@ class SearchTestCase(base.TestCase):
         self.assertStatusOk(resp)
         self.assertEqual(1, len(resp.json['assetstore']))
 
+    def testResourceFileSearch(self):
+        admin = User().findOne({'login': 'adminlogin'})
+
+        resp = self.request(path='/resource/search', params={
+            'q': 'public',
+            'types': '["file"]'
+        })
+        self.assertStatusOk(resp)
+        self.assertEqual(len(resp.json['file']), 1)
+        resp = self.request(path='/resource/search', params={
+            'q': 'personal',
+            'types': '["file"]'
+        })
+        self.assertStatusOk(resp)
+        self.assertEqual(len(resp.json['file']), 0)
+        resp = self.request(path='/resource/search', params={
+            'q': 'file',
+            'types': '["file"]'
+        })
+        self.assertStatusOk(resp)
+        self.assertEqual(len(resp.json['file']), 1)
+        resp = self.request(path='/resource/search', params={
+            'q': 'personal',
+            'types': '["file"]'
+        }, user=admin)
+        self.assertStatusOk(resp)
+        self.assertEqual(len(resp.json['file']), 1)
+        resp = self.request(path='/resource/search', params={
+            'q': 'file',
+            'types': '["file"]'
+        }, user=admin)
+        self.assertStatusOk(resp)
+        self.assertEqual(len(resp.json['file']), 2)
+
     def testSearchModeRegistry(self):
         def testSearchHandler(query, types, user, level, limit, offset):
             return {

--- a/tests/cases/search_test.yml
+++ b/tests/cases/search_test.yml
@@ -26,11 +26,17 @@ collections:
         public: true
         items:
           - name: 'Public object'
+            files:
+            - name: 'Public file'
+              path: 'search_test.yml'
 
       - name: 'Private test folder'
         public: false
         items:
           - name: 'Secret object'
+            files:
+            - name: 'Personal file'
+              path: 'search_test.yml'
 
   - name: 'Magic collection'
     description: 'private'


### PR DESCRIPTION
Allow files to be searched via `resource/search`.