### PR TITLE
Allow uploading of empty files in python client

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -873,9 +873,6 @@ class GirderClient(object):
         filepath = os.path.abspath(filepath)
         filesize = os.path.getsize(filepath)
 
-        if filesize == 0:
-            return
-
         # Check if the file already exists by name and size in the file.
         fileId, current = self.isFileCurrent(itemId, filename, filepath)
         if fileId is not None and current:
@@ -991,9 +988,6 @@ class GirderClient(object):
         filename = os.path.basename(filename)
         filepath = os.path.abspath(filepath)
         filesize = os.path.getsize(filepath)
-
-        if filesize == 0:
-            return
 
         if mimeType is None:
             # Attempt to guess MIME type if not passed explicitly


### PR DESCRIPTION
@msmolens discovered an ancient bug in girder_client that disallowed uploading of an empty file, which is supported by the server.