### PR TITLE
Add retry logic to the girder-client cli

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ Python Client
 ^^^^^^^^^^^^^
 * Added a ``--token`` option to the girder-client command line interface to allow users to specify
   a pre-created authentication token. (`#2689 <https://github.com/girder/girder/pull/2689>`_).
+* Added a ``--retry`` option to the girder-client command line interface to retry connection and
+  certain error responses (`#2697 <https://github.com/girder/girder/pull/2697>`_).
 
 Girder 2.5.0
 ============

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -89,10 +89,10 @@ class GirderCli(GirderClient):
         elif username:
             self.authenticate(username, password, interactive=interactive)
 
-    def _requestFunc(self, *args, **kwargs):
+    def sendRestRequest(self, *args, **kwargs):
         with self.session() as session:
             session.verify = self.sslVerify
-            return super(GirderCli, self)._requestFunc(*args, **kwargs)
+            return super(GirderCli, self).sendRestRequest(*args, **kwargs)
 
 
 class _HiddenOption(click.Option):


### PR DESCRIPTION
The retry logic is added following the description in this blog post:

https://www.peterbe.com/plog/best-practice-with-retries-with-requests

In the first commit, I had to do some refactoring of how sessions are injected by `girder_client.cli`.  It turns out sessions were being closed before the request was performed, which in turn closed all attached adapters.  The changes in `girder_client.lib` ensure that all requests now go through the `sendRestRequest` method.

For testing, I'm only asserting the retry adapter is attached to the session.  I originally tried to assert that the retries actually occurred, but simulating server failures turned out to be too difficult.  httmock can't be used for this purpose because it also mocks out the lower level retry logic.