### PR TITLE
Fix Python client uploading existing files to item

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -836,8 +836,7 @@ class GirderClient(object):
         :param filename: name of file to look for under the parent item.
         :param filepath: path to file on disk.
         """
-        path = 'item/' + itemId + '/files'
-        itemFiles = self.get(path)
+        itemFiles = self.listFile(itemId)
         for itemFile in itemFiles:
             if filename == itemFile['name']:
                 file_id = itemFile['_id']


### PR DESCRIPTION
As discussed on discourse.girder,
https://discourse.girder.org/t/uploading-dicom-files-to-item-how-to-bypass-the-limit/123
the python client fails on checking for already existing files because
of request return limit.