### PR TITLE
Upgrade to Vega3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
             "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.2.tgz",
             "integrity": "sha512-+Jty46mPaWe1VAyZbfvgJM4BAdklLWxrT5tc/RjvCgLrtk6gzRY6AOnoWFv4p6hVxhJshDdr2hGVn56alBp97Q==",
             "requires": {
-                "@types/babel-types": "*"
+                "@types/babel-types": "7.0.2"
             }
         },
         "@types/node": {
@@ -45,7 +45,7 @@
             "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
             "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
             "requires": {
-                "acorn": "^4.0.3"
+                "acorn": "4.0.13"
             },
             "dependencies": {
                 "acorn": {
@@ -60,7 +60,7 @@
             "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
             "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
             "requires": {
-                "acorn": "^4.0.4"
+                "acorn": "4.0.13"
             },
             "dependencies": {
                 "acorn": {
@@ -76,7 +76,7 @@
             "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
             "dev": true,
             "requires": {
-                "acorn": "^3.0.4"
+                "acorn": "3.3.0"
             }
         },
         "ajv": {
@@ -84,10 +84,10 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "requires": {
-                "co": "^4.6.0",
-                "fast-deep-equal": "^1.0.0",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.3.0"
+                "co": "4.6.0",
+                "fast-deep-equal": "1.1.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
             }
         },
         "ajv-keywords": {
@@ -100,9 +100,9 @@
             "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
             "requires": {
-                "kind-of": "^3.0.2",
-                "longest": "^1.0.1",
-                "repeat-string": "^1.5.2"
+                "kind-of": "3.2.2",
+                "longest": "1.0.1",
+                "repeat-string": "1.6.1"
             }
         },
         "alphanum-sort": {
@@ -136,8 +136,8 @@
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
             "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
             "requires": {
-                "micromatch": "^3.1.4",
-                "normalize-path": "^2.1.1"
+                "micromatch": "3.1.10",
+                "normalize-path": "2.1.1"
             }
         },
         "aproba": {
@@ -150,7 +150,7 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "requires": {
-                "sprintf-js": "~1.0.2"
+                "sprintf-js": "1.0.3"
             }
         },
         "arr-diff": {
@@ -179,7 +179,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "^1.0.1"
+                "array-uniq": "1.0.3"
             }
         },
         "array-uniq": {
@@ -220,9 +220,9 @@
             "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
             "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
             "requires": {
-                "bn.js": "^4.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0"
+                "bn.js": "4.11.8",
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.1"
             }
         },
         "assert": {
@@ -249,7 +249,7 @@
             "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
             "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
             "requires": {
-                "lodash": "^4.14.0"
+                "lodash": "4.17.10"
             }
         },
         "async-each": {
@@ -278,12 +278,12 @@
             "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
             "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
             "requires": {
-                "browserslist": "^1.7.6",
-                "caniuse-db": "^1.0.30000634",
-                "normalize-range": "^0.1.2",
-                "num2fraction": "^1.2.2",
-                "postcss": "^5.2.16",
-                "postcss-value-parser": "^3.2.3"
+                "browserslist": "1.7.7",
+                "caniuse-db": "1.0.30000841",
+                "normalize-range": "0.1.2",
+                "num2fraction": "1.2.2",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
             },
             "dependencies": {
                 "browserslist": {
@@ -291,8 +291,8 @@
                     "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
                     "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
                     "requires": {
-                        "caniuse-db": "^1.0.30000639",
-                        "electron-to-chromium": "^1.2.7"
+                        "caniuse-db": "1.0.30000841",
+                        "electron-to-chromium": "1.3.46"
                     }
                 }
             }
@@ -314,9 +314,9 @@
             "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "requires": {
-                "chalk": "^1.1.3",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.2"
+                "chalk": "1.1.3",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
             }
         },
         "babel-core": {
@@ -324,25 +324,25 @@
             "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
             "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
             "requires": {
-                "babel-code-frame": "^6.26.0",
-                "babel-generator": "^6.26.0",
-                "babel-helpers": "^6.24.1",
-                "babel-messages": "^6.23.0",
-                "babel-register": "^6.26.0",
-                "babel-runtime": "^6.26.0",
-                "babel-template": "^6.26.0",
-                "babel-traverse": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0",
-                "convert-source-map": "^1.5.1",
-                "debug": "^2.6.9",
-                "json5": "^0.5.1",
-                "lodash": "^4.17.4",
-                "minimatch": "^3.0.4",
-                "path-is-absolute": "^1.0.1",
-                "private": "^0.1.8",
-                "slash": "^1.0.0",
-                "source-map": "^0.5.7"
+                "babel-code-frame": "6.26.0",
+                "babel-generator": "6.26.1",
+                "babel-helpers": "6.24.1",
+                "babel-messages": "6.23.0",
+                "babel-register": "6.26.0",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "convert-source-map": "1.5.1",
+                "debug": "2.6.9",
+                "json5": "0.5.1",
+                "lodash": "4.17.10",
+                "minimatch": "3.0.4",
+                "path-is-absolute": "1.0.1",
+                "private": "0.1.8",
+                "slash": "1.0.0",
+                "source-map": "0.5.7"
             }
         },
         "babel-generator": {
@@ -350,14 +350,14 @@
             "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
             "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
             "requires": {
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "detect-indent": "^4.0.0",
-                "jsesc": "^1.3.0",
-                "lodash": "^4.17.4",
-                "source-map": "^0.5.7",
-                "trim-right": "^1.0.1"
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "detect-indent": "4.0.0",
+                "jsesc": "1.3.0",
+                "lodash": "4.17.10",
+                "source-map": "0.5.7",
+                "trim-right": "1.0.1"
             }
         },
         "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -365,9 +365,9 @@
             "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
             "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
             "requires": {
-                "babel-helper-explode-assignable-expression": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
+                "babel-helper-explode-assignable-expression": "6.24.1",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-helper-call-delegate": {
@@ -375,10 +375,10 @@
             "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
             "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
             "requires": {
-                "babel-helper-hoist-variables": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
+                "babel-helper-hoist-variables": "6.24.1",
+                "babel-runtime": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-helper-define-map": {
@@ -386,10 +386,10 @@
             "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
             "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
             "requires": {
-                "babel-helper-function-name": "^6.24.1",
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "lodash": "^4.17.4"
+                "babel-helper-function-name": "6.24.1",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "lodash": "4.17.10"
             }
         },
         "babel-helper-explode-assignable-expression": {
@@ -397,9 +397,9 @@
             "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
             "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
             "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
+                "babel-runtime": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-helper-function-name": {
@@ -407,11 +407,11 @@
             "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
             "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
             "requires": {
-                "babel-helper-get-function-arity": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
+                "babel-helper-get-function-arity": "6.24.1",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-helper-get-function-arity": {
@@ -419,8 +419,8 @@
             "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
             "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
             "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-helper-hoist-variables": {
@@ -428,8 +428,8 @@
             "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
             "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
             "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-helper-optimise-call-expression": {
@@ -437,8 +437,8 @@
             "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
             "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
             "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-helper-regex": {
@@ -446,9 +446,9 @@
             "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
             "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
             "requires": {
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "lodash": "^4.17.4"
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "lodash": "4.17.10"
             }
         },
         "babel-helper-remap-async-to-generator": {
@@ -456,11 +456,11 @@
             "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
             "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
             "requires": {
-                "babel-helper-function-name": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
+                "babel-helper-function-name": "6.24.1",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-helper-replace-supers": {
@@ -468,12 +468,12 @@
             "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
             "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
             "requires": {
-                "babel-helper-optimise-call-expression": "^6.24.1",
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
+                "babel-helper-optimise-call-expression": "6.24.1",
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-helpers": {
@@ -481,8 +481,8 @@
             "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
             "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
             "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0"
             }
         },
         "babel-loader": {
@@ -490,9 +490,9 @@
             "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.4.tgz",
             "integrity": "sha512-/hbyEvPzBJuGpk9o80R0ZyTej6heEOr59GoEUtn8qFKbnx4cJm9FWES6J/iv644sYgrtVw9JJQkjaLW/bqb5gw==",
             "requires": {
-                "find-cache-dir": "^1.0.0",
-                "loader-utils": "^1.0.2",
-                "mkdirp": "^0.5.1"
+                "find-cache-dir": "1.0.0",
+                "loader-utils": "1.1.0",
+                "mkdirp": "0.5.1"
             }
         },
         "babel-messages": {
@@ -500,7 +500,7 @@
             "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
             "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
             "requires": {
-                "babel-runtime": "^6.22.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-check-es2015-constants": {
@@ -508,7 +508,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
             "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
             "requires": {
-                "babel-runtime": "^6.22.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-istanbul": {
@@ -517,10 +517,10 @@
             "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
             "dev": true,
             "requires": {
-                "babel-plugin-syntax-object-rest-spread": "^6.13.0",
-                "find-up": "^2.1.0",
-                "istanbul-lib-instrument": "^1.10.1",
-                "test-exclude": "^4.2.1"
+                "babel-plugin-syntax-object-rest-spread": "6.13.0",
+                "find-up": "2.1.0",
+                "istanbul-lib-instrument": "1.10.1",
+                "test-exclude": "4.2.1"
             }
         },
         "babel-plugin-syntax-async-functions": {
@@ -549,9 +549,9 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
             "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
             "requires": {
-                "babel-helper-remap-async-to-generator": "^6.24.1",
-                "babel-plugin-syntax-async-functions": "^6.8.0",
-                "babel-runtime": "^6.22.0"
+                "babel-helper-remap-async-to-generator": "6.24.1",
+                "babel-plugin-syntax-async-functions": "6.13.0",
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-arrow-functions": {
@@ -559,7 +559,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
             "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
             "requires": {
-                "babel-runtime": "^6.22.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -567,7 +567,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
             "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
             "requires": {
-                "babel-runtime": "^6.22.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-block-scoping": {
@@ -575,11 +575,11 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
             "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
             "requires": {
-                "babel-runtime": "^6.26.0",
-                "babel-template": "^6.26.0",
-                "babel-traverse": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "lodash": "^4.17.4"
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "lodash": "4.17.10"
             }
         },
         "babel-plugin-transform-es2015-classes": {
@@ -587,15 +587,15 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
             "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
             "requires": {
-                "babel-helper-define-map": "^6.24.1",
-                "babel-helper-function-name": "^6.24.1",
-                "babel-helper-optimise-call-expression": "^6.24.1",
-                "babel-helper-replace-supers": "^6.24.1",
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
+                "babel-helper-define-map": "6.26.0",
+                "babel-helper-function-name": "6.24.1",
+                "babel-helper-optimise-call-expression": "6.24.1",
+                "babel-helper-replace-supers": "6.24.1",
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-computed-properties": {
@@ -603,8 +603,8 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
             "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
             "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-destructuring": {
@@ -612,7 +612,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
             "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
             "requires": {
-                "babel-runtime": "^6.22.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-duplicate-keys": {
@@ -620,8 +620,8 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
             "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
             "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-for-of": {
@@ -629,7 +629,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
             "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
             "requires": {
-                "babel-runtime": "^6.22.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-function-name": {
@@ -637,9 +637,9 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
             "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
             "requires": {
-                "babel-helper-function-name": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
+                "babel-helper-function-name": "6.24.1",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-literals": {
@@ -647,7 +647,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
             "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
             "requires": {
-                "babel-runtime": "^6.22.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-modules-amd": {
@@ -655,9 +655,9 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
             "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
             "requires": {
-                "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
+                "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-modules-commonjs": {
@@ -665,10 +665,10 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
             "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
             "requires": {
-                "babel-plugin-transform-strict-mode": "^6.24.1",
-                "babel-runtime": "^6.26.0",
-                "babel-template": "^6.26.0",
-                "babel-types": "^6.26.0"
+                "babel-plugin-transform-strict-mode": "6.24.1",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-modules-systemjs": {
@@ -676,9 +676,9 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
             "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
             "requires": {
-                "babel-helper-hoist-variables": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
+                "babel-helper-hoist-variables": "6.24.1",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-modules-umd": {
@@ -686,9 +686,9 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
             "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
             "requires": {
-                "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
+                "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-object-super": {
@@ -696,8 +696,8 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
             "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
             "requires": {
-                "babel-helper-replace-supers": "^6.24.1",
-                "babel-runtime": "^6.22.0"
+                "babel-helper-replace-supers": "6.24.1",
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-parameters": {
@@ -705,12 +705,12 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
             "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
             "requires": {
-                "babel-helper-call-delegate": "^6.24.1",
-                "babel-helper-get-function-arity": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
+                "babel-helper-call-delegate": "6.24.1",
+                "babel-helper-get-function-arity": "6.24.1",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-shorthand-properties": {
@@ -718,8 +718,8 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
             "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
             "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-spread": {
@@ -727,7 +727,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
             "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
             "requires": {
-                "babel-runtime": "^6.22.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-sticky-regex": {
@@ -735,9 +735,9 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
             "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
             "requires": {
-                "babel-helper-regex": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
+                "babel-helper-regex": "6.26.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-template-literals": {
@@ -745,7 +745,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
             "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
             "requires": {
-                "babel-runtime": "^6.22.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-typeof-symbol": {
@@ -753,7 +753,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
             "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
             "requires": {
-                "babel-runtime": "^6.22.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-unicode-regex": {
@@ -761,9 +761,9 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
             "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
             "requires": {
-                "babel-helper-regex": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "regexpu-core": "^2.0.0"
+                "babel-helper-regex": "6.26.0",
+                "babel-runtime": "6.26.0",
+                "regexpu-core": "2.0.0"
             }
         },
         "babel-plugin-transform-exponentiation-operator": {
@@ -771,9 +771,9 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
             "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
             "requires": {
-                "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-                "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-                "babel-runtime": "^6.22.0"
+                "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+                "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-transform-regenerator": {
@@ -781,7 +781,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
             "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
             "requires": {
-                "regenerator-transform": "^0.10.0"
+                "regenerator-transform": "0.10.1"
             }
         },
         "babel-plugin-transform-strict-mode": {
@@ -789,8 +789,8 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
             "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
             "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-preset-env": {
@@ -798,36 +798,36 @@
             "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
             "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
             "requires": {
-                "babel-plugin-check-es2015-constants": "^6.22.0",
-                "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-                "babel-plugin-transform-async-to-generator": "^6.22.0",
-                "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-                "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-                "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-                "babel-plugin-transform-es2015-classes": "^6.23.0",
-                "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-                "babel-plugin-transform-es2015-destructuring": "^6.23.0",
-                "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-                "babel-plugin-transform-es2015-for-of": "^6.23.0",
-                "babel-plugin-transform-es2015-function-name": "^6.22.0",
-                "babel-plugin-transform-es2015-literals": "^6.22.0",
-                "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-                "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-                "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-                "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-                "babel-plugin-transform-es2015-object-super": "^6.22.0",
-                "babel-plugin-transform-es2015-parameters": "^6.23.0",
-                "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-                "babel-plugin-transform-es2015-spread": "^6.22.0",
-                "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-                "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-                "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-                "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-                "babel-plugin-transform-exponentiation-operator": "^6.22.0",
-                "babel-plugin-transform-regenerator": "^6.22.0",
-                "browserslist": "^3.2.6",
-                "invariant": "^2.2.2",
-                "semver": "^5.3.0"
+                "babel-plugin-check-es2015-constants": "6.22.0",
+                "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+                "babel-plugin-transform-async-to-generator": "6.24.1",
+                "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+                "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+                "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+                "babel-plugin-transform-es2015-classes": "6.24.1",
+                "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+                "babel-plugin-transform-es2015-destructuring": "6.23.0",
+                "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+                "babel-plugin-transform-es2015-for-of": "6.23.0",
+                "babel-plugin-transform-es2015-function-name": "6.24.1",
+                "babel-plugin-transform-es2015-literals": "6.22.0",
+                "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+                "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+                "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+                "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+                "babel-plugin-transform-es2015-object-super": "6.24.1",
+                "babel-plugin-transform-es2015-parameters": "6.24.1",
+                "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+                "babel-plugin-transform-es2015-spread": "6.22.0",
+                "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+                "babel-plugin-transform-es2015-template-literals": "6.22.0",
+                "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+                "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+                "babel-plugin-transform-exponentiation-operator": "6.24.1",
+                "babel-plugin-transform-regenerator": "6.26.0",
+                "browserslist": "3.2.7",
+                "invariant": "2.2.4",
+                "semver": "5.5.0"
             }
         },
         "babel-register": {
@@ -835,13 +835,13 @@
             "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
             "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
             "requires": {
-                "babel-core": "^6.26.0",
-                "babel-runtime": "^6.26.0",
-                "core-js": "^2.5.0",
-                "home-or-tmp": "^2.0.0",
-                "lodash": "^4.17.4",
-                "mkdirp": "^0.5.1",
-                "source-map-support": "^0.4.15"
+                "babel-core": "6.26.3",
+                "babel-runtime": "6.26.0",
+                "core-js": "2.5.6",
+                "home-or-tmp": "2.0.0",
+                "lodash": "4.17.10",
+                "mkdirp": "0.5.1",
+                "source-map-support": "0.4.18"
             }
         },
         "babel-runtime": {
@@ -849,8 +849,8 @@
             "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
             "requires": {
-                "core-js": "^2.4.0",
-                "regenerator-runtime": "^0.11.0"
+                "core-js": "2.5.6",
+                "regenerator-runtime": "0.11.1"
             }
         },
         "babel-template": {
@@ -858,11 +858,11 @@
             "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
             "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
             "requires": {
-                "babel-runtime": "^6.26.0",
-                "babel-traverse": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0",
-                "lodash": "^4.17.4"
+                "babel-runtime": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "lodash": "4.17.10"
             }
         },
         "babel-traverse": {
@@ -870,15 +870,15 @@
             "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
             "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
             "requires": {
-                "babel-code-frame": "^6.26.0",
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0",
-                "debug": "^2.6.8",
-                "globals": "^9.18.0",
-                "invariant": "^2.2.2",
-                "lodash": "^4.17.4"
+                "babel-code-frame": "6.26.0",
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "debug": "2.6.9",
+                "globals": "9.18.0",
+                "invariant": "2.2.4",
+                "lodash": "4.17.10"
             }
         },
         "babel-types": {
@@ -886,10 +886,10 @@
             "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
             "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
             "requires": {
-                "babel-runtime": "^6.26.0",
-                "esutils": "^2.0.2",
-                "lodash": "^4.17.4",
-                "to-fast-properties": "^1.0.3"
+                "babel-runtime": "6.26.0",
+                "esutils": "2.0.2",
+                "lodash": "4.17.10",
+                "to-fast-properties": "1.0.3"
             }
         },
         "babylon": {
@@ -902,7 +902,7 @@
             "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.3.3.tgz",
             "integrity": "sha1-TMgOp8sWMaxHSInOQPL4vGg7KZk=",
             "requires": {
-                "underscore": ">=1.8.3"
+                "underscore": "1.9.0"
             }
         },
         "balanced-match": {
@@ -915,13 +915,13 @@
             "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "requires": {
-                "cache-base": "^1.0.1",
-                "class-utils": "^0.3.5",
-                "component-emitter": "^1.2.1",
-                "define-property": "^1.0.0",
-                "isobject": "^3.0.1",
-                "mixin-deep": "^1.2.0",
-                "pascalcase": "^0.1.1"
+                "cache-base": "1.0.1",
+                "class-utils": "0.3.6",
+                "component-emitter": "1.2.1",
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "mixin-deep": "1.3.1",
+                "pascalcase": "0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -929,7 +929,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -937,7 +937,7 @@
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -945,7 +945,7 @@
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -953,9 +953,9 @@
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 },
                 "kind-of": {
@@ -977,7 +977,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "tweetnacl": "^0.14.3"
+                "tweetnacl": "0.14.5"
             }
         },
         "big.js": {
@@ -990,8 +990,8 @@
             "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
             "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
             "requires": {
-                "buffers": "~0.1.1",
-                "chainsaw": "~0.1.0"
+                "buffers": "0.1.1",
+                "chainsaw": "0.1.0"
             }
         },
         "binary-extensions": {
@@ -1021,7 +1021,7 @@
             "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
             "dev": true,
             "requires": {
-                "hoek": "4.x.x"
+                "hoek": "4.2.1"
             }
         },
         "bootstrap": {
@@ -1047,7 +1047,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "requires": {
-                "balanced-match": "^1.0.0",
+                "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -1056,16 +1056,16 @@
             "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
             "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
             "requires": {
-                "arr-flatten": "^1.1.0",
-                "array-unique": "^0.3.2",
-                "extend-shallow": "^2.0.1",
-                "fill-range": "^4.0.0",
-                "isobject": "^3.0.1",
-                "repeat-element": "^1.1.2",
-                "snapdragon": "^0.8.1",
-                "snapdragon-node": "^2.0.1",
-                "split-string": "^3.0.2",
-                "to-regex": "^3.0.1"
+                "arr-flatten": "1.1.0",
+                "array-unique": "0.3.2",
+                "extend-shallow": "2.0.1",
+                "fill-range": "4.0.0",
+                "isobject": "3.0.1",
+                "repeat-element": "1.1.2",
+                "snapdragon": "0.8.2",
+                "snapdragon-node": "2.1.1",
+                "split-string": "3.1.0",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -1073,7 +1073,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -1088,12 +1088,12 @@
             "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
             "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
             "requires": {
-                "buffer-xor": "^1.0.3",
-                "cipher-base": "^1.0.0",
-                "create-hash": "^1.1.0",
-                "evp_bytestokey": "^1.0.3",
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "buffer-xor": "1.0.3",
+                "cipher-base": "1.0.4",
+                "create-hash": "1.2.0",
+                "evp_bytestokey": "1.0.3",
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.2"
             }
         },
         "browserify-cipher": {
@@ -1101,9 +1101,9 @@
             "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
             "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
             "requires": {
-                "browserify-aes": "^1.0.4",
-                "browserify-des": "^1.0.0",
-                "evp_bytestokey": "^1.0.0"
+                "browserify-aes": "1.2.0",
+                "browserify-des": "1.0.1",
+                "evp_bytestokey": "1.0.3"
             }
         },
         "browserify-des": {
@@ -1111,9 +1111,9 @@
             "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz",
             "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
             "requires": {
-                "cipher-base": "^1.0.1",
-                "des.js": "^1.0.0",
-                "inherits": "^2.0.1"
+                "cipher-base": "1.0.4",
+                "des.js": "1.0.0",
+                "inherits": "2.0.3"
             }
         },
         "browserify-rsa": {
@@ -1121,8 +1121,8 @@
             "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
             "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
             "requires": {
-                "bn.js": "^4.1.0",
-                "randombytes": "^2.0.1"
+                "bn.js": "4.11.8",
+                "randombytes": "2.0.6"
             }
         },
         "browserify-sign": {
@@ -1130,13 +1130,13 @@
             "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
             "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
             "requires": {
-                "bn.js": "^4.1.1",
-                "browserify-rsa": "^4.0.0",
-                "create-hash": "^1.1.0",
-                "create-hmac": "^1.1.2",
-                "elliptic": "^6.0.0",
-                "inherits": "^2.0.1",
-                "parse-asn1": "^5.0.0"
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.2.0",
+                "create-hmac": "1.1.7",
+                "elliptic": "6.4.0",
+                "inherits": "2.0.3",
+                "parse-asn1": "5.1.1"
             }
         },
         "browserify-zlib": {
@@ -1144,7 +1144,7 @@
             "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
             "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
             "requires": {
-                "pako": "~0.2.0"
+                "pako": "0.2.9"
             }
         },
         "browserslist": {
@@ -1152,8 +1152,8 @@
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.7.tgz",
             "integrity": "sha512-oYVLxFVqpX9uMhOIQBLtZL+CX4uY8ZpWcjNTaxyWl5rO8yA9SSNikFnAfvk8J3P/7z3BZwNmEqFKaJoYltj3MQ==",
             "requires": {
-                "caniuse-lite": "^1.0.30000835",
-                "electron-to-chromium": "^1.3.45"
+                "caniuse-lite": "1.0.30000841",
+                "electron-to-chromium": "1.3.46"
             }
         },
         "buffer": {
@@ -1161,9 +1161,9 @@
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
             "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
             "requires": {
-                "base64-js": "^1.0.2",
-                "ieee754": "^1.1.4",
-                "isarray": "^1.0.0"
+                "base64-js": "1.3.0",
+                "ieee754": "1.1.11",
+                "isarray": "1.0.0"
             }
         },
         "buffer-crc32": {
@@ -1201,19 +1201,19 @@
             "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
             "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
             "requires": {
-                "bluebird": "^3.5.1",
-                "chownr": "^1.0.1",
-                "glob": "^7.1.2",
-                "graceful-fs": "^4.1.11",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^2.0.0",
-                "mkdirp": "^0.5.1",
-                "move-concurrently": "^1.0.1",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^2.6.2",
-                "ssri": "^5.2.4",
-                "unique-filename": "^1.1.0",
-                "y18n": "^4.0.0"
+                "bluebird": "3.5.1",
+                "chownr": "1.0.1",
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "lru-cache": "4.1.3",
+                "mississippi": "2.0.0",
+                "mkdirp": "0.5.1",
+                "move-concurrently": "1.0.1",
+                "promise-inflight": "1.0.1",
+                "rimraf": "2.6.2",
+                "ssri": "5.3.0",
+                "unique-filename": "1.1.0",
+                "y18n": "4.0.0"
             },
             "dependencies": {
                 "glob": {
@@ -1221,12 +1221,12 @@
                     "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "rimraf": {
@@ -1234,7 +1234,7 @@
                     "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
                     "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
                     "requires": {
-                        "glob": "^7.0.5"
+                        "glob": "7.1.2"
                     }
                 }
             }
@@ -1244,15 +1244,15 @@
             "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "requires": {
-                "collection-visit": "^1.0.0",
-                "component-emitter": "^1.2.1",
-                "get-value": "^2.0.6",
-                "has-value": "^1.0.0",
-                "isobject": "^3.0.1",
-                "set-value": "^2.0.0",
-                "to-object-path": "^0.3.0",
-                "union-value": "^1.0.0",
-                "unset-value": "^1.0.0"
+                "collection-visit": "1.0.0",
+                "component-emitter": "1.2.1",
+                "get-value": "2.0.6",
+                "has-value": "1.0.0",
+                "isobject": "3.0.1",
+                "set-value": "2.0.0",
+                "to-object-path": "0.3.0",
+                "union-value": "1.0.0",
+                "unset-value": "1.0.0"
             }
         },
         "caller-path": {
@@ -1261,7 +1261,7 @@
             "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
             "dev": true,
             "requires": {
-                "callsites": "^0.2.0"
+                "callsites": "0.2.0"
             }
         },
         "callsites": {
@@ -1280,8 +1280,8 @@
             "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
             "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
             "requires": {
-                "camelcase": "^2.0.0",
-                "map-obj": "^1.0.0"
+                "camelcase": "2.1.1",
+                "map-obj": "1.0.1"
             }
         },
         "caniuse-api": {
@@ -1289,10 +1289,10 @@
             "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
             "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
             "requires": {
-                "browserslist": "^1.3.6",
-                "caniuse-db": "^1.0.30000529",
-                "lodash.memoize": "^4.1.2",
-                "lodash.uniq": "^4.5.0"
+                "browserslist": "1.7.7",
+                "caniuse-db": "1.0.30000841",
+                "lodash.memoize": "4.1.2",
+                "lodash.uniq": "4.5.0"
             },
             "dependencies": {
                 "browserslist": {
@@ -1300,8 +1300,8 @@
                     "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
                     "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
                     "requires": {
-                        "caniuse-db": "^1.0.30000639",
-                        "electron-to-chromium": "^1.2.7"
+                        "caniuse-db": "1.0.30000841",
+                        "electron-to-chromium": "1.3.46"
                     }
                 }
             }
@@ -1327,8 +1327,8 @@
             "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
             "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
             "requires": {
-                "align-text": "^0.1.3",
-                "lazy-cache": "^1.0.3"
+                "align-text": "0.1.4",
+                "lazy-cache": "1.0.4"
             }
         },
         "chainsaw": {
@@ -1336,7 +1336,7 @@
             "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
             "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
             "requires": {
-                "traverse": ">=0.3.0 <0.4"
+                "traverse": "0.3.9"
             }
         },
         "chalk": {
@@ -1344,11 +1344,11 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
             }
         },
         "character-parser": {
@@ -1356,7 +1356,7 @@
             "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
             "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
             "requires": {
-                "is-regex": "^1.0.3"
+                "is-regex": "1.0.4"
             }
         },
         "chardet": {
@@ -1371,12 +1371,12 @@
             "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
             "dev": true,
             "requires": {
-                "css-select": "~1.2.0",
-                "dom-serializer": "~0.1.0",
-                "entities": "~1.1.1",
-                "htmlparser2": "^3.9.1",
-                "lodash": "^4.15.0",
-                "parse5": "^3.0.1"
+                "css-select": "1.2.0",
+                "dom-serializer": "0.1.0",
+                "entities": "1.1.1",
+                "htmlparser2": "3.9.2",
+                "lodash": "4.17.10",
+                "parse5": "3.0.3"
             }
         },
         "chokidar": {
@@ -1384,18 +1384,18 @@
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
             "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
             "requires": {
-                "anymatch": "^2.0.0",
-                "async-each": "^1.0.0",
-                "braces": "^2.3.0",
-                "fsevents": "^1.1.2",
-                "glob-parent": "^3.1.0",
-                "inherits": "^2.0.1",
-                "is-binary-path": "^1.0.0",
-                "is-glob": "^4.0.0",
-                "normalize-path": "^2.1.1",
-                "path-is-absolute": "^1.0.0",
-                "readdirp": "^2.0.0",
-                "upath": "^1.0.0"
+                "anymatch": "2.0.0",
+                "async-each": "1.0.1",
+                "braces": "2.3.2",
+                "fsevents": "1.2.4",
+                "glob-parent": "3.1.0",
+                "inherits": "2.0.3",
+                "is-binary-path": "1.0.1",
+                "is-glob": "4.0.0",
+                "normalize-path": "2.1.1",
+                "path-is-absolute": "1.0.1",
+                "readdirp": "2.1.0",
+                "upath": "1.1.0"
             }
         },
         "chownr": {
@@ -1408,8 +1408,8 @@
             "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
             "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
             "requires": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.2"
             }
         },
         "circular-json": {
@@ -1423,7 +1423,7 @@
             "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
             "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
             "requires": {
-                "chalk": "^1.1.3"
+                "chalk": "1.1.3"
             }
         },
         "class-utils": {
@@ -1431,10 +1431,10 @@
             "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "requires": {
-                "arr-union": "^3.1.0",
-                "define-property": "^0.2.5",
-                "isobject": "^3.0.0",
-                "static-extend": "^0.1.1"
+                "arr-union": "3.1.0",
+                "define-property": "0.2.5",
+                "isobject": "3.0.1",
+                "static-extend": "0.1.2"
             },
             "dependencies": {
                 "define-property": {
@@ -1442,7 +1442,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 }
             }
@@ -1452,7 +1452,7 @@
             "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.11.tgz",
             "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
             "requires": {
-                "source-map": "0.5.x"
+                "source-map": "0.5.7"
             }
         },
         "cli-cursor": {
@@ -1461,7 +1461,7 @@
             "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
             "dev": true,
             "requires": {
-                "restore-cursor": "^2.0.0"
+                "restore-cursor": "2.0.0"
             }
         },
         "cli-width": {
@@ -1475,8 +1475,8 @@
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
             "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
             "requires": {
-                "center-align": "^0.1.1",
-                "right-align": "^0.1.1",
+                "center-align": "0.1.3",
+                "right-align": "0.1.3",
                 "wordwrap": "0.0.2"
             }
         },
@@ -1495,7 +1495,7 @@
             "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
             "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
             "requires": {
-                "q": "^1.1.2"
+                "q": "1.5.1"
             }
         },
         "code-point-at": {
@@ -1513,8 +1513,8 @@
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "requires": {
-                "map-visit": "^1.0.0",
-                "object-visit": "^1.0.0"
+                "map-visit": "1.0.0",
+                "object-visit": "1.0.1"
             }
         },
         "color": {
@@ -1522,9 +1522,9 @@
             "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
             "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
             "requires": {
-                "clone": "^1.0.2",
-                "color-convert": "^1.3.0",
-                "color-string": "^0.3.0"
+                "clone": "1.0.4",
+                "color-convert": "1.9.1",
+                "color-string": "0.3.0"
             }
         },
         "color-convert": {
@@ -1532,7 +1532,7 @@
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
             "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "requires": {
-                "color-name": "^1.1.1"
+                "color-name": "1.1.3"
             }
         },
         "color-logger": {
@@ -1551,7 +1551,7 @@
             "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
             "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
             "requires": {
-                "color-name": "^1.0.0"
+                "color-name": "1.1.3"
             }
         },
         "colormin": {
@@ -1559,9 +1559,9 @@
             "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
             "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
             "requires": {
-                "color": "^0.11.0",
+                "color": "0.11.4",
                 "css-color-names": "0.0.4",
-                "has": "^1.0.1"
+                "has": "1.0.1"
             }
         },
         "colors": {
@@ -1575,8 +1575,8 @@
             "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
             "dev": true,
             "requires": {
-                "strip-ansi": "^3.0.0",
-                "wcwidth": "^1.0.0"
+                "strip-ansi": "3.0.1",
+                "wcwidth": "1.0.1"
             }
         },
         "combined-stream": {
@@ -1585,7 +1585,7 @@
             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "dev": true,
             "requires": {
-                "delayed-stream": "~1.0.0"
+                "delayed-stream": "1.0.0"
             }
         },
         "commander": {
@@ -1613,10 +1613,10 @@
             "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
             "requires": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
+                "buffer-from": "1.0.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "typedarray": "0.0.6"
             }
         },
         "console-browserify": {
@@ -1624,7 +1624,7 @@
             "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
             "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
             "requires": {
-                "date-now": "^0.1.4"
+                "date-now": "0.1.4"
             }
         },
         "constantinople": {
@@ -1632,10 +1632,10 @@
             "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.2.tgz",
             "integrity": "sha512-yePcBqEFhLOqSBtwYOGGS1exHo/s1xjekXiinh4itpNQGCu4KA1euPh1fg07N2wMITZXQkBz75Ntdt1ctGZouw==",
             "requires": {
-                "@types/babel-types": "^7.0.0",
-                "@types/babylon": "^6.16.2",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0"
+                "@types/babel-types": "7.0.2",
+                "@types/babylon": "6.16.2",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0"
             }
         },
         "constants-browserify": {
@@ -1659,12 +1659,12 @@
             "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
             "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
             "requires": {
-                "aproba": "^1.1.1",
-                "fs-write-stream-atomic": "^1.0.8",
-                "iferr": "^0.1.5",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.0"
+                "aproba": "1.2.0",
+                "fs-write-stream-atomic": "1.0.10",
+                "iferr": "0.1.5",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "run-queue": "1.0.3"
             },
             "dependencies": {
                 "rimraf": {
@@ -1672,7 +1672,7 @@
                     "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
                     "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
                     "requires": {
-                        "glob": "^7.0.5"
+                        "glob": "7.0.6"
                     }
                 }
             }
@@ -1697,8 +1697,8 @@
             "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
             "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
             "requires": {
-                "bn.js": "^4.1.0",
-                "elliptic": "^6.0.0"
+                "bn.js": "4.11.8",
+                "elliptic": "6.4.0"
             }
         },
         "create-hash": {
@@ -1706,11 +1706,11 @@
             "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
             "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
             "requires": {
-                "cipher-base": "^1.0.1",
-                "inherits": "^2.0.1",
-                "md5.js": "^1.3.4",
-                "ripemd160": "^2.0.1",
-                "sha.js": "^2.4.0"
+                "cipher-base": "1.0.4",
+                "inherits": "2.0.3",
+                "md5.js": "1.3.4",
+                "ripemd160": "2.0.2",
+                "sha.js": "2.4.11"
             }
         },
         "create-hmac": {
@@ -1718,12 +1718,12 @@
             "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
             "requires": {
-                "cipher-base": "^1.0.3",
-                "create-hash": "^1.1.0",
-                "inherits": "^2.0.1",
-                "ripemd160": "^2.0.0",
-                "safe-buffer": "^5.0.1",
-                "sha.js": "^2.4.8"
+                "cipher-base": "1.0.4",
+                "create-hash": "1.2.0",
+                "inherits": "2.0.3",
+                "ripemd160": "2.0.2",
+                "safe-buffer": "5.1.2",
+                "sha.js": "2.4.11"
             }
         },
         "cross-spawn": {
@@ -1732,9 +1732,9 @@
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
             "dev": true,
             "requires": {
-                "lru-cache": "^4.0.1",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
+                "lru-cache": "4.1.3",
+                "shebang-command": "1.2.0",
+                "which": "1.2.14"
             }
         },
         "cryptiles": {
@@ -1743,7 +1743,7 @@
             "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
             "dev": true,
             "requires": {
-                "boom": "5.x.x"
+                "boom": "5.2.0"
             },
             "dependencies": {
                 "boom": {
@@ -1752,7 +1752,7 @@
                     "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
                     "dev": true,
                     "requires": {
-                        "hoek": "4.x.x"
+                        "hoek": "4.2.1"
                     }
                 }
             }
@@ -1762,17 +1762,17 @@
             "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
             "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
             "requires": {
-                "browserify-cipher": "^1.0.0",
-                "browserify-sign": "^4.0.0",
-                "create-ecdh": "^4.0.0",
-                "create-hash": "^1.1.0",
-                "create-hmac": "^1.1.0",
-                "diffie-hellman": "^5.0.0",
-                "inherits": "^2.0.1",
-                "pbkdf2": "^3.0.3",
-                "public-encrypt": "^4.0.0",
-                "randombytes": "^2.0.0",
-                "randomfill": "^1.0.3"
+                "browserify-cipher": "1.0.1",
+                "browserify-sign": "4.0.4",
+                "create-ecdh": "4.0.3",
+                "create-hash": "1.2.0",
+                "create-hmac": "1.1.7",
+                "diffie-hellman": "5.0.3",
+                "inherits": "2.0.3",
+                "pbkdf2": "3.0.16",
+                "public-encrypt": "4.0.2",
+                "randombytes": "2.0.6",
+                "randomfill": "1.0.4"
             }
         },
         "css-color-names": {
@@ -1785,18 +1785,18 @@
             "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.26.4.tgz",
             "integrity": "sha1-th6eMNuUMD5v/IkvEOzQmtAlof0=",
             "requires": {
-                "babel-code-frame": "^6.11.0",
-                "css-selector-tokenizer": "^0.7.0",
-                "cssnano": ">=2.6.1 <4",
-                "loader-utils": "^1.0.2",
-                "lodash.camelcase": "^4.3.0",
-                "object-assign": "^4.0.1",
-                "postcss": "^5.0.6",
-                "postcss-modules-extract-imports": "^1.0.0",
-                "postcss-modules-local-by-default": "^1.0.1",
-                "postcss-modules-scope": "^1.0.0",
-                "postcss-modules-values": "^1.1.0",
-                "source-list-map": "^0.1.7"
+                "babel-code-frame": "6.26.0",
+                "css-selector-tokenizer": "0.7.0",
+                "cssnano": "3.10.0",
+                "loader-utils": "1.1.0",
+                "lodash.camelcase": "4.3.0",
+                "object-assign": "4.1.1",
+                "postcss": "5.2.18",
+                "postcss-modules-extract-imports": "1.1.0",
+                "postcss-modules-local-by-default": "1.2.0",
+                "postcss-modules-scope": "1.1.0",
+                "postcss-modules-values": "1.3.0",
+                "source-list-map": "0.1.8"
             }
         },
         "css-parse": {
@@ -1810,10 +1810,10 @@
             "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
             "dev": true,
             "requires": {
-                "boolbase": "~1.0.0",
-                "css-what": "2.1",
+                "boolbase": "1.0.0",
+                "css-what": "2.1.0",
                 "domutils": "1.5.1",
-                "nth-check": "~1.0.1"
+                "nth-check": "1.0.1"
             }
         },
         "css-selector-parser": {
@@ -1827,9 +1827,9 @@
             "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
             "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
             "requires": {
-                "cssesc": "^0.1.0",
-                "fastparse": "^1.1.1",
-                "regexpu-core": "^1.0.0"
+                "cssesc": "0.1.0",
+                "fastparse": "1.1.1",
+                "regexpu-core": "1.0.0"
             },
             "dependencies": {
                 "regexpu-core": {
@@ -1837,9 +1837,9 @@
                     "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
                     "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
                     "requires": {
-                        "regenerate": "^1.2.1",
-                        "regjsgen": "^0.2.0",
-                        "regjsparser": "^0.1.4"
+                        "regenerate": "1.4.0",
+                        "regjsgen": "0.2.0",
+                        "regjsparser": "0.1.5"
                     }
                 }
             }
@@ -1860,38 +1860,38 @@
             "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
             "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
             "requires": {
-                "autoprefixer": "^6.3.1",
-                "decamelize": "^1.1.2",
-                "defined": "^1.0.0",
-                "has": "^1.0.1",
-                "object-assign": "^4.0.1",
-                "postcss": "^5.0.14",
-                "postcss-calc": "^5.2.0",
-                "postcss-colormin": "^2.1.8",
-                "postcss-convert-values": "^2.3.4",
-                "postcss-discard-comments": "^2.0.4",
-                "postcss-discard-duplicates": "^2.0.1",
-                "postcss-discard-empty": "^2.0.1",
-                "postcss-discard-overridden": "^0.1.1",
-                "postcss-discard-unused": "^2.2.1",
-                "postcss-filter-plugins": "^2.0.0",
-                "postcss-merge-idents": "^2.1.5",
-                "postcss-merge-longhand": "^2.0.1",
-                "postcss-merge-rules": "^2.0.3",
-                "postcss-minify-font-values": "^1.0.2",
-                "postcss-minify-gradients": "^1.0.1",
-                "postcss-minify-params": "^1.0.4",
-                "postcss-minify-selectors": "^2.0.4",
-                "postcss-normalize-charset": "^1.1.0",
-                "postcss-normalize-url": "^3.0.7",
-                "postcss-ordered-values": "^2.1.0",
-                "postcss-reduce-idents": "^2.2.2",
-                "postcss-reduce-initial": "^1.0.0",
-                "postcss-reduce-transforms": "^1.0.3",
-                "postcss-svgo": "^2.1.1",
-                "postcss-unique-selectors": "^2.0.2",
-                "postcss-value-parser": "^3.2.3",
-                "postcss-zindex": "^2.0.1"
+                "autoprefixer": "6.7.7",
+                "decamelize": "1.2.0",
+                "defined": "1.0.0",
+                "has": "1.0.1",
+                "object-assign": "4.1.1",
+                "postcss": "5.2.18",
+                "postcss-calc": "5.3.1",
+                "postcss-colormin": "2.2.2",
+                "postcss-convert-values": "2.6.1",
+                "postcss-discard-comments": "2.0.4",
+                "postcss-discard-duplicates": "2.1.0",
+                "postcss-discard-empty": "2.1.0",
+                "postcss-discard-overridden": "0.1.1",
+                "postcss-discard-unused": "2.2.3",
+                "postcss-filter-plugins": "2.0.2",
+                "postcss-merge-idents": "2.1.7",
+                "postcss-merge-longhand": "2.0.2",
+                "postcss-merge-rules": "2.1.2",
+                "postcss-minify-font-values": "1.0.5",
+                "postcss-minify-gradients": "1.0.5",
+                "postcss-minify-params": "1.2.2",
+                "postcss-minify-selectors": "2.1.1",
+                "postcss-normalize-charset": "1.1.1",
+                "postcss-normalize-url": "3.0.8",
+                "postcss-ordered-values": "2.2.3",
+                "postcss-reduce-idents": "2.4.0",
+                "postcss-reduce-initial": "1.0.1",
+                "postcss-reduce-transforms": "1.0.4",
+                "postcss-svgo": "2.1.6",
+                "postcss-unique-selectors": "2.0.2",
+                "postcss-value-parser": "3.3.0",
+                "postcss-zindex": "2.2.0"
             }
         },
         "csso": {
@@ -1899,8 +1899,8 @@
             "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
             "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
             "requires": {
-                "clap": "^1.0.9",
-                "source-map": "^0.5.3"
+                "clap": "1.2.3",
+                "source-map": "0.5.7"
             }
         },
         "cssom": {
@@ -1916,7 +1916,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "cssom": "0.3.x"
+                "cssom": "0.3.2"
             }
         },
         "currently-unhandled": {
@@ -1924,7 +1924,7 @@
             "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
             "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
             "requires": {
-                "array-find-index": "^1.0.1"
+                "array-find-index": "1.0.2"
             }
         },
         "cyclist": {
@@ -1938,7 +1938,7 @@
             "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
             "dev": true,
             "requires": {
-                "es5-ext": "^0.10.9"
+                "es5-ext": "0.10.42"
             }
         },
         "dashdash": {
@@ -1947,7 +1947,7 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "date-now": {
@@ -1960,8 +1960,8 @@
             "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
             "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
             "requires": {
-                "get-stdin": "^4.0.1",
-                "meow": "^3.3.0"
+                "get-stdin": "4.0.1",
+                "meow": "3.7.0"
             }
         },
         "debug": {
@@ -1987,7 +1987,7 @@
             "resolved": "https://registry.npmjs.org/deep-for-each/-/deep-for-each-2.0.3.tgz",
             "integrity": "sha512-Y9mu+rplGcNZ7veer+5rqcdI9w3aPb7/WyE/nYnsuPevaE2z5YuC2u7/Gz/hIKsa0zo8sE8gKoBimSNsO/sr+A==",
             "requires": {
-                "lodash.isplainobject": "^4.0.6"
+                "lodash.isplainobject": "4.0.6"
             }
         },
         "deep-is": {
@@ -2002,7 +2002,7 @@
             "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
             "dev": true,
             "requires": {
-                "clone": "^1.0.2"
+                "clone": "1.0.4"
             }
         },
         "define-property": {
@@ -2010,8 +2010,8 @@
             "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "requires": {
-                "is-descriptor": "^1.0.2",
-                "isobject": "^3.0.1"
+                "is-descriptor": "1.0.2",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "is-accessor-descriptor": {
@@ -2019,7 +2019,7 @@
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -2027,7 +2027,7 @@
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -2035,9 +2035,9 @@
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 },
                 "kind-of": {
@@ -2058,13 +2058,13 @@
             "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
             "dev": true,
             "requires": {
-                "globby": "^5.0.0",
-                "is-path-cwd": "^1.0.0",
-                "is-path-in-cwd": "^1.0.0",
-                "object-assign": "^4.0.1",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0",
-                "rimraf": "^2.2.8"
+                "globby": "5.0.0",
+                "is-path-cwd": "1.0.0",
+                "is-path-in-cwd": "1.0.1",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "rimraf": "2.2.8"
             },
             "dependencies": {
                 "pify": {
@@ -2086,8 +2086,8 @@
             "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
             "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
             "requires": {
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0"
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.1"
             }
         },
         "detect-indent": {
@@ -2095,7 +2095,7 @@
             "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
             "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
             "requires": {
-                "repeating": "^2.0.0"
+                "repeating": "2.0.1"
             }
         },
         "diffie-hellman": {
@@ -2103,9 +2103,9 @@
             "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
             "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
             "requires": {
-                "bn.js": "^4.1.0",
-                "miller-rabin": "^4.0.0",
-                "randombytes": "^2.0.0"
+                "bn.js": "4.11.8",
+                "miller-rabin": "4.0.1",
+                "randombytes": "2.0.6"
             }
         },
         "doctrine": {
@@ -2114,7 +2114,7 @@
             "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
             "dev": true,
             "requires": {
-                "esutils": "^2.0.2"
+                "esutils": "2.0.2"
             }
         },
         "doctypes": {
@@ -2128,8 +2128,8 @@
             "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
             "dev": true,
             "requires": {
-                "domelementtype": "~1.1.1",
-                "entities": "~1.1.1"
+                "domelementtype": "1.1.3",
+                "entities": "1.1.1"
             },
             "dependencies": {
                 "domelementtype": {
@@ -2157,7 +2157,7 @@
             "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
             "dev": true,
             "requires": {
-                "domelementtype": "1"
+                "domelementtype": "1.3.0"
             }
         },
         "domutils": {
@@ -2166,8 +2166,8 @@
             "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
             "dev": true,
             "requires": {
-                "dom-serializer": "0",
-                "domelementtype": "1"
+                "dom-serializer": "0.1.0",
+                "domelementtype": "1.3.0"
             }
         },
         "duplexify": {
@@ -2175,10 +2175,10 @@
             "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
             "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
             "requires": {
-                "end-of-stream": "^1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
-                "stream-shift": "^1.0.0"
+                "end-of-stream": "1.4.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "stream-shift": "1.0.0"
             }
         },
         "ecc-jsbn": {
@@ -2188,7 +2188,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "jsbn": "~0.1.0"
+                "jsbn": "0.1.1"
             }
         },
         "electron-to-chromium": {
@@ -2201,13 +2201,13 @@
             "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
             "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
             "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0",
+                "hash.js": "1.1.3",
+                "hmac-drbg": "1.0.1",
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.1",
+                "minimalistic-crypto-utils": "1.0.1"
             }
         },
         "emojis-list": {
@@ -2220,7 +2220,7 @@
             "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
             "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
             "requires": {
-                "iconv-lite": "~0.4.13"
+                "iconv-lite": "0.4.23"
             }
         },
         "end-of-stream": {
@@ -2228,7 +2228,7 @@
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "requires": {
-                "once": "^1.4.0"
+                "once": "1.4.0"
             }
         },
         "enhanced-resolve": {
@@ -2236,10 +2236,10 @@
             "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
             "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "memory-fs": "^0.4.0",
-                "object-assign": "^4.0.1",
-                "tapable": "^0.2.7"
+                "graceful-fs": "4.1.11",
+                "memory-fs": "0.4.1",
+                "object-assign": "4.1.1",
+                "tapable": "0.2.8"
             }
         },
         "entities": {
@@ -2253,10 +2253,10 @@
             "resolved": "https://registry.npmjs.org/eonasdan-bootstrap-datetimepicker/-/eonasdan-bootstrap-datetimepicker-4.17.47.tgz",
             "integrity": "sha1-ekmXAEQGUnbnll79Fvgic1IZ5zU=",
             "requires": {
-                "bootstrap": "^3.3",
-                "jquery": "^1.8.3 || ^2.0 || ^3.0",
-                "moment": "^2.10",
-                "moment-timezone": "^0.4.0"
+                "bootstrap": "3.3.7",
+                "jquery": "3.2.1",
+                "moment": "2.20.1",
+                "moment-timezone": "0.4.1"
             }
         },
         "errno": {
@@ -2264,7 +2264,7 @@
             "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
             "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
             "requires": {
-                "prr": "~1.0.1"
+                "prr": "1.0.1"
             }
         },
         "error-ex": {
@@ -2272,7 +2272,7 @@
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
             "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
             "requires": {
-                "is-arrayish": "^0.2.1"
+                "is-arrayish": "0.2.1"
             }
         },
         "es5-ext": {
@@ -2281,9 +2281,9 @@
             "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
             "dev": true,
             "requires": {
-                "es6-iterator": "~2.0.3",
-                "es6-symbol": "~3.1.1",
-                "next-tick": "1"
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1",
+                "next-tick": "1.0.0"
             }
         },
         "es6-iterator": {
@@ -2292,9 +2292,9 @@
             "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
             "dev": true,
             "requires": {
-                "d": "1",
-                "es5-ext": "^0.10.35",
-                "es6-symbol": "^3.1.1"
+                "d": "1.0.0",
+                "es5-ext": "0.10.42",
+                "es6-symbol": "3.1.1"
             }
         },
         "es6-promise": {
@@ -2309,8 +2309,8 @@
             "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
             "dev": true,
             "requires": {
-                "d": "1",
-                "es5-ext": "~0.10.14"
+                "d": "1.0.0",
+                "es5-ext": "0.10.42"
             }
         },
         "escape-html": {
@@ -2331,11 +2331,11 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "esprima": "^3.1.3",
-                "estraverse": "^4.2.0",
-                "esutils": "^2.0.2",
-                "optionator": "^0.8.1",
-                "source-map": "~0.6.1"
+                "esprima": "3.1.3",
+                "estraverse": "4.2.0",
+                "esutils": "2.0.2",
+                "optionator": "0.8.2",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "esprima": {
@@ -2402,22 +2402,22 @@
                     "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
                     "dev": true,
                     "requires": {
-                        "css-select": "~1.2.0",
-                        "dom-serializer": "~0.1.0",
-                        "entities": "~1.1.1",
-                        "htmlparser2": "^3.9.1",
-                        "lodash.assignin": "^4.0.9",
-                        "lodash.bind": "^4.1.4",
-                        "lodash.defaults": "^4.0.1",
-                        "lodash.filter": "^4.4.0",
-                        "lodash.flatten": "^4.2.0",
-                        "lodash.foreach": "^4.3.0",
-                        "lodash.map": "^4.4.0",
-                        "lodash.merge": "^4.4.0",
-                        "lodash.pick": "^4.2.1",
-                        "lodash.reduce": "^4.4.0",
-                        "lodash.reject": "^4.4.0",
-                        "lodash.some": "^4.4.0"
+                        "css-select": "1.2.0",
+                        "dom-serializer": "0.1.0",
+                        "entities": "1.1.1",
+                        "htmlparser2": "3.9.2",
+                        "lodash.assignin": "4.2.0",
+                        "lodash.bind": "4.2.1",
+                        "lodash.defaults": "4.2.0",
+                        "lodash.filter": "4.6.0",
+                        "lodash.flatten": "4.4.0",
+                        "lodash.foreach": "4.5.0",
+                        "lodash.map": "4.6.0",
+                        "lodash.merge": "4.6.1",
+                        "lodash.pick": "4.4.0",
+                        "lodash.reduce": "4.6.0",
+                        "lodash.reject": "4.6.0",
+                        "lodash.some": "4.6.0"
                     }
                 }
             }
@@ -2443,9 +2443,9 @@
                     "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "jsonfile": "^2.1.0",
-                        "klaw": "^1.0.0"
+                        "graceful-fs": "4.1.11",
+                        "jsonfile": "2.4.0",
+                        "klaw": "1.3.1"
                     }
                 },
                 "jsonfile": {
@@ -2454,7 +2454,7 @@
                     "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.6"
+                        "graceful-fs": "4.1.11"
                     }
                 }
             }
@@ -2498,12 +2498,12 @@
                     "integrity": "sha1-FPaTOrsgxiZm0n47e59bncBxKpo=",
                     "dev": true,
                     "requires": {
-                        "babel-messages": "^6.8.0",
-                        "babel-runtime": "^6.9.0",
-                        "babel-types": "^6.10.2",
-                        "detect-indent": "^3.0.1",
-                        "lodash": "^4.2.0",
-                        "source-map": "^0.5.0"
+                        "babel-messages": "6.23.0",
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "detect-indent": "3.0.1",
+                        "lodash": "4.17.10",
+                        "source-map": "0.5.7"
                     }
                 },
                 "cheerio": {
@@ -2512,22 +2512,22 @@
                     "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
                     "dev": true,
                     "requires": {
-                        "css-select": "~1.2.0",
-                        "dom-serializer": "~0.1.0",
-                        "entities": "~1.1.1",
-                        "htmlparser2": "^3.9.1",
-                        "lodash.assignin": "^4.0.9",
-                        "lodash.bind": "^4.1.4",
-                        "lodash.defaults": "^4.0.1",
-                        "lodash.filter": "^4.4.0",
-                        "lodash.flatten": "^4.2.0",
-                        "lodash.foreach": "^4.3.0",
-                        "lodash.map": "^4.4.0",
-                        "lodash.merge": "^4.4.0",
-                        "lodash.pick": "^4.2.1",
-                        "lodash.reduce": "^4.4.0",
-                        "lodash.reject": "^4.4.0",
-                        "lodash.some": "^4.4.0"
+                        "css-select": "1.2.0",
+                        "dom-serializer": "0.1.0",
+                        "entities": "1.1.1",
+                        "htmlparser2": "3.9.2",
+                        "lodash.assignin": "4.2.0",
+                        "lodash.bind": "4.2.1",
+                        "lodash.defaults": "4.2.0",
+                        "lodash.filter": "4.6.0",
+                        "lodash.flatten": "4.4.0",
+                        "lodash.foreach": "4.5.0",
+                        "lodash.map": "4.6.0",
+                        "lodash.merge": "4.6.1",
+                        "lodash.pick": "4.4.0",
+                        "lodash.reduce": "4.6.0",
+                        "lodash.reject": "4.6.0",
+                        "lodash.some": "4.6.0"
                     }
                 },
                 "detect-indent": {
@@ -2536,9 +2536,9 @@
                     "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
                     "dev": true,
                     "requires": {
-                        "get-stdin": "^4.0.1",
-                        "minimist": "^1.1.0",
-                        "repeating": "^1.1.0"
+                        "get-stdin": "4.0.1",
+                        "minimist": "1.2.0",
+                        "repeating": "1.1.3"
                     }
                 },
                 "fs-extra": {
@@ -2547,9 +2547,9 @@
                     "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "jsonfile": "^2.1.0",
-                        "klaw": "^1.0.0"
+                        "graceful-fs": "4.1.11",
+                        "jsonfile": "2.4.0",
+                        "klaw": "1.3.1"
                     }
                 },
                 "jsonfile": {
@@ -2558,7 +2558,7 @@
                     "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.6"
+                        "graceful-fs": "4.1.11"
                     }
                 },
                 "minimist": {
@@ -2573,7 +2573,7 @@
                     "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
                     "dev": true,
                     "requires": {
-                        "is-finite": "^1.0.0"
+                        "is-finite": "1.0.2"
                     }
                 },
                 "taffydb": {
@@ -2590,17 +2590,17 @@
             "integrity": "sha1-ZhIBysfvhokkkCRG/awVJyU8XU0=",
             "dev": true,
             "requires": {
-                "esdoc-accessor-plugin": "^1.0.0",
-                "esdoc-brand-plugin": "^1.0.0",
-                "esdoc-coverage-plugin": "^1.0.0",
-                "esdoc-external-ecmascript-plugin": "^1.0.0",
-                "esdoc-integrate-manual-plugin": "^1.0.0",
-                "esdoc-integrate-test-plugin": "^1.0.0",
-                "esdoc-lint-plugin": "^1.0.0",
-                "esdoc-publish-html-plugin": "^1.0.0",
-                "esdoc-type-inference-plugin": "^1.0.0",
-                "esdoc-undocumented-identifier-plugin": "^1.0.0",
-                "esdoc-unexported-identifier-plugin": "^1.0.0"
+                "esdoc-accessor-plugin": "1.0.0",
+                "esdoc-brand-plugin": "1.0.1",
+                "esdoc-coverage-plugin": "1.1.0",
+                "esdoc-external-ecmascript-plugin": "1.0.0",
+                "esdoc-integrate-manual-plugin": "1.0.0",
+                "esdoc-integrate-test-plugin": "1.0.0",
+                "esdoc-lint-plugin": "1.0.2",
+                "esdoc-publish-html-plugin": "1.1.2",
+                "esdoc-type-inference-plugin": "1.0.2",
+                "esdoc-undocumented-identifier-plugin": "1.0.0",
+                "esdoc-unexported-identifier-plugin": "1.0.0"
             }
         },
         "esdoc-type-inference-plugin": {
@@ -2627,44 +2627,44 @@
             "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
             "dev": true,
             "requires": {
-                "ajv": "^5.3.0",
-                "babel-code-frame": "^6.22.0",
-                "chalk": "^2.1.0",
-                "concat-stream": "^1.6.0",
-                "cross-spawn": "^5.1.0",
-                "debug": "^3.1.0",
-                "doctrine": "^2.1.0",
-                "eslint-scope": "^3.7.1",
-                "eslint-visitor-keys": "^1.0.0",
-                "espree": "^3.5.4",
-                "esquery": "^1.0.0",
-                "esutils": "^2.0.2",
-                "file-entry-cache": "^2.0.0",
-                "functional-red-black-tree": "^1.0.1",
-                "glob": "^7.1.2",
-                "globals": "^11.0.1",
-                "ignore": "^3.3.3",
-                "imurmurhash": "^0.1.4",
-                "inquirer": "^3.0.6",
-                "is-resolvable": "^1.0.0",
-                "js-yaml": "^3.9.1",
-                "json-stable-stringify-without-jsonify": "^1.0.1",
-                "levn": "^0.3.0",
-                "lodash": "^4.17.4",
-                "minimatch": "^3.0.2",
-                "mkdirp": "^0.5.1",
-                "natural-compare": "^1.4.0",
-                "optionator": "^0.8.2",
-                "path-is-inside": "^1.0.2",
-                "pluralize": "^7.0.0",
-                "progress": "^2.0.0",
-                "regexpp": "^1.0.1",
-                "require-uncached": "^1.0.3",
-                "semver": "^5.3.0",
-                "strip-ansi": "^4.0.0",
-                "strip-json-comments": "~2.0.1",
+                "ajv": "5.5.2",
+                "babel-code-frame": "6.26.0",
+                "chalk": "2.4.1",
+                "concat-stream": "1.6.2",
+                "cross-spawn": "5.1.0",
+                "debug": "3.1.0",
+                "doctrine": "2.1.0",
+                "eslint-scope": "3.7.1",
+                "eslint-visitor-keys": "1.0.0",
+                "espree": "3.5.4",
+                "esquery": "1.0.1",
+                "esutils": "2.0.2",
+                "file-entry-cache": "2.0.0",
+                "functional-red-black-tree": "1.0.1",
+                "glob": "7.1.2",
+                "globals": "11.5.0",
+                "ignore": "3.3.8",
+                "imurmurhash": "0.1.4",
+                "inquirer": "3.3.0",
+                "is-resolvable": "1.1.0",
+                "js-yaml": "3.11.0",
+                "json-stable-stringify-without-jsonify": "1.0.1",
+                "levn": "0.3.0",
+                "lodash": "4.17.10",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "natural-compare": "1.4.0",
+                "optionator": "0.8.2",
+                "path-is-inside": "1.0.2",
+                "pluralize": "7.0.0",
+                "progress": "2.0.0",
+                "regexpp": "1.1.0",
+                "require-uncached": "1.0.3",
+                "semver": "5.5.0",
+                "strip-ansi": "4.0.0",
+                "strip-json-comments": "2.0.1",
                 "table": "4.0.2",
-                "text-table": "~0.2.0"
+                "text-table": "0.2.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -2679,7 +2679,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
@@ -2688,9 +2688,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
                     }
                 },
                 "debug": {
@@ -2714,12 +2714,12 @@
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "globals": {
@@ -2740,8 +2740,8 @@
                     "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
                     "dev": true,
                     "requires": {
-                        "argparse": "^1.0.7",
-                        "esprima": "^4.0.0"
+                        "argparse": "1.0.10",
+                        "esprima": "4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -2750,7 +2750,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 },
                 "supports-color": {
@@ -2759,7 +2759,7 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -2788,8 +2788,8 @@
             "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
             "dev": true,
             "requires": {
-                "debug": "^2.6.9",
-                "resolve": "^1.5.0"
+                "debug": "2.6.9",
+                "resolve": "1.7.1"
             },
             "dependencies": {
                 "resolve": {
@@ -2798,7 +2798,7 @@
                     "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
                     "dev": true,
                     "requires": {
-                        "path-parse": "^1.0.5"
+                        "path-parse": "1.0.5"
                     }
                 }
             }
@@ -2809,8 +2809,8 @@
             "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
             "dev": true,
             "requires": {
-                "debug": "^2.6.8",
-                "pkg-dir": "^1.0.0"
+                "debug": "2.6.9",
+                "pkg-dir": "1.0.0"
             },
             "dependencies": {
                 "find-up": {
@@ -2855,16 +2855,16 @@
             "integrity": "sha1-Fa7qN6Z0mdhI6OmBgG1GJ7VQOBY=",
             "dev": true,
             "requires": {
-                "contains-path": "^0.1.0",
-                "debug": "^2.6.8",
+                "contains-path": "0.1.0",
+                "debug": "2.6.9",
                 "doctrine": "1.5.0",
-                "eslint-import-resolver-node": "^0.3.1",
-                "eslint-module-utils": "^2.2.0",
-                "has": "^1.0.1",
-                "lodash": "^4.17.4",
-                "minimatch": "^3.0.3",
-                "read-pkg-up": "^2.0.0",
-                "resolve": "^1.6.0"
+                "eslint-import-resolver-node": "0.3.2",
+                "eslint-module-utils": "2.2.0",
+                "has": "1.0.1",
+                "lodash": "4.17.10",
+                "minimatch": "3.0.4",
+                "read-pkg-up": "2.0.0",
+                "resolve": "1.7.1"
             },
             "dependencies": {
                 "doctrine": {
@@ -2931,7 +2931,7 @@
                     "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
                     "dev": true,
                     "requires": {
-                        "path-parse": "^1.0.5"
+                        "path-parse": "1.0.5"
                     }
                 },
                 "strip-bom": {
@@ -2948,9 +2948,9 @@
             "integrity": "sha512-xhPXrh0Vl/b7870uEbaumb2Q+LxaEcOQ3kS1jtIXanBAwpMre1l5q/l2l/hESYJGEFKuI78bp6Uw50hlpr7B+g==",
             "dev": true,
             "requires": {
-                "ignore": "^3.3.6",
-                "minimatch": "^3.0.4",
-                "resolve": "^1.3.3",
+                "ignore": "3.3.8",
+                "minimatch": "3.0.4",
+                "resolve": "1.7.1",
                 "semver": "5.3.0"
             },
             "dependencies": {
@@ -2960,7 +2960,7 @@
                     "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
                     "dev": true,
                     "requires": {
-                        "path-parse": "^1.0.5"
+                        "path-parse": "1.0.5"
                     }
                 },
                 "semver": {
@@ -2989,7 +2989,7 @@
             "integrity": "sha1-CBm45gOVhD7x5s6j5JZoR40XfJc=",
             "dev": true,
             "requires": {
-                "lodash": "^3.10.1"
+                "lodash": "3.10.1"
             },
             "dependencies": {
                 "lodash": {
@@ -3006,8 +3006,8 @@
             "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
             "dev": true,
             "requires": {
-                "esrecurse": "^4.1.0",
-                "estraverse": "^4.1.1"
+                "esrecurse": "4.2.1",
+                "estraverse": "4.2.0"
             }
         },
         "eslint-visitor-keys": {
@@ -3022,8 +3022,8 @@
             "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
             "dev": true,
             "requires": {
-                "acorn": "^5.5.0",
-                "acorn-jsx": "^3.0.0"
+                "acorn": "5.5.3",
+                "acorn-jsx": "3.0.1"
             },
             "dependencies": {
                 "acorn": {
@@ -3045,7 +3045,7 @@
             "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
             "dev": true,
             "requires": {
-                "estraverse": "^4.0.0"
+                "estraverse": "4.2.0"
             }
         },
         "esrecurse": {
@@ -3054,7 +3054,7 @@
             "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
             "dev": true,
             "requires": {
-                "estraverse": "^4.1.0"
+                "estraverse": "4.2.0"
             }
         },
         "estraverse": {
@@ -3074,7 +3074,7 @@
             "integrity": "sha1-y6lVKMbsMmigUnlhmt9YLS+HwAU=",
             "dev": true,
             "requires": {
-                "es5-ext": "~0.10.2"
+                "es5-ext": "0.10.42"
             }
         },
         "eventemitter2": {
@@ -3092,8 +3092,8 @@
             "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
             "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
             "requires": {
-                "md5.js": "^1.3.4",
-                "safe-buffer": "^5.1.1"
+                "md5.js": "1.3.4",
+                "safe-buffer": "5.1.2"
             }
         },
         "exit": {
@@ -3106,13 +3106,13 @@
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
             "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
             "requires": {
-                "debug": "^2.3.3",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "posix-character-classes": "^0.1.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "posix-character-classes": "0.1.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "define-property": {
@@ -3120,7 +3120,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "extend-shallow": {
@@ -3128,7 +3128,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -3139,7 +3139,7 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "^2.1.0"
+                "fill-range": "2.2.4"
             },
             "dependencies": {
                 "fill-range": {
@@ -3148,11 +3148,11 @@
                     "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
                     "dev": true,
                     "requires": {
-                        "is-number": "^2.1.0",
-                        "isobject": "^2.0.0",
-                        "randomatic": "^3.0.0",
-                        "repeat-element": "^1.1.2",
-                        "repeat-string": "^1.5.2"
+                        "is-number": "2.1.0",
+                        "isobject": "2.1.0",
+                        "randomatic": "3.0.0",
+                        "repeat-element": "1.1.2",
+                        "repeat-string": "1.6.1"
                     }
                 },
                 "is-number": {
@@ -3161,7 +3161,7 @@
                     "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     }
                 },
                 "isobject": {
@@ -3186,8 +3186,8 @@
             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "requires": {
-                "assign-symbols": "^1.0.0",
-                "is-extendable": "^1.0.1"
+                "assign-symbols": "1.0.0",
+                "is-extendable": "1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -3195,7 +3195,7 @@
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "requires": {
-                        "is-plain-object": "^2.0.4"
+                        "is-plain-object": "2.0.4"
                     }
                 }
             }
@@ -3205,7 +3205,7 @@
             "resolved": "https://registry.npmjs.org/extendify/-/extendify-1.0.0.tgz",
             "integrity": "sha1-md3P961Fxxb1xjrDu8tNn/BAHmE=",
             "requires": {
-                "lodash": "^2.4.1"
+                "lodash": "2.4.2"
             },
             "dependencies": {
                 "lodash": {
@@ -3221,9 +3221,9 @@
             "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
             "dev": true,
             "requires": {
-                "chardet": "^0.4.0",
-                "iconv-lite": "^0.4.17",
-                "tmp": "^0.0.33"
+                "chardet": "0.4.2",
+                "iconv-lite": "0.4.23",
+                "tmp": "0.0.33"
             }
         },
         "extglob": {
@@ -3231,14 +3231,14 @@
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
             "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
             "requires": {
-                "array-unique": "^0.3.2",
-                "define-property": "^1.0.0",
-                "expand-brackets": "^2.1.4",
-                "extend-shallow": "^2.0.1",
-                "fragment-cache": "^0.2.1",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "expand-brackets": "2.1.4",
+                "extend-shallow": "2.0.1",
+                "fragment-cache": "0.2.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "define-property": {
@@ -3246,7 +3246,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "extend-shallow": {
@@ -3254,7 +3254,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -3262,7 +3262,7 @@
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -3270,7 +3270,7 @@
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -3278,9 +3278,9 @@
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 },
                 "kind-of": {
@@ -3295,10 +3295,10 @@
             "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.2.tgz",
             "integrity": "sha1-dW7076gVXDaBgz+8NNpTuUF0bWw=",
             "requires": {
-                "async": "^2.1.2",
-                "loader-utils": "^1.0.2",
-                "schema-utils": "^0.3.0",
-                "webpack-sources": "^1.0.1"
+                "async": "2.6.0",
+                "loader-utils": "1.1.0",
+                "schema-utils": "0.3.0",
+                "webpack-sources": "1.1.0"
             }
         },
         "extract-zip": {
@@ -3319,9 +3319,9 @@
                     "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
                     "dev": true,
                     "requires": {
-                        "inherits": "^2.0.3",
-                        "readable-stream": "^2.2.2",
-                        "typedarray": "^0.0.6"
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6",
+                        "typedarray": "0.0.6"
                     }
                 },
                 "mkdirp": {
@@ -3376,7 +3376,7 @@
             "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
             "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
             "requires": {
-                "pend": "~1.2.0"
+                "pend": "1.2.0"
             }
         },
         "figures": {
@@ -3384,8 +3384,8 @@
             "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
             "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
             "requires": {
-                "escape-string-regexp": "^1.0.5",
-                "object-assign": "^4.1.0"
+                "escape-string-regexp": "1.0.5",
+                "object-assign": "4.1.1"
             }
         },
         "file-entry-cache": {
@@ -3394,8 +3394,8 @@
             "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
             "dev": true,
             "requires": {
-                "flat-cache": "^1.2.1",
-                "object-assign": "^4.0.1"
+                "flat-cache": "1.3.0",
+                "object-assign": "4.1.1"
             }
         },
         "file-loader": {
@@ -3403,7 +3403,7 @@
             "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.11.2.tgz",
             "integrity": "sha512-N+uhF3mswIFeziHQjGScJ/yHXYt3DiLBeC+9vWW+WjUBiClMSOlV1YrXQi+7KM2aA3Rn4Bybgv+uXFQbfkzpvg==",
             "requires": {
-                "loader-utils": "^1.0.2"
+                "loader-utils": "1.1.0"
             }
         },
         "file-sync-cmp": {
@@ -3422,10 +3422,10 @@
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
             "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
             "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1",
-                "to-regex-range": "^2.1.0"
+                "extend-shallow": "2.0.1",
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1",
+                "to-regex-range": "2.1.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -3433,7 +3433,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -3443,9 +3443,9 @@
             "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
             "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
             "requires": {
-                "commondir": "^1.0.1",
-                "make-dir": "^1.0.0",
-                "pkg-dir": "^2.0.0"
+                "commondir": "1.0.1",
+                "make-dir": "1.3.0",
+                "pkg-dir": "2.0.0"
             }
         },
         "find-line-column": {
@@ -3459,7 +3459,7 @@
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
             "requires": {
-                "locate-path": "^2.0.0"
+                "locate-path": "2.0.0"
             }
         },
         "findup-sync": {
@@ -3467,7 +3467,7 @@
             "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
             "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
             "requires": {
-                "glob": "~5.0.0"
+                "glob": "5.0.15"
             },
             "dependencies": {
                 "glob": {
@@ -3475,11 +3475,11 @@
                     "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "requires": {
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "2 || 3",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 }
             }
@@ -3490,10 +3490,10 @@
             "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
             "dev": true,
             "requires": {
-                "circular-json": "^0.3.1",
-                "del": "^2.0.2",
-                "graceful-fs": "^4.1.2",
-                "write": "^0.2.1"
+                "circular-json": "0.3.3",
+                "del": "2.2.2",
+                "graceful-fs": "4.1.11",
+                "write": "0.2.1"
             }
         },
         "flatten": {
@@ -3506,8 +3506,8 @@
             "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
             "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
             "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.4"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
             }
         },
         "for-in": {
@@ -3521,7 +3521,7 @@
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "dev": true,
             "requires": {
-                "for-in": "^1.0.1"
+                "for-in": "1.0.2"
             }
         },
         "forever-agent": {
@@ -3536,9 +3536,9 @@
             "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
             "dev": true,
             "requires": {
-                "asynckit": "^0.4.0",
+                "asynckit": "0.4.0",
                 "combined-stream": "1.0.6",
-                "mime-types": "^2.1.12"
+                "mime-types": "2.1.18"
             }
         },
         "fragment-cache": {
@@ -3546,7 +3546,7 @@
             "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "requires": {
-                "map-cache": "^0.2.2"
+                "map-cache": "0.2.2"
             }
         },
         "from2": {
@@ -3554,8 +3554,8 @@
             "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
             "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
             "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
             }
         },
         "fs-extra": {
@@ -3564,9 +3564,9 @@
             "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
+                "graceful-fs": "4.1.11",
+                "jsonfile": "4.0.0",
+                "universalify": "0.1.1"
             }
         },
         "fs-write-stream-atomic": {
@@ -3574,10 +3574,10 @@
             "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
             "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "iferr": "^0.1.5",
-                "imurmurhash": "^0.1.4",
-                "readable-stream": "1 || 2"
+                "graceful-fs": "4.1.11",
+                "iferr": "0.1.5",
+                "imurmurhash": "0.1.4",
+                "readable-stream": "2.3.6"
             }
         },
         "fs.realpath": {
@@ -3591,8 +3591,8 @@
             "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
             "optional": true,
             "requires": {
-                "nan": "^2.9.2",
-                "node-pre-gyp": "^0.10.0"
+                "nan": "2.10.0",
+                "node-pre-gyp": "0.10.0"
             },
             "dependencies": {
                 "abbrev": {
@@ -4052,10 +4052,10 @@
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
             "integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
             "requires": {
-                "graceful-fs": "~3.0.2",
-                "inherits": "~2.0.0",
-                "mkdirp": "0.5",
-                "rimraf": "2"
+                "graceful-fs": "3.0.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.2.8"
             },
             "dependencies": {
                 "graceful-fs": {
@@ -4063,7 +4063,7 @@
                     "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
                     "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
                     "requires": {
-                        "natives": "^1.1.0"
+                        "natives": "1.1.3"
                     }
                 }
             }
@@ -4105,24 +4105,24 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "girder": {
             "version": "file:clients/web/src",
             "requires": {
-                "as-jqplot": "~1.0.8",
-                "backbone": "~1.3.3",
-                "bootstrap": "~3.3.7",
-                "bootstrap-switch": "~3.3.4",
-                "eonasdan-bootstrap-datetimepicker": "~4.17",
-                "jquery": "~3.2.1",
-                "jsoneditor": "~5.9.3",
-                "moment": "~2.20.1",
-                "remarkable": "~1.7.1",
-                "sprintf-js": "~1.1.1",
-                "swagger-ui": "~2.2.10",
-                "underscore": "~1.8.3"
+                "as-jqplot": "1.0.8",
+                "backbone": "1.3.3",
+                "bootstrap": "3.3.7",
+                "bootstrap-switch": "3.3.4",
+                "eonasdan-bootstrap-datetimepicker": "4.17.47",
+                "jquery": "3.2.1",
+                "jsoneditor": "5.9.6",
+                "moment": "2.20.1",
+                "remarkable": "1.7.1",
+                "sprintf-js": "1.1.1",
+                "swagger-ui": "2.2.10",
+                "underscore": "1.8.3"
             },
             "dependencies": {
                 "sprintf-js": {
@@ -4140,12 +4140,12 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
             "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
             "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.2",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
             }
         },
         "glob-base": {
@@ -4154,8 +4154,8 @@
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
-                "glob-parent": "^2.0.0",
-                "is-glob": "^2.0.0"
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
             },
             "dependencies": {
                 "glob-parent": {
@@ -4164,7 +4164,7 @@
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "^2.0.0"
+                        "is-glob": "2.0.1"
                     }
                 },
                 "is-extglob": {
@@ -4179,7 +4179,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 }
             }
@@ -4189,8 +4189,8 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "requires": {
-                "is-glob": "^3.1.0",
-                "path-dirname": "^1.0.0"
+                "is-glob": "3.1.0",
+                "path-dirname": "1.0.2"
             },
             "dependencies": {
                 "is-glob": {
@@ -4198,7 +4198,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "requires": {
-                        "is-extglob": "^2.1.0"
+                        "is-extglob": "2.1.1"
                     }
                 }
             }
@@ -4214,12 +4214,12 @@
             "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
             "dev": true,
             "requires": {
-                "array-union": "^1.0.1",
-                "arrify": "^1.0.0",
-                "glob": "^7.0.3",
-                "object-assign": "^4.0.1",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "glob": "7.0.6",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
             },
             "dependencies": {
                 "pify": {
@@ -4235,10 +4235,10 @@
             "resolved": "https://registry.npmjs.org/google-fonts-webpack-plugin/-/google-fonts-webpack-plugin-0.4.4.tgz",
             "integrity": "sha512-+e2D9/DVBG9EDydRovzoqMZ658SsTBGbC0c65GyZqkwNvdj8vRSYQKXqbz7/yt7QaXsCPT1MpH45r3ivWOitcw==",
             "requires": {
-                "lodash": "^4.17.4",
-                "node-fetch": "^1.6.3",
-                "webpack-sources": "^0.2.0",
-                "yauzl": "^2.8.0"
+                "lodash": "4.17.10",
+                "node-fetch": "1.7.3",
+                "webpack-sources": "0.2.3",
+                "yauzl": "2.9.1"
             },
             "dependencies": {
                 "source-list-map": {
@@ -4267,22 +4267,22 @@
             "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.2.tgz",
             "integrity": "sha1-TmpeaVtwRy/VME9fqeNCNoNqc7w=",
             "requires": {
-                "coffeescript": "~1.10.0",
-                "dateformat": "~1.0.12",
-                "eventemitter2": "~0.4.13",
-                "exit": "~0.1.1",
-                "findup-sync": "~0.3.0",
-                "glob": "~7.0.0",
-                "grunt-cli": "~1.2.0",
-                "grunt-known-options": "~1.1.0",
-                "grunt-legacy-log": "~1.0.0",
-                "grunt-legacy-util": "~1.0.0",
-                "iconv-lite": "~0.4.13",
-                "js-yaml": "~3.5.2",
-                "minimatch": "~3.0.2",
-                "nopt": "~3.0.6",
-                "path-is-absolute": "~1.0.0",
-                "rimraf": "~2.2.8"
+                "coffeescript": "1.10.0",
+                "dateformat": "1.0.12",
+                "eventemitter2": "0.4.14",
+                "exit": "0.1.2",
+                "findup-sync": "0.3.0",
+                "glob": "7.0.6",
+                "grunt-cli": "1.2.0",
+                "grunt-known-options": "1.1.0",
+                "grunt-legacy-log": "1.0.2",
+                "grunt-legacy-util": "1.0.0",
+                "iconv-lite": "0.4.23",
+                "js-yaml": "3.5.5",
+                "minimatch": "3.0.4",
+                "nopt": "3.0.6",
+                "path-is-absolute": "1.0.1",
+                "rimraf": "2.2.8"
             },
             "dependencies": {
                 "js-yaml": {
@@ -4301,10 +4301,10 @@
             "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
             "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
             "requires": {
-                "findup-sync": "~0.3.0",
-                "grunt-known-options": "~1.1.0",
-                "nopt": "~3.0.6",
-                "resolve": "~1.1.0"
+                "findup-sync": "0.3.0",
+                "grunt-known-options": "1.1.0",
+                "nopt": "3.0.6",
+                "resolve": "1.1.7"
             }
         },
         "grunt-contrib-copy": {
@@ -4312,8 +4312,8 @@
             "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
             "integrity": "sha1-cGDGWB6QS4qw0A8HbgqPbj58NXM=",
             "requires": {
-                "chalk": "^1.1.1",
-                "file-sync-cmp": "^0.1.0"
+                "chalk": "1.1.3",
+                "file-sync-cmp": "0.1.1"
             }
         },
         "grunt-contrib-pug": {
@@ -4321,8 +4321,8 @@
             "resolved": "https://registry.npmjs.org/grunt-contrib-pug/-/grunt-contrib-pug-1.0.0.tgz",
             "integrity": "sha1-tSWlwK/wRiL3Vw4x+SQQbxb4G0Y=",
             "requires": {
-                "chalk": "^1.0.0",
-                "pug": "^2.0.0-alpha3"
+                "chalk": "1.1.3",
+                "pug": "2.0.3"
             }
         },
         "grunt-contrib-stylus": {
@@ -4330,11 +4330,11 @@
             "resolved": "https://registry.npmjs.org/grunt-contrib-stylus/-/grunt-contrib-stylus-1.2.0.tgz",
             "integrity": "sha1-R9RG7wVESW7/naQY0A9XdFQ0crs=",
             "requires": {
-                "async": "^1.5.2",
-                "chalk": "^1.0.0",
-                "lodash": "^4.0.0",
-                "nib": "^1.1.0",
-                "stylus": "^0.54.0"
+                "async": "1.5.2",
+                "chalk": "1.1.3",
+                "lodash": "4.17.10",
+                "nib": "1.1.2",
+                "stylus": "0.54.5"
             },
             "dependencies": {
                 "async": {
@@ -4349,10 +4349,10 @@
             "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-3.3.0.tgz",
             "integrity": "sha512-W9O7lJE3PlD8VCc5fyaf98QV7f5wEDiU4PBIh0+/6UBbk2LhgzEFS0/p+taH5UD3+PlEn7QPN0o06Z0To6SqXw==",
             "requires": {
-                "chalk": "^1.0.0",
-                "maxmin": "^1.1.0",
-                "uglify-js": "~3.3.0",
-                "uri-path": "^1.0.0"
+                "chalk": "1.1.3",
+                "maxmin": "1.1.0",
+                "uglify-js": "3.3.25",
+                "uri-path": "1.0.0"
             },
             "dependencies": {
                 "source-map": {
@@ -4365,8 +4365,8 @@
                     "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.25.tgz",
                     "integrity": "sha512-hobogryjDV36VrLK3Y69ou4REyrTApzUblVFmdQOYRe8cYaSmFJXMb4dR9McdvYDSbeNdzUgYr2YVukJaErJcA==",
                     "requires": {
-                        "commander": "~2.15.0",
-                        "source-map": "~0.6.1"
+                        "commander": "2.15.1",
+                        "source-map": "0.6.1"
                     }
                 }
             }
@@ -4381,11 +4381,11 @@
             "resolved": "https://registry.npmjs.org/grunt-fontello/-/grunt-fontello-0.3.4.tgz",
             "integrity": "sha1-IFcw+qYUfWJsAUaJQBkQNTjcpIA=",
             "requires": {
-                "async": "~0.2.9",
-                "grunt": "~1.0.1",
-                "mkdirp": "~0.3.5",
-                "needle": "~0.11.0",
-                "unzip": "~0.1.9"
+                "async": "0.2.10",
+                "grunt": "1.0.2",
+                "mkdirp": "0.3.5",
+                "needle": "0.11.0",
+                "unzip": "0.1.11"
             },
             "dependencies": {
                 "async": {
@@ -4405,9 +4405,9 @@
             "resolved": "https://registry.npmjs.org/grunt-gitinfo/-/grunt-gitinfo-0.1.8.tgz",
             "integrity": "sha1-MHEhX1eKSIFRwN/Y2Wvyq857UNI=",
             "requires": {
-                "async": "~0.9.0",
-                "getobject": "~0.1.0",
-                "lodash": "~2.4.1"
+                "async": "0.9.2",
+                "getobject": "0.1.0",
+                "lodash": "2.4.2"
             },
             "dependencies": {
                 "async": {
@@ -4432,10 +4432,10 @@
             "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.2.tgz",
             "integrity": "sha512-WdedTJ/6zCXnI/coaouzqvkI19uwqbcPkdsXiDRKJyB5rOUlOxnCnTVbpeUdEckKVir2uHF3rDBYppj2p6N3+g==",
             "requires": {
-                "colors": "~1.1.2",
-                "grunt-legacy-log-utils": "~1.0.0",
-                "hooker": "~0.2.3",
-                "lodash": "~4.17.5"
+                "colors": "1.1.2",
+                "grunt-legacy-log-utils": "1.0.0",
+                "hooker": "0.2.3",
+                "lodash": "4.17.10"
             },
             "dependencies": {
                 "colors": {
@@ -4450,8 +4450,8 @@
             "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-1.0.0.tgz",
             "integrity": "sha1-p7ji0Ps1taUPSvmG/BEnSevJbz0=",
             "requires": {
-                "chalk": "~1.1.1",
-                "lodash": "~4.3.0"
+                "chalk": "1.1.3",
+                "lodash": "4.3.0"
             },
             "dependencies": {
                 "lodash": {
@@ -4466,13 +4466,13 @@
             "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.0.0.tgz",
             "integrity": "sha1-OGqnjcbtUJhsKxiVcmWxtIq7m4Y=",
             "requires": {
-                "async": "~1.5.2",
-                "exit": "~0.1.1",
-                "getobject": "~0.1.0",
-                "hooker": "~0.2.3",
-                "lodash": "~4.3.0",
-                "underscore.string": "~3.2.3",
-                "which": "~1.2.1"
+                "async": "1.5.2",
+                "exit": "0.1.2",
+                "getobject": "0.1.0",
+                "hooker": "0.2.3",
+                "lodash": "4.3.0",
+                "underscore.string": "3.2.3",
+                "which": "1.2.14"
             },
             "dependencies": {
                 "async": {
@@ -4502,8 +4502,8 @@
             "resolved": "https://registry.npmjs.org/grunt-shell/-/grunt-shell-2.1.0.tgz",
             "integrity": "sha1-Q595FZ7RHmSmUaacyKPQK+v17MI=",
             "requires": {
-                "chalk": "^1.0.0",
-                "npm-run-path": "^2.0.0"
+                "chalk": "1.1.3",
+                "npm-run-path": "2.0.2"
             }
         },
         "grunt-webpack": {
@@ -4511,8 +4511,8 @@
             "resolved": "https://registry.npmjs.org/grunt-webpack/-/grunt-webpack-3.1.2.tgz",
             "integrity": "sha512-Ngixl4W/mNJYyghyXJ+JzJ7pUaVRcVKgvC+74ePXPglAEodc9jMlBrGszZAzmspCuvo5dkhbBIcuBHn+Wv1pOQ==",
             "requires": {
-                "deep-for-each": "^2.0.2",
-                "lodash": "^4.7.0"
+                "deep-for-each": "2.0.3",
+                "lodash": "4.17.10"
             }
         },
         "grunt-zip": {
@@ -4520,8 +4520,8 @@
             "resolved": "https://registry.npmjs.org/grunt-zip/-/grunt-zip-0.17.1.tgz",
             "integrity": "sha1-IYr6NzUcRvebn7HWovw8hFGaUtA=",
             "requires": {
-                "grunt-retro": "~0.6.0",
-                "jszip": "~2.5.0"
+                "grunt-retro": "0.6.4",
+                "jszip": "2.5.0"
             }
         },
         "gzip-size": {
@@ -4529,8 +4529,8 @@
             "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
             "integrity": "sha1-Zs+LEBBHInuVus5uodoMF37Vwi8=",
             "requires": {
-                "browserify-zlib": "^0.1.4",
-                "concat-stream": "^1.4.1"
+                "browserify-zlib": "0.1.4",
+                "concat-stream": "1.6.2"
             }
         },
         "har-schema": {
@@ -4545,8 +4545,8 @@
             "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
             "dev": true,
             "requires": {
-                "ajv": "^5.1.0",
-                "har-schema": "^2.0.0"
+                "ajv": "5.5.2",
+                "har-schema": "2.0.0"
             }
         },
         "has": {
@@ -4554,7 +4554,7 @@
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
             "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
             "requires": {
-                "function-bind": "^1.0.2"
+                "function-bind": "1.1.1"
             }
         },
         "has-ansi": {
@@ -4562,7 +4562,7 @@
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "has-flag": {
@@ -4575,9 +4575,9 @@
             "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "requires": {
-                "get-value": "^2.0.6",
-                "has-values": "^1.0.0",
-                "isobject": "^3.0.0"
+                "get-value": "2.0.6",
+                "has-values": "1.0.0",
+                "isobject": "3.0.1"
             }
         },
         "has-values": {
@@ -4585,8 +4585,8 @@
             "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "requires": {
-                "is-number": "^3.0.0",
-                "kind-of": "^4.0.0"
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -4594,7 +4594,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -4604,8 +4604,8 @@
             "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
             "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
             "requires": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.2"
             }
         },
         "hash.js": {
@@ -4613,8 +4613,8 @@
             "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
             "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
             "requires": {
-                "inherits": "^2.0.3",
-                "minimalistic-assert": "^1.0.0"
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.1"
             }
         },
         "hasha": {
@@ -4623,8 +4623,8 @@
             "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
             "dev": true,
             "requires": {
-                "is-stream": "^1.0.1",
-                "pinkie-promise": "^2.0.0"
+                "is-stream": "1.1.0",
+                "pinkie-promise": "2.0.1"
             }
         },
         "hawk": {
@@ -4633,10 +4633,10 @@
             "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
             "dev": true,
             "requires": {
-                "boom": "4.x.x",
-                "cryptiles": "3.x.x",
-                "hoek": "4.x.x",
-                "sntp": "2.x.x"
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.1",
+                "sntp": "2.1.0"
             }
         },
         "hmac-drbg": {
@@ -4644,9 +4644,9 @@
             "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
             "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
             "requires": {
-                "hash.js": "^1.0.3",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.1"
+                "hash.js": "1.1.3",
+                "minimalistic-assert": "1.0.1",
+                "minimalistic-crypto-utils": "1.0.1"
             }
         },
         "hoek": {
@@ -4660,8 +4660,8 @@
             "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
             "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
             "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.1"
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
             }
         },
         "hooker": {
@@ -4685,12 +4685,12 @@
             "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
             "dev": true,
             "requires": {
-                "domelementtype": "^1.3.0",
-                "domhandler": "^2.3.0",
-                "domutils": "^1.5.1",
-                "entities": "^1.1.1",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.2"
+                "domelementtype": "1.3.0",
+                "domhandler": "2.4.2",
+                "domutils": "1.5.1",
+                "entities": "1.1.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
             }
         },
         "http-signature": {
@@ -4699,9 +4699,9 @@
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.14.1"
             }
         },
         "https-browserify": {
@@ -4725,12 +4725,12 @@
                     "integrity": "sha1-XHEPK6uVZTJyhCugHG6mGzVF7DU=",
                     "dev": true,
                     "requires": {
-                        "css-select": "~1.2.0",
-                        "dom-serializer": "~0.1.0",
-                        "entities": "~1.1.1",
-                        "htmlparser2": "~3.8.1",
-                        "jsdom": "^7.0.2",
-                        "lodash": "^4.1.0"
+                        "css-select": "1.2.0",
+                        "dom-serializer": "0.1.0",
+                        "entities": "1.1.1",
+                        "htmlparser2": "3.8.3",
+                        "jsdom": "7.2.2",
+                        "lodash": "4.17.10"
                     }
                 },
                 "color-logger": {
@@ -4745,7 +4745,7 @@
                     "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
                     "dev": true,
                     "requires": {
-                        "domelementtype": "1"
+                        "domelementtype": "1.3.0"
                     }
                 },
                 "htmlparser2": {
@@ -4754,11 +4754,11 @@
                     "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
                     "dev": true,
                     "requires": {
-                        "domelementtype": "1",
-                        "domhandler": "2.3",
-                        "domutils": "1.5",
-                        "entities": "1.0",
-                        "readable-stream": "1.1"
+                        "domelementtype": "1.3.0",
+                        "domhandler": "2.3.0",
+                        "domutils": "1.5.1",
+                        "entities": "1.0.0",
+                        "readable-stream": "1.1.14"
                     },
                     "dependencies": {
                         "entities": {
@@ -4781,10 +4781,10 @@
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                     }
                 },
                 "string_decoder": {
@@ -4800,7 +4800,7 @@
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
             "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
             "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
+                "safer-buffer": "2.1.2"
             }
         },
         "icss-replace-symbols": {
@@ -4834,7 +4834,7 @@
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
             "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
             "requires": {
-                "repeating": "^2.0.0"
+                "repeating": "2.0.1"
             }
         },
         "indexes-of": {
@@ -4852,8 +4852,8 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
             }
         },
         "inherits": {
@@ -4867,20 +4867,20 @@
             "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
             "dev": true,
             "requires": {
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.0",
-                "cli-cursor": "^2.1.0",
-                "cli-width": "^2.0.0",
-                "external-editor": "^2.0.4",
-                "figures": "^2.0.0",
-                "lodash": "^4.3.0",
+                "ansi-escapes": "3.1.0",
+                "chalk": "2.4.1",
+                "cli-cursor": "2.1.0",
+                "cli-width": "2.2.0",
+                "external-editor": "2.2.0",
+                "figures": "2.0.0",
+                "lodash": "4.17.10",
                 "mute-stream": "0.0.7",
-                "run-async": "^2.2.0",
-                "rx-lite": "^4.0.8",
-                "rx-lite-aggregates": "^4.0.8",
-                "string-width": "^2.1.0",
-                "strip-ansi": "^4.0.0",
-                "through": "^2.3.6"
+                "run-async": "2.3.0",
+                "rx-lite": "4.0.8",
+                "rx-lite-aggregates": "4.0.8",
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "through": "2.3.8"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -4895,7 +4895,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
@@ -4904,9 +4904,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
                     }
                 },
                 "figures": {
@@ -4915,7 +4915,7 @@
                     "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
                     "dev": true,
                     "requires": {
-                        "escape-string-regexp": "^1.0.5"
+                        "escape-string-regexp": "1.0.5"
                     }
                 },
                 "has-flag": {
@@ -4936,8 +4936,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -4946,7 +4946,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 },
                 "supports-color": {
@@ -4955,7 +4955,7 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -4970,7 +4970,7 @@
             "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
             "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
             "requires": {
-                "loose-envify": "^1.0.0"
+                "loose-envify": "1.3.1"
             }
         },
         "invert-kv": {
@@ -4988,7 +4988,7 @@
             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             }
         },
         "is-arrayish": {
@@ -5001,7 +5001,7 @@
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "requires": {
-                "binary-extensions": "^1.0.0"
+                "binary-extensions": "1.11.0"
             }
         },
         "is-buffer": {
@@ -5014,7 +5014,7 @@
             "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "requires": {
-                "builtin-modules": "^1.0.0"
+                "builtin-modules": "1.1.1"
             }
         },
         "is-data-descriptor": {
@@ -5022,7 +5022,7 @@
             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             }
         },
         "is-descriptor": {
@@ -5030,9 +5030,9 @@
             "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
             "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -5054,7 +5054,7 @@
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
-                "is-primitive": "^2.0.0"
+                "is-primitive": "2.0.0"
             }
         },
         "is-expression": {
@@ -5062,8 +5062,8 @@
             "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-3.0.0.tgz",
             "integrity": "sha1-Oayqa+f9HzRx3ELHQW5hwkMXrJ8=",
             "requires": {
-                "acorn": "~4.0.2",
-                "object-assign": "^4.0.1"
+                "acorn": "4.0.13",
+                "object-assign": "4.1.1"
             },
             "dependencies": {
                 "acorn": {
@@ -5088,7 +5088,7 @@
             "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
             "requires": {
-                "number-is-nan": "^1.0.0"
+                "number-is-nan": "1.0.1"
             }
         },
         "is-fullwidth-code-point": {
@@ -5096,7 +5096,7 @@
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
             "requires": {
-                "number-is-nan": "^1.0.0"
+                "number-is-nan": "1.0.1"
             }
         },
         "is-glob": {
@@ -5104,7 +5104,7 @@
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
             "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
             "requires": {
-                "is-extglob": "^2.1.1"
+                "is-extglob": "2.1.1"
             }
         },
         "is-number": {
@@ -5112,7 +5112,7 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
             "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             }
         },
         "is-odd": {
@@ -5120,7 +5120,7 @@
             "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
             "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
             "requires": {
-                "is-number": "^4.0.0"
+                "is-number": "4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -5142,7 +5142,7 @@
             "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
             "dev": true,
             "requires": {
-                "is-path-inside": "^1.0.0"
+                "is-path-inside": "1.0.1"
             }
         },
         "is-path-inside": {
@@ -5151,7 +5151,7 @@
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "dev": true,
             "requires": {
-                "path-is-inside": "^1.0.1"
+                "path-is-inside": "1.0.2"
             }
         },
         "is-plain-obj": {
@@ -5164,7 +5164,7 @@
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "requires": {
-                "isobject": "^3.0.1"
+                "isobject": "3.0.1"
             }
         },
         "is-posix-bracket": {
@@ -5189,7 +5189,7 @@
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
             "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
             "requires": {
-                "has": "^1.0.1"
+                "has": "1.0.1"
             }
         },
         "is-resolvable": {
@@ -5208,7 +5208,7 @@
             "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
             "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
             "requires": {
-                "html-comment-regex": "^1.1.0"
+                "html-comment-regex": "1.1.1"
             }
         },
         "is-typedarray": {
@@ -5260,13 +5260,13 @@
             "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
             "dev": true,
             "requires": {
-                "babel-generator": "^6.18.0",
-                "babel-template": "^6.16.0",
-                "babel-traverse": "^6.18.0",
-                "babel-types": "^6.18.0",
-                "babylon": "^6.18.0",
-                "istanbul-lib-coverage": "^1.2.0",
-                "semver": "^5.3.0"
+                "babel-generator": "6.26.1",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "istanbul-lib-coverage": "1.2.0",
+                "semver": "5.5.0"
             }
         },
         "javascript-natural-sort": {
@@ -5299,8 +5299,8 @@
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
             "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
             "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^2.6.0"
+                "argparse": "1.0.10",
+                "esprima": "2.7.3"
             }
         },
         "jsbn": {
@@ -5317,21 +5317,21 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "abab": "^1.0.0",
-                "acorn": "^2.4.0",
-                "acorn-globals": "^1.0.4",
-                "cssom": ">= 0.3.0 < 0.4.0",
-                "cssstyle": ">= 0.2.29 < 0.3.0",
-                "escodegen": "^1.6.1",
-                "nwmatcher": ">= 1.3.7 < 2.0.0",
-                "parse5": "^1.5.1",
-                "request": "^2.55.0",
-                "sax": "^1.1.4",
-                "symbol-tree": ">= 3.1.0 < 4.0.0",
-                "tough-cookie": "^2.2.0",
-                "webidl-conversions": "^2.0.0",
-                "whatwg-url-compat": "~0.6.5",
-                "xml-name-validator": ">= 2.0.1 < 3.0.0"
+                "abab": "1.0.4",
+                "acorn": "2.7.0",
+                "acorn-globals": "1.0.9",
+                "cssom": "0.3.2",
+                "cssstyle": "0.2.37",
+                "escodegen": "1.9.1",
+                "nwmatcher": "1.4.4",
+                "parse5": "1.5.1",
+                "request": "2.86.0",
+                "sax": "1.2.4",
+                "symbol-tree": "3.2.2",
+                "tough-cookie": "2.3.4",
+                "webidl-conversions": "2.0.1",
+                "whatwg-url-compat": "0.6.5",
+                "xml-name-validator": "2.0.1"
             },
             "dependencies": {
                 "acorn": {
@@ -5347,7 +5347,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "acorn": "^2.1.0"
+                        "acorn": "2.7.0"
                     }
                 },
                 "parse5": {
@@ -5385,7 +5385,7 @@
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "requires": {
-                "jsonify": "~0.0.0"
+                "jsonify": "0.0.0"
             }
         },
         "json-stable-stringify-without-jsonify": {
@@ -5420,10 +5420,10 @@
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.0.tgz",
                     "integrity": "sha1-wXNQJMXaLvdcwZBxMHPUTwmL9IY=",
                     "requires": {
-                        "co": "^4.6.0",
-                        "fast-deep-equal": "^0.1.0",
-                        "json-schema-traverse": "^0.3.0",
-                        "json-stable-stringify": "^1.0.1"
+                        "co": "4.6.0",
+                        "fast-deep-equal": "0.1.0",
+                        "json-schema-traverse": "0.3.1",
+                        "json-stable-stringify": "1.0.1"
                     }
                 },
                 "fast-deep-equal": {
@@ -5439,7 +5439,7 @@
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.6"
+                "graceful-fs": "4.1.11"
             }
         },
         "jsonify": {
@@ -5464,8 +5464,8 @@
             "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
             "integrity": "sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=",
             "requires": {
-                "is-promise": "^2.0.0",
-                "promise": "^7.0.1"
+                "is-promise": "2.1.0",
+                "promise": "7.3.1"
             }
         },
         "jszip": {
@@ -5473,7 +5473,7 @@
             "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.5.0.tgz",
             "integrity": "sha1-dET9hVHd8+XacZj+oMkbyDCMwnQ=",
             "requires": {
-                "pako": "~0.2.5"
+                "pako": "0.2.9"
             }
         },
         "kew": {
@@ -5487,7 +5487,7 @@
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
             }
         },
         "klaw": {
@@ -5496,7 +5496,7 @@
             "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.9"
+                "graceful-fs": "4.1.11"
             }
         },
         "lazy-cache": {
@@ -5509,7 +5509,7 @@
             "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
             "requires": {
-                "invert-kv": "^1.0.0"
+                "invert-kv": "1.0.0"
             }
         },
         "levn": {
@@ -5518,8 +5518,8 @@
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "dev": true,
             "requires": {
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2"
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
             }
         },
         "load-json-file": {
@@ -5527,11 +5527,11 @@
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "parse-json": "^2.2.0",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0",
-                "strip-bom": "^2.0.0"
+                "graceful-fs": "4.1.11",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "strip-bom": "2.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -5551,9 +5551,9 @@
             "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
             "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
             "requires": {
-                "big.js": "^3.1.3",
-                "emojis-list": "^2.0.0",
-                "json5": "^0.5.0"
+                "big.js": "3.2.0",
+                "emojis-list": "2.1.0",
+                "json5": "0.5.1"
             }
         },
         "locate-path": {
@@ -5561,8 +5561,8 @@
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "requires": {
-                "p-locate": "^2.0.0",
-                "path-exists": "^3.0.0"
+                "p-locate": "2.0.0",
+                "path-exists": "3.0.0"
             }
         },
         "lodash": {
@@ -5695,7 +5695,7 @@
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
             "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
             "requires": {
-                "js-tokens": "^3.0.0"
+                "js-tokens": "3.0.2"
             }
         },
         "loud-rejection": {
@@ -5703,8 +5703,8 @@
             "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
             "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
             "requires": {
-                "currently-unhandled": "^0.4.1",
-                "signal-exit": "^3.0.0"
+                "currently-unhandled": "0.4.1",
+                "signal-exit": "3.0.2"
             }
         },
         "lru-cache": {
@@ -5712,8 +5712,8 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
             "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
             "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
             }
         },
         "macaddress": {
@@ -5726,7 +5726,7 @@
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
             "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
             "requires": {
-                "pify": "^3.0.0"
+                "pify": "3.0.0"
             }
         },
         "map-cache": {
@@ -5744,7 +5744,7 @@
             "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "requires": {
-                "object-visit": "^1.0.0"
+                "object-visit": "1.0.1"
             }
         },
         "marked": {
@@ -5758,8 +5758,8 @@
             "resolved": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
             "integrity": "sha1-mesFAJOzTf+t5CG5rAtBCpz6F88=",
             "requires": {
-                "buffers": "~0.1.1",
-                "readable-stream": "~1.0.0"
+                "buffers": "0.1.1",
+                "readable-stream": "1.0.34"
             },
             "dependencies": {
                 "isarray": {
@@ -5772,10 +5772,10 @@
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                     }
                 },
                 "string_decoder": {
@@ -5801,10 +5801,10 @@
             "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-1.1.0.tgz",
             "integrity": "sha1-cTZehKmd2Piz99X94vANHn9zvmE=",
             "requires": {
-                "chalk": "^1.0.0",
-                "figures": "^1.0.1",
-                "gzip-size": "^1.0.0",
-                "pretty-bytes": "^1.0.0"
+                "chalk": "1.1.3",
+                "figures": "1.7.0",
+                "gzip-size": "1.0.0",
+                "pretty-bytes": "1.0.4"
             }
         },
         "md5.js": {
@@ -5812,8 +5812,8 @@
             "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
             "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
             "requires": {
-                "hash-base": "^3.0.0",
-                "inherits": "^2.0.1"
+                "hash-base": "3.0.4",
+                "inherits": "2.0.3"
             }
         },
         "memory-fs": {
@@ -5821,8 +5821,8 @@
             "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
             "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
             "requires": {
-                "errno": "^0.1.3",
-                "readable-stream": "^2.0.1"
+                "errno": "0.1.7",
+                "readable-stream": "2.3.6"
             }
         },
         "meow": {
@@ -5830,16 +5830,16 @@
             "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
             "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
             "requires": {
-                "camelcase-keys": "^2.0.0",
-                "decamelize": "^1.1.2",
-                "loud-rejection": "^1.0.0",
-                "map-obj": "^1.0.1",
-                "minimist": "^1.1.3",
-                "normalize-package-data": "^2.3.4",
-                "object-assign": "^4.0.1",
-                "read-pkg-up": "^1.0.1",
-                "redent": "^1.0.0",
-                "trim-newlines": "^1.0.0"
+                "camelcase-keys": "2.1.0",
+                "decamelize": "1.2.0",
+                "loud-rejection": "1.6.0",
+                "map-obj": "1.0.1",
+                "minimist": "1.2.0",
+                "normalize-package-data": "2.4.0",
+                "object-assign": "4.1.1",
+                "read-pkg-up": "1.0.1",
+                "redent": "1.0.0",
+                "trim-newlines": "1.0.0"
             },
             "dependencies": {
                 "minimist": {
@@ -5854,19 +5854,19 @@
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
             "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
             "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "braces": "^2.3.1",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "extglob": "^2.0.4",
-                "fragment-cache": "^0.2.1",
-                "kind-of": "^6.0.2",
-                "nanomatch": "^1.2.9",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.2"
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "braces": "2.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "extglob": "2.0.4",
+                "fragment-cache": "0.2.1",
+                "kind-of": "6.0.2",
+                "nanomatch": "1.2.9",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -5881,8 +5881,8 @@
             "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
             "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
             "requires": {
-                "bn.js": "^4.0.0",
-                "brorand": "^1.0.1"
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0"
             }
         },
         "mime-db": {
@@ -5897,7 +5897,7 @@
             "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
             "dev": true,
             "requires": {
-                "mime-db": "~1.33.0"
+                "mime-db": "1.33.0"
             }
         },
         "mimic-fn": {
@@ -5921,7 +5921,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.11"
             }
         },
         "minimist": {
@@ -5934,16 +5934,16 @@
             "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
             "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
             "requires": {
-                "concat-stream": "^1.5.0",
-                "duplexify": "^3.4.2",
-                "end-of-stream": "^1.1.0",
-                "flush-write-stream": "^1.0.0",
-                "from2": "^2.1.0",
-                "parallel-transform": "^1.1.0",
-                "pump": "^2.0.1",
-                "pumpify": "^1.3.3",
-                "stream-each": "^1.1.0",
-                "through2": "^2.0.0"
+                "concat-stream": "1.6.2",
+                "duplexify": "3.6.0",
+                "end-of-stream": "1.4.1",
+                "flush-write-stream": "1.0.3",
+                "from2": "2.3.0",
+                "parallel-transform": "1.1.0",
+                "pump": "2.0.1",
+                "pumpify": "1.5.0",
+                "stream-each": "1.2.2",
+                "through2": "2.0.3"
             }
         },
         "mixin-deep": {
@@ -5951,8 +5951,8 @@
             "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "requires": {
-                "for-in": "^1.0.2",
-                "is-extendable": "^1.0.1"
+                "for-in": "1.0.2",
+                "is-extendable": "1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -5960,7 +5960,7 @@
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "requires": {
-                        "is-plain-object": "^2.0.4"
+                        "is-plain-object": "2.0.4"
                     }
                 }
             }
@@ -5983,7 +5983,7 @@
             "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.1.tgz",
             "integrity": "sha1-gfWYw61eIs2teWtn7NjYjQ9bqgY=",
             "requires": {
-                "moment": ">= 2.6.0"
+                "moment": "2.20.1"
             }
         },
         "mout": {
@@ -5997,12 +5997,12 @@
             "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
             "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
             "requires": {
-                "aproba": "^1.1.1",
-                "copy-concurrently": "^1.0.0",
-                "fs-write-stream-atomic": "^1.0.8",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.3"
+                "aproba": "1.2.0",
+                "copy-concurrently": "1.0.5",
+                "fs-write-stream-atomic": "1.0.10",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "run-queue": "1.0.3"
             },
             "dependencies": {
                 "rimraf": {
@@ -6010,7 +6010,7 @@
                     "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
                     "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
                     "requires": {
-                        "glob": "^7.0.5"
+                        "glob": "7.0.6"
                     }
                 }
             }
@@ -6037,18 +6037,18 @@
             "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
             "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
             "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "fragment-cache": "^0.2.1",
-                "is-odd": "^2.0.0",
-                "is-windows": "^1.0.2",
-                "kind-of": "^6.0.2",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "fragment-cache": "0.2.1",
+                "is-odd": "2.0.0",
+                "is-windows": "1.0.2",
+                "kind-of": "6.0.2",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -6074,8 +6074,8 @@
             "resolved": "https://registry.npmjs.org/needle/-/needle-0.11.0.tgz",
             "integrity": "sha1-AqcbAI6vfVWuifuf12hbe4jXvCk=",
             "requires": {
-                "debug": "^2.1.2",
-                "iconv-lite": "^0.4.4"
+                "debug": "2.6.9",
+                "iconv-lite": "0.4.23"
             }
         },
         "neo-async": {
@@ -6102,8 +6102,8 @@
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
             "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
             "requires": {
-                "encoding": "^0.1.11",
-                "is-stream": "^1.0.1"
+                "encoding": "0.1.12",
+                "is-stream": "1.1.0"
             }
         },
         "node-libs-browser": {
@@ -6111,28 +6111,28 @@
             "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
             "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
             "requires": {
-                "assert": "^1.1.1",
-                "browserify-zlib": "^0.2.0",
-                "buffer": "^4.3.0",
-                "console-browserify": "^1.1.0",
-                "constants-browserify": "^1.0.0",
-                "crypto-browserify": "^3.11.0",
-                "domain-browser": "^1.1.1",
-                "events": "^1.0.0",
-                "https-browserify": "^1.0.0",
-                "os-browserify": "^0.3.0",
+                "assert": "1.4.1",
+                "browserify-zlib": "0.2.0",
+                "buffer": "4.9.1",
+                "console-browserify": "1.1.0",
+                "constants-browserify": "1.0.0",
+                "crypto-browserify": "3.12.0",
+                "domain-browser": "1.2.0",
+                "events": "1.1.1",
+                "https-browserify": "1.0.0",
+                "os-browserify": "0.3.0",
                 "path-browserify": "0.0.0",
-                "process": "^0.11.10",
-                "punycode": "^1.2.4",
-                "querystring-es3": "^0.2.0",
-                "readable-stream": "^2.3.3",
-                "stream-browserify": "^2.0.1",
-                "stream-http": "^2.7.2",
-                "string_decoder": "^1.0.0",
-                "timers-browserify": "^2.0.4",
+                "process": "0.11.10",
+                "punycode": "1.4.1",
+                "querystring-es3": "0.2.1",
+                "readable-stream": "2.3.6",
+                "stream-browserify": "2.0.1",
+                "stream-http": "2.8.2",
+                "string_decoder": "1.1.1",
+                "timers-browserify": "2.0.10",
                 "tty-browserify": "0.0.0",
-                "url": "^0.11.0",
-                "util": "^0.10.3",
+                "url": "0.11.0",
+                "util": "0.10.3",
                 "vm-browserify": "0.0.4"
             },
             "dependencies": {
@@ -6141,7 +6141,7 @@
                     "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
                     "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
                     "requires": {
-                        "pako": "~1.0.5"
+                        "pako": "1.0.6"
                     }
                 },
                 "pako": {
@@ -6161,7 +6161,7 @@
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
             "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
             "requires": {
-                "abbrev": "1"
+                "abbrev": "1.1.1"
             }
         },
         "normalize-package-data": {
@@ -6169,10 +6169,10 @@
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
             "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
             "requires": {
-                "hosted-git-info": "^2.1.4",
-                "is-builtin-module": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
+                "hosted-git-info": "2.6.0",
+                "is-builtin-module": "1.0.0",
+                "semver": "5.5.0",
+                "validate-npm-package-license": "3.0.3"
             }
         },
         "normalize-path": {
@@ -6180,7 +6180,7 @@
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "requires": {
-                "remove-trailing-separator": "^1.0.1"
+                "remove-trailing-separator": "1.1.0"
             }
         },
         "normalize-range": {
@@ -6193,10 +6193,10 @@
             "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
             "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
             "requires": {
-                "object-assign": "^4.0.1",
-                "prepend-http": "^1.0.0",
-                "query-string": "^4.1.0",
-                "sort-keys": "^1.0.0"
+                "object-assign": "4.1.1",
+                "prepend-http": "1.0.4",
+                "query-string": "4.3.4",
+                "sort-keys": "1.1.2"
             }
         },
         "npm-run-path": {
@@ -6204,7 +6204,7 @@
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "requires": {
-                "path-key": "^2.0.0"
+                "path-key": "2.0.1"
             }
         },
         "nth-check": {
@@ -6213,7 +6213,7 @@
             "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
             "dev": true,
             "requires": {
-                "boolbase": "~1.0.0"
+                "boolbase": "1.0.0"
             }
         },
         "num2fraction": {
@@ -6239,33 +6239,33 @@
             "integrity": "sha512-PUFq1PSsx5OinSk5g5aaZygcDdI3QQT5XUlbR9QRMihtMS6w0Gm8xj4BxmKeeAlpQXC5M2DIhH16Y+KejceivQ==",
             "dev": true,
             "requires": {
-                "archy": "^1.0.0",
-                "arrify": "^1.0.1",
-                "caching-transform": "^1.0.0",
-                "convert-source-map": "^1.5.1",
-                "debug-log": "^1.0.1",
-                "default-require-extensions": "^1.0.0",
-                "find-cache-dir": "^0.1.1",
-                "find-up": "^2.1.0",
-                "foreground-child": "^1.5.3",
-                "glob": "^7.0.6",
-                "istanbul-lib-coverage": "^1.1.2",
-                "istanbul-lib-hook": "^1.1.0",
-                "istanbul-lib-instrument": "^1.10.0",
-                "istanbul-lib-report": "^1.1.3",
-                "istanbul-lib-source-maps": "^1.2.3",
-                "istanbul-reports": "^1.4.0",
-                "md5-hex": "^1.2.0",
-                "merge-source-map": "^1.1.0",
-                "micromatch": "^3.1.10",
-                "mkdirp": "^0.5.0",
-                "resolve-from": "^2.0.0",
-                "rimraf": "^2.6.2",
-                "signal-exit": "^3.0.1",
-                "spawn-wrap": "^1.4.2",
-                "test-exclude": "^4.2.0",
+                "archy": "1.0.0",
+                "arrify": "1.0.1",
+                "caching-transform": "1.0.1",
+                "convert-source-map": "1.5.1",
+                "debug-log": "1.0.1",
+                "default-require-extensions": "1.0.0",
+                "find-cache-dir": "0.1.1",
+                "find-up": "2.1.0",
+                "foreground-child": "1.5.6",
+                "glob": "7.1.2",
+                "istanbul-lib-coverage": "1.2.0",
+                "istanbul-lib-hook": "1.1.0",
+                "istanbul-lib-instrument": "1.10.1",
+                "istanbul-lib-report": "1.1.3",
+                "istanbul-lib-source-maps": "1.2.3",
+                "istanbul-reports": "1.4.0",
+                "md5-hex": "1.3.0",
+                "merge-source-map": "1.1.0",
+                "micromatch": "3.1.10",
+                "mkdirp": "0.5.1",
+                "resolve-from": "2.0.0",
+                "rimraf": "2.6.2",
+                "signal-exit": "3.0.2",
+                "spawn-wrap": "1.4.2",
+                "test-exclude": "4.2.1",
                 "yargs": "11.1.0",
-                "yargs-parser": "^8.0.0"
+                "yargs-parser": "8.1.0"
             },
             "dependencies": {
                 "align-text": {
@@ -6273,9 +6273,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2",
-                        "longest": "^1.0.1",
-                        "repeat-string": "^1.5.2"
+                        "kind-of": "3.2.2",
+                        "longest": "1.0.1",
+                        "repeat-string": "1.6.1"
                     }
                 },
                 "amdefine": {
@@ -6298,7 +6298,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "default-require-extensions": "^1.0.0"
+                        "default-require-extensions": "1.0.0"
                     }
                 },
                 "archy": {
@@ -6351,9 +6351,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "chalk": "^1.1.3",
-                        "esutils": "^2.0.2",
-                        "js-tokens": "^3.0.2"
+                        "chalk": "1.1.3",
+                        "esutils": "2.0.2",
+                        "js-tokens": "3.0.2"
                     }
                 },
                 "babel-generator": {
@@ -6361,14 +6361,14 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "babel-messages": "^6.23.0",
-                        "babel-runtime": "^6.26.0",
-                        "babel-types": "^6.26.0",
-                        "detect-indent": "^4.0.0",
-                        "jsesc": "^1.3.0",
-                        "lodash": "^4.17.4",
-                        "source-map": "^0.5.7",
-                        "trim-right": "^1.0.1"
+                        "babel-messages": "6.23.0",
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "detect-indent": "4.0.0",
+                        "jsesc": "1.3.0",
+                        "lodash": "4.17.10",
+                        "source-map": "0.5.7",
+                        "trim-right": "1.0.1"
                     }
                 },
                 "babel-messages": {
@@ -6376,7 +6376,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "babel-runtime": "^6.22.0"
+                        "babel-runtime": "6.26.0"
                     }
                 },
                 "babel-runtime": {
@@ -6384,8 +6384,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "core-js": "^2.4.0",
-                        "regenerator-runtime": "^0.11.0"
+                        "core-js": "2.5.6",
+                        "regenerator-runtime": "0.11.1"
                     }
                 },
                 "babel-template": {
@@ -6393,11 +6393,11 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "babel-runtime": "^6.26.0",
-                        "babel-traverse": "^6.26.0",
-                        "babel-types": "^6.26.0",
-                        "babylon": "^6.18.0",
-                        "lodash": "^4.17.4"
+                        "babel-runtime": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "babylon": "6.18.0",
+                        "lodash": "4.17.10"
                     }
                 },
                 "babel-traverse": {
@@ -6405,15 +6405,15 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "babel-code-frame": "^6.26.0",
-                        "babel-messages": "^6.23.0",
-                        "babel-runtime": "^6.26.0",
-                        "babel-types": "^6.26.0",
-                        "babylon": "^6.18.0",
-                        "debug": "^2.6.8",
-                        "globals": "^9.18.0",
-                        "invariant": "^2.2.2",
-                        "lodash": "^4.17.4"
+                        "babel-code-frame": "6.26.0",
+                        "babel-messages": "6.23.0",
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "babylon": "6.18.0",
+                        "debug": "2.6.9",
+                        "globals": "9.18.0",
+                        "invariant": "2.2.4",
+                        "lodash": "4.17.10"
                     }
                 },
                 "babel-types": {
@@ -6421,10 +6421,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "babel-runtime": "^6.26.0",
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.4",
-                        "to-fast-properties": "^1.0.3"
+                        "babel-runtime": "6.26.0",
+                        "esutils": "2.0.2",
+                        "lodash": "4.17.10",
+                        "to-fast-properties": "1.0.3"
                     }
                 },
                 "babylon": {
@@ -6442,13 +6442,13 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cache-base": "^1.0.1",
-                        "class-utils": "^0.3.5",
-                        "component-emitter": "^1.2.1",
-                        "define-property": "^1.0.0",
-                        "isobject": "^3.0.1",
-                        "mixin-deep": "^1.2.0",
-                        "pascalcase": "^0.1.1"
+                        "cache-base": "1.0.1",
+                        "class-utils": "0.3.6",
+                        "component-emitter": "1.2.1",
+                        "define-property": "1.0.0",
+                        "isobject": "3.0.1",
+                        "mixin-deep": "1.3.1",
+                        "pascalcase": "0.1.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -6456,7 +6456,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^1.0.0"
+                                "is-descriptor": "1.0.2"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -6464,7 +6464,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^6.0.0"
+                                "kind-of": "6.0.2"
                             }
                         },
                         "is-data-descriptor": {
@@ -6472,7 +6472,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^6.0.0"
+                                "kind-of": "6.0.2"
                             }
                         },
                         "is-descriptor": {
@@ -6480,9 +6480,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "^1.0.0",
-                                "is-data-descriptor": "^1.0.0",
-                                "kind-of": "^6.0.2"
+                                "is-accessor-descriptor": "1.0.0",
+                                "is-data-descriptor": "1.0.0",
+                                "kind-of": "6.0.2"
                             }
                         },
                         "isobject": {
@@ -6502,7 +6502,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -6511,16 +6511,16 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "^1.1.0",
-                        "array-unique": "^0.3.2",
-                        "extend-shallow": "^2.0.1",
-                        "fill-range": "^4.0.0",
-                        "isobject": "^3.0.1",
-                        "repeat-element": "^1.1.2",
-                        "snapdragon": "^0.8.1",
-                        "snapdragon-node": "^2.0.1",
-                        "split-string": "^3.0.2",
-                        "to-regex": "^3.0.1"
+                        "arr-flatten": "1.1.0",
+                        "array-unique": "0.3.2",
+                        "extend-shallow": "2.0.1",
+                        "fill-range": "4.0.0",
+                        "isobject": "3.0.1",
+                        "repeat-element": "1.1.2",
+                        "snapdragon": "0.8.2",
+                        "snapdragon-node": "2.1.1",
+                        "split-string": "3.1.0",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -6528,7 +6528,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -6543,15 +6543,15 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "collection-visit": "^1.0.0",
-                        "component-emitter": "^1.2.1",
-                        "get-value": "^2.0.6",
-                        "has-value": "^1.0.0",
-                        "isobject": "^3.0.1",
-                        "set-value": "^2.0.0",
-                        "to-object-path": "^0.3.0",
-                        "union-value": "^1.0.0",
-                        "unset-value": "^1.0.0"
+                        "collection-visit": "1.0.0",
+                        "component-emitter": "1.2.1",
+                        "get-value": "2.0.6",
+                        "has-value": "1.0.0",
+                        "isobject": "3.0.1",
+                        "set-value": "2.0.0",
+                        "to-object-path": "0.3.0",
+                        "union-value": "1.0.0",
+                        "unset-value": "1.0.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -6566,9 +6566,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "md5-hex": "^1.2.0",
-                        "mkdirp": "^0.5.1",
-                        "write-file-atomic": "^1.1.4"
+                        "md5-hex": "1.3.0",
+                        "mkdirp": "0.5.1",
+                        "write-file-atomic": "1.3.4"
                     }
                 },
                 "camelcase": {
@@ -6583,8 +6583,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "align-text": "^0.1.3",
-                        "lazy-cache": "^1.0.3"
+                        "align-text": "0.1.4",
+                        "lazy-cache": "1.0.4"
                     }
                 },
                 "chalk": {
@@ -6592,11 +6592,11 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
                     }
                 },
                 "class-utils": {
@@ -6604,10 +6604,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "arr-union": "^3.1.0",
-                        "define-property": "^0.2.5",
-                        "isobject": "^3.0.0",
-                        "static-extend": "^0.1.1"
+                        "arr-union": "3.1.0",
+                        "define-property": "0.2.5",
+                        "isobject": "3.0.1",
+                        "static-extend": "0.1.2"
                     },
                     "dependencies": {
                         "define-property": {
@@ -6615,7 +6615,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^0.1.0"
+                                "is-descriptor": "0.1.6"
                             }
                         },
                         "isobject": {
@@ -6631,8 +6631,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "center-align": "^0.1.1",
-                        "right-align": "^0.1.1",
+                        "center-align": "0.1.3",
+                        "right-align": "0.1.3",
                         "wordwrap": "0.0.2"
                     },
                     "dependencies": {
@@ -6654,8 +6654,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "map-visit": "^1.0.0",
-                        "object-visit": "^1.0.0"
+                        "map-visit": "1.0.0",
+                        "object-visit": "1.0.1"
                     }
                 },
                 "commondir": {
@@ -6693,8 +6693,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "lru-cache": "^4.0.1",
-                        "which": "^1.2.9"
+                        "lru-cache": "4.1.3",
+                        "which": "1.3.0"
                     }
                 },
                 "debug": {
@@ -6725,7 +6725,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "strip-bom": "^2.0.0"
+                        "strip-bom": "2.0.0"
                     }
                 },
                 "define-property": {
@@ -6733,8 +6733,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^1.0.2",
-                        "isobject": "^3.0.1"
+                        "is-descriptor": "1.0.2",
+                        "isobject": "3.0.1"
                     },
                     "dependencies": {
                         "is-accessor-descriptor": {
@@ -6742,7 +6742,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^6.0.0"
+                                "kind-of": "6.0.2"
                             }
                         },
                         "is-data-descriptor": {
@@ -6750,7 +6750,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^6.0.0"
+                                "kind-of": "6.0.2"
                             }
                         },
                         "is-descriptor": {
@@ -6758,9 +6758,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "^1.0.0",
-                                "is-data-descriptor": "^1.0.0",
-                                "kind-of": "^6.0.2"
+                                "is-accessor-descriptor": "1.0.0",
+                                "is-data-descriptor": "1.0.0",
+                                "kind-of": "6.0.2"
                             }
                         },
                         "isobject": {
@@ -6780,7 +6780,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "repeating": "^2.0.0"
+                        "repeating": "2.0.1"
                     }
                 },
                 "error-ex": {
@@ -6788,7 +6788,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-arrayish": "^0.2.1"
+                        "is-arrayish": "0.2.1"
                     }
                 },
                 "escape-string-regexp": {
@@ -6806,13 +6806,13 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "^5.0.1",
-                        "get-stream": "^3.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
                     },
                     "dependencies": {
                         "cross-spawn": {
@@ -6820,9 +6820,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "lru-cache": "^4.0.1",
-                                "shebang-command": "^1.2.0",
-                                "which": "^1.2.9"
+                                "lru-cache": "4.1.3",
+                                "shebang-command": "1.2.0",
+                                "which": "1.3.0"
                             }
                         }
                     }
@@ -6832,13 +6832,13 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "debug": "^2.3.3",
-                        "define-property": "^0.2.5",
-                        "extend-shallow": "^2.0.1",
-                        "posix-character-classes": "^0.1.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
+                        "debug": "2.6.9",
+                        "define-property": "0.2.5",
+                        "extend-shallow": "2.0.1",
+                        "posix-character-classes": "0.1.1",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "define-property": {
@@ -6846,7 +6846,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^0.1.0"
+                                "is-descriptor": "0.1.6"
                             }
                         },
                         "extend-shallow": {
@@ -6854,7 +6854,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -6864,8 +6864,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "assign-symbols": "^1.0.0",
-                        "is-extendable": "^1.0.1"
+                        "assign-symbols": "1.0.0",
+                        "is-extendable": "1.0.1"
                     },
                     "dependencies": {
                         "is-extendable": {
@@ -6873,7 +6873,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-plain-object": "^2.0.4"
+                                "is-plain-object": "2.0.4"
                             }
                         }
                     }
@@ -6883,14 +6883,14 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "array-unique": "^0.3.2",
-                        "define-property": "^1.0.0",
-                        "expand-brackets": "^2.1.4",
-                        "extend-shallow": "^2.0.1",
-                        "fragment-cache": "^0.2.1",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
+                        "array-unique": "0.3.2",
+                        "define-property": "1.0.0",
+                        "expand-brackets": "2.1.4",
+                        "extend-shallow": "2.0.1",
+                        "fragment-cache": "0.2.1",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "define-property": {
@@ -6898,7 +6898,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^1.0.0"
+                                "is-descriptor": "1.0.2"
                             }
                         },
                         "extend-shallow": {
@@ -6906,7 +6906,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -6914,7 +6914,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^6.0.0"
+                                "kind-of": "6.0.2"
                             }
                         },
                         "is-data-descriptor": {
@@ -6922,7 +6922,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^6.0.0"
+                                "kind-of": "6.0.2"
                             }
                         },
                         "is-descriptor": {
@@ -6930,9 +6930,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "^1.0.0",
-                                "is-data-descriptor": "^1.0.0",
-                                "kind-of": "^6.0.2"
+                                "is-accessor-descriptor": "1.0.0",
+                                "is-data-descriptor": "1.0.0",
+                                "kind-of": "6.0.2"
                             }
                         },
                         "kind-of": {
@@ -6947,10 +6947,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1",
-                        "to-regex-range": "^2.1.0"
+                        "extend-shallow": "2.0.1",
+                        "is-number": "3.0.0",
+                        "repeat-string": "1.6.1",
+                        "to-regex-range": "2.1.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -6958,7 +6958,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -6968,9 +6968,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "commondir": "^1.0.1",
-                        "mkdirp": "^0.5.1",
-                        "pkg-dir": "^1.0.0"
+                        "commondir": "1.0.1",
+                        "mkdirp": "0.5.1",
+                        "pkg-dir": "1.0.0"
                     }
                 },
                 "find-up": {
@@ -6978,7 +6978,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "locate-path": "^2.0.0"
+                        "locate-path": "2.0.0"
                     }
                 },
                 "for-in": {
@@ -6991,8 +6991,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "^4",
-                        "signal-exit": "^3.0.0"
+                        "cross-spawn": "4.0.2",
+                        "signal-exit": "3.0.2"
                     }
                 },
                 "fragment-cache": {
@@ -7000,7 +7000,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "map-cache": "^0.2.2"
+                        "map-cache": "0.2.2"
                     }
                 },
                 "fs.realpath": {
@@ -7028,12 +7028,12 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "globals": {
@@ -7051,10 +7051,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "async": "^1.4.0",
-                        "optimist": "^0.6.1",
-                        "source-map": "^0.4.4",
-                        "uglify-js": "^2.6"
+                        "async": "1.5.2",
+                        "optimist": "0.6.1",
+                        "source-map": "0.4.4",
+                        "uglify-js": "2.8.29"
                     },
                     "dependencies": {
                         "source-map": {
@@ -7062,7 +7062,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "amdefine": ">=0.0.4"
+                                "amdefine": "1.0.1"
                             }
                         }
                     }
@@ -7072,7 +7072,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 },
                 "has-flag": {
@@ -7085,9 +7085,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "get-value": "^2.0.6",
-                        "has-values": "^1.0.0",
-                        "isobject": "^3.0.0"
+                        "get-value": "2.0.6",
+                        "has-values": "1.0.0",
+                        "isobject": "3.0.1"
                     },
                     "dependencies": {
                         "isobject": {
@@ -7102,8 +7102,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-number": "^3.0.0",
-                        "kind-of": "^4.0.0"
+                        "is-number": "3.0.0",
+                        "kind-of": "4.0.0"
                     },
                     "dependencies": {
                         "is-number": {
@@ -7111,7 +7111,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^3.0.2"
+                                "kind-of": "3.2.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -7119,7 +7119,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "^1.1.5"
+                                        "is-buffer": "1.1.6"
                                     }
                                 }
                             }
@@ -7129,7 +7129,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-buffer": "^1.1.5"
+                                "is-buffer": "1.1.6"
                             }
                         }
                     }
@@ -7149,8 +7149,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
                     }
                 },
                 "inherits": {
@@ -7163,7 +7163,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "loose-envify": "^1.0.0"
+                        "loose-envify": "1.3.1"
                     }
                 },
                 "invert-kv": {
@@ -7176,7 +7176,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     }
                 },
                 "is-arrayish": {
@@ -7194,7 +7194,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "builtin-modules": "^1.0.0"
+                        "builtin-modules": "1.1.1"
                     }
                 },
                 "is-data-descriptor": {
@@ -7202,7 +7202,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     }
                 },
                 "is-descriptor": {
@@ -7210,9 +7210,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^0.1.6",
-                        "is-data-descriptor": "^0.1.4",
-                        "kind-of": "^5.0.0"
+                        "is-accessor-descriptor": "0.1.6",
+                        "is-data-descriptor": "0.1.4",
+                        "kind-of": "5.1.0"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -7232,7 +7232,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "^1.0.0"
+                        "number-is-nan": "1.0.1"
                     }
                 },
                 "is-fullwidth-code-point": {
@@ -7245,7 +7245,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     }
                 },
                 "is-odd": {
@@ -7253,7 +7253,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-number": "^4.0.0"
+                        "is-number": "4.0.0"
                     },
                     "dependencies": {
                         "is-number": {
@@ -7268,7 +7268,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "isobject": "^3.0.1"
+                        "isobject": "3.0.1"
                     },
                     "dependencies": {
                         "isobject": {
@@ -7318,7 +7318,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "append-transform": "^0.4.0"
+                        "append-transform": "0.4.0"
                     }
                 },
                 "istanbul-lib-instrument": {
@@ -7326,13 +7326,13 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "babel-generator": "^6.18.0",
-                        "babel-template": "^6.16.0",
-                        "babel-traverse": "^6.18.0",
-                        "babel-types": "^6.18.0",
-                        "babylon": "^6.18.0",
-                        "istanbul-lib-coverage": "^1.2.0",
-                        "semver": "^5.3.0"
+                        "babel-generator": "6.26.1",
+                        "babel-template": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "babylon": "6.18.0",
+                        "istanbul-lib-coverage": "1.2.0",
+                        "semver": "5.5.0"
                     }
                 },
                 "istanbul-lib-report": {
@@ -7340,10 +7340,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "istanbul-lib-coverage": "^1.1.2",
-                        "mkdirp": "^0.5.1",
-                        "path-parse": "^1.0.5",
-                        "supports-color": "^3.1.2"
+                        "istanbul-lib-coverage": "1.2.0",
+                        "mkdirp": "0.5.1",
+                        "path-parse": "1.0.5",
+                        "supports-color": "3.2.3"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -7351,7 +7351,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "has-flag": "^1.0.0"
+                                "has-flag": "1.0.0"
                             }
                         }
                     }
@@ -7361,11 +7361,11 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "debug": "^3.1.0",
-                        "istanbul-lib-coverage": "^1.1.2",
-                        "mkdirp": "^0.5.1",
-                        "rimraf": "^2.6.1",
-                        "source-map": "^0.5.3"
+                        "debug": "3.1.0",
+                        "istanbul-lib-coverage": "1.2.0",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.2",
+                        "source-map": "0.5.7"
                     },
                     "dependencies": {
                         "debug": {
@@ -7383,7 +7383,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "handlebars": "^4.0.3"
+                        "handlebars": "4.0.11"
                     }
                 },
                 "js-tokens": {
@@ -7401,7 +7401,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 },
                 "lazy-cache": {
@@ -7415,7 +7415,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "invert-kv": "^1.0.0"
+                        "invert-kv": "1.0.0"
                     }
                 },
                 "load-json-file": {
@@ -7423,11 +7423,11 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^2.2.0",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0",
-                        "strip-bom": "^2.0.0"
+                        "graceful-fs": "4.1.11",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1",
+                        "strip-bom": "2.0.0"
                     }
                 },
                 "locate-path": {
@@ -7435,8 +7435,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "p-locate": "^2.0.0",
-                        "path-exists": "^3.0.0"
+                        "p-locate": "2.0.0",
+                        "path-exists": "3.0.0"
                     },
                     "dependencies": {
                         "path-exists": {
@@ -7461,7 +7461,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "js-tokens": "^3.0.0"
+                        "js-tokens": "3.0.2"
                     }
                 },
                 "lru-cache": {
@@ -7469,8 +7469,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "pseudomap": "^1.0.2",
-                        "yallist": "^2.1.2"
+                        "pseudomap": "1.0.2",
+                        "yallist": "2.1.2"
                     }
                 },
                 "map-cache": {
@@ -7483,7 +7483,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "object-visit": "^1.0.0"
+                        "object-visit": "1.0.1"
                     }
                 },
                 "md5-hex": {
@@ -7491,7 +7491,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "md5-o-matic": "^0.1.1"
+                        "md5-o-matic": "0.1.1"
                     }
                 },
                 "md5-o-matic": {
@@ -7504,7 +7504,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "mimic-fn": "^1.0.0"
+                        "mimic-fn": "1.2.0"
                     }
                 },
                 "merge-source-map": {
@@ -7512,7 +7512,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "source-map": "^0.6.1"
+                        "source-map": "0.6.1"
                     },
                     "dependencies": {
                         "source-map": {
@@ -7527,19 +7527,19 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "arr-diff": "^4.0.0",
-                        "array-unique": "^0.3.2",
-                        "braces": "^2.3.1",
-                        "define-property": "^2.0.2",
-                        "extend-shallow": "^3.0.2",
-                        "extglob": "^2.0.4",
-                        "fragment-cache": "^0.2.1",
-                        "kind-of": "^6.0.2",
-                        "nanomatch": "^1.2.9",
-                        "object.pick": "^1.3.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.2"
+                        "arr-diff": "4.0.0",
+                        "array-unique": "0.3.2",
+                        "braces": "2.3.2",
+                        "define-property": "2.0.2",
+                        "extend-shallow": "3.0.2",
+                        "extglob": "2.0.4",
+                        "fragment-cache": "0.2.1",
+                        "kind-of": "6.0.2",
+                        "nanomatch": "1.2.9",
+                        "object.pick": "1.3.0",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -7559,7 +7559,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "^1.1.7"
+                        "brace-expansion": "1.1.11"
                     }
                 },
                 "minimist": {
@@ -7572,8 +7572,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "for-in": "^1.0.2",
-                        "is-extendable": "^1.0.1"
+                        "for-in": "1.0.2",
+                        "is-extendable": "1.0.1"
                     },
                     "dependencies": {
                         "is-extendable": {
@@ -7581,7 +7581,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-plain-object": "^2.0.4"
+                                "is-plain-object": "2.0.4"
                             }
                         }
                     }
@@ -7604,18 +7604,18 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "arr-diff": "^4.0.0",
-                        "array-unique": "^0.3.2",
-                        "define-property": "^2.0.2",
-                        "extend-shallow": "^3.0.2",
-                        "fragment-cache": "^0.2.1",
-                        "is-odd": "^2.0.0",
-                        "is-windows": "^1.0.2",
-                        "kind-of": "^6.0.2",
-                        "object.pick": "^1.3.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
+                        "arr-diff": "4.0.0",
+                        "array-unique": "0.3.2",
+                        "define-property": "2.0.2",
+                        "extend-shallow": "3.0.2",
+                        "fragment-cache": "0.2.1",
+                        "is-odd": "2.0.0",
+                        "is-windows": "1.0.2",
+                        "kind-of": "6.0.2",
+                        "object.pick": "1.3.0",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "arr-diff": {
@@ -7640,10 +7640,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "hosted-git-info": "^2.1.4",
-                        "is-builtin-module": "^1.0.0",
-                        "semver": "2 || 3 || 4 || 5",
-                        "validate-npm-package-license": "^3.0.1"
+                        "hosted-git-info": "2.6.0",
+                        "is-builtin-module": "1.0.0",
+                        "semver": "5.5.0",
+                        "validate-npm-package-license": "3.0.3"
                     }
                 },
                 "npm-run-path": {
@@ -7651,7 +7651,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "path-key": "^2.0.0"
+                        "path-key": "2.0.1"
                     }
                 },
                 "number-is-nan": {
@@ -7669,9 +7669,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "copy-descriptor": "^0.1.0",
-                        "define-property": "^0.2.5",
-                        "kind-of": "^3.0.3"
+                        "copy-descriptor": "0.1.1",
+                        "define-property": "0.2.5",
+                        "kind-of": "3.2.2"
                     },
                     "dependencies": {
                         "define-property": {
@@ -7679,7 +7679,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^0.1.0"
+                                "is-descriptor": "0.1.6"
                             }
                         }
                     }
@@ -7689,7 +7689,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "isobject": "^3.0.0"
+                        "isobject": "3.0.1"
                     },
                     "dependencies": {
                         "isobject": {
@@ -7704,7 +7704,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "isobject": "^3.0.1"
+                        "isobject": "3.0.1"
                     },
                     "dependencies": {
                         "isobject": {
@@ -7719,7 +7719,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "wrappy": "1"
+                        "wrappy": "1.0.2"
                     }
                 },
                 "optimist": {
@@ -7727,8 +7727,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "minimist": "~0.0.1",
-                        "wordwrap": "~0.0.2"
+                        "minimist": "0.0.8",
+                        "wordwrap": "0.0.3"
                     }
                 },
                 "os-homedir": {
@@ -7741,9 +7741,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "execa": "^0.7.0",
-                        "lcid": "^1.0.0",
-                        "mem": "^1.1.0"
+                        "execa": "0.7.0",
+                        "lcid": "1.0.0",
+                        "mem": "1.1.0"
                     }
                 },
                 "p-finally": {
@@ -7756,7 +7756,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "p-try": "^1.0.0"
+                        "p-try": "1.0.0"
                     }
                 },
                 "p-locate": {
@@ -7764,7 +7764,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "p-limit": "^1.1.0"
+                        "p-limit": "1.2.0"
                     }
                 },
                 "p-try": {
@@ -7777,7 +7777,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "error-ex": "^1.2.0"
+                        "error-ex": "1.3.1"
                     }
                 },
                 "pascalcase": {
@@ -7790,7 +7790,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "^2.0.0"
+                        "pinkie-promise": "2.0.1"
                     }
                 },
                 "path-is-absolute": {
@@ -7813,9 +7813,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
+                        "graceful-fs": "4.1.11",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
                     }
                 },
                 "pify": {
@@ -7833,7 +7833,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "pinkie": "^2.0.0"
+                        "pinkie": "2.0.4"
                     }
                 },
                 "pkg-dir": {
@@ -7841,7 +7841,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "find-up": "^1.0.0"
+                        "find-up": "1.1.2"
                     },
                     "dependencies": {
                         "find-up": {
@@ -7849,8 +7849,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "path-exists": "^2.0.0",
-                                "pinkie-promise": "^2.0.0"
+                                "path-exists": "2.1.0",
+                                "pinkie-promise": "2.0.1"
                             }
                         }
                     }
