### PR TITLE
Fix loading files attached to plugin models

### DIFF
--- a/girder/utility/acl_mixin.py
+++ b/girder/utility/acl_mixin.py
@@ -67,7 +67,12 @@ class AccessControlMixin(object):
             else:
                 loadType = doc.get('attachedToType')
                 loadId = doc.get('attachedToId')
-            self.model(loadType).load(loadId, level=level, user=user, exc=exc)
+            if isinstance(loadType, six.string_types):
+                self.model(loadType).load(loadId, level=level, user=user, exc=exc)
+            elif isinstance(loadType, list) and len(loadType) == 2:
+                self.model(*loadType).load(loadId, level=level, user=user, exc=exc)
+            else:
+                raise Exception('Invalid model type: %s' % str(loadType))
 
             self._removeSupplementalFields(doc, fields)
 


### PR DESCRIPTION
Plugins may attach files to a model type defined in the plugin. In that case, the "attachedToType" field is a list of the form ["model_type", "plugin_name"].

This commit fixes errors like the following when loading such files:

    {
        "TypeError: TypeError("unhashable type: 'list'",)",
        "trace": [
            ...
            [
                "/path/to/girder/girder/utility/acl_mixin.py",
                70,
                "load",
                "self.model(loadType).load(loadId, level=level, user=user, exc=exc)"
            ],
            [
                "/path/to/girder/girder/utility/model_importer.py",
                88,
                "model",
                "if model not in _modelInstances[plugin]:"
            ]
        ],
        "type": "internal"
    }