### PR TITLE
Also catch TypeErrors from GeoJSON parsing

### DIFF
--- a/plugins/geospatial/server/geospatial.py
+++ b/plugins/geospatial/server/geospatial.py
@@ -326,7 +326,7 @@ class GeospatialItem(Resource):
             if v:
                 try:
                     GeoJSON.to_instance(v, strict=True)
-                except ValueError:
+                except (ValueError, TypeError):
                     raise RestException('Geospatial field with key %s does not'
                                         ' contain valid GeoJSON: %s' % (k, v))
 


### PR DESCRIPTION
Fixes #2744 

It's quite possible that the design of the REST endpoints in the geospatial plugin is fundamentally bad, but I don't know. In either case, though, we need to catch this exception type.