@@ -7870,9 +7870,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "load-json-file": "^1.0.0",
-                        "normalize-package-data": "^2.3.2",
-                        "path-type": "^1.0.0"
+                        "load-json-file": "1.1.0",
+                        "normalize-package-data": "2.4.0",
+                        "path-type": "1.1.0"
                     }
                 },
                 "read-pkg-up": {
@@ -7880,8 +7880,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "find-up": "^1.0.0",
-                        "read-pkg": "^1.0.0"
+                        "find-up": "1.1.2",
+                        "read-pkg": "1.1.0"
                     },
                     "dependencies": {
                         "find-up": {
@@ -7889,8 +7889,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "path-exists": "^2.0.0",
-                                "pinkie-promise": "^2.0.0"
+                                "path-exists": "2.1.0",
+                                "pinkie-promise": "2.0.1"
                             }
                         }
                     }
@@ -7905,8 +7905,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "^3.0.2",
-                        "safe-regex": "^1.1.0"
+                        "extend-shallow": "3.0.2",
+                        "safe-regex": "1.1.0"
                     }
                 },
                 "repeat-element": {
@@ -7924,7 +7924,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-finite": "^1.0.0"
+                        "is-finite": "1.0.2"
                     }
                 },
                 "require-directory": {
@@ -7958,7 +7958,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "align-text": "^0.1.1"
+                        "align-text": "0.1.4"
                     }
                 },
                 "rimraf": {
@@ -7966,7 +7966,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "glob": "^7.0.5"
+                        "glob": "7.1.2"
                     }
                 },
                 "safe-regex": {
@@ -7974,7 +7974,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ret": "~0.1.10"
+                        "ret": "0.1.15"
                     }
                 },
                 "semver": {
@@ -7992,10 +7992,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-extendable": "^0.1.1",
-                        "is-plain-object": "^2.0.3",
-                        "split-string": "^3.0.1"
+                        "extend-shallow": "2.0.1",
+                        "is-extendable": "0.1.1",
+                        "is-plain-object": "2.0.4",
+                        "split-string": "3.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -8003,7 +8003,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -8013,7 +8013,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "shebang-regex": "^1.0.0"
+                        "shebang-regex": "1.0.0"
                     }
                 },
                 "shebang-regex": {
@@ -8036,14 +8036,14 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "base": "^0.11.1",
-                        "debug": "^2.2.0",
-                        "define-property": "^0.2.5",
-                        "extend-shallow": "^2.0.1",
-                        "map-cache": "^0.2.2",
-                        "source-map": "^0.5.6",
-                        "source-map-resolve": "^0.5.0",
-                        "use": "^3.1.0"
+                        "base": "0.11.2",
+                        "debug": "2.6.9",
+                        "define-property": "0.2.5",
+                        "extend-shallow": "2.0.1",
+                        "map-cache": "0.2.2",
+                        "source-map": "0.5.7",
+                        "source-map-resolve": "0.5.1",
+                        "use": "3.1.0"
                     },
                     "dependencies": {
                         "define-property": {
@@ -8051,7 +8051,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^0.1.0"
+                                "is-descriptor": "0.1.6"
                             }
                         },
                         "extend-shallow": {
@@ -8059,7 +8059,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -8069,9 +8069,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "define-property": "^1.0.0",
-                        "isobject": "^3.0.0",
-                        "snapdragon-util": "^3.0.1"
+                        "define-property": "1.0.0",
+                        "isobject": "3.0.1",
+                        "snapdragon-util": "3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -8079,7 +8079,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^1.0.0"
+                                "is-descriptor": "1.0.2"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -8087,7 +8087,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^6.0.0"
+                                "kind-of": "6.0.2"
                             }
                         },
                         "is-data-descriptor": {
@@ -8095,7 +8095,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^6.0.0"
+                                "kind-of": "6.0.2"
                             }
                         },
                         "is-descriptor": {
@@ -8103,9 +8103,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "^1.0.0",
-                                "is-data-descriptor": "^1.0.0",
-                                "kind-of": "^6.0.2"
+                                "is-accessor-descriptor": "1.0.0",
+                                "is-data-descriptor": "1.0.0",
+                                "kind-of": "6.0.2"
                             }
                         },
                         "isobject": {
@@ -8125,7 +8125,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.2.0"
+                        "kind-of": "3.2.2"
                     }
                 },
                 "source-map": {
@@ -8138,11 +8138,11 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "atob": "^2.0.0",
-                        "decode-uri-component": "^0.2.0",
-                        "resolve-url": "^0.2.1",
-                        "source-map-url": "^0.4.0",
-                        "urix": "^0.1.0"
+                        "atob": "2.1.1",
+                        "decode-uri-component": "0.2.0",
+                        "resolve-url": "0.2.1",
+                        "source-map-url": "0.4.0",
+                        "urix": "0.1.0"
                     }
                 },
                 "source-map-url": {
@@ -8155,12 +8155,12 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "foreground-child": "^1.5.6",
-                        "mkdirp": "^0.5.0",
-                        "os-homedir": "^1.0.1",
-                        "rimraf": "^2.6.2",
-                        "signal-exit": "^3.0.2",
-                        "which": "^1.3.0"
+                        "foreground-child": "1.5.6",
+                        "mkdirp": "0.5.1",
+                        "os-homedir": "1.0.2",
+                        "rimraf": "2.6.2",
+                        "signal-exit": "3.0.2",
+                        "which": "1.3.0"
                     }
                 },
                 "spdx-correct": {
@@ -8168,8 +8168,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "spdx-expression-parse": "^3.0.0",
-                        "spdx-license-ids": "^3.0.0"
+                        "spdx-expression-parse": "3.0.0",
+                        "spdx-license-ids": "3.0.0"
                     }
                 },
                 "spdx-exceptions": {
@@ -8182,8 +8182,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "spdx-exceptions": "^2.1.0",
-                        "spdx-license-ids": "^3.0.0"
+                        "spdx-exceptions": "2.1.0",
+                        "spdx-license-ids": "3.0.0"
                     }
                 },
                 "spdx-license-ids": {
@@ -8196,7 +8196,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "^3.0.0"
+                        "extend-shallow": "3.0.2"
                     }
                 },
                 "static-extend": {
@@ -8204,8 +8204,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "define-property": "^0.2.5",
-                        "object-copy": "^0.1.0"
+                        "define-property": "0.2.5",
+                        "object-copy": "0.1.0"
                     },
                     "dependencies": {
                         "define-property": {
@@ -8213,7 +8213,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^0.1.0"
+                                "is-descriptor": "0.1.6"
                             }
                         }
                     }
