### PR TITLE
Use updated Pytest methods for getting markers

### DIFF
--- a/pytest_girder/pytest_girder/fixtures.py
+++ b/pytest_girder/pytest_girder/fixtures.py
@@ -98,21 +98,21 @@ def server(db, request):
     girder.events.daemon = girder.events.AsyncEventsThread()
 
     enabledPlugins = []
-    installedPluginMarkers = request.node.get_marker('plugin')
-    testPluginMarkers = request.node.get_marker('testPlugin')
+    hasInstalledPluginMarkers = request.node.get_closest_marker('plugin') is not None
+    hasTestPluginMarkers = request.node.get_closest_marker('testPlugin') is not None
 
-    if installedPluginMarkers is not None and testPluginMarkers is not None:
+    if hasInstalledPluginMarkers and hasTestPluginMarkers:
         raise Exception(
             'The "testPlugin" and "plugin" markers cannot both be used on a single test'
         )
 
-    elif installedPluginMarkers is not None:
-        for installedPluginMarker in installedPluginMarkers:
+    elif hasInstalledPluginMarkers:
+        for installedPluginMarker in request.node.iter_markers('plugin'):
             pluginName = installedPluginMarker.args[0]
             enabledPlugins.append(pluginName)
 
-    elif testPluginMarkers is not None:
-        for testPluginMarker in testPluginMarkers:
+    elif hasTestPluginMarkers:
+        for testPluginMarker in request.node.iter_markers('testPlugin'):
             pluginName = testPluginMarker.args[0]
             enabledPlugins.append(pluginName)
 

--- a/pytest_girder/setup.py
+++ b/pytest_girder/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         'girder',
         'mongomock',
-        'pytest',
+        'pytest>=3.6',
         'pymongo'
     ],
     entry_points={

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ httmock
 mock
 mongomock
 moto[server]
-pytest
+pytest>=3.6
 pytest-cov
 pytest-xdist
 python-dateutil<2.7 # required for botocore=1.9.8


### PR DESCRIPTION
Per https://docs.pytest.org/en/latest/mark.html#marker-revamp-and-iteration , the latest Pytest 3.6 has deprecated `Node.get_marker` in favor of new methods.