### PR TITLE
Improve the access widget.

### DIFF
--- a/clients/web/src/views/widgets/AccessWidget.js
+++ b/clients/web/src/views/widgets/AccessWidget.js
@@ -68,6 +68,7 @@ var AccessWidget = View.extend({
         this.isAdmin = !!(this.currentUser && this.currentUser.get('admin'));
         this.searchWidget = new SearchFieldWidget({
             placeholder: 'Start typing a name...',
+            noResultsPage: true,
             modes: ['prefix', 'text'],
             types: ['group', 'user'],
             parentView: this
@@ -338,7 +339,7 @@ var AccessWidget = View.extend({
                 name: $el.find('.g-desc-title').html(),
                 id: $el.attr('resourceid'),
                 level: parseInt(
-                    $el.find('.g-access-col-right>select').val(),
+                    $el.find('.g-access-col-right>select').val() || 0,
                     10
                 ),
                 flags: _.map($el.find('.g-flag-checkbox:checked'),
@@ -354,7 +355,7 @@ var AccessWidget = View.extend({
                 name: $el.find('.g-desc-title').html(),
                 id: $el.attr('resourceid'),
                 level: parseInt(
-                    $el.find('.g-access-col-right>select').val(),
+                    $el.find('.g-access-col-right>select').val() || 0,
                     10
                 ),
                 flags: _.map($el.find('.g-flag-checkbox:checked'),

--- a/clients/web/src/views/widgets/SearchFieldWidget.js
+++ b/clients/web/src/views/widgets/SearchFieldWidget.js
@@ -41,7 +41,7 @@ var SearchFieldWidget = View.extend({
             var list, pos;
             if (code === 13 && this.noResourceSelected) { /* enter without resource seleted */
                 e.preventDefault();
-                if (this.$('.g-search-field').val() !== '') {
+                if (this.$('.g-search-field').val() !== '' && !this.noResultsPage) {
                     this._goToResultPage(this.$('.g-search-field').val(), this.currentMode);
                 }
             } else if (code === 40 || code === 38) {
@@ -91,12 +91,15 @@ var SearchFieldWidget = View.extend({
      *        representing the allowed search modes. Supported modes: "text", "prefix".
      *        If multiple are allowed, users are able to select which one to use
      *        via a dropdown.
+     * @param [settings.noResultsPage=false] If truthy, don't jump to a results
+     *        page if enter is typed with a list of search results.
      */
     initialize: function (settings) {
         this.ajaxLock = false;
         this.pending = null;
         this.noResourceSelected = true;
         this.placeholder = settings.placeholder || 'Search...';
+        this.noResultsPage = settings.noResultsPage || false;
         this.getInfoCallback = settings.getInfoCallback || null;
         /* The order of settings.types give the order of the display of the elements :
          *     ['collection', 'folder', 'item'] will be render like this

--- a/clients/web/test/spec/customWidgetsSpec.js
+++ b/clients/web/test/spec/customWidgetsSpec.js
@@ -640,6 +640,29 @@ describe('Test access widget with non-standard options', function () {
                 widget.$('.g-recursive-container').length === 0 &&
                 widget.$('.g-user-access-entry select').length === 0;
         }, 'check if all component are hidden');
+
+        runs(function () {
+            widget.$('.g-search-field').val('First').trigger('input');
+        });
+        waitsFor(function () {
+            return widget.$('.g-search-result-element').length > 0;
+        });
+        runs(function () {
+            // this should do nothing
+            var e = $.Event('keydown');
+            e.which = 13;
+            widget.$('.g-search-field').trigger(e);
+            // this should add the user to the access list
+            widget.$('.g-search-result-element').eq(0).click();
+        });
+        waitsFor(function () {
+            return widget.getAccessList().users.length > 0;
+        });
+        runs(function () {
+            expect(widget.getAccessList().users[0].login).toBe('mylogin');
+            // the level should be zero
+            expect(widget.getAccessList().users[0].level).toBe(0);
+        });
     });
 });
 


### PR DESCRIPTION
If the access widget does not show the access type, it would store `level: Nan` in the access records.  This changes it to store `0` instead.

If enter was typed in the search field of the access widget, the UI would switch to a results page, losing any changes in the access widget.  This adds an option to the search field widget to not jump to a results page.