@@ -8223,8 +8223,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
                     },
                     "dependencies": {
                         "ansi-regex": {
@@ -8237,7 +8237,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "ansi-regex": "^3.0.0"
+                                "ansi-regex": "3.0.0"
                             }
                         }
                     }
@@ -8247,7 +8247,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 },
                 "strip-bom": {
@@ -8255,7 +8255,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-utf8": "^0.2.0"
+                        "is-utf8": "0.2.1"
                     }
                 },
                 "strip-eof": {
@@ -8273,11 +8273,11 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "arrify": "^1.0.1",
-                        "micromatch": "^3.1.8",
-                        "object-assign": "^4.1.0",
-                        "read-pkg-up": "^1.0.1",
-                        "require-main-filename": "^1.0.1"
+                        "arrify": "1.0.1",
+                        "micromatch": "3.1.10",
+                        "object-assign": "4.1.1",
+                        "read-pkg-up": "1.0.1",
+                        "require-main-filename": "1.0.1"
                     },
                     "dependencies": {
                         "arr-diff": {
@@ -8295,16 +8295,16 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "arr-flatten": "^1.1.0",
-                                "array-unique": "^0.3.2",
-                                "extend-shallow": "^2.0.1",
-                                "fill-range": "^4.0.0",
-                                "isobject": "^3.0.1",
-                                "repeat-element": "^1.1.2",
-                                "snapdragon": "^0.8.1",
-                                "snapdragon-node": "^2.0.1",
-                                "split-string": "^3.0.2",
-                                "to-regex": "^3.0.1"
+                                "arr-flatten": "1.1.0",
+                                "array-unique": "0.3.2",
+                                "extend-shallow": "2.0.1",
+                                "fill-range": "4.0.0",
+                                "isobject": "3.0.1",
+                                "repeat-element": "1.1.2",
+                                "snapdragon": "0.8.2",
+                                "snapdragon-node": "2.1.1",
+                                "split-string": "3.1.0",
+                                "to-regex": "3.0.2"
                             },
                             "dependencies": {
                                 "extend-shallow": {
@@ -8312,7 +8312,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "is-extendable": "^0.1.0"
+                                        "is-extendable": "0.1.1"
                                     }
                                 }
                             }
