### PR TITLE
Ensure that a text input doesn't appear after downloading checked items

### DIFF
--- a/clients/web/src/views/widgets/HierarchyWidget.js
+++ b/clients/web/src/views/widgets/HierarchyWidget.js
@@ -906,7 +906,7 @@ var HierarchyWidget = View.extend({
             form.append($('<input/>').attr({type: 'text', name: key, value: value}));
         });
         // $(form).submit() will *not* work w/ Firefox (http://stackoverflow.com/q/7117084/250457)
-        $(form).appendTo('body').submit();
+        $(form).appendTo('body').submit().remove();
     },
 
     editAccess: function () {


### PR DESCRIPTION
This commit fixes a problem in the web client where a text input appears at the bottom of the page after checking items and selecting "Download checked resources".

To avoid long query strings in GET requests--in case a large number of files are checked--this download mechanism creates and submits a temporary form. For compatibility with Firefox, the form must be in the DOM for submission to work.

This commit removes the temporary form from the DOM after it's submitted.

Screenshot of the old behavior after downloading:
![screenshot from 2018-06-11 11-30-57](https://user-images.githubusercontent.com/7122091/41242952-fa3fb43c-6d6e-11e8-8e7f-50c9fa60f28e.png)
