### PR TITLE
Ensure models connect to current pytest database

### DIFF
--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -54,6 +54,10 @@ class _ModelSingleton(type):
         if cls._instance is None:
             cls._instance = super(_ModelSingleton, cls).__call__(*args, **kwargs)
             _modelSingletons.append(cls._instance)
+            # It is not safe to ever set cls._instance back to None in an attempt to force singleton
+            # recreation, since some models have event bindings that will not be destroyed (so the
+            # old singletons will still have instance-bound methods that are event-bound to and fire
+            # on model-related events)
         return cls._instance
 
 

--- a/pytest_girder/pytest_girder/fixtures.py
+++ b/pytest_girder/pytest_girder/fixtures.py
@@ -57,7 +57,8 @@ def db(request):
 
     connection.drop_database(dbName)
 
-    # Since some models bind to events during initialize(), we force reinitialization
+    # Since models store a local reference to the current database, we need to force them all to
+    # reconnect
     for model in model_base._modelSingletons:
         model.reconnect()
 

--- a/pytest_girder/pytest_girder/fixtures.py
+++ b/pytest_girder/pytest_girder/fixtures.py
@@ -58,7 +58,8 @@ def db(request):
     connection.drop_database(dbName)
 
     # Since some models bind to events during initialize(), we force reinitialization
-    model_base._modelSingletons = []
+    for model in model_base._modelSingletons:
+        model.reconnect()
 
     yield connection
 

--- a/pytest_girder/pytest_girder/fixtures.py
+++ b/pytest_girder/pytest_girder/fixtures.py
@@ -183,8 +183,6 @@ def admin(db):
 
     yield u
 
-    User().remove(u)
-
 
 @pytest.fixture
 def user(db, admin):
@@ -199,8 +197,6 @@ def user(db, admin):
                           lastName='user', password='password', admin=False)
 
     yield u
-
-    User().remove(u)
 
 
 @pytest.fixture

--- a/test/test_folder.py
+++ b/test/test_folder.py
@@ -46,8 +46,6 @@ def parentChain(admin):
         'privateFolder': privateFolder,
         'folder4': F4
     }
-    # Delete the parent chain
-    Folder().remove(F1)
 
 
 def testParentsToRootAdmin(parentChain, admin):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -289,7 +289,6 @@ def group(user):
         creator=user
     )
     yield g
-    Group().remove(g)
 
 
 @pytest.fixture
@@ -308,7 +307,6 @@ def documentWithGroup(group, admin, user, FakeAcModel):
     doc1 = FakeAcModel().setGroupAccess(doc1, group1, level=AccessType.WRITE)
     doc1 = FakeAcModel().save(doc1)
     yield doc1
-    FakeAcModel().remove(doc1)
 
 
 class TestAccessControlCleanup(object):

--- a/test/test_size.py
+++ b/test/test_size.py
@@ -45,9 +45,6 @@ def hierarchy(admin, fsAssetstore):
 
     yield Hierarchy(collections=(c1, c2), folders=(f1, f2), items=(i1, i2), files=(file1, file2))
 
-    Collection().remove(c1)
-    Collection().remove(c2)
-
 
 def assertNodeSize(resource, model, size):
     __tracebackhide__ = True


### PR DESCRIPTION
This fixes an issue where tests run serially were not reconnecting to the correct new database each time.