### PR TITLE
Skip autoDescribeRoute behavior for header params

### DIFF
--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -689,6 +689,8 @@ class autoDescribeRoute(describeRoute):  # noqa: class name
                         self._passArg(fun, kwargs, name, val)
                     else:
                         self._passArg(fun, kwargs, name, cherrypy.request.body)
+                elif descParam['in'] == 'header':
+                    continue  # For now, do nothing with header params
                 elif 'default' in descParam:
                     self._passArg(fun, kwargs, name, descParam['default'])
                 elif descParam['required']:


### PR DESCRIPTION
@brianhelba this is actually option 2 from my proposal on #2724, just to show the very simple fix, which is to do nothing with header params. We can merge this if you think it's a worthwhile stop-gap support for header params, otherwise it will take a bit more time to get the "option 1" solution logic in place.