### PR TITLE
Fix plugin webroots not working under WSGI deployment

### DIFF
--- a/girder/wsgi.py
+++ b/girder/wsgi.py
@@ -27,7 +27,8 @@ cherrypy.config['server'].update({'cherrypy_server': False,
                                   'disable_event_daemon': True})
 
 # 'application' is the default callable object for WSGI implementations, see PEP 3333 for more.
-application = server.setup()
+server.setup()
+application = cherrypy.tree
 
 cherrypy.server.unsubscribe()
 cherrypy.engine.start()


### PR DESCRIPTION
Prior to this, we were exposing the primary webroot as the WSGI
application. In the case of plugin webroots we mount multiple webroots
onto cherrypy.tree which itself is a WSGI-compliant application.

Steps to test:
1) `girder-install plugin -s test/test_plugins/has_webroot`
2) Run Girder via uWSGI
    `uwsgi -p4 --lazy-apps --http :8081 --module girder.wsgi --check-static clients/web` 
3) Enable the "has webroot plugin" and restart the uwsgi process.
4) Verify http://localhost:8081/has_webroot displays "some webroot" (prior to this PR it will 404)
