### PR TITLE
Fix the units shown on the job's time series graph.

### DIFF
--- a/plugins/jobs/web_client/views/timeChartConfig.js
+++ b/plugins/jobs/web_client/views/timeChartConfig.js
@@ -12,6 +12,11 @@ const timeChartConfig = {
                     'test': 'datum.elapsed > 0'
                 },
                 {
+                    'type': 'formula',
+                    'field': 'elapsed',
+                    'expr': 'datum.elapsed/1000'
+                },
+                {
                     'type': 'aggregate',
                     'groupby': ['id', 'title', 'currentStatus'],
                     'summarize': [
@@ -104,10 +109,7 @@ const timeChartConfig = {
             'title': 'seconds',
             'properties': {
                 'labels': {
-                    'itemName': {
-                        'value': 'ylabel'
-                    },
-                    'text': { 'template': '{{datum.label|slice:0,-1}}' }
+                    'itemName': { 'value': 'ylabel' }
                 }
             }
         }

--- a/plugins/jobs/web_client/views/timingHistoryChartConfig.js
+++ b/plugins/jobs/web_client/views/timingHistoryChartConfig.js
@@ -11,7 +11,7 @@ const timingHistoryChartConfig = {
                 {
                     'type': 'formula',
                     'field': 'adjElapsed',
-                    'expr': 'clamp(datum["elapsed"]/1000,-86400,86400)'
+                    'expr': 'clamp(datum.elapsed/1000,-86400,86400)'
                 }
             ]
         },


### PR DESCRIPTION
The job's time series graph didn't show units when the seconds were over 1000.  For instance, instead of showing '1.4k' as the timing history displays, it was just showing '1.4'.  Partly this was due to plotting the time in milliseconds.  This fixes the display.

Modified a line of code in the timing history vega specification for consistency.

Moved vega to version ^3.0.0 to be consistent with the candela plugin.