@@ -8322,13 +8322,13 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "debug": "^2.3.3",
-                                "define-property": "^0.2.5",
-                                "extend-shallow": "^2.0.1",
-                                "posix-character-classes": "^0.1.0",
-                                "regex-not": "^1.0.0",
-                                "snapdragon": "^0.8.1",
-                                "to-regex": "^3.0.1"
+                                "debug": "2.6.9",
+                                "define-property": "0.2.5",
+                                "extend-shallow": "2.0.1",
+                                "posix-character-classes": "0.1.1",
+                                "regex-not": "1.0.2",
+                                "snapdragon": "0.8.2",
+                                "to-regex": "3.0.2"
                             },
                             "dependencies": {
                                 "define-property": {
@@ -8336,7 +8336,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "is-descriptor": "^0.1.0"
+                                        "is-descriptor": "0.1.6"
                                     }
                                 },
                                 "extend-shallow": {
@@ -8344,7 +8344,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "is-extendable": "^0.1.0"
+                                        "is-extendable": "0.1.1"
                                     }
                                 },
                                 "is-accessor-descriptor": {
@@ -8352,7 +8352,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "kind-of": "^3.0.2"
+                                        "kind-of": "3.2.2"
                                     },
                                     "dependencies": {
                                         "kind-of": {
@@ -8360,7 +8360,7 @@
                                             "bundled": true,
                                             "dev": true,
                                             "requires": {
-                                                "is-buffer": "^1.1.5"
+                                                "is-buffer": "1.1.6"
                                             }
                                         }
                                     }
