### PR TITLE
Use consistent field to return S3 HTTP request information

### DIFF
--- a/clients/web/src/utilities/S3UploadHandler.js
+++ b/clients/web/src/utilities/S3UploadHandler.js
@@ -267,7 +267,7 @@ prototype._finalizeMultiChunkUpload = function () {
             root.appendChild(partEl);
         });
 
-        var req = resp.s3FinalizeRequest;
+        var req = resp.s3.request;
         var xhr = new XMLHttpRequest();
 
         xhr.open(req.method, req.url);
@@ -278,7 +278,7 @@ prototype._finalizeMultiChunkUpload = function () {
 
         xhr.onload = () => {
             if (xhr.status === 200) {
-                delete resp.s3FinalizeRequest;
+                delete resp.s3;
                 this.trigger('g:upload.complete', resp);
             } else {
                 this.trigger('g:upload.error', {

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -335,12 +335,12 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
                         'Key': upload['s3']['key'],
                         'UploadId': upload['s3']['uploadId']
                     })
-                file['s3FinalizeRequest'] = {
+                file.setdefault('s3', {})['request'] = {
                     'method': 'POST',
                     'url': url,
                     'headers': {'Content-Type': 'text/plain;charset=UTF-8'}
                 }
-                file['additionalFinalizeKeys'] = ('s3FinalizeRequest',)
+                file['additionalFinalizeKeys'] = ('s3',)
         return file
 
     def downloadFile(self, file, offset=0, headers=True, endByte=None,

--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -636,8 +636,8 @@ class AssetstoreTestCase(base.TestCase):
             params={'uploadId': multiChunkUpload['_id']})
         largeFile = resp.json
         self.assertStatusOk(resp)
-        six.assertRegex(self, resp.json['s3FinalizeRequest']['url'], s3Regex)
-        self.assertEqual(resp.json['s3FinalizeRequest']['method'], 'POST')
+        six.assertRegex(self, resp.json['s3']['request']['url'], s3Regex)
+        self.assertEqual(resp.json['s3']['request']['method'], 'POST')
 
         # Test init for an empty file (should be no-op)
         params['size'] = 0

--- a/tests/cases/upload_test.py
+++ b/tests/cases/upload_test.py
@@ -165,12 +165,12 @@ class UploadTestCase(base.TestCase):
             path='/file/completion', method='POST', user=self.user,
             params={'uploadId': upload['_id']})
         self.assertStatusOk(resp)
-        if 's3FinalizeRequest' in resp.json:
+        if 's3' in resp.json and 'request' in resp.json['s3']:
             xml = '<CompleteMultipartUpload>'
             for i, tag in enumerate(etags, 1):
                 xml += '<Part><PartNumber>%d</PartNumber><ETag>%s</ETag></Part>' % (i, tag)
             xml += '</CompleteMultipartUpload>'
-            _send_s3_request(resp.json['s3FinalizeRequest'], data=xml)
+            _send_s3_request(resp.json['s3']['request'], data=xml)
         return upload
 
     def _uploadFileWithInitialChunk(self, name, partial=False, largeFile=False, oneChunk=False):


### PR DESCRIPTION
To perform a direct-to-S3 upload, a client makes a series of HTTP requests to various /file endpoints. The responses include information for the client to make an HTTP request to send data to S3 using a pre-signed URL.

For a multi-part (chunked) upload, the `POST /file` and `POST /file/chunk` endpoints return the request information in the `s3.request` field. In contrast, the `POST /file/completion` endpoint returns the request information in a `s3FinalizeRequest` field.

To make `POST /file/completion` consistent with the earlier steps in the multi-part direct-to-S3 upload workflow, this commit changes the response to use the `s3.request` field instead of `s3FinalizeRequest`.