### PR TITLE
Upgrade node to version 8.x in ansible role

### DIFF
--- a/.circleci/girder_test_py2/Dockerfile
+++ b/.circleci/girder_test_py2/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Kitware, Inc. <kitware@kitware.com>
 # Don't use "sudo"
 USER root
 
-# Install Node.js 6
+# Install Node.js 8
 RUN curl --silent --location https://deb.nodesource.com/setup_8.x | bash - \
   && apt-get install --assume-yes nodejs \
   && npm install --global npm

--- a/.circleci/girder_test_py2/Dockerfile
+++ b/.circleci/girder_test_py2/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Kitware, Inc. <kitware@kitware.com>
 USER root
 
 # Install Node.js 6
-RUN curl --silent --location https://deb.nodesource.com/setup_6.x | bash - \
+RUN curl --silent --location https://deb.nodesource.com/setup_8.x | bash - \
   && apt-get install --assume-yes nodejs \
   && npm install --global npm
 

--- a/.circleci/girder_test_py3/Dockerfile
+++ b/.circleci/girder_test_py3/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Kitware, Inc. <kitware@kitware.com>
 USER root
 
 # Install Node.js 8
-RUN curl --silent --location https://deb.nodesource.com/setup_8.x | bash - \
+RUN curl --silent --location https://deb.nodesource.com/setup_10.x | bash - \
   && apt-get install --assume-yes nodejs \
   && npm install --global npm
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,12 @@ details, see the commit logs at https://github.com/girder/girder
 Unreleased
 ==========
 
+Changes
+-------
+
+* Move minimum node version to 8.x due to upstream packages using newer ES features.
+  (`#2707 <https://github.com/girder/girder/pull/2707>`_).
+
 Added Features
 --------------
 

--- a/devops/ansible/roles/girder/tasks/npm-Debian.yml
+++ b/devops/ansible/roles/girder/tasks/npm-Debian.yml
@@ -9,7 +9,7 @@
 
 - name: NodeJS | Add PPA
   apt_repository:
-    repo: "deb https://deb.nodesource.com/node_6.x {{ ansible_distribution_release }} main"
+    repo: "deb https://deb.nodesource.com/node_8.x {{ ansible_distribution_release }} main"
   become: yes
   become_user: root
 

--- a/devops/ansible/roles/girder/tasks/npm-Debian.yml
+++ b/devops/ansible/roles/girder/tasks/npm-Debian.yml
@@ -9,7 +9,7 @@
 
 - name: NodeJS | Add PPA
   apt_repository:
-    repo: "deb https://deb.nodesource.com/node_8.x {{ ansible_distribution_release }} main"
+    repo: "deb https://deb.nodesource.com/node_10.x {{ ansible_distribution_release }} main"
   become: yes
   become_user: root
 

--- a/devops/ansible/roles/girder/tasks/npm-RedHat.yml
+++ b/devops/ansible/roles/girder/tasks/npm-RedHat.yml
@@ -4,7 +4,7 @@
   yum_repository:
     name: nodesource
     description: Node.js Packages for Enterprise Linux 7 - $basearch
-    baseurl: https://rpm.nodesource.com/pub_6.x/el/7/$basearch
+    baseurl: https://rpm.nodesource.com/pub_8.x/el/7/$basearch
     gpgcheck: yes
     gpgkey: https://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL
     enabled: yes

--- a/devops/ansible/roles/girder/tasks/npm-RedHat.yml
+++ b/devops/ansible/roles/girder/tasks/npm-RedHat.yml
@@ -4,7 +4,7 @@
   yum_repository:
     name: nodesource
     description: Node.js Packages for Enterprise Linux 7 - $basearch
-    baseurl: https://rpm.nodesource.com/pub_8.x/el/7/$basearch
+    baseurl: https://rpm.nodesource.com/pub_10.x/el/7/$basearch
     gpgcheck: yes
     gpgkey: https://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL
     enabled: yes

--- a/docs/prerequisites.rst
+++ b/docs/prerequisites.rst
@@ -96,7 +96,7 @@ and start it with: ::
 
 Enable the Node.js APT repository: ::
 
-    curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+    curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 
 Install Node.js and NPM using APT: ::
 
@@ -136,7 +136,7 @@ Install MongoDB server using YUM: ::
 
 Enable the Node.js YUM repository: ::
 
-    curl --silent --location https://rpm.nodesource.com/setup_8.x | bash -
+    curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
 
 Install Node.js and NPM using YUM: ::
 

--- a/docs/prerequisites.rst
+++ b/docs/prerequisites.rst
@@ -6,7 +6,7 @@ The following software packages are required to be installed on your system:
 * `Python 2.7 or 3.5+ <https://www.python.org>`_
 * `pip <https://pypi.python.org/pypi/pi>`_
 * `MongoDB 3.2+ <http://www.mongodb.org/>`_
-* `Node.js 6.5+ <http://nodejs.org/>`_
+* `Node.js 8+ <http://nodejs.org/>`_
 * `curl <http://curl.haxx.se/>`_
 * `zlib <http://www.zlib.net/>`_
 * `libjpeg <http://libjpeg.sourceforge.net/>`_
@@ -96,7 +96,7 @@ and start it with: ::
 
 Enable the Node.js APT repository: ::
 
-    curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+    curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
 
 Install Node.js and NPM using APT: ::
 
@@ -136,7 +136,7 @@ Install MongoDB server using YUM: ::
 
 Enable the Node.js YUM repository: ::
 
-    curl --silent --location https://rpm.nodesource.com/setup_6.x | bash -
+    curl --silent --location https://rpm.nodesource.com/setup_8.x | bash -
 
 Install Node.js and NPM using YUM: ::
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "url": "https://github.com/girder/girder.git"
     },
     "engines": {
-        "node": ">=6.5",
+        "node": ">=8.0",
         "npm": ">=5.2"
     },
     "dependencies": {


### PR DESCRIPTION
Currently, girder-install web --all-plugins is breaking; some of our upstream packages are using newer ES features than node 6 supports.