@@ -8370,7 +8370,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "kind-of": "^3.0.2"
+                                        "kind-of": "3.2.2"
                                     },
                                     "dependencies": {
                                         "kind-of": {
@@ -8378,7 +8378,7 @@
                                             "bundled": true,
                                             "dev": true,
                                             "requires": {
-                                                "is-buffer": "^1.1.5"
+                                                "is-buffer": "1.1.6"
                                             }
                                         }
                                     }
@@ -8388,9 +8388,9 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "is-accessor-descriptor": "^0.1.6",
-                                        "is-data-descriptor": "^0.1.4",
-                                        "kind-of": "^5.0.0"
+                                        "is-accessor-descriptor": "0.1.6",
+                                        "is-data-descriptor": "0.1.4",
+                                        "kind-of": "5.1.0"
                                     }
                                 },
                                 "kind-of": {
@@ -8405,14 +8405,14 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "array-unique": "^0.3.2",
-                                "define-property": "^1.0.0",
-                                "expand-brackets": "^2.1.4",
-                                "extend-shallow": "^2.0.1",
-                                "fragment-cache": "^0.2.1",
-                                "regex-not": "^1.0.0",
-                                "snapdragon": "^0.8.1",
-                                "to-regex": "^3.0.1"
+                                "array-unique": "0.3.2",
+                                "define-property": "1.0.0",
+                                "expand-brackets": "2.1.4",
+                                "extend-shallow": "2.0.1",
+                                "fragment-cache": "0.2.1",
+                                "regex-not": "1.0.2",
+                                "snapdragon": "0.8.2",
+                                "to-regex": "3.0.2"
                             },
                             "dependencies": {
                                 "define-property": {
@@ -8420,7 +8420,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "is-descriptor": "^1.0.0"
+                                        "is-descriptor": "1.0.2"
                                     }
                                 },
                                 "extend-shallow": {
@@ -8428,7 +8428,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "is-extendable": "^0.1.0"
+                                        "is-extendable": "0.1.1"
                                     }
                                 }
                             }
@@ -8438,10 +8438,10 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "extend-shallow": "^2.0.1",
-                                "is-number": "^3.0.0",
-                                "repeat-string": "^1.6.1",
-                                "to-regex-range": "^2.1.0"
+                                "extend-shallow": "2.0.1",
+                                "is-number": "3.0.0",
+                                "repeat-string": "1.6.1",
+                                "to-regex-range": "2.1.1"
                             },
                             "dependencies": {
                                 "extend-shallow": {
@@ -8449,7 +8449,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "is-extendable": "^0.1.0"
+                                        "is-extendable": "0.1.1"
                                     }
                                 }
                             }
@@ -8459,7 +8459,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^6.0.0"
+                                "kind-of": "6.0.2"
                             }
                         },
                         "is-data-descriptor": {
@@ -8467,7 +8467,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^6.0.0"
+                                "kind-of": "6.0.2"
                             }
                         },
                         "is-descriptor": {
@@ -8475,9 +8475,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "^1.0.0",
-                                "is-data-descriptor": "^1.0.0",
-                                "kind-of": "^6.0.2"
+                                "is-accessor-descriptor": "1.0.0",
+                                "is-data-descriptor": "1.0.0",
+                                "kind-of": "6.0.2"
                             }
                         },
                         "is-number": {
@@ -8485,7 +8485,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^3.0.2"
+                                "kind-of": "3.2.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -8493,7 +8493,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "^1.1.5"
+                                        "is-buffer": "1.1.6"
                                     }
                                 }
                             }
@@ -8513,19 +8513,19 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "arr-diff": "^4.0.0",
-                                "array-unique": "^0.3.2",
-                                "braces": "^2.3.1",
-                                "define-property": "^2.0.2",
-                                "extend-shallow": "^3.0.2",
-                                "extglob": "^2.0.4",
-                                "fragment-cache": "^0.2.1",
-                                "kind-of": "^6.0.2",
-                                "nanomatch": "^1.2.9",
-                                "object.pick": "^1.3.0",
-                                "regex-not": "^1.0.0",
-                                "snapdragon": "^0.8.1",
-                                "to-regex": "^3.0.2"
+                                "arr-diff": "4.0.0",
+                                "array-unique": "0.3.2",
+                                "braces": "2.3.2",
+                                "define-property": "2.0.2",
+                                "extend-shallow": "3.0.2",
+                                "extglob": "2.0.4",
+                                "fragment-cache": "0.2.1",
+                                "kind-of": "6.0.2",
+                                "nanomatch": "1.2.9",
+                                "object.pick": "1.3.0",
+                                "regex-not": "1.0.2",
+                                "snapdragon": "0.8.2",
+                                "to-regex": "3.0.2"
                             }
                         }
                     }
@@ -8540,7 +8540,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     }
                 },
                 "to-regex": {
@@ -8548,10 +8548,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "define-property": "^2.0.2",
-                        "extend-shallow": "^3.0.2",
-                        "regex-not": "^1.0.2",
-                        "safe-regex": "^1.1.0"
+                        "define-property": "2.0.2",
+                        "extend-shallow": "3.0.2",
+                        "regex-not": "1.0.2",
+                        "safe-regex": "1.1.0"
                     }
                 },
                 "to-regex-range": {
@@ -8559,8 +8559,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1"
+                        "is-number": "3.0.0",
+                        "repeat-string": "1.6.1"
                     },
                     "dependencies": {
                         "is-number": {
@@ -8568,7 +8568,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^3.0.2"
+                                "kind-of": "3.2.2"
                             }
                         }
                     }
@@ -8584,9 +8584,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "source-map": "~0.5.1",
-                        "uglify-to-browserify": "~1.0.0",
-                        "yargs": "~3.10.0"
+                        "source-map": "0.5.7",
+                        "uglify-to-browserify": "1.0.2",
+                        "yargs": "3.10.0"
                     },
                     "dependencies": {
                         "yargs": {
@@ -8595,9 +8595,9 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "camelcase": "^1.0.2",
-                                "cliui": "^2.1.0",
-                                "decamelize": "^1.0.0",
+                                "camelcase": "1.2.1",
+                                "cliui": "2.1.0",
+                                "decamelize": "1.2.0",
                                 "window-size": "0.1.0"
                             }
                         }
@@ -8614,10 +8614,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "arr-union": "^3.1.0",
-                        "get-value": "^2.0.6",
-                        "is-extendable": "^0.1.1",
-                        "set-value": "^0.4.3"
+                        "arr-union": "3.1.0",
+                        "get-value": "2.0.6",
+                        "is-extendable": "0.1.1",
+                        "set-value": "0.4.3"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -8625,7 +8625,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         },
                         "set-value": {
@@ -8633,10 +8633,10 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "extend-shallow": "^2.0.1",
-                                "is-extendable": "^0.1.1",
-                                "is-plain-object": "^2.0.1",
-                                "to-object-path": "^0.3.0"
+                                "extend-shallow": "2.0.1",
+                                "is-extendable": "0.1.1",
+                                "is-plain-object": "2.0.4",
+                                "to-object-path": "0.3.0"
                             }
                         }
                     }
@@ -8646,8 +8646,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "has-value": "^0.3.1",
-                        "isobject": "^3.0.0"
+                        "has-value": "0.3.1",
+                        "isobject": "3.0.1"
                     },
                     "dependencies": {
                         "has-value": {
@@ -8655,9 +8655,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "get-value": "^2.0.3",
-                                "has-values": "^0.1.4",
-                                "isobject": "^2.0.0"
+                                "get-value": "2.0.6",
+                                "has-values": "0.1.4",
+                                "isobject": "2.1.0"
                             },
                             "dependencies": {
                                 "isobject": {
@@ -8692,7 +8692,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.2"
+                        "kind-of": "6.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -8707,8 +8707,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "spdx-correct": "^3.0.0",
-                        "spdx-expression-parse": "^3.0.0"
+                        "spdx-correct": "3.0.0",
+                        "spdx-expression-parse": "3.0.0"
                     }
                 },
                 "which": {
@@ -8716,7 +8716,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "isexe": "^2.0.0"
+                        "isexe": "2.0.0"
                     }
                 },
                 "which-module": {
@@ -8740,8 +8740,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1"
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1"
                     },
                     "dependencies": {
                         "is-fullwidth-code-point": {
@@ -8749,7 +8749,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "number-is-nan": "^1.0.0"
+                                "number-is-nan": "1.0.1"
                             }
                         },
                         "string-width": {
@@ -8757,9 +8757,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "code-point-at": "^1.0.0",
-                                "is-fullwidth-code-point": "^1.0.0",
-                                "strip-ansi": "^3.0.0"
+                                "code-point-at": "1.1.0",
+                                "is-fullwidth-code-point": "1.0.0",
+                                "strip-ansi": "3.0.1"
                             }
                         }
                     }
@@ -8774,9 +8774,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.11",
-                        "imurmurhash": "^0.1.4",
-                        "slide": "^1.1.5"
+                        "graceful-fs": "4.1.11",
+                        "imurmurhash": "0.1.4",
+                        "slide": "1.1.6"
                     }
                 },
                 "y18n": {
@@ -8794,18 +8794,18 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cliui": "^4.0.0",
-                        "decamelize": "^1.1.1",
-                        "find-up": "^2.1.0",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^2.0.0",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^2.0.0",
-                        "which-module": "^2.0.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^9.0.2"
+                        "cliui": "4.1.0",
+                        "decamelize": "1.2.0",
+                        "find-up": "2.1.0",
+                        "get-caller-file": "1.0.2",
+                        "os-locale": "2.1.0",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "2.1.1",
+                        "which-module": "2.0.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "9.0.2"
                     },
                     "dependencies": {
                         "ansi-regex": {
@@ -8823,9 +8823,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "string-width": "^2.1.1",
-                                "strip-ansi": "^4.0.0",
-                                "wrap-ansi": "^2.0.0"
+                                "string-width": "2.1.1",
+                                "strip-ansi": "4.0.0",
+                                "wrap-ansi": "2.1.0"
                             }
                         },
                         "strip-ansi": {
@@ -8833,7 +8833,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "ansi-regex": "^3.0.0"
+                                "ansi-regex": "3.0.0"
                             }
                         },
                         "yargs-parser": {
@@ -8841,7 +8841,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "camelcase": "^4.1.0"
+                                "camelcase": "4.1.0"
                             }
                         }
                     }
