### PR TITLE
Improve the duration tooltips on the job time graphs.

### DIFF
--- a/plugins/jobs/web_client/views/timeChartConfig.js
+++ b/plugins/jobs/web_client/views/timeChartConfig.js
@@ -136,7 +136,14 @@ const timeChartConfig = {
         {
             'name': 'tt1',
             'value': {},
-            'update': '{ sum_y:!tt0.sum_y?"":timeFormat(datetime(0,0,0,0,0,0,tt0.sum_y), tt0.sum_y>3600000? "%H:%M:%S.%Ls":(tt0.sum_y>60000?"%M:%S.%Ls":"%S.%Ls")) }'
+            'update': '{ sum_y: ' +
+                '!tt0.sum_y ? "" : ' +
+                'floor(tt0.sum_y/(' +
+                '  tt0.sum_y >= 3600000 ? 3600000 : (' +
+                '    tt0.sum_y >= 60000 ? 60000 : 1000))) + ' +
+                'timeFormat(datetime(0,0,0,0,0,0,tt0.sum_y), ' +
+                '  tt0.sum_y >= 3600000 ? ":%M:%S.%L": (' +
+                '    tt0.sum_y >= 60000 ? ":%S.%L" : ".%Ls")) }'
         },
         {
             'name': 'tt2',

--- a/plugins/jobs/web_client/views/timingHistoryChartConfig.js
+++ b/plugins/jobs/web_client/views/timingHistoryChartConfig.js
@@ -134,7 +134,14 @@ const timingHistoryChartConfig = {
         {
             'name': 'tt1',
             'value': {},
-            'update': '{ elapsed:!tt0.elapsed?"":timeFormat(datetime(0,0,0,0,0,0,tt0.elapsed), tt0.elapsed>3600000? "%H:%M:%S.%Ls":(tt0.elapsed>60000?"%M:%S.%Ls":"%S.%Ls")) }'
+            'update': '{ elapsed: ' +
+                '!tt0.elapsed ? "" : ' +
+                'floor(tt0.elapsed/(' +
+                '  tt0.elapsed >= 3600000 ? 3600000 : (' +
+                '    tt0.elapsed >= 60000 ? 60000 : 1000))) + ' +
+                'timeFormat(datetime(0,0,0,0,0,0,tt0.elapsed), ' +
+                '  tt0.elapsed >= 3600000 ? ":%M:%S.%L": (' +
+                '    tt0.elapsed >= 60000 ? ":%S.%L" : ".%Ls")) }'
         },
         {
             'name': 'tt2',


### PR DESCRIPTION
This fixes an issue with times that were exactly 1 minute or 1 hour or were greater than or equal to a day.  Durations are shown in different ways depending if they are less than a minute, between a minute and an hour, or longer than an hour.

Before this change, durations were displayed, e.g., 01.234s, 01:23.456s, 01:23:45.678s, where there was often a needless leading zero and always a trailing 's' implying seconds.  Further, values greater than 24 hours would show the duration modulo 24 hours.  Due to the wrong inequality being used, a duration of exactly 1 minute would show as 00.000s, and 1 hour would show as 00:00.000s.

After this change, durations are displayed, e.g., 1.234s, 1:23.456, 1:23:45.678.  No leading zero is displayed.  The 's' suffix is only added if the duration is less than a minute.  Values greater than 24 hours will show with the full number of hours, e.g. 123:45:67.890.

This fixes #2726.