@@ -8851,7 +8851,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "camelcase": "^4.1.0"
+                        "camelcase": "4.1.0"
                     },
                     "dependencies": {
                         "camelcase": {
@@ -8879,9 +8879,9 @@
             "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "requires": {
-                "copy-descriptor": "^0.1.0",
-                "define-property": "^0.2.5",
-                "kind-of": "^3.0.3"
+                "copy-descriptor": "0.1.1",
+                "define-property": "0.2.5",
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "define-property": {
@@ -8889,7 +8889,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 }
             }
@@ -8899,7 +8899,7 @@
             "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "requires": {
-                "isobject": "^3.0.0"
+                "isobject": "3.0.1"
             }
         },
         "object.omit": {
@@ -8908,8 +8908,8 @@
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
-                "for-own": "^0.1.4",
-                "is-extendable": "^0.1.1"
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
             }
         },
         "object.pick": {
@@ -8917,7 +8917,7 @@
             "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "requires": {
-                "isobject": "^3.0.1"
+                "isobject": "3.0.1"
             }
         },
         "once": {
@@ -8925,7 +8925,7 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
             }
         },
         "onetime": {
@@ -8934,7 +8934,7 @@
             "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
             "dev": true,
             "requires": {
-                "mimic-fn": "^1.0.0"
+                "mimic-fn": "1.2.0"
             }
         },
         "optionator": {
@@ -8943,12 +8943,12 @@
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
             "dev": true,
             "requires": {
-                "deep-is": "~0.1.3",
-                "fast-levenshtein": "~2.0.4",
-                "levn": "~0.3.0",
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2",
-                "wordwrap": "~1.0.0"
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "2.0.6",
+                "levn": "0.3.0",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "1.0.0"
             },
             "dependencies": {
                 "wordwrap": {
@@ -8974,7 +8974,7 @@
             "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
             "requires": {
-                "lcid": "^1.0.0"
+                "lcid": "1.0.0"
             }
         },
         "os-tmpdir": {
@@ -8992,7 +8992,7 @@
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
             "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
             "requires": {
-                "p-try": "^1.0.0"
+                "p-try": "1.0.0"
             }
         },
         "p-locate": {
@@ -9000,7 +9000,7 @@
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "requires": {
-                "p-limit": "^1.1.0"
+                "p-limit": "1.2.0"
             }
         },
         "p-try": {
@@ -9018,9 +9018,9 @@
             "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
             "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
             "requires": {
-                "cyclist": "~0.2.2",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.1.5"
+                "cyclist": "0.2.2",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
             }
         },
         "parse-asn1": {
@@ -9028,11 +9028,11 @@
             "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
             "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
             "requires": {
-                "asn1.js": "^4.0.0",
-                "browserify-aes": "^1.0.0",
-                "create-hash": "^1.1.0",
-                "evp_bytestokey": "^1.0.0",
-                "pbkdf2": "^3.0.3"
+                "asn1.js": "4.10.1",
+                "browserify-aes": "1.2.0",
+                "create-hash": "1.2.0",
+                "evp_bytestokey": "1.0.3",
+                "pbkdf2": "3.0.16"
             }
         },
         "parse-glob": {
@@ -9041,10 +9041,10 @@
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
-                "glob-base": "^0.3.0",
-                "is-dotfile": "^1.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.0"
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
             },
             "dependencies": {
                 "is-extglob": {
@@ -9059,7 +9059,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 }
             }
@@ -9069,7 +9069,7 @@
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "requires": {
-                "error-ex": "^1.2.0"
+                "error-ex": "1.3.1"
             }
         },
         "parse5": {
@@ -9078,7 +9078,7 @@
             "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
             "dev": true,
             "requires": {
-                "@types/node": "*"
+                "@types/node": "10.1.0"
             }
         },
         "pascalcase": {
@@ -9128,9 +9128,9 @@
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
+                "graceful-fs": "4.1.11",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
             },
             "dependencies": {
                 "pify": {
@@ -9145,11 +9145,11 @@
             "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
             "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
             "requires": {
-                "create-hash": "^1.1.2",
-                "create-hmac": "^1.1.4",
-                "ripemd160": "^2.0.1",
-                "safe-buffer": "^5.0.1",
-                "sha.js": "^2.4.8"
+                "create-hash": "1.2.0",
+                "create-hmac": "1.1.7",
+                "ripemd160": "2.0.2",
+                "safe-buffer": "5.1.2",
+                "sha.js": "2.4.11"
             }
         },
         "pend": {
@@ -9169,15 +9169,15 @@
             "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
             "dev": true,
             "requires": {
-                "es6-promise": "^4.0.3",
-                "extract-zip": "^1.6.5",
-                "fs-extra": "^1.0.0",
-                "hasha": "^2.2.0",
-                "kew": "^0.7.0",
-                "progress": "^1.1.8",
-                "request": "^2.81.0",
-                "request-progress": "^2.0.1",
-                "which": "^1.2.10"
+                "es6-promise": "4.2.4",
+                "extract-zip": "1.6.6",
+                "fs-extra": "1.0.0",
+                "hasha": "2.2.0",
+                "kew": "0.7.0",
+                "progress": "1.1.8",
+                "request": "2.86.0",
+                "request-progress": "2.0.1",
+                "which": "1.2.14"
             },
             "dependencies": {
                 "fs-extra": {
@@ -9186,9 +9186,9 @@
                     "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "jsonfile": "^2.1.0",
-                        "klaw": "^1.0.0"
+                        "graceful-fs": "4.1.11",
+                        "jsonfile": "2.4.0",
+                        "klaw": "1.3.1"
                     }
                 },
                 "jsonfile": {
@@ -9197,7 +9197,7 @@
                     "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.6"
+                        "graceful-fs": "4.1.11"
                     }
                 },
                 "progress": {
@@ -9223,7 +9223,7 @@
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "requires": {
-                "pinkie": "^2.0.0"
+                "pinkie": "2.0.4"
             }
         },
         "pkg-conf": {
@@ -9232,10 +9232,10 @@
             "integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
             "dev": true,
             "requires": {
-                "find-up": "^1.0.0",
-                "load-json-file": "^1.1.0",
-                "object-assign": "^4.0.1",
-                "symbol": "^0.2.1"
+                "find-up": "1.1.2",
+                "load-json-file": "1.1.0",
+                "object-assign": "4.1.1",
+                "symbol": "0.2.3"
             },
             "dependencies": {
                 "find-up": {
@@ -9244,8 +9244,8 @@
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                     "dev": true,
                     "requires": {
-                        "path-exists": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
+                        "path-exists": "2.1.0",
+                        "pinkie-promise": "2.0.1"
                     }
                 },
                 "path-exists": {
@@ -9254,7 +9254,7 @@
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "^2.0.0"
+                        "pinkie-promise": "2.0.1"
                     }
                 }
             }
@@ -9264,7 +9264,7 @@
             "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
             "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
             "requires": {
-                "find-up": "^2.1.0"
+                "find-up": "2.1.0"
             }
         },
         "pluralize": {
@@ -9283,10 +9283,10 @@
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
             "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
             "requires": {
-                "chalk": "^1.1.3",
-                "js-base64": "^2.1.9",
-                "source-map": "^0.5.6",
-                "supports-color": "^3.2.3"
+                "chalk": "1.1.3",
+                "js-base64": "2.4.3",
+                "source-map": "0.5.7",
+                "supports-color": "3.2.3"
             },
             "dependencies": {
                 "supports-color": {
@@ -9304,9 +9304,9 @@
             "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
             "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
             "requires": {
-                "postcss": "^5.0.2",
-                "postcss-message-helpers": "^2.0.0",
-                "reduce-css-calc": "^1.2.6"
+                "postcss": "5.2.18",
+                "postcss-message-helpers": "2.0.0",
+                "reduce-css-calc": "1.3.0"
             }
         },
         "postcss-colormin": {
@@ -9314,9 +9314,9 @@
             "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
             "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
             "requires": {
-                "colormin": "^1.0.5",
-                "postcss": "^5.0.13",
-                "postcss-value-parser": "^3.2.3"
+                "colormin": "1.1.2",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
             }
         },
         "postcss-convert-values": {
@@ -9324,8 +9324,8 @@
             "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
             "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
             "requires": {
-                "postcss": "^5.0.11",
-                "postcss-value-parser": "^3.1.2"
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
             }
         },
         "postcss-discard-comments": {
@@ -9333,7 +9333,7 @@
             "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
             "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
             "requires": {
-                "postcss": "^5.0.14"
+                "postcss": "5.2.18"
             }
         },
         "postcss-discard-duplicates": {
@@ -9341,7 +9341,7 @@
             "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
             "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
             "requires": {
-                "postcss": "^5.0.4"
+                "postcss": "5.2.18"
             }
         },
         "postcss-discard-empty": {
@@ -9349,7 +9349,7 @@
             "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
             "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
             "requires": {
-                "postcss": "^5.0.14"
+                "postcss": "5.2.18"
             }
         },
         "postcss-discard-overridden": {
@@ -9357,7 +9357,7 @@
             "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
             "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
             "requires": {
-                "postcss": "^5.0.16"
+                "postcss": "5.2.18"
             }
         },
         "postcss-discard-unused": {
@@ -9365,8 +9365,8 @@
             "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
             "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
             "requires": {
-                "postcss": "^5.0.14",
-                "uniqs": "^2.0.0"
+                "postcss": "5.2.18",
+                "uniqs": "2.0.0"
             }
         },
         "postcss-filter-plugins": {
@@ -9374,8 +9374,8 @@
             "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
             "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
             "requires": {
-                "postcss": "^5.0.4",
-                "uniqid": "^4.0.0"
+                "postcss": "5.2.18",
+                "uniqid": "4.1.1"
             }
         },
         "postcss-merge-idents": {
@@ -9383,9 +9383,9 @@
             "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
             "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
             "requires": {
-                "has": "^1.0.1",
-                "postcss": "^5.0.10",
-                "postcss-value-parser": "^3.1.1"
+                "has": "1.0.1",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
             }
         },
         "postcss-merge-longhand": {
@@ -9393,7 +9393,7 @@
             "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
             "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
             "requires": {
-                "postcss": "^5.0.4"
+                "postcss": "5.2.18"
             }
         },
         "postcss-merge-rules": {
@@ -9401,11 +9401,11 @@
             "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
             "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
             "requires": {
-                "browserslist": "^1.5.2",
-                "caniuse-api": "^1.5.2",
-                "postcss": "^5.0.4",
-                "postcss-selector-parser": "^2.2.2",
-                "vendors": "^1.0.0"
+                "browserslist": "1.7.7",
+                "caniuse-api": "1.6.1",
+                "postcss": "5.2.18",
+                "postcss-selector-parser": "2.2.3",
+                "vendors": "1.0.2"
             },
             "dependencies": {
                 "browserslist": {
@@ -9413,8 +9413,8 @@
                     "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
                     "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
                     "requires": {
-                        "caniuse-db": "^1.0.30000639",
-                        "electron-to-chromium": "^1.2.7"
+                        "caniuse-db": "1.0.30000841",
+                        "electron-to-chromium": "1.3.46"
                     }
                 }
             }
@@ -9429,9 +9429,9 @@
             "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
             "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
             "requires": {
-                "object-assign": "^4.0.1",
-                "postcss": "^5.0.4",
-                "postcss-value-parser": "^3.0.2"
+                "object-assign": "4.1.1",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
             }
         },
         "postcss-minify-gradients": {
@@ -9439,8 +9439,8 @@
             "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
             "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
             "requires": {
-                "postcss": "^5.0.12",
-                "postcss-value-parser": "^3.3.0"
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
             }
         },
         "postcss-minify-params": {
@@ -9448,10 +9448,10 @@
             "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
             "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
             "requires": {
-                "alphanum-sort": "^1.0.1",
-                "postcss": "^5.0.2",
-                "postcss-value-parser": "^3.0.2",
-                "uniqs": "^2.0.0"
+                "alphanum-sort": "1.0.2",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0",
+                "uniqs": "2.0.0"
             }
         },
         "postcss-minify-selectors": {
@@ -9459,10 +9459,10 @@
             "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
             "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
             "requires": {
-                "alphanum-sort": "^1.0.2",
-                "has": "^1.0.1",
-                "postcss": "^5.0.14",
-                "postcss-selector-parser": "^2.0.0"
+                "alphanum-sort": "1.0.2",
+                "has": "1.0.1",
+                "postcss": "5.2.18",
+                "postcss-selector-parser": "2.2.3"
             }
         },
         "postcss-modules-extract-imports": {
@@ -9470,7 +9470,7 @@
             "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
             "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
             "requires": {
-                "postcss": "^6.0.1"
+                "postcss": "6.0.22"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9478,7 +9478,7 @@
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
@@ -9486,9 +9486,9 @@
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -9501,9 +9501,9 @@
                     "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
                     "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
                     "requires": {
-                        "chalk": "^2.4.1",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^5.4.0"
+                        "chalk": "2.4.1",
+                        "source-map": "0.6.1",
+                        "supports-color": "5.4.0"
                     }
                 },
                 "source-map": {
@@ -9516,7 +9516,7 @@
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -9526,8 +9526,8 @@
             "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
             "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
             "requires": {
-                "css-selector-tokenizer": "^0.7.0",
-                "postcss": "^6.0.1"
+                "css-selector-tokenizer": "0.7.0",
+                "postcss": "6.0.22"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9535,7 +9535,7 @@
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
@@ -9543,9 +9543,9 @@
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -9558,9 +9558,9 @@
                     "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
                     "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
                     "requires": {
-                        "chalk": "^2.4.1",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^5.4.0"
+                        "chalk": "2.4.1",
+                        "source-map": "0.6.1",
+                        "supports-color": "5.4.0"
                     }
                 },
                 "source-map": {
@@ -9573,7 +9573,7 @@
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -9583,8 +9583,8 @@
             "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
             "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
             "requires": {
-                "css-selector-tokenizer": "^0.7.0",
-                "postcss": "^6.0.1"
+                "css-selector-tokenizer": "0.7.0",
+                "postcss": "6.0.22"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9592,7 +9592,7 @@
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
@@ -9600,9 +9600,9 @@
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -9615,9 +9615,9 @@
                     "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
                     "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
                     "requires": {
-                        "chalk": "^2.4.1",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^5.4.0"
+                        "chalk": "2.4.1",
+                        "source-map": "0.6.1",
+                        "supports-color": "5.4.0"
                     }
                 },
                 "source-map": {
@@ -9630,7 +9630,7 @@
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -9640,8 +9640,8 @@
             "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
             "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
             "requires": {
-                "icss-replace-symbols": "^1.1.0",
-                "postcss": "^6.0.1"
+                "icss-replace-symbols": "1.1.0",
+                "postcss": "6.0.22"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9649,7 +9649,7 @@
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
@@ -9657,9 +9657,9 @@
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -9672,9 +9672,9 @@
                     "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
                     "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
                     "requires": {
-                        "chalk": "^2.4.1",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^5.4.0"
+                        "chalk": "2.4.1",
+                        "source-map": "0.6.1",
+                        "supports-color": "5.4.0"
                     }
                 },
                 "source-map": {
@@ -9687,7 +9687,7 @@
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -9697,7 +9697,7 @@
             "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
             "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
             "requires": {
-                "postcss": "^5.0.5"
+                "postcss": "5.2.18"
             }
         },
         "postcss-normalize-url": {
@@ -9705,10 +9705,10 @@
             "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
             "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
             "requires": {
-                "is-absolute-url": "^2.0.0",
-                "normalize-url": "^1.4.0",
-                "postcss": "^5.0.14",
-                "postcss-value-parser": "^3.2.3"
+                "is-absolute-url": "2.1.0",
+                "normalize-url": "1.9.1",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
             }
         },
         "postcss-ordered-values": {
@@ -9716,8 +9716,8 @@
             "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
             "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
             "requires": {
-                "postcss": "^5.0.4",
-                "postcss-value-parser": "^3.0.1"
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
             }
         },
         "postcss-reduce-idents": {
@@ -9725,8 +9725,8 @@
             "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
             "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
             "requires": {
-                "postcss": "^5.0.4",
-                "postcss-value-parser": "^3.0.2"
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
             }
         },
         "postcss-reduce-initial": {
@@ -9734,7 +9734,7 @@
             "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
             "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
             "requires": {
-                "postcss": "^5.0.4"
+                "postcss": "5.2.18"
             }
         },
         "postcss-reduce-transforms": {
@@ -9742,9 +9742,9 @@
             "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
             "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
             "requires": {
-                "has": "^1.0.1",
-                "postcss": "^5.0.8",
-                "postcss-value-parser": "^3.0.1"
+                "has": "1.0.1",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
             }
         },
         "postcss-selector-parser": {
@@ -9752,9 +9752,9 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
             "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
             "requires": {
-                "flatten": "^1.0.2",
-                "indexes-of": "^1.0.1",
-                "uniq": "^1.0.1"
+                "flatten": "1.0.2",
+                "indexes-of": "1.0.1",
+                "uniq": "1.0.1"
             }
         },
         "postcss-svgo": {
@@ -9762,10 +9762,10 @@
             "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
             "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
             "requires": {
-                "is-svg": "^2.0.0",
-                "postcss": "^5.0.14",
-                "postcss-value-parser": "^3.2.3",
-                "svgo": "^0.7.0"
+                "is-svg": "2.1.0",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0",
+                "svgo": "0.7.2"
             }
         },
         "postcss-unique-selectors": {
@@ -9773,9 +9773,9 @@
             "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
             "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
             "requires": {
-                "alphanum-sort": "^1.0.1",
-                "postcss": "^5.0.4",
-                "uniqs": "^2.0.0"
+                "alphanum-sort": "1.0.2",
+                "postcss": "5.2.18",
+                "uniqs": "2.0.0"
             }
         },
         "postcss-value-parser": {
@@ -9788,9 +9788,9 @@
             "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
             "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
             "requires": {
-                "has": "^1.0.1",
-                "postcss": "^5.0.4",
-                "uniqs": "^2.0.0"
+                "has": "1.0.1",
+                "postcss": "5.2.18",
+                "uniqs": "2.0.0"
             }
         },
         "prelude-ls": {
@@ -9815,8 +9815,8 @@
             "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
             "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
             "requires": {
-                "get-stdin": "^4.0.1",
-                "meow": "^3.1.0"
+                "get-stdin": "4.0.1",
+                "meow": "3.7.0"
             }
         },
         "private": {
@@ -9845,7 +9845,7 @@
             "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
             "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
             "requires": {
-                "asap": "~2.0.3"
+                "asap": "2.0.6"
             }
         },
         "promise-inflight": {
@@ -9868,11 +9868,11 @@
             "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
             "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
             "requires": {
-                "bn.js": "^4.1.0",
-                "browserify-rsa": "^4.0.0",
-                "create-hash": "^1.1.0",
-                "parse-asn1": "^5.0.0",
-                "randombytes": "^2.0.1"
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.2.0",
+                "parse-asn1": "5.1.1",
+                "randombytes": "2.0.6"
             }
         },
         "pug": {
@@ -9880,14 +9880,14 @@
             "resolved": "https://registry.npmjs.org/pug/-/pug-2.0.3.tgz",
             "integrity": "sha1-ccuoJTfJWl6rftBGluQiH1Oqh44=",
             "requires": {
-                "pug-code-gen": "^2.0.1",
-                "pug-filters": "^3.1.0",
-                "pug-lexer": "^4.0.0",
-                "pug-linker": "^3.0.5",
-                "pug-load": "^2.0.11",
-                "pug-parser": "^5.0.0",
-                "pug-runtime": "^2.0.4",
-                "pug-strip-comments": "^1.0.3"
+                "pug-code-gen": "2.0.1",
+                "pug-filters": "3.1.0",
+                "pug-lexer": "4.0.0",
+                "pug-linker": "3.0.5",
+                "pug-load": "2.0.11",
+                "pug-parser": "5.0.0",
+                "pug-runtime": "2.0.4",
+                "pug-strip-comments": "1.0.3"
             }
         },
         "pug-attrs": {
@@ -9895,9 +9895,9 @@
             "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-2.0.3.tgz",
             "integrity": "sha1-owlflw5kFR972tlX7vVftdeQXRU=",
             "requires": {
-                "constantinople": "^3.0.1",
-                "js-stringify": "^1.0.1",
-                "pug-runtime": "^2.0.4"
+                "constantinople": "3.1.2",
+                "js-stringify": "1.0.2",
+                "pug-runtime": "2.0.4"
             }
         },
         "pug-code-gen": {
@@ -9905,14 +9905,14 @@
             "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-2.0.1.tgz",
             "integrity": "sha1-CVHsgyJddNjPxHan+Zolm199BQw=",
             "requires": {
-                "constantinople": "^3.0.1",
-                "doctypes": "^1.1.0",
-                "js-stringify": "^1.0.1",
-                "pug-attrs": "^2.0.3",
-                "pug-error": "^1.3.2",
-                "pug-runtime": "^2.0.4",
-                "void-elements": "^2.0.1",
-                "with": "^5.0.0"
+                "constantinople": "3.1.2",
+                "doctypes": "1.1.0",
+                "js-stringify": "1.0.2",
+                "pug-attrs": "2.0.3",
+                "pug-error": "1.3.2",
+                "pug-runtime": "2.0.4",
+                "void-elements": "2.0.1",
+                "with": "5.1.1"
             }
         },
         "pug-error": {
@@ -9925,13 +9925,13 @@
             "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-3.1.0.tgz",
             "integrity": "sha1-JxZVVbwEwjbkqisDZiRt+gIbYm4=",
             "requires": {
-                "clean-css": "^4.1.11",
-                "constantinople": "^3.0.1",
+                "clean-css": "4.1.11",
+                "constantinople": "3.1.2",
                 "jstransformer": "1.0.0",
-                "pug-error": "^1.3.2",
-                "pug-walk": "^1.1.7",
-                "resolve": "^1.1.6",
-                "uglify-js": "^2.6.1"
+                "pug-error": "1.3.2",
+                "pug-walk": "1.1.7",
+                "resolve": "1.1.7",
+                "uglify-js": "2.8.29"
             }
         },
         "pug-lexer": {
@@ -9939,9 +9939,9 @@
             "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-4.0.0.tgz",
             "integrity": "sha1-IQwYRX7y4XYCQnQMXmR715TOwng=",
             "requires": {
-                "character-parser": "^2.1.1",
-                "is-expression": "^3.0.0",
-                "pug-error": "^1.3.2"
+                "character-parser": "2.2.0",
+                "is-expression": "3.0.0",
+                "pug-error": "1.3.2"
             }
         },
         "pug-linker": {
@@ -9949,8 +9949,8 @@
             "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-3.0.5.tgz",
             "integrity": "sha1-npp65ABWgtAn3uuWsAD4juuDoC8=",
             "requires": {
-                "pug-error": "^1.3.2",
-                "pug-walk": "^1.1.7"
+                "pug-error": "1.3.2",
+                "pug-walk": "1.1.7"
             }
         },
         "pug-lint": {
@@ -9959,19 +9959,19 @@
             "integrity": "sha1-RBnuMBrspF9UBhsOykqaRx86qak=",
             "dev": true,
             "requires": {
-                "acorn": "^4.0.1",
-                "commander": "^2.9.0",
-                "css-selector-parser": "^1.1.0",
-                "find-line-column": "^0.5.2",
-                "glob": "^7.0.3",
-                "minimatch": "^3.0.3",
-                "path-is-absolute": "^1.0.0",
-                "pug-attrs": "^2.0.1",
-                "pug-error": "^1.3.0",
-                "pug-lexer": "^2.0.1",
-                "resolve": "^1.1.7",
-                "strip-json-comments": "^2.0.1",
-                "void-elements": "^2.0.1"
+                "acorn": "4.0.13",
+                "commander": "2.15.1",
+                "css-selector-parser": "1.3.0",
+                "find-line-column": "0.5.2",
+                "glob": "7.0.6",
+                "minimatch": "3.0.4",
+                "path-is-absolute": "1.0.1",
+                "pug-attrs": "2.0.3",
+                "pug-error": "1.3.2",
+                "pug-lexer": "2.3.2",
+                "resolve": "1.1.7",
+                "strip-json-comments": "2.0.1",
+                "void-elements": "2.0.1"
             },
             "dependencies": {
                 "acorn": {
@@ -9986,9 +9986,9 @@
                     "integrity": "sha1-aLGdlupdwOSoYUiwHLlmwXgVphQ=",
                     "dev": true,
                     "requires": {
-                        "character-parser": "^2.1.1",
-                        "is-expression": "^3.0.0",
-                        "pug-error": "^1.3.2"
+                        "character-parser": "2.2.0",
+                        "is-expression": "3.0.0",
+                        "pug-error": "1.3.2"
                     }
                 }
             }
@@ -9998,8 +9998,8 @@
             "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-2.0.11.tgz",
             "integrity": "sha1-5kjlftET/iwfRdV4WOorrWvAFSc=",
             "requires": {
-                "object-assign": "^4.1.0",
-                "pug-walk": "^1.1.7"
+                "object-assign": "4.1.1",
+                "pug-walk": "1.1.7"
             }
         },
         "pug-loader": {
@@ -10007,9 +10007,9 @@
             "resolved": "https://registry.npmjs.org/pug-loader/-/pug-loader-2.4.0.tgz",
             "integrity": "sha512-cD4bU2wmkZ1EEVyu0IfKOsh1F26KPva5oglO1Doc3knx8VpBIXmFHw16k9sITYIjQMCnRv1vb4vfQgy7VdR6eg==",
             "requires": {
-                "loader-utils": "^1.1.0",
-                "pug-walk": "^1.0.0",
-                "resolve": "^1.1.7"
+                "loader-utils": "1.1.0",
+                "pug-walk": "1.1.7",
+                "resolve": "1.1.7"
             }
         },
         "pug-parser": {
@@ -10017,7 +10017,7 @@
             "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-5.0.0.tgz",
             "integrity": "sha1-45Stmz/KkxI5QK/4hcBuRKt+aOQ=",
             "requires": {
-                "pug-error": "^1.3.2",
+                "pug-error": "1.3.2",
                 "token-stream": "0.0.1"
             }
         },
@@ -10031,7 +10031,7 @@
             "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-1.0.3.tgz",
             "integrity": "sha1-8VWVkiBu3G+FMQ2s9K+0igJa9Z8=",
             "requires": {
-                "pug-error": "^1.3.2"
+                "pug-error": "1.3.2"
             }
         },
         "pug-walk": {
@@ -10044,10 +10044,10 @@
             "resolved": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.1.tgz",
             "integrity": "sha1-1vs79a7Wl+gxFQ6xACwlo/iuExQ=",
             "requires": {
-                "over": ">= 0.0.5 < 1",
-                "readable-stream": "~1.0.31",
-                "setimmediate": ">= 1.0.2 < 2",
-                "slice-stream": ">= 1.0.0 < 2"
+                "over": "0.0.5",
+                "readable-stream": "1.0.34",
+                "setimmediate": "1.0.5",
+                "slice-stream": "1.0.0"
             },
             "dependencies": {
                 "isarray": {
@@ -10060,10 +10060,10 @@
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                     }
                 },
                 "string_decoder": {
@@ -10078,8 +10078,8 @@
             "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
             "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
             "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
             }
         },
         "pumpify": {
@@ -10087,9 +10087,9 @@
             "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.0.tgz",
             "integrity": "sha512-UWi0klDoq8xtVzlMRgENV9F7iCTZExaJQSQL187UXsxpk9NnrKGqTqqUNYAKGOzucSOxs2+jUnRNI+rLviPhJg==",
             "requires": {
-                "duplexify": "^3.6.0",
-                "inherits": "^2.0.3",
-                "pump": "^2.0.0"
+                "duplexify": "3.6.0",
+                "inherits": "2.0.3",
+                "pump": "2.0.1"
             }
         },
         "punycode": {
@@ -10113,8 +10113,8 @@
             "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
             "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
             "requires": {
-                "object-assign": "^4.1.0",
-                "strict-uri-encode": "^1.0.0"
+                "object-assign": "4.1.1",
+                "strict-uri-encode": "1.1.0"
             }
         },
         "querystring": {
@@ -10133,9 +10133,9 @@
             "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
             "dev": true,
             "requires": {
-                "is-number": "^4.0.0",
-                "kind-of": "^6.0.0",
-                "math-random": "^1.0.1"
+                "is-number": "4.0.0",
+                "kind-of": "6.0.2",
+                "math-random": "1.0.1"
             },
             "dependencies": {
                 "is-number": {
@@ -10157,7 +10157,7 @@
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
             "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
             "requires": {
-                "safe-buffer": "^5.1.0"
+                "safe-buffer": "5.1.2"
             }
         },
         "randomfill": {
@@ -10165,8 +10165,8 @@
             "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
             "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
             "requires": {
-                "randombytes": "^2.0.5",
-                "safe-buffer": "^5.1.0"
+                "randombytes": "2.0.6",
+                "safe-buffer": "5.1.2"
             }
         },
         "read-pkg": {
@@ -10174,9 +10174,9 @@
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
             "requires": {
-                "load-json-file": "^1.0.0",
-                "normalize-package-data": "^2.3.2",
-                "path-type": "^1.0.0"
+                "load-json-file": "1.1.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "1.1.0"
             }
         },
         "read-pkg-up": {
@@ -10184,8 +10184,8 @@
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
             "requires": {
-                "find-up": "^1.0.0",
-                "read-pkg": "^1.0.0"
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
             },
             "dependencies": {
                 "find-up": {
@@ -10193,8 +10193,8 @@
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                     "requires": {
-                        "path-exists": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
+                        "path-exists": "2.1.0",
+                        "pinkie-promise": "2.0.1"
                     }
                 },
                 "path-exists": {
@@ -10202,7 +10202,7 @@
                     "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "requires": {
-                        "pinkie-promise": "^2.0.0"
+                        "pinkie-promise": "2.0.1"
                     }
                 }
             }
@@ -10212,13 +10212,13 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
             }
         },
         "readdirp": {
@@ -10226,10 +10226,10 @@
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "minimatch": "^3.0.2",
-                "readable-stream": "^2.0.2",
-                "set-immediate-shim": "^1.0.1"
+                "graceful-fs": "4.1.11",
+                "minimatch": "3.0.4",
+                "readable-stream": "2.3.6",
+                "set-immediate-shim": "1.0.1"
             }
         },
         "redent": {
@@ -10237,8 +10237,8 @@
             "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
             "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
             "requires": {
-                "indent-string": "^2.1.0",
-                "strip-indent": "^1.0.1"
+                "indent-string": "2.1.0",
+                "strip-indent": "1.0.1"
             }
         },
         "reduce-css-calc": {
@@ -10246,9 +10246,9 @@
             "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
             "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
             "requires": {
-                "balanced-match": "^0.4.2",
-                "math-expression-evaluator": "^1.2.14",
-                "reduce-function-call": "^1.0.1"
+                "balanced-match": "0.4.2",
+                "math-expression-evaluator": "1.2.17",
+                "reduce-function-call": "1.0.2"
             },
             "dependencies": {
                 "balanced-match": {
@@ -10263,7 +10263,7 @@
             "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
             "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
             "requires": {
-                "balanced-match": "^0.4.2"
+                "balanced-match": "0.4.2"
             },
             "dependencies": {
                 "balanced-match": {
@@ -10288,9 +10288,9 @@
             "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
             "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
             "requires": {
-                "babel-runtime": "^6.18.0",
-                "babel-types": "^6.19.0",
-                "private": "^0.1.6"
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "private": "0.1.8"
             }
         },
         "regex-cache": {
@@ -10299,7 +10299,7 @@
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "^0.1.3"
+                "is-equal-shallow": "0.1.3"
             }
         },
         "regex-not": {
@@ -10307,8 +10307,8 @@
             "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "requires": {
-                "extend-shallow": "^3.0.2",
-                "safe-regex": "^1.1.0"
+                "extend-shallow": "3.0.2",
+                "safe-regex": "1.1.0"
             }
         },
         "regexpp": {
@@ -10322,9 +10322,9 @@
             "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
             "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
             "requires": {
-                "regenerate": "^1.2.1",
-                "regjsgen": "^0.2.0",
-                "regjsparser": "^0.1.4"
+                "regenerate": "1.4.0",
+                "regjsgen": "0.2.0",
+                "regjsparser": "0.1.5"
             }
         },
         "regjsgen": {
@@ -10337,7 +10337,7 @@
             "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
             "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
             "requires": {
-                "jsesc": "~0.5.0"
+                "jsesc": "0.5.0"
             },
             "dependencies": {
                 "jsesc": {
@@ -10352,8 +10352,8 @@
             "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz",
             "integrity": "sha1-qspJchALZqZCpjoQIcpLrBvjv/Y=",
             "requires": {
-                "argparse": "~0.1.15",
-                "autolinker": "~0.15.0"
+                "argparse": "0.1.16",
+                "autolinker": "0.15.3"
             },
             "dependencies": {
                 "argparse": {
@@ -10361,8 +10361,8 @@
                     "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
                     "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
                     "requires": {
-                        "underscore": "~1.7.0",
-                        "underscore.string": "~2.4.0"
+                        "underscore": "1.7.0",
+                        "underscore.string": "2.4.0"
                     }
                 },
                 "underscore": {
@@ -10392,7 +10392,7 @@
             "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "requires": {
-                "is-finite": "^1.0.0"
+                "is-finite": "1.0.2"
             }
         },
         "request": {
@@ -10401,27 +10401,27 @@
             "integrity": "sha512-BQZih67o9r+Ys94tcIW4S7Uu8pthjrQVxhsZ/weOwHbDfACxvIyvnAbzFQxjy1jMtvFSzv5zf4my6cZsJBbVzw==",
             "dev": true,
             "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.6.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.1",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.1",
-                "har-validator": "~5.0.3",
-                "hawk": "~6.0.2",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.17",
-                "oauth-sign": "~0.8.2",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.1",
-                "safe-buffer": "^5.1.1",
-                "tough-cookie": "~2.3.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.1.0"
+                "aws-sign2": "0.7.0",
+                "aws4": "1.7.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.6",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.2",
+                "har-validator": "5.0.3",
+                "hawk": "6.0.2",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.18",
+                "oauth-sign": "0.8.2",
+                "performance-now": "2.1.0",
+                "qs": "6.5.2",
+                "safe-buffer": "5.1.2",
+                "tough-cookie": "2.3.4",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.2.1"
             }
         },
         "request-progress": {
@@ -10430,7 +10430,7 @@
             "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
             "dev": true,
             "requires": {
-                "throttleit": "^1.0.0"
+                "throttleit": "1.0.0"
             }
         },
         "require-directory": {
@@ -10449,8 +10449,8 @@
             "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
             "dev": true,
             "requires": {
-                "caller-path": "^0.1.0",
-                "resolve-from": "^1.0.0"
+                "caller-path": "0.1.0",
+                "resolve-from": "1.0.1"
             }
         },
         "resolve": {
@@ -10475,8 +10475,8 @@
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
             "dev": true,
             "requires": {
-                "onetime": "^2.0.0",
-                "signal-exit": "^3.0.2"
+                "onetime": "2.0.1",
+                "signal-exit": "3.0.2"
             }
         },
         "ret": {
@@ -10489,7 +10489,7 @@
             "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
             "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
             "requires": {
-                "align-text": "^0.1.1"
+                "align-text": "0.1.4"
             }
         },
         "rimraf": {
@@ -10502,8 +10502,8 @@
             "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
             "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
             "requires": {
-                "hash-base": "^3.0.0",
-                "inherits": "^2.0.1"
+                "hash-base": "3.0.4",
+                "inherits": "2.0.3"
             }
         },
         "run-async": {
@@ -10512,7 +10512,7 @@
             "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
             "dev": true,
             "requires": {
-                "is-promise": "^2.1.0"
+                "is-promise": "2.1.0"
             }
         },
         "run-queue": {
@@ -10520,7 +10520,7 @@
             "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
             "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
             "requires": {
-                "aproba": "^1.1.1"
+                "aproba": "1.2.0"
             }
         },
         "rx-lite": {
@@ -10535,7 +10535,7 @@
             "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
             "dev": true,
             "requires": {
-                "rx-lite": "*"
+                "rx-lite": "4.0.8"
             }
         },
         "safe-buffer": {
@@ -10548,7 +10548,7 @@
             "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "requires": {
-                "ret": "~0.1.10"
+                "ret": "0.1.15"
             }
         },
         "safer-buffer": {
@@ -10566,7 +10566,7 @@
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
             "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
             "requires": {
-                "ajv": "^5.0.0"
+                "ajv": "5.5.2"
             }
         },
         "semver": {
@@ -10594,10 +10594,10 @@
             "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
             "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-extendable": "^0.1.1",
-                "is-plain-object": "^2.0.3",
-                "split-string": "^3.0.1"
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "split-string": "3.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -10605,7 +10605,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -10620,8 +10620,8 @@
             "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
             "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
             "requires": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.2"
             }
         },
         "shebang-command": {
@@ -10630,7 +10630,7 @@
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
             "requires": {
-                "shebang-regex": "^1.0.0"
+                "shebang-regex": "1.0.0"
             }
         },
         "shebang-regex": {
@@ -10655,7 +10655,7 @@
             "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "^2.0.0"
+                "is-fullwidth-code-point": "2.0.0"
             },
             "dependencies": {
                 "is-fullwidth-code-point": {
@@ -10671,7 +10671,7 @@
             "resolved": "https://registry.npmjs.org/slice-stream/-/slice-stream-1.0.0.tgz",
             "integrity": "sha1-WzO9ZvATsaf4ZGCwPUY97DmtPqA=",
             "requires": {
-                "readable-stream": "~1.0.31"
+                "readable-stream": "1.0.34"
             },
             "dependencies": {
                 "isarray": {
@@ -10684,10 +10684,10 @@
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                     }
                 },
                 "string_decoder": {
@@ -10702,14 +10702,14 @@
             "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "requires": {
-                "base": "^0.11.1",
-                "debug": "^2.2.0",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "map-cache": "^0.2.2",
-                "source-map": "^0.5.6",
-                "source-map-resolve": "^0.5.0",
-                "use": "^3.1.0"
+                "base": "0.11.2",
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "map-cache": "0.2.2",
+                "source-map": "0.5.7",
+                "source-map-resolve": "0.5.2",
+                "use": "3.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -10717,7 +10717,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "extend-shallow": {
@@ -10725,7 +10725,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -10735,9 +10735,9 @@
             "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "requires": {
-                "define-property": "^1.0.0",
-                "isobject": "^3.0.0",
-                "snapdragon-util": "^3.0.1"
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "snapdragon-util": "3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -10745,7 +10745,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -10753,7 +10753,7 @@
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -10761,7 +10761,7 @@
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -10769,9 +10769,9 @@
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 },
                 "kind-of": {
@@ -10786,7 +10786,7 @@
             "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "requires": {
-                "kind-of": "^3.2.0"
+                "kind-of": "3.2.2"
             }
         },
         "sntp": {
@@ -10795,7 +10795,7 @@
             "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
             "dev": true,
             "requires": {
-                "hoek": "4.x.x"
+                "hoek": "4.2.1"
             }
         },
         "sort-keys": {
@@ -10803,7 +10803,7 @@
             "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
             "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
             "requires": {
-                "is-plain-obj": "^1.0.0"
+                "is-plain-obj": "1.1.0"
             }
         },
         "source-list-map": {
@@ -10821,11 +10821,11 @@
             "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
             "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
             "requires": {
-                "atob": "^2.1.1",
-                "decode-uri-component": "^0.2.0",
-                "resolve-url": "^0.2.1",
-                "source-map-url": "^0.4.0",
-                "urix": "^0.1.0"
+                "atob": "2.1.1",
+                "decode-uri-component": "0.2.0",
+                "resolve-url": "0.2.1",
+                "source-map-url": "0.4.0",
+                "urix": "0.1.0"
             }
         },
         "source-map-support": {
@@ -10833,7 +10833,7 @@
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
             "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
             "requires": {
-                "source-map": "^0.5.6"
+                "source-map": "0.5.7"
             }
         },
         "source-map-url": {
@@ -10846,8 +10846,8 @@
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
             "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
             "requires": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
+                "spdx-expression-parse": "3.0.0",
+                "spdx-license-ids": "3.0.0"
             }
         },
         "spdx-exceptions": {
@@ -10860,8 +10860,8 @@
             "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
             "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
+                "spdx-exceptions": "2.1.0",
+                "spdx-license-ids": "3.0.0"
             }
         },
         "spdx-license-ids": {
@@ -10874,7 +10874,7 @@
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "requires": {
-                "extend-shallow": "^3.0.0"
+                "extend-shallow": "3.0.2"
             }
         },
         "sprintf-js": {
@@ -10888,14 +10888,14 @@
             "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
             "dev": true,
             "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "tweetnacl": "~0.14.0"
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
             }
         },
         "ssri": {
@@ -10903,7 +10903,7 @@
             "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
             "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
             "requires": {
-                "safe-buffer": "^5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "stampit": {
@@ -10912,7 +10912,7 @@
             "integrity": "sha1-UfnGoIwUZHP80CGvVRyfMu1ce50=",
             "dev": true,
             "requires": {
-                "mout": "~0.5.0"
+                "mout": "0.5.0"
             }
         },
         "static-extend": {
@@ -10920,8 +10920,8 @@
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "requires": {
-                "define-property": "^0.2.5",
-                "object-copy": "^0.1.0"
+                "define-property": "0.2.5",
+                "object-copy": "0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -10929,7 +10929,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 }
             }
@@ -10939,8 +10939,8 @@
             "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
             "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
             "requires": {
-                "inherits": "~2.0.1",
-                "readable-stream": "^2.0.2"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
             }
         },
         "stream-each": {
@@ -10948,8 +10948,8 @@
             "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
             "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
             "requires": {
-                "end-of-stream": "^1.1.0",
-                "stream-shift": "^1.0.0"
+                "end-of-stream": "1.4.1",
+                "stream-shift": "1.0.0"
             }
         },
         "stream-http": {
@@ -10957,11 +10957,11 @@
             "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.2.tgz",
             "integrity": "sha512-QllfrBhqF1DPcz46WxKTs6Mz1Bpc+8Qm6vbqOpVav5odAXwbyzwnEczoWqtxrsmlO+cJqtPrp/8gWKWjaKLLlA==",
             "requires": {
-                "builtin-status-codes": "^3.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.3.6",
-                "to-arraybuffer": "^1.0.0",
-                "xtend": "^4.0.0"
+                "builtin-status-codes": "3.0.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "to-arraybuffer": "1.0.1",
+                "xtend": "4.0.1"
             }
         },
         "stream-shift": {
@@ -10979,9 +10979,9 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
             "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
             }
         },
         "string_decoder": {
@@ -10989,7 +10989,7 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
             }
         },
         "strip-ansi": {
@@ -10997,7 +10997,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "strip-bom": {
@@ -11005,7 +11005,7 @@
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "requires": {
-                "is-utf8": "^0.2.0"
+                "is-utf8": "0.2.1"
             }
         },
         "strip-indent": {
@@ -11013,7 +11013,7 @@
             "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
             "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
             "requires": {
-                "get-stdin": "^4.0.1"
+                "get-stdin": "4.0.1"
             }
         },
         "strip-json-comments": {
@@ -11027,7 +11027,7 @@
             "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.13.2.tgz",
             "integrity": "sha1-dFMzhM9pjHEEx5URULSXF63C87s=",
             "requires": {
-                "loader-utils": "^1.0.2"
+                "loader-utils": "1.1.0"
             }
         },
         "stylint": {
@@ -11055,8 +11055,8 @@
                     "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
                     "dev": true,
                     "requires": {
-                        "micromatch": "^2.1.5",
-                        "normalize-path": "^2.0.0"
+                        "micromatch": "2.3.11",
+                        "normalize-path": "2.1.1"
                     }
                 },
                 "arr-diff": {
@@ -11065,7 +11065,7 @@
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "^1.0.1"
+                        "arr-flatten": "1.1.0"
                     }
                 },
                 "array-unique": {
@@ -11086,9 +11086,9 @@
                     "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
                     "dev": true,
                     "requires": {
-                        "expand-range": "^1.8.1",
-                        "preserve": "^0.2.0",
-                        "repeat-element": "^1.1.2"
+                        "expand-range": "1.8.2",
+                        "preserve": "0.2.0",
+                        "repeat-element": "1.1.2"
                     }
                 },
                 "camelcase": {
@@ -11103,15 +11103,15 @@
                     "integrity": "sha1-KT5yhkDMk92Cd0JDNLPG1K06NIo=",
                     "dev": true,
                     "requires": {
-                        "anymatch": "^1.3.0",
-                        "async-each": "^1.0.0",
-                        "fsevents": "^1.0.0",
-                        "glob-parent": "^2.0.0",
-                        "inherits": "^2.0.1",
-                        "is-binary-path": "^1.0.0",
-                        "is-glob": "^2.0.0",
-                        "path-is-absolute": "^1.0.0",
-                        "readdirp": "^2.0.0"
+                        "anymatch": "1.3.2",
+                        "async-each": "1.0.1",
+                        "fsevents": "1.2.4",
+                        "glob-parent": "2.0.0",
+                        "inherits": "2.0.3",
+                        "is-binary-path": "1.0.1",
+                        "is-glob": "2.0.1",
+                        "path-is-absolute": "1.0.0",
+                        "readdirp": "2.1.0"
                     }
                 },
                 "cliui": {
@@ -11120,9 +11120,9 @@
                     "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                     "dev": true,
                     "requires": {
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1",
-                        "wrap-ansi": "^2.0.0"
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wrap-ansi": "2.1.0"
                     }
                 },
                 "expand-brackets": {
@@ -11131,7 +11131,7 @@
                     "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
                     "dev": true,
                     "requires": {
-                        "is-posix-bracket": "^0.1.0"
+                        "is-posix-bracket": "0.1.1"
                     }
                 },
                 "extglob": {
@@ -11140,7 +11140,7 @@
                     "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 },
                 "glob": {
@@ -11149,12 +11149,12 @@
                     "integrity": "sha1-O0SvoJQ73DGyA3uTR5Hi4IS8t/Y=",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "2 || 3",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.0"
                     }
                 },
                 "glob-parent": {
@@ -11163,7 +11163,7 @@
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "^2.0.0"
+                        "is-glob": "2.0.1"
                     }
                 },
                 "is-extglob": {
@@ -11178,7 +11178,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 },
                 "lodash.defaults": {
@@ -11187,8 +11187,8 @@
                     "integrity": "sha1-BWeOYSqXFsZLW/LOzwRRMco9NAI=",
                     "dev": true,
                     "requires": {
-                        "lodash.assigninwith": "^4.0.0",
-                        "lodash.rest": "^4.0.0"
+                        "lodash.assigninwith": "4.2.0",
+                        "lodash.rest": "4.0.5"
                     }
                 },
                 "micromatch": {
@@ -11197,19 +11197,19 @@
                     "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "^2.0.0",
-                        "array-unique": "^0.2.1",
-                        "braces": "^1.8.2",
-                        "expand-brackets": "^0.1.4",
-                        "extglob": "^0.3.1",
-                        "filename-regex": "^2.0.0",
-                        "is-extglob": "^1.0.0",
-                        "is-glob": "^2.0.1",
-                        "kind-of": "^3.0.2",
-                        "normalize-path": "^2.0.1",
-                        "object.omit": "^2.0.0",
-                        "parse-glob": "^3.0.4",
-                        "regex-cache": "^0.4.2"
+                        "arr-diff": "2.0.0",
+                        "array-unique": "0.2.1",
+                        "braces": "1.8.5",
+                        "expand-brackets": "0.1.5",
+                        "extglob": "0.3.2",
+                        "filename-regex": "2.0.1",
+                        "is-extglob": "1.0.0",
+                        "is-glob": "2.0.1",
+                        "kind-of": "3.2.2",
+                        "normalize-path": "2.1.1",
+                        "object.omit": "2.0.1",
+                        "parse-glob": "3.0.4",
+                        "regex-cache": "0.4.4"
                     }
                 },
                 "path-is-absolute": {
@@ -11242,19 +11242,19 @@
                     "integrity": "sha1-5gQyZYozh/8mnAKOrN5KUS5Djf8=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^3.0.0",
-                        "cliui": "^3.2.0",
-                        "decamelize": "^1.1.1",
-                        "lodash.assign": "^4.0.3",
-                        "os-locale": "^1.4.0",
-                        "pkg-conf": "^1.1.2",
-                        "read-pkg-up": "^1.0.1",
-                        "require-main-filename": "^1.0.1",
-                        "set-blocking": "^1.0.0",
-                        "string-width": "^1.0.1",
-                        "window-size": "^0.2.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^2.4.0"
+                        "camelcase": "3.0.0",
+                        "cliui": "3.2.0",
+                        "decamelize": "1.2.0",
+                        "lodash.assign": "4.2.0",
+                        "os-locale": "1.4.0",
+                        "pkg-conf": "1.1.3",
+                        "read-pkg-up": "1.0.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "1.0.0",
+                        "string-width": "1.0.2",
+                        "window-size": "0.2.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "2.4.1"
                     }
                 },
                 "yargs-parser": {
@@ -11263,8 +11263,8 @@
                     "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^3.0.0",
-                        "lodash.assign": "^4.0.6"
+                        "camelcase": "3.0.0",
+                        "lodash.assign": "4.2.0"
                     }
                 }
             }
@@ -11274,12 +11274,12 @@
             "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.54.5.tgz",
             "integrity": "sha1-QrlWCTHKcJDOhRWnmLqeaqPW3Hk=",
             "requires": {
-                "css-parse": "1.7.x",
-                "debug": "*",
-                "glob": "7.0.x",
-                "mkdirp": "0.5.x",
-                "sax": "0.5.x",
-                "source-map": "0.1.x"
+                "css-parse": "1.7.0",
+                "debug": "2.6.9",
+                "glob": "7.0.6",
+                "mkdirp": "0.5.1",
+                "sax": "0.5.8",
+                "source-map": "0.1.43"
             },
             "dependencies": {
                 "sax": {
@@ -11292,7 +11292,7 @@
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                     "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
                     "requires": {
-                        "amdefine": ">=0.0.4"
+                        "amdefine": "1.0.1"
                     }
                 }
             }
@@ -11302,9 +11302,9 @@
             "resolved": "https://registry.npmjs.org/stylus-loader/-/stylus-loader-3.0.2.tgz",
             "integrity": "sha512-+VomPdZ6a0razP+zinir61yZgpw2NfljeSsdUF5kJuEzlo3khXhY19Fn6l8QQz1GRJGtMCo8nG5C04ePyV7SUA==",
             "requires": {
-                "loader-utils": "^1.0.2",
-                "lodash.clonedeep": "^4.5.0",
-                "when": "~3.6.x"
+                "loader-utils": "1.1.0",
+                "lodash.clonedeep": "4.5.0",
+                "when": "3.6.4"
             }
         },
         "supports-color": {
@@ -11317,13 +11317,13 @@
             "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
             "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
             "requires": {
-                "coa": "~1.0.1",
-                "colors": "~1.1.2",
-                "csso": "~2.3.1",
-                "js-yaml": "~3.7.0",
-                "mkdirp": "~0.5.1",
-                "sax": "~1.2.1",
-                "whet.extend": "~0.9.9"
+                "coa": "1.0.4",
+                "colors": "1.1.2",
+                "csso": "2.3.2",
+                "js-yaml": "3.7.0",
+                "mkdirp": "0.5.1",
+                "sax": "1.2.4",
+                "whet.extend": "0.9.9"
             },
             "dependencies": {
                 "colors": {
@@ -11357,12 +11357,12 @@
             "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
             "dev": true,
             "requires": {
-                "ajv": "^5.2.3",
-                "ajv-keywords": "^2.1.0",
-                "chalk": "^2.1.0",
-                "lodash": "^4.17.4",
+                "ajv": "5.5.2",
+                "ajv-keywords": "2.1.1",
+                "chalk": "2.4.1",
+                "lodash": "4.17.10",
                 "slice-ansi": "1.0.0",
-                "string-width": "^2.1.1"
+                "string-width": "2.1.1"
             },
             "dependencies": {
                 "ajv-keywords": {
@@ -11383,7 +11383,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
@@ -11392,9 +11392,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -11434,7 +11434,7 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -11456,11 +11456,11 @@
             "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
             "dev": true,
             "requires": {
-                "arrify": "^1.0.1",
-                "micromatch": "^3.1.8",
-                "object-assign": "^4.1.0",
-                "read-pkg-up": "^1.0.1",
-                "require-main-filename": "^1.0.1"
+                "arrify": "1.0.1",
+                "micromatch": "3.1.10",
+                "object-assign": "4.1.1",
+                "read-pkg-up": "1.0.1",
+                "require-main-filename": "1.0.1"
             }
         },
         "text-table": {
@@ -11486,8 +11486,8 @@
             "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "requires": {
-                "readable-stream": "^2.1.5",
-                "xtend": "~4.0.1"
+                "readable-stream": "2.3.6",
+                "xtend": "4.0.1"
             }
         },
         "timers-browserify": {
@@ -11495,7 +11495,7 @@
             "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
             "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
             "requires": {
-                "setimmediate": "^1.0.4"
+                "setimmediate": "1.0.5"
             }
         },
         "tmp": {
@@ -11504,7 +11504,7 @@
             "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
             "dev": true,
             "requires": {
-                "os-tmpdir": "~1.0.2"
+                "os-tmpdir": "1.0.2"
             }
         },
         "to-arraybuffer": {
@@ -11522,7 +11522,7 @@
             "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             }
         },
         "to-regex": {
@@ -11530,10 +11530,10 @@
             "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "requires": {
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "regex-not": "^1.0.2",
-                "safe-regex": "^1.1.0"
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "regex-not": "1.0.2",
+                "safe-regex": "1.1.0"
             }
         },
         "to-regex-range": {
@@ -11541,8 +11541,8 @@
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "requires": {
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1"
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1"
             }
         },
         "token-stream": {
@@ -11561,7 +11561,7 @@
             "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
             "dev": true,
             "requires": {
-                "punycode": "^1.4.1"
+                "punycode": "1.4.1"
             },
             "dependencies": {
                 "punycode": {
@@ -11605,7 +11605,7 @@
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "dev": true,
             "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "tweetnacl": {
@@ -11621,7 +11621,7 @@
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "dev": true,
             "requires": {
-                "prelude-ls": "~1.1.2"
+                "prelude-ls": "1.1.2"
             }
         },
         "typedarray": {
@@ -11634,9 +11634,9 @@
             "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
             "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
             "requires": {
-                "source-map": "~0.5.1",
-                "uglify-to-browserify": "~1.0.0",
-                "yargs": "~3.10.0"
+                "source-map": "0.5.7",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.10.0"
             }
         },
         "uglify-to-browserify": {
@@ -11650,14 +11650,14 @@
             "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.5.tgz",
             "integrity": "sha512-hIQJ1yxAPhEA2yW/i7Fr+SXZVMp+VEI3d42RTHBgQd2yhp/1UdBcR3QEWPV5ahBxlqQDMEMTuTEvDHSFINfwSw==",
             "requires": {
-                "cacache": "^10.0.4",
-                "find-cache-dir": "^1.0.0",
-                "schema-utils": "^0.4.5",
-                "serialize-javascript": "^1.4.0",
-                "source-map": "^0.6.1",
-                "uglify-es": "^3.3.4",
-                "webpack-sources": "^1.1.0",
-                "worker-farm": "^1.5.2"
+                "cacache": "10.0.4",
+                "find-cache-dir": "1.0.0",
+                "schema-utils": "0.4.5",
+                "serialize-javascript": "1.5.0",
+                "source-map": "0.6.1",
+                "uglify-es": "3.3.9",
+                "webpack-sources": "1.1.0",
+                "worker-farm": "1.6.0"
             },
             "dependencies": {
                 "ajv": {
@@ -11665,10 +11665,10 @@
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.0.tgz",
                     "integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
                     "requires": {
-                        "fast-deep-equal": "^2.0.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.3.0",
-                        "uri-js": "^4.2.1"
+                        "fast-deep-equal": "2.0.1",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "json-schema-traverse": "0.3.1",
+                        "uri-js": "4.2.1"
                     }
                 },
                 "commander": {
@@ -11686,8 +11686,8 @@
                     "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
                     "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
                     "requires": {
-                        "ajv": "^6.1.0",
-                        "ajv-keywords": "^3.1.0"
+                        "ajv": "6.5.0",
+                        "ajv-keywords": "3.2.0"
                     }
                 },
                 "source-map": {
@@ -11700,8 +11700,8 @@
                     "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
                     "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
                     "requires": {
-                        "commander": "~2.13.0",
-                        "source-map": "~0.6.1"
+                        "commander": "2.13.0",
+                        "source-map": "0.6.1"
                     }
                 }
             }
@@ -11721,10 +11721,10 @@
             "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
             "requires": {
-                "arr-union": "^3.1.0",
-                "get-value": "^2.0.6",
-                "is-extendable": "^0.1.1",
-                "set-value": "^0.4.3"
+                "arr-union": "3.1.0",
+                "get-value": "2.0.6",
+                "is-extendable": "0.1.1",
+                "set-value": "0.4.3"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -11732,7 +11732,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 },
                 "set-value": {
@@ -11740,10 +11740,10 @@
                     "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                     "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-extendable": "^0.1.1",
-                        "is-plain-object": "^2.0.1",
-                        "to-object-path": "^0.3.0"
+                        "extend-shallow": "2.0.1",
+                        "is-extendable": "0.1.1",
+                        "is-plain-object": "2.0.4",
+                        "to-object-path": "0.3.0"
                     }
                 }
             }
@@ -11758,7 +11758,7 @@
             "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
             "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
             "requires": {
-                "macaddress": "^0.2.8"
+                "macaddress": "0.2.8"
             }
         },
         "uniqs": {
@@ -11771,7 +11771,7 @@
             "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
             "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
             "requires": {
-                "unique-slug": "^2.0.0"
+                "unique-slug": "2.0.0"
             }
         },
         "unique-slug": {
@@ -11779,7 +11779,7 @@
             "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
             "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
             "requires": {
-                "imurmurhash": "^0.1.4"
+                "imurmurhash": "0.1.4"
             }
         },
         "universalify": {
@@ -11793,8 +11793,8 @@
             "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "requires": {
-                "has-value": "^0.3.1",
-                "isobject": "^3.0.0"
+                "has-value": "0.3.1",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "has-value": {
@@ -11802,9 +11802,9 @@
                     "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "requires": {
-                        "get-value": "^2.0.3",
-                        "has-values": "^0.1.4",
-                        "isobject": "^2.0.0"
+                        "get-value": "2.0.6",
+                        "has-values": "0.1.4",
+                        "isobject": "2.1.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -11829,12 +11829,12 @@
             "resolved": "https://registry.npmjs.org/unzip/-/unzip-0.1.11.tgz",
             "integrity": "sha1-iXScY7BY19kNYZ+GuYqhU107l/A=",
             "requires": {
-                "binary": ">= 0.3.0 < 1",
-                "fstream": ">= 0.1.30 < 1",
-                "match-stream": ">= 0.0.2 < 1",
-                "pullstream": ">= 0.4.1 < 1",
-                "readable-stream": "~1.0.31",
-                "setimmediate": ">= 1.0.1 < 2"
+                "binary": "0.3.0",
+                "fstream": "0.1.31",
+                "match-stream": "0.0.2",
+                "pullstream": "0.4.1",
+                "readable-stream": "1.0.34",
+                "setimmediate": "1.0.5"
             },
             "dependencies": {
                 "isarray": {
@@ -11847,10 +11847,10 @@
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                     }
                 },
                 "string_decoder": {
@@ -11870,7 +11870,7 @@
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.1.tgz",
             "integrity": "sha512-jpKCA3HjsBfSDOEgxRDAxQCNyHfCPSbq57PqCkd3gAyBuPb3IWxw54EHncqESznIdqSetHfw3D7ylThu2Kcc9A==",
             "requires": {
-                "punycode": "^2.1.0"
+                "punycode": "2.1.0"
             }
         },
         "uri-path": {
@@ -11904,7 +11904,7 @@
             "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
             "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
             "requires": {
-                "kind-of": "^6.0.2"
+                "kind-of": "6.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -11920,7 +11920,7 @@
             "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
             "dev": true,
             "requires": {
-                "os-homedir": "^1.0.0"
+                "os-homedir": "1.0.2"
             }
         },
         "util": {
@@ -11954,8 +11954,8 @@
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
             "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
             "requires": {
-                "spdx-correct": "^3.0.0",
-                "spdx-expression-parse": "^3.0.0"
+                "spdx-correct": "3.0.0",
+                "spdx-expression-parse": "3.0.0"
             }
         },
         "vendors": {
@@ -11969,9 +11969,9 @@
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0",
+                "assert-plus": "1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
+                "extsprintf": "1.3.0"
             }
         },
         "vm-browserify": {
@@ -11997,9 +11997,9 @@
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
             "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
             "requires": {
-                "chokidar": "^2.0.2",
-                "graceful-fs": "^4.1.2",
-                "neo-async": "^2.5.0"
+                "chokidar": "2.0.3",
+                "graceful-fs": "4.1.11",
+                "neo-async": "2.5.1"
             }
         },
         "wcwidth": {
@@ -12008,7 +12008,7 @@
             "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
             "dev": true,
             "requires": {
-                "defaults": "^1.0.3"
+                "defaults": "1.0.3"
             }
         },
         "webidl-conversions": {
@@ -12023,27 +12023,27 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.7.0.tgz",
             "integrity": "sha512-MjAA0ZqO1ba7ZQJRnoCdbM56mmFpipOPUv/vQpwwfSI42p5PVDdoiuK2AL2FwFUVgT859Jr43bFZXRg/LNsqvg==",
             "requires": {
-                "acorn": "^5.0.0",
-                "acorn-dynamic-import": "^2.0.0",
-                "ajv": "^4.7.0",
-                "ajv-keywords": "^1.1.1",
-                "async": "^2.1.2",
-                "enhanced-resolve": "^3.3.0",
-                "interpret": "^1.0.0",
-                "json-loader": "^0.5.4",
-                "json5": "^0.5.1",
-                "loader-runner": "^2.3.0",
-                "loader-utils": "^0.2.16",
-                "memory-fs": "~0.4.1",
-                "mkdirp": "~0.5.0",
-                "node-libs-browser": "^2.0.0",
-                "source-map": "^0.5.3",
-                "supports-color": "^3.1.0",
-                "tapable": "~0.2.5",
-                "uglify-js": "^2.8.27",
-                "watchpack": "^1.3.1",
-                "webpack-sources": "^1.0.1",
-                "yargs": "^6.0.0"
+                "acorn": "5.5.3",
+                "acorn-dynamic-import": "2.0.2",
+                "ajv": "4.11.8",
+                "ajv-keywords": "1.5.1",
+                "async": "2.6.0",
+                "enhanced-resolve": "3.4.1",
+                "interpret": "1.1.0",
+                "json-loader": "0.5.7",
+                "json5": "0.5.1",
+                "loader-runner": "2.3.0",
+                "loader-utils": "0.2.17",
+                "memory-fs": "0.4.1",
+                "mkdirp": "0.5.1",
+                "node-libs-browser": "2.1.0",
+                "source-map": "0.5.7",
+                "supports-color": "3.2.3",
+                "tapable": "0.2.8",
+                "uglify-js": "2.8.29",
+                "watchpack": "1.6.0",
+                "webpack-sources": "1.1.0",
+                "yargs": "6.6.0"
             },
             "dependencies": {
                 "acorn": {
@@ -12056,8 +12056,8 @@
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
                     "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
                     "requires": {
-                        "co": "^4.6.0",
-                        "json-stable-stringify": "^1.0.1"
+                        "co": "4.6.0",
+                        "json-stable-stringify": "1.0.1"
                     }
                 },
                 "ajv-keywords": {
@@ -12075,9 +12075,9 @@
                     "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
                     "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                     "requires": {
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1",
-                        "wrap-ansi": "^2.0.0"
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wrap-ansi": "2.1.0"
                     }
                 },
                 "loader-utils": {
@@ -12085,10 +12085,10 @@
                     "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
                     "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
                     "requires": {
-                        "big.js": "^3.1.3",
-                        "emojis-list": "^2.0.0",
-                        "json5": "^0.5.0",
-                        "object-assign": "^4.0.1"
+                        "big.js": "3.2.0",
+                        "emojis-list": "2.1.0",
+                        "json5": "0.5.1",
+                        "object-assign": "4.1.1"
                     }
                 },
                 "supports-color": {
@@ -12096,7 +12096,7 @@
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "requires": {
-                        "has-flag": "^1.0.0"
+                        "has-flag": "1.0.0"
                     }
                 },
                 "y18n": {
@@ -12109,19 +12109,19 @@
                     "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
                     "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
                     "requires": {
-                        "camelcase": "^3.0.0",
-                        "cliui": "^3.2.0",
-                        "decamelize": "^1.1.1",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^1.4.0",
-                        "read-pkg-up": "^1.0.1",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^1.0.2",
-                        "which-module": "^1.0.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^4.2.0"
+                        "camelcase": "3.0.0",
+                        "cliui": "3.2.0",
+                        "decamelize": "1.2.0",
+                        "get-caller-file": "1.0.2",
+                        "os-locale": "1.4.0",
+                        "read-pkg-up": "1.0.1",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "1.0.2",
+                        "which-module": "1.0.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "4.2.1"
                     }
                 }
             }
@@ -12131,8 +12131,8 @@
             "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
             "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
             "requires": {
-                "source-list-map": "^2.0.0",
-                "source-map": "~0.6.1"
+                "source-list-map": "2.0.0",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-list-map": {
@@ -12154,7 +12154,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "tr46": "~0.0.1"
+                "tr46": "0.0.3"
             }
         },
         "when": {
@@ -12172,7 +12172,7 @@
             "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
             "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
             "requires": {
-                "isexe": "^2.0.0"
+                "isexe": "2.0.0"
             }
         },
         "which-module": {
@@ -12190,8 +12190,8 @@
             "resolved": "https://registry.npmjs.org/with/-/with-5.1.1.tgz",
             "integrity": "sha1-+k2qktrzLE6pTtRTyB8EaGtXXf4=",
             "requires": {
-                "acorn": "^3.1.0",
-                "acorn-globals": "^3.0.0"
+                "acorn": "3.3.0",
+                "acorn-globals": "3.1.0"
             }
         },
         "wordwrap": {
@@ -12204,7 +12204,7 @@
             "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
             "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
             "requires": {
-                "errno": "~0.1.7"
+                "errno": "0.1.7"
             }
         },
         "wrap-ansi": {
@@ -12212,8 +12212,8 @@
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1"
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1"
             }
         },
         "wrappy": {
@@ -12227,7 +12227,7 @@
             "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
             "dev": true,
             "requires": {
-                "mkdirp": "^0.5.1"
+                "mkdirp": "0.5.1"
             }
         },
         "xml-name-validator": {
@@ -12257,9 +12257,9 @@
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
             "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
             "requires": {
-                "camelcase": "^1.0.2",
-                "cliui": "^2.1.0",
-                "decamelize": "^1.0.0",
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
                 "window-size": "0.1.0"
             },
             "dependencies": {
@@ -12275,7 +12275,7 @@
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
             "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
             "requires": {
-                "camelcase": "^3.0.0"
+                "camelcase": "3.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -12290,8 +12290,8 @@
             "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
             "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
             "requires": {
-                "buffer-crc32": "~0.2.3",
-                "fd-slicer": "~1.0.1"
+                "buffer-crc32": "0.2.13",
+                "fd-slicer": "1.0.1"
             }
         }
     }

--- a/plugins/jobs/plugin.yml
+++ b/plugins/jobs/plugin.yml
@@ -4,4 +4,4 @@ url: http://girder.readthedocs.io/en/latest/plugins.html#jobs
 version: 2.0.0
 npm:
   dependencies:
-    vega: ^3.3.1
+    vega-lib: ^3.3.1

--- a/plugins/jobs/plugin.yml
+++ b/plugins/jobs/plugin.yml
@@ -4,4 +4,4 @@ url: http://girder.readthedocs.io/en/latest/plugins.html#jobs
 version: 2.0.0
 npm:
   dependencies:
-    vega: ^2.6.0
+    vega: ^3.3.1

--- a/plugins/jobs/plugin_tests/jobsSpec.js
+++ b/plugins/jobs/plugin_tests/jobsSpec.js
@@ -497,11 +497,11 @@ describe('Unit test the job list widget.', function () {
         });
         waitsFor(function () {
             // Charts will render asynchronously with Vega
-            return widget.$('.g-jobs-graph svg .mark-rect.timing rect').length;
+            return widget.$('.g-jobs-graph svg .mark-rect.timing path').length;
         }, 'timing history graph to render');
 
         runs(function () {
-            expect(widget.$('.g-jobs-graph svg .mark-rect.timing rect').length).toBe(6);
+            expect(widget.$('.g-jobs-graph svg .mark-rect.timing path').length).toBe(9);
             $('.g-jobs.nav.nav-tabs li a[name="time"]').tab('show');
         });
         waitsFor(function () {

--- a/plugins/jobs/web_client/views/JobGraphWidget.js
+++ b/plugins/jobs/web_client/views/JobGraphWidget.js
@@ -1,7 +1,7 @@
 import _ from 'underscore';
 import $ from 'jquery';
 import { parse,
-         View as VegaView } from 'vega';
+    View as VegaView } from 'vega';
 import moment from 'moment';
 
 import View from 'girder/views/View';
@@ -74,7 +74,7 @@ const JobGraphWidget = View.extend({
             config.height = this.$('.g-jobs-graph').height();
             config.data[0].values = vegaData;
 
-            const minval = Math.min(0, Math.min.apply(this, vegaData.map(d => d.elapsed === undefined ? 10 : d.elapsed)) / 1000);
+            const minval = Math.min(0, Math.min.apply(this, vegaData.map((d) => d.elapsed === undefined ? 10 : d.elapsed)) / 1000);
             config.data[1].values = [minval < -86400 ? -86400 : minval];
 
             config.scales[1].type = this.yScale;

--- a/plugins/jobs/web_client/views/JobGraphWidget.js
+++ b/plugins/jobs/web_client/views/JobGraphWidget.js
@@ -1,6 +1,7 @@
 import _ from 'underscore';
 import $ from 'jquery';
-import vg from 'vega';
+import { parse,
+         View as VegaView } from 'vega';
 import moment from 'moment';
 
 import View from 'girder/views/View';
@@ -67,7 +68,7 @@ const JobGraphWidget = View.extend({
             let withForEachJob = width / numberOfJobs;
             // if the width for each job is less than 20px, remove axe labels
             if (withForEachJob < 20) {
-                config.axes[0].properties.labels.opacity = { value: 0 };
+                config.axes[0].encode.labels.opacity = { value: 0 };
             }
             config.width = width;
             config.height = this.$('.g-jobs-graph').height();
@@ -79,13 +80,13 @@ const JobGraphWidget = View.extend({
             config.scales[3].domain = this.collection.pluck('_id');
             config.scales[3].range = this.collection.pluck('title');
 
-            vg.parse.spec(config, (chart) => {
-                var view = chart({
-                    el: this.$('.g-jobs-graph').get(0),
-                    renderer: 'svg'
-                }).update();
-                view.on('click', openDetailView(view));
-            });
+            const runtime = parse(config);
+            const view = new VegaView(runtime)
+                .initialize(document.querySelector('.g-jobs-graph'))
+                .renderer('svg')
+                .hover()
+                .run();
+            view.addEventListener('click', openDetailView(view));
 
             let positiveTimings = _.clone(this.timingFilter);
             this.timingFilterWidget.setItems(positiveTimings);
@@ -103,7 +104,7 @@ const JobGraphWidget = View.extend({
             // if the width for each job is less than 20px, remove date axe and axe labels
             if (withForEachJob < 20) {
                 config.axes.splice(0, 1);
-                config.axes[0].properties.labels.opacity = { value: 0 };
+                config.axes[0].encode.labels.opacity = { value: 0 };
             }
             config.width = width;
             config.height = this.$('.g-jobs-graph').height();

--- a/plugins/jobs/web_client/views/JobGraphWidget.js
+++ b/plugins/jobs/web_client/views/JobGraphWidget.js
@@ -127,13 +127,13 @@ const JobGraphWidget = View.extend({
             config.scales[4].domain = allStatus.map((status) => status.text);
             config.scales[4].range = allStatus.map((status) => status.color);
 
-            vg.parse.spec(config, (chart) => {
-                var view = chart({
-                    el: this.$('.g-jobs-graph').get(0),
-                    renderer: 'svg'
-                }).update();
-                view.on('click', openDetailView(view));
-            });
+            const runtime = parse(config);
+            const view = new VegaView(runtime)
+                .initialize(document.querySelector('.g-jobs-graph'))
+                .renderer('svg')
+                .hover()
+                .run();
+            view.addEventListener('click', openDetailView(view));
 
             let positiveTimings = _.clone(this.timingFilter);
             delete positiveTimings['Inactive'];

--- a/plugins/jobs/web_client/views/JobGraphWidget.js
+++ b/plugins/jobs/web_client/views/JobGraphWidget.js
@@ -65,9 +65,9 @@ const JobGraphWidget = View.extend({
             // the minimum width needed for each job is 10px
             let numberOfJobs = Math.min(this.collection.size(), Math.floor(width / 10));
             let vegaData = this._prepareDataForChart(numberOfJobs);
-            let withForEachJob = width / numberOfJobs;
+            let widthForEachJob = width / numberOfJobs;
             // if the width for each job is less than 20px, remove axe labels
-            if (withForEachJob < 20) {
+            if (widthForEachJob < 20) {
                 config.axes[0].encode.labels.opacity = { value: 0 };
             }
             config.width = width;
@@ -104,9 +104,9 @@ const JobGraphWidget = View.extend({
             // the minimum width needed for each job is 6px
             let numberOfJobs = Math.min(this.collection.size(), Math.floor(width / 6));
             let vegaData = this._prepareDataForChart(numberOfJobs);
-            let withForEachJob = width / numberOfJobs;
+            let widthForEachJob = width / numberOfJobs;
             // if the width for each job is less than 20px, remove date axe and axe labels
-            if (withForEachJob < 20) {
+            if (widthForEachJob < 20) {
                 config.axes.splice(0, 1);
                 config.axes[0].encode.labels.opacity = { value: 0 };
             }

--- a/plugins/jobs/web_client/views/JobGraphWidget.js
+++ b/plugins/jobs/web_client/views/JobGraphWidget.js
@@ -1,7 +1,7 @@
 import _ from 'underscore';
 import $ from 'jquery';
 import { parse,
-    View as VegaView } from 'vega';
+    View as VegaView } from 'vega-lib';
 import moment from 'moment';
 
 import View from 'girder/views/View';

--- a/plugins/jobs/web_client/views/JobGraphWidget.js
+++ b/plugins/jobs/web_client/views/JobGraphWidget.js
@@ -73,6 +73,10 @@ const JobGraphWidget = View.extend({
             config.width = width;
             config.height = this.$('.g-jobs-graph').height();
             config.data[0].values = vegaData;
+
+            const minval = Math.min(0, Math.min.apply(this, vegaData.map(d => d.elapsed === undefined ? 10 : d.elapsed)) / 1000);
+            config.data[1].values = [minval < -86400 ? -86400 : minval];
+
             config.scales[1].type = this.yScale;
             let allStatus = JobStatus.getAll().filter((status) => this.timingFilter ? this.timingFilter[status.text] : true);
             config.scales[2].domain = allStatus.map((status) => status.text);

--- a/plugins/jobs/web_client/views/timeChartConfig.js
+++ b/plugins/jobs/web_client/views/timeChartConfig.js
@@ -29,7 +29,7 @@ const timeChartConfig = {
     'scales': [
         {
             'name': 'x',
-            'type': 'band',
+            'type': 'point',
             'points': true,
             'range': 'width',
             'domain': {

--- a/plugins/jobs/web_client/views/timeChartConfig.js
+++ b/plugins/jobs/web_client/views/timeChartConfig.js
@@ -1,7 +1,7 @@
 const timeChartConfig = {
     'width': 894,
     'height': 673,
-    'padding': 'strict',
+    'autosize': 'fit',
     'data': [
         {
             'name': 'table',
@@ -9,23 +9,19 @@ const timeChartConfig = {
             'transform': [
                 {
                     'type': 'filter',
-                    'test': 'datum.elapsed > 0'
+                    'expr': 'datum.elapsed > 0'
                 },
                 {
                     'type': 'formula',
-                    'field': 'elapsed',
+                    'as': 'elapsed',
                     'expr': 'datum.elapsed/1000'
                 },
                 {
                     'type': 'aggregate',
                     'groupby': ['id', 'title', 'currentStatus'],
-                    'summarize': [
-                        {
-                            'field': 'elapsed',
-                            'ops': ['sum'],
-                            'as': ['sum_y']
-                        }
-                    ]
+                    'fields': ['elapsed'],
+                    'ops': ['sum'],
+                    'as': ['sum_y']
                 }
             ]
         }
@@ -33,7 +29,7 @@ const timeChartConfig = {
     'scales': [
         {
             'name': 'x',
-            'type': 'ordinal',
+            'type': 'band',
             'points': true,
             'range': 'width',
             'domain': {
@@ -75,39 +71,40 @@ const timeChartConfig = {
     ],
     'axes': [
         {
-            'type': 'x',
             'scale': 'x',
             'orient': 'top',
-            'properties': {
+            'encode': {
                 'labels': {
-                    'text': { 'scale': 'xlabels2' },
-                    'angle': { 'value': -50 },
-                    'align': { 'value': 'left' },
-                    'itemName': { 'value': 'xlabel2' }
+                    'update': {
+                        'text': { 'field': 'value', 'scale': 'xlabels2' },
+                        'angle': { 'value': -50 },
+                        'align': { 'value': 'left' },
+                        'itemName': { 'value': 'xlabel2' }
+                    }
                 }
             },
             'offset': 10
         },
         {
-            'type': 'x',
             'scale': 'x',
             'orient': 'bottom',
-            'subdivide': 3,
-            'properties': {
+            'encode': {
                 'labels': {
-                    'text': { 'scale': 'xlabels' },
-                    'angle': { 'value': 50 },
-                    'align': { 'value': 'left' },
-                    'itemName': { 'value': 'xlabel' }
+                    'update': {
+                        'text': { 'field': 'value', 'scale': 'xlabels' },
+                        'angle': { 'value': 50 },
+                        'align': { 'value': 'left' },
+                        'itemName': { 'value': 'xlabel' }
+                    }
                 }
             }
         },
         {
-            'type': 'y',
+            'orient': 'left',
             'scale': 'y',
             'format': 's',
             'title': 'seconds',
-            'properties': {
+            'encode': {
                 'labels': {
                     'itemName': { 'value': 'ylabel' }
                 }
@@ -117,40 +114,40 @@ const timeChartConfig = {
     'signals': [
         {
             'name': 'hover',
-            'init': {
+            'value': {
                 'pos': {},
                 'datum': {}
             },
-            'streams': [
+            'on': [
                 {
-                    'type': '@circle:mousemove',
-                    'expr': '{ pos: {x: eventX(), y: eventY()}, datum:datum}'
+                    'events': '@circle:mousemove',
+                    'update': '{ pos: {x: x(), y: y()}, datum:datum}'
                 },
                 {
-                    'type': '@circle:mouseout',
-                    'expr': '{pos:{},datum:{}}'
+                    'events': '@circle:mouseout',
+                    'update': '{pos:{},datum:{}}'
                 }
             ]
         },
         {
             'name': 'tt0',
-            'init': {},
-            'expr': '{ title:hover.datum.title, sum_y:hover.datum["sum_y"] }'
+            'value': {},
+            'update': '{ title:hover.datum.title, sum_y:hover.datum["sum_y"] }'
         },
         {
             'name': 'tt1',
-            'init': {},
-            'expr': '{ sum_y:!tt0.sum_y?"":timeFormat(tt0.sum_y>3600000? "%H:%M:%S.%Ls":(tt0.sum_y>60000?"%M:%S.%Ls":"%S.%Ls"), datetime(0,0,0,0,0,0,tt0.sum_y)) }'
+            'value': {},
+            'update': '{ sum_y:!tt0.sum_y?"":timeFormat(datetime(0,0,0,0,0,tt0.sum_y,0), tt0.sum_y>3600? "%H:%M:%S.%Ls":(tt0.sum_y>60?"%M:%S.%Ls":"%S.%Ls")) }'
         },
         {
             'name': 'tt2',
-            'init': {},
-            'expr': '{ width:!tt0.title?0:max(tt0.title.length, tt1.sum_y.length)*7 }'
+            'value': {},
+            'update': '{ width:!tt0.title?0:max(tt0.title.length, tt1.sum_y.length)*7 }'
         },
         {
             'name': 'tooltip',
-            'init': {},
-            'expr': '{ y:hover.pos.y+30, x:(hover.pos.x>width-tt2.width+5?hover.pos.x-tt2.width-5:hover.pos.x+5), width:tt2.width, title:tt0.title, sum_y:tt1.sum_y }'
+            'value': {},
+            'update': '{ y:hover.pos.y+30, x:(hover.pos.x>width-tt2.width+5?hover.pos.x-tt2.width-5:hover.pos.x+5), width:tt2.width, title:tt0.title, sum_y:tt1.sum_y }'
         }
     ],
     'marks': [
@@ -160,7 +157,7 @@ const timeChartConfig = {
             'from': {
                 'data': 'table'
             },
-            'properties': {
+            'encode': {
                 'enter': {
                     'x': {
                         'scale': 'x',
@@ -196,7 +193,7 @@ const timeChartConfig = {
             'from': {
                 'data': 'table'
             },
-            'properties': {
+            'encode': {
                 'enter': {
                     'x': {
                         'scale': 'x',
@@ -228,7 +225,7 @@ const timeChartConfig = {
         },
         {
             'type': 'group',
-            'properties': {
+            'encode': {
                 'update': {
                     'x': { 'signal': 'tooltip.x' },
                     'y': { 'signal': 'tooltip.y' },
@@ -244,7 +241,7 @@ const timeChartConfig = {
                 {
                     'name': 'title',
                     'type': 'text',
-                    'properties': {
+                    'encode': {
                         'update': {
                             'x': { 'value': 6 },
                             'y': { 'value': 14 },
@@ -256,7 +253,7 @@ const timeChartConfig = {
                 {
                     'name': 'elapsed',
                     'type': 'text',
-                    'properties': {
+                    'encode': {
                         'update': {
                             'x': { 'value': 6 },
                             'y': { 'value': 30 },
@@ -274,7 +271,7 @@ const timeChartConfig = {
             'fill': 'timing',
             'title': 'Status',
             'offset': -3,
-            'properties': {
+            'encode': {
                 'title': {
                     'dx': { 'value': 13 },
                     'fontSize': { 'value': 12 }

--- a/plugins/jobs/web_client/views/timeChartConfig.js
+++ b/plugins/jobs/web_client/views/timeChartConfig.js
@@ -270,7 +270,7 @@ const timeChartConfig = {
         {
             'fill': 'timing',
             'title': 'Status',
-            'offset': -3,
+            'offset': 20,
             'encode': {
                 'title': {
                     'dx': { 'value': 13 },

--- a/plugins/jobs/web_client/views/timeChartConfig.js
+++ b/plugins/jobs/web_client/views/timeChartConfig.js
@@ -30,7 +30,6 @@ const timeChartConfig = {
         {
             'name': 'x',
             'type': 'point',
-            'points': true,
             'range': 'width',
             'domain': {
                 'data': 'table',

--- a/plugins/jobs/web_client/views/timeChartConfig.js
+++ b/plugins/jobs/web_client/views/timeChartConfig.js
@@ -12,16 +12,16 @@ const timeChartConfig = {
                     'expr': 'datum.elapsed > 0'
                 },
                 {
-                    'type': 'formula',
-                    'as': 'elapsed',
-                    'expr': 'datum.elapsed/1000'
-                },
-                {
                     'type': 'aggregate',
                     'groupby': ['id', 'title', 'currentStatus'],
                     'fields': ['elapsed'],
                     'ops': ['sum'],
                     'as': ['sum_y']
+                },
+                {
+                    'type': 'formula',
+                    'as': 'adjSum_y',
+                    'expr': 'datum.sum_y/1000'
                 }
             ]
         }
@@ -45,7 +45,7 @@ const timeChartConfig = {
                 'fields': [
                     {
                         'data': 'table',
-                        'field': 'sum_y'
+                        'field': 'adjSum_y'
                     }
                 ]
             }
@@ -137,7 +137,7 @@ const timeChartConfig = {
         {
             'name': 'tt1',
             'value': {},
-            'update': '{ sum_y:!tt0.sum_y?"":timeFormat(datetime(0,0,0,0,0,tt0.sum_y,0), tt0.sum_y>3600? "%H:%M:%S.%Ls":(tt0.sum_y>60?"%M:%S.%Ls":"%S.%Ls")) }'
+            'update': '{ sum_y:!tt0.sum_y?"":timeFormat(datetime(0,0,0,0,0,0,tt0.sum_y), tt0.sum_y>3600000? "%H:%M:%S.%Ls":(tt0.sum_y>60000?"%M:%S.%Ls":"%S.%Ls")) }'
         },
         {
             'name': 'tt2',
@@ -165,7 +165,7 @@ const timeChartConfig = {
                     },
                     'y': {
                         'scale': 'y',
-                        'field': 'sum_y'
+                        'field': 'adjSum_y'
                     },
                     'itemName': {
                         'value': 'line'
@@ -201,7 +201,7 @@ const timeChartConfig = {
                     },
                     'y': {
                         'scale': 'y',
-                        'field': 'sum_y'
+                        'field': 'adjSum_y'
                     },
                     'itemName': {
                         'value': 'circle'

--- a/plugins/jobs/web_client/views/timingHistoryChartConfig.js
+++ b/plugins/jobs/web_client/views/timingHistoryChartConfig.js
@@ -59,7 +59,7 @@ const timingHistoryChartConfig = {
         },
         {
             'name': 'status2',
-            'source': 'negative',
+            'source': 'table',
             'transform': [
                 {
                     'type': 'aggregate',

--- a/plugins/jobs/web_client/views/timingHistoryChartConfig.js
+++ b/plugins/jobs/web_client/views/timingHistoryChartConfig.js
@@ -117,11 +117,11 @@ const timingHistoryChartConfig = {
             'value': { 'pos': {}, 'datum': {} },
             'on': [
                 {
-                    'events': 'rect:mousemove',
+                    'events': '@timing:mousemove',
                     'update': '{ pos: {x: x(), y: y()}, datum:datum}'
                 },
                 {
-                    'events': 'rect:mouseout',
+                    'events': '@timing:mouseout',
                     'update': '{pos:{},datum:{}}'
                 }
             ]
@@ -151,11 +151,11 @@ const timingHistoryChartConfig = {
             'value': { 'pos': {}, 'datum': {} },
             'on': [
                 {
-                    'events': '@status:mousemove',
-                    'update': '{ pos: {x: x(), y: y()}, datum:datum}'
+                    'events': '@statusmark:mousemove',
+                    'update': 'warn(datum, { pos: {x: x(), y: y()}, datum:datum})'
                 },
                 {
-                    'events': '@status:mouseout',
+                    'events': '@statusmark:mouseout',
                     'update': '{pos:{},datum:{}}'
                 }
             ]
@@ -163,7 +163,7 @@ const timingHistoryChartConfig = {
         {
             'name': 'stt0',
             'value': {},
-            'update': '{ status:sHover.datum.b?sHover.datum.b.currentStatus:"" }'
+            'update': '{ status:sHover.datum?sHover.datum.currentStatus:"" }'
         },
         {
             'name': 'stt1',
@@ -173,7 +173,7 @@ const timingHistoryChartConfig = {
         {
             'name': 'sTooltip',
             'value': {},
-            'update': '{ y:sHover.pos.y+30, x:(sHover.pos.x>width-stt1.width+5?sHover.pos.x-stt1.width-5:sHover.pos.x+5), width:stt1.width, status:stt0.status }'
+            'update': '{ y:sHover.pos.y+30, x:(sHover.pos.x>width-stt1.width-7?sHover.pos.x-stt1.width-5:sHover.pos.x+5), width:stt1.width, status:stt0.status }'
         }
     ],
     'marks': [

--- a/plugins/jobs/web_client/views/timingHistoryChartConfig.js
+++ b/plugins/jobs/web_client/views/timingHistoryChartConfig.js
@@ -16,56 +16,17 @@ const timingHistoryChartConfig = {
             ]
         },
         {
-            'name': 'positive',
-            'source': 'table',
-            'transform': [
-                {
-                    'type': 'filter',
-                    'expr': 'datum.adjElapsed > 0'
-                }
-            ]
+            'name': 'min_y',
+            'values': []
         },
         {
-            'name': 'positiveStacked',
-            'source': 'positive',
+            'name': 'stacked',
+            'source': 'table',
             'transform': [
                 {
                   'type': 'stack',
                   'groupby': ['id'],
                   'field': 'adjElapsed'
-                }
-            ]
-        },
-        {
-            'name': 'negative',
-            'source': 'table',
-            'transform': [
-                {
-                    'type': 'filter',
-                    'expr': 'datum.adjElapsed < 0'
-                }
-            ]
-        },
-        {
-            'name': 'negativeStacked',
-            'source': 'negative',
-            'transform': [
-                {
-                  'type': 'stack',
-                  'groupby': ['id'],
-                  'field': 'adjElapsed'
-                }
-            ]
-        },
-        {
-            'name': 'status2',
-            'source': 'table',
-            'transform': [
-                {
-                    'type': 'aggregate',
-                    'fields': ['adjElapsed'],
-                    'ops': ['min'],
-                    'as': ['min_y']
                 }
             ]
         },
@@ -83,7 +44,7 @@ const timingHistoryChartConfig = {
                 {
                     'type': 'formula',
                     'as': 'min_y',
-                    'expr': 'data("status2")[0].min_y'
+                    'expr': 'data("min_y")[0].data'
                 }
             ]
         }
@@ -220,7 +181,7 @@ const timingHistoryChartConfig = {
             'type': 'rect',
             'name': 'timing',
             'from': {
-                'data': 'positiveStacked'
+                'data': 'stacked'
             },
             'encode': {
                 'enter': {
@@ -239,19 +200,19 @@ const timingHistoryChartConfig = {
             }
         },
         {
+            'name': 'statusmarkbase',
             'type': 'rect',
-            'name': 'neg_timing',
             'from': {
-                'data': 'negativeStacked'
+                'data': 'stats'
             },
             'encode': {
                 'enter': {
-                    'x': { 'scale': 'x', 'field': 'id' },
-                    'width': { 'scale': 'x', 'band': true, 'offset': -2 },
-                    'y': { 'scale': 'y', 'field': 'y0' },
-                    'y2': { 'scale': 'y', 'field': 'y1' },
-                    'fill': { 'scale': 'color', 'field': 'status' },
-                    'itemName': { 'value': 'bar' }
+                    'width': { 'scale': 'x', 'band': true, 'offset': -4 },
+                    'height': { 'value': 6 },
+                    'x': { 'scale': 'x', 'field': 'id', 'offset': 1 },
+                    'y': { 'scale': 'y', 'field': 'min_y', 'offset': 9 },
+                    'fill': { 'value': 'rgb(204,204,204)' },
+                    'itemName': { 'value': 'status' }
                 },
                 'update': { 'fillOpacity': { 'value': 1 } },
                 'hover': {

--- a/plugins/jobs/web_client/views/timingHistoryChartConfig.js
+++ b/plugins/jobs/web_client/views/timingHistoryChartConfig.js
@@ -24,9 +24,9 @@ const timingHistoryChartConfig = {
             'source': 'table',
             'transform': [
                 {
-                  'type': 'stack',
-                  'groupby': ['id'],
-                  'field': 'adjElapsed'
+                    'type': 'stack',
+                    'groupby': ['id'],
+                    'field': 'adjElapsed'
                 }
             ]
         },

--- a/plugins/jobs/web_client/views/timingHistoryChartConfig.js
+++ b/plugins/jobs/web_client/views/timingHistoryChartConfig.js
@@ -144,7 +144,7 @@ const timingHistoryChartConfig = {
         {
             'name': 'tooltip',
             'value': {},
-            'update': '{ y:hover.pos.y+30, x:(hover.pos.x>width-tt2.width+5?hover.pos.x-tt2.width-5:hover.pos.x+5), width:tt2.width, title:tt0.title, updated:tt0.updated, status:tt0.status, elapsed:tt1.elapsed }'
+            'update': '{ y:hover.pos.y+30, x:(hover.pos.x>width-tt2.width-5?hover.pos.x-tt2.width-5:hover.pos.x+5), width:tt2.width, title:tt0.title, updated:tt0.updated, status:tt0.status, elapsed:tt1.elapsed }'
         },
         {
             'name': 'sHover',
@@ -345,17 +345,22 @@ const timingHistoryChartConfig = {
         {
             'fill': 'color',
             'title': 'Selected Phases',
-            'offset': -3,
+            'offset': 20,
             'encode': {
                 'title': {
-                    'dx': { 'value': 10 },
-                    'fontSize': { 'value': 12 }
+                    'update': {
+                        'fontSize': { 'value': 12 }
+                    }
                 },
                 'symbols': {
-                    'shape': { 'value': 'square' }
+                    'update': {
+                        'shape': { 'value': 'square' }
+                    }
                 },
                 'labels': {
-                    'fontSize': { 'value': 12 }
+                    'update': {
+                        'fontSize': { 'value': 12 }
+                    }
                 }
             }
         }

--- a/plugins/jobs/web_client/views/timingHistoryChartConfig.js
+++ b/plugins/jobs/web_client/views/timingHistoryChartConfig.js
@@ -134,7 +134,7 @@ const timingHistoryChartConfig = {
         {
             'name': 'tt1',
             'value': {},
-            'update': '{ elapsed:!tt0.elapsed?"":timeFormat(tt0.elapsed>3600000? "%H:%M:%S.%Ls":(tt0.elapsed>60000?"%M:%S.%Ls":"%S.%Ls"), datetime(0,0,0,0,0,0,tt0.elapsed)) }'
+            'update': 'warn(tt0.elapsed, { elapsed:!tt0.elapsed?"":timeFormat(datetime(0,0,0,0,0,0,tt0.elapsed), tt0.elapsed>3600000? "%H:%M:%S.%Ls":(tt0.elapsed>60000?"%M:%S.%Ls":"%S.%Ls")) })'
         },
         {
             'name': 'tt2',
@@ -152,7 +152,7 @@ const timingHistoryChartConfig = {
             'on': [
                 {
                     'events': '@statusmark:mousemove',
-                    'update': 'warn(datum, { pos: {x: x(), y: y()}, datum:datum})'
+                    'update': '{ pos: {x: x(), y: y()}, datum:datum}'
                 },
                 {
                     'events': '@statusmark:mouseout',

--- a/plugins/jobs/web_client/views/timingHistoryChartConfig.js
+++ b/plugins/jobs/web_client/views/timingHistoryChartConfig.js
@@ -134,7 +134,7 @@ const timingHistoryChartConfig = {
         {
             'name': 'tt1',
             'value': {},
-            'update': 'warn(tt0.elapsed, { elapsed:!tt0.elapsed?"":timeFormat(datetime(0,0,0,0,0,0,tt0.elapsed), tt0.elapsed>3600000? "%H:%M:%S.%Ls":(tt0.elapsed>60000?"%M:%S.%Ls":"%S.%Ls")) })'
+            'update': '{ elapsed:!tt0.elapsed?"":timeFormat(datetime(0,0,0,0,0,0,tt0.elapsed), tt0.elapsed>3600000? "%H:%M:%S.%Ls":(tt0.elapsed>60000?"%M:%S.%Ls":"%S.%Ls")) }'
         },
         {
             'name': 'tt2',

--- a/plugins/jobs/web_client/views/timingHistoryChartConfig.js
+++ b/plugins/jobs/web_client/views/timingHistoryChartConfig.js
@@ -1,7 +1,7 @@
 const timingHistoryChartConfig = {
     'width': 800,
     'height': 500,
-    'padding': 'strict',
+    'autosize': 'fit',
     'data': [
         {
             'name': 'table',
@@ -10,7 +10,7 @@ const timingHistoryChartConfig = {
             'transform': [
                 {
                     'type': 'formula',
-                    'field': 'adjElapsed',
+                    'as': 'adjElapsed',
                     'expr': 'clamp(datum.elapsed/1000,-86400,86400)'
                 }
             ]
@@ -21,7 +21,18 @@ const timingHistoryChartConfig = {
             'transform': [
                 {
                     'type': 'filter',
-                    'test': 'datum.adjElapsed > 0'
+                    'expr': 'datum.adjElapsed > 0'
+                }
+            ]
+        },
+        {
+            'name': 'positiveStacked',
+            'source': 'positive',
+            'transform': [
+                {
+                  'type': 'stack',
+                  'groupby': ['id'],
+                  'field': 'adjElapsed'
                 }
             ]
         },
@@ -31,7 +42,30 @@ const timingHistoryChartConfig = {
             'transform': [
                 {
                     'type': 'filter',
-                    'test': 'datum.adjElapsed < 0'
+                    'expr': 'datum.adjElapsed < 0'
+                }
+            ]
+        },
+        {
+            'name': 'negativeStacked',
+            'source': 'negative',
+            'transform': [
+                {
+                  'type': 'stack',
+                  'groupby': ['id'],
+                  'field': 'adjElapsed'
+                }
+            ]
+        },
+        {
+            'name': 'status2',
+            'source': 'negative',
+            'transform': [
+                {
+                    'type': 'aggregate',
+                    'fields': ['adjElapsed'],
+                    'ops': ['min'],
+                    'as': ['min_y']
                 }
             ]
         },
@@ -42,33 +76,14 @@ const timingHistoryChartConfig = {
                 {
                     'type': 'aggregate',
                     'groupby': ['id', 'title', 'currentStatus'],
-                    'summarize': [
-                        {
-                            'field': 'adjElapsed',
-                            'ops': ['sum'],
-                            'as': ['sum_y']
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            'name': 'status',
-            'source': 'negative',
-            'transform': [
-                {
-                    'type': 'aggregate',
-                    'summarize': [
-                        {
-                            'field': 'adjElapsed',
-                            'ops': ['min'],
-                            'as': ['min_y']
-                        }
-                    ]
+                    'fields': ['adjElapsed'],
+                    'ops': ['sum'],
+                    'as': ['sum_y']
                 },
                 {
-                    'type': 'cross',
-                    'with': 'stats'
+                    'type': 'formula',
+                    'as': 'min_y',
+                    'expr': 'data("status2")[0].min_y'
                 }
             ]
         }
@@ -76,7 +91,7 @@ const timingHistoryChartConfig = {
     'scales': [
         {
             'name': 'x',
-            'type': 'ordinal',
+            'type': 'band',
             'range': 'width',
             'domain': { 'data': 'table', 'field': 'id' }
         },
@@ -107,30 +122,30 @@ const timingHistoryChartConfig = {
     ],
     'axes': [
         {
-            'type': 'x',
             'scale': 'x',
             'orient': 'bottom',
-            'ticks': 0,
-            'subdivide': 4,
-            'properties': {
+            'encode': {
                 'labels': {
-                    'text': { 'scale': 'xlabels' },
-                    'angle': { 'value': 50 },
-                    'align': { 'value': 'left' },
-                    'itemName': { 'value': 'xlabel' },
-                    'dy': { 'value': 5 },
-                    'dx': { 'value': 7 }
+                    'update': {
+                        'text': { 'field': 'value', 'scale': 'xlabels' },
+                        'angle': { 'value': 50 },
+                        'align': { 'value': 'left' },
+                        'dy': { 'value': 5 },
+                        'dx': { 'value': 7 }
+                    }
                 }
             }
         },
         {
-            'type': 'y',
+            'orient': 'left',
             'scale': 'y',
             'format': 's',
             'title': 'seconds',
-            'properties': {
+            'encode': {
                 'labels': {
-                    'itemName': { 'value': 'ylabel' }
+                    'update': {
+                        'itemName': { 'value': 'ylabel' }
+                    }
                 }
             }
         }
@@ -138,66 +153,66 @@ const timingHistoryChartConfig = {
     'signals': [
         {
             'name': 'hover',
-            'init': { 'pos': {}, 'datum': {} },
-            'streams': [
+            'value': { 'pos': {}, 'datum': {} },
+            'on': [
                 {
-                    'type': 'rect:mousemove',
-                    'expr': '{ pos: {x: eventX(), y: eventY()}, datum:datum}'
+                    'events': 'rect:mousemove',
+                    'update': '{ pos: {x: x(), y: y()}, datum:datum}'
                 },
                 {
-                    'type': 'rect:mouseout',
-                    'expr': '{pos:{},datum:{}}'
+                    'events': 'rect:mouseout',
+                    'update': '{pos:{},datum:{}}'
                 }
             ]
         },
         {
             'name': 'tt0',
-            'init': {},
-            'expr': '{ title:hover.datum.title, updated:hover.datum.updated, status:!hover.datum.status?"":hover.datum.status+":", elapsed:abs(hover.datum["elapsed"]) }'
+            'value': {},
+            'update': '{ title:hover.datum.title, updated:hover.datum.updated, status:!hover.datum.status?"":hover.datum.status+":", elapsed:abs(hover.datum["elapsed"]) }'
         },
         {
             'name': 'tt1',
-            'init': {},
-            'expr': '{ elapsed:!tt0.elapsed?"":timeFormat(tt0.elapsed>3600000? "%H:%M:%S.%Ls":(tt0.elapsed>60000?"%M:%S.%Ls":"%S.%Ls"), datetime(0,0,0,0,0,0,tt0.elapsed)) }'
+            'value': {},
+            'update': '{ elapsed:!tt0.elapsed?"":timeFormat(tt0.elapsed>3600000? "%H:%M:%S.%Ls":(tt0.elapsed>60000?"%M:%S.%Ls":"%S.%Ls"), datetime(0,0,0,0,0,0,tt0.elapsed)) }'
         },
         {
             'name': 'tt2',
-            'init': {},
-            'expr': '{ width:!tt0.title?0:max(max(max(tt0.title.length,tt0.status.length),tt1.elapsed.length),tt0.updated.length)*7 }'
+            'value': {},
+            'update': '{ width:!tt0.title?0:max(max(max(tt0.title.length,tt0.status.length),tt1.elapsed.length),tt0.updated.length)*7 }'
         },
         {
             'name': 'tooltip',
-            'init': {},
-            'expr': '{ y:hover.pos.y+30, x:(hover.pos.x>width-tt2.width+5?hover.pos.x-tt2.width-5:hover.pos.x+5), width:tt2.width, title:tt0.title, updated:tt0.updated, status:tt0.status, elapsed:tt1.elapsed }'
+            'value': {},
+            'update': '{ y:hover.pos.y+30, x:(hover.pos.x>width-tt2.width+5?hover.pos.x-tt2.width-5:hover.pos.x+5), width:tt2.width, title:tt0.title, updated:tt0.updated, status:tt0.status, elapsed:tt1.elapsed }'
         },
         {
             'name': 'sHover',
-            'init': { 'pos': {}, 'datum': {} },
-            'streams': [
+            'value': { 'pos': {}, 'datum': {} },
+            'on': [
                 {
-                    'type': '@status:mousemove',
-                    'expr': '{ pos: {x: eventX(), y: eventY()}, datum:datum}'
+                    'events': '@status:mousemove',
+                    'update': '{ pos: {x: x(), y: y()}, datum:datum}'
                 },
                 {
-                    'type': '@status:mouseout',
-                    'expr': '{pos:{},datum:{}}'
+                    'events': '@status:mouseout',
+                    'update': '{pos:{},datum:{}}'
                 }
             ]
         },
         {
             'name': 'stt0',
-            'init': {},
-            'expr': '{ status:sHover.datum.b?sHover.datum.b.currentStatus:"" }'
+            'value': {},
+            'update': '{ status:sHover.datum.b?sHover.datum.b.currentStatus:"" }'
         },
         {
             'name': 'stt1',
-            'init': {},
-            'expr': '{ width:(stt0.status?stt0.status.length:0)*9 }'
+            'value': {},
+            'update': '{ width:(stt0.status?stt0.status.length:0)*9 }'
         },
         {
             'name': 'sTooltip',
-            'init': {},
-            'expr': '{ y:sHover.pos.y+30, x:(sHover.pos.x>width-stt1.width+5?sHover.pos.x-stt1.width-5:sHover.pos.x+5), width:stt1.width, status:stt0.status }'
+            'value': {},
+            'update': '{ y:sHover.pos.y+30, x:(sHover.pos.x>width-stt1.width+5?sHover.pos.x-stt1.width-5:sHover.pos.x+5), width:stt1.width, status:stt0.status }'
         }
     ],
     'marks': [
@@ -205,21 +220,14 @@ const timingHistoryChartConfig = {
             'type': 'rect',
             'name': 'timing',
             'from': {
-                'data': 'positive',
-                'transform': [
-                    {
-                        'type': 'stack',
-                        'groupby': ['id'],
-                        'field': 'adjElapsed'
-                    }
-                ]
+                'data': 'positiveStacked'
             },
-            'properties': {
+            'encode': {
                 'enter': {
                     'x': { 'scale': 'x', 'field': 'id' },
                     'width': { 'scale': 'x', 'band': true, 'offset': -2 },
-                    'y': { 'scale': 'y', 'field': 'layout_start' },
-                    'y2': { 'scale': 'y', 'field': 'layout_end' },
+                    'y': { 'scale': 'y', 'field': 'y0' },
+                    'y2': { 'scale': 'y', 'field': 'y1' },
                     'fill': { 'scale': 'color', 'field': 'status' },
                     'itemName': { 'value': 'bar' },
                     'cursor': { 'value': 'pointer' }
@@ -232,23 +240,16 @@ const timingHistoryChartConfig = {
         },
         {
             'type': 'rect',
-            'name': 'timing',
+            'name': 'neg_timing',
             'from': {
-                'data': 'negative',
-                'transform': [
-                    {
-                        'type': 'stack',
-                        'groupby': ['id'],
-                        'field': 'adjElapsed'
-                    }
-                ]
+                'data': 'negativeStacked'
             },
-            'properties': {
+            'encode': {
                 'enter': {
                     'x': { 'scale': 'x', 'field': 'id' },
                     'width': { 'scale': 'x', 'band': true, 'offset': -2 },
-                    'y': { 'scale': 'y', 'field': 'layout_start' },
-                    'y2': { 'scale': 'y', 'field': 'layout_end' },
+                    'y': { 'scale': 'y', 'field': 'y0' },
+                    'y2': { 'scale': 'y', 'field': 'y1' },
                     'fill': { 'scale': 'color', 'field': 'status' },
                     'itemName': { 'value': 'bar' }
                 },
@@ -259,18 +260,18 @@ const timingHistoryChartConfig = {
             }
         },
         {
-            'name': 'status',
+            'name': 'statusmark',
             'type': 'rect',
             'from': {
-                'data': 'status'
+                'data': 'stats'
             },
-            'properties': {
+            'encode': {
                 'enter': {
                     'width': { 'scale': 'x', 'band': true, 'offset': -4 },
                     'height': { 'value': 6 },
-                    'x': { 'scale': 'x', 'field': 'b.id', 'offset': 1 },
-                    'y': { 'scale': 'y', 'field': 'a.min_y', 'offset': 9 },
-                    'fill': { 'scale': 'color', 'field': 'b.currentStatus' },
+                    'x': { 'scale': 'x', 'field': 'id', 'offset': 1 },
+                    'y': { 'scale': 'y', 'field': 'min_y', 'offset': 9 },
+                    'fill': { 'scale': 'color', 'field': 'currentStatus' },
                     'itemName': { 'value': 'status' }
                 },
                 'update': { 'fillOpacity': { 'value': 1 } },
@@ -282,7 +283,7 @@ const timingHistoryChartConfig = {
         {
             'name': 'timingTooltip',
             'type': 'group',
-            'properties': {
+            'encode': {
                 'update': {
                     'x': { 'signal': 'tooltip.x' },
                     'y': { 'signal': 'tooltip.y' },
@@ -298,7 +299,7 @@ const timingHistoryChartConfig = {
                 {
                     'name': 'title',
                     'type': 'text',
-                    'properties': {
+                    'encode': {
                         'update': {
                             'x': { 'value': 6 },
                             'y': { 'value': 14 },
@@ -308,9 +309,9 @@ const timingHistoryChartConfig = {
                     }
                 },
                 {
-                    'name': 'title',
+                    'name': 'updated',
                     'type': 'text',
-                    'properties': {
+                    'encode': {
                         'update': {
                             'x': { 'value': 6 },
                             'y': { 'value': 29 },
@@ -322,7 +323,7 @@ const timingHistoryChartConfig = {
                 {
                     'name': 'status',
                     'type': 'text',
-                    'properties': {
+                    'encode': {
                         'update': {
                             'x': { 'value': 6 },
                             'y': { 'value': 44 },
@@ -335,7 +336,7 @@ const timingHistoryChartConfig = {
                 {
                     'name': 'elapsed',
                     'type': 'text',
-                    'properties': {
+                    'encode': {
                         'update': {
                             'x': { 'value': 6 },
                             'y': { 'value': 59 },
@@ -350,7 +351,7 @@ const timingHistoryChartConfig = {
         {
             'name': 'statusTooltip',
             'type': 'group',
-            'properties': {
+            'encode': {
                 'update': {
                     'x': { 'signal': 'sTooltip.x' },
                     'y': { 'signal': 'sTooltip.y' },
@@ -366,7 +367,7 @@ const timingHistoryChartConfig = {
                 {
                     'name': 'status',
                     'type': 'text',
-                    'properties': {
+                    'encode': {
                         'update': {
                             'x': { 'value': 8 },
                             'y': { 'value': 16 },
@@ -384,7 +385,7 @@ const timingHistoryChartConfig = {
             'fill': 'color',
             'title': 'Selected Phases',
             'offset': -3,
-            'properties': {
+            'encode': {
                 'title': {
                     'dx': { 'value': 10 },
                     'fontSize': { 'value': 12 }

--- a/plugins/vega/plugin.json
+++ b/plugins/vega/plugin.json
@@ -5,7 +5,7 @@
     "version": "2.0.0",
     "npm": {
         "dependencies": {
-            "vega": "^3.3.1"
+            "vega-lib": "^3.3.1"
         }
     }
 }

--- a/plugins/vega/plugin.json
+++ b/plugins/vega/plugin.json
@@ -2,10 +2,10 @@
     "name": "Vega Visualization",
     "description": "Render Vega visualizations in the item page.",
     "url": "http://girder.readthedocs.io/en/latest/plugins.html#vega-visualization",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "npm": {
         "dependencies": {
-            "vega": "^2.6.0"
+            "vega": "^3.3.1"
         }
     }
 }

--- a/plugins/vega/web_client/views/VegaWidget.js
+++ b/plugins/vega/web_client/views/VegaWidget.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 
 import { parse,
-    View as VegaView } from 'vega';
+    View as VegaView } from 'vega-lib';
 
 import View from 'girder/views/View';
 import { AccessType } from 'girder/constants';

--- a/plugins/vega/web_client/views/VegaWidget.js
+++ b/plugins/vega/web_client/views/VegaWidget.js
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 
-import vg from 'vega';
+import { parse,
+         View as VegaView } from 'vega';
 
 import View from 'girder/views/View';
 import { AccessType } from 'girder/constants';
@@ -29,12 +30,11 @@ var VegaWidget = View.extend({
                 url: `item/${this.item.id}/download`
             })
                 .done(function (spec) {
-                    vg.parse.spec(spec, function (chart) {
-                        chart({
-                            el: '.g-item-vega-vis',
-                            renderer: 'svg'
-                        }).update();
-                    });
+                    let runtime = parse(spec);
+                    let view = new VegaView(runtime)
+                        .initialize(document.querySelector('.g-item-vega-vis'))
+                        .renderer('svg')
+                        .run();
                 });
         } else {
             $('.g-item-vega')

--- a/plugins/vega/web_client/views/VegaWidget.js
+++ b/plugins/vega/web_client/views/VegaWidget.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 
 import { parse,
-         View as VegaView } from 'vega';
+    View as VegaView } from 'vega';
 
 import View from 'girder/views/View';
 import { AccessType } from 'girder/constants';
@@ -33,8 +33,8 @@ var VegaWidget = View.extend({
                     let runtime = parse(spec);
                     let view = new VegaView(runtime)
                         .initialize(document.querySelector('.g-item-vega-vis'))
-                        .renderer('svg')
-                        .run();
+                        .renderer('svg');
+                    view.run();
                 });
         } else {
             $('.g-item-vega')


### PR DESCRIPTION
This PR upgrades Girder's Vega dependency from 2.x to 3.x. This includes the following updates:
- the `vega` plugin now works with Vega 3 specifications
- the `jobs` plugin uses Vega 3 for its two visualizations: a bar chart and a line chart
  - a bug in the line chart, where the wrong time was shown on hover, has been fixed

TODO:
- [ ] verify that Girder no longer depends on Vega 2
- [ ] add a test for the `vega` plugin update

@manthey PTAL.