### PR TITLE
Existing folder and item names are considered valid.

### DIFF
--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -79,9 +79,11 @@ class Folder(AccessControlledModel):
                                   doc['parentCollection'],
                                   'girder.models.folder.invalid-parent-type')
         name = doc['name']
+        # If the folder already exists with the current name, don't check.
+        checkName = '_id' not in doc or not self.findOne({'_id': doc['_id'], 'name': name})
         n = 0
         itemModel = Item()
-        while True:
+        while checkName:
             q = {
                 'parentId': doc['parentId'],
                 'name': name,

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -80,6 +80,12 @@ class Folder(AccessControlledModel):
                                   'girder.models.folder.invalid-parent-type')
         name = doc['name']
         # If the folder already exists with the current name, don't check.
+        # Although we don't want duplicate names, they can occur when there are
+        # simultaneous uploads, and also because Mongo has no guaranteed
+        # multi-collection uniqueness constraints.  If this occurs, and we are
+        # changing a non-name property, don't validate the name (since that may
+        # fail).  If the name is being changed, validate that it is probably
+        # unique.
         checkName = '_id' not in doc or not self.findOne({'_id': doc['_id'], 'name': name})
         n = 0
         itemModel = Item()

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -81,6 +81,12 @@ class Item(acl_mixin.AccessControlMixin, Model):
         # onto the end of the name, incrementing n until the name is unique.
         name = doc['name']
         # If the item already exists with the current name, don't check.
+        # Although we don't want duplicate names, they can occur when there are
+        # simultaneous uploads, and also because Mongo has no guaranteed
+        # multi-collection uniqueness constraints.  If this occurs, and we are
+        # changing a non-name property, don't validate the name (since that may
+        # fail).  If the name is being changed, validate that it is probably
+        # unique.
         checkName = '_id' not in doc or not self.findOne({'_id': doc['_id'], 'name': name})
         n = 0
         while checkName:

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -80,8 +80,10 @@ class Item(acl_mixin.AccessControlMixin, Model):
         # name collides with an existing item or folder, we will append (n)
         # onto the end of the name, incrementing n until the name is unique.
         name = doc['name']
+        # If the item already exists with the current name, don't check.
+        checkName = '_id' not in doc or not self.findOne({'_id': doc['_id'], 'name': name})
         n = 0
-        while True:
+        while checkName:
             q = {
                 'name': name,
                 'folderId': doc['folderId']
@@ -98,7 +100,7 @@ class Item(acl_mixin.AccessControlMixin, Model):
             dupFolder = Folder().findOne(q, fields=['_id'])
             if dupItem is None and dupFolder is None:
                 doc['name'] = name
-                break
+                checkName = False
             else:
                 n += 1
                 name = '%s (%d)' % (doc['name'], n)

--- a/tests/cases/folder_test.py
+++ b/tests/cases/folder_test.py
@@ -746,3 +746,15 @@ class FolderTestCase(base.TestCase):
             path='/folder/%s/copy' % subFolder['_id'], method='POST',
             user=self.admin, params={'public': 'false', 'progress': True})
         self.assertStatusOk(resp)
+
+    def testUpdateDuplicatedName(self):
+        folder1 = Folder().createFolder(
+            name='foo', parent=self.admin, parentType='user', creator=self.admin)
+        folder2 = Folder().createFolder(
+            name='bar', parent=self.admin, parentType='user', creator=self.admin)
+        folder2['name'] = 'foo'
+        Folder().save(folder2, validate=False)
+        self.assertEqual(folder2['name'], 'foo')
+        folder1['size'] = 3
+        Folder().save(folder1)
+        self.assertEqual(folder1['name'], 'foo')

--- a/tests/cases/item_test.py
+++ b/tests/cases/item_test.py
@@ -777,3 +777,13 @@ class ItemTestCase(base.TestCase):
         self.assertEqual(item1['_id'], item3['_id'])
         self.assertEqual(item2['name'], 'to be reused (1)')
         self.assertEqual(item3['name'], 'to be reused')
+
+    def testUpdateDuplicatedName(self):
+        item1 = Item().createItem('foo', creator=self.users[0], folder=self.publicFolder)
+        item2 = Item().createItem('bar', creator=self.users[0], folder=self.publicFolder)
+        item2['name'] = 'foo'
+        Item().save(item2, validate=False)
+        self.assertEqual(item2['name'], 'foo')
+        item1['size'] = 3
+        Item().save(item1)
+        self.assertEqual(item1['name'], 'foo')


### PR DESCRIPTION
Don't validate folder and item names for existing entries for uniqueness.  If the folder or item doesn't change its name and is not unique, changing non-name properties should validate.

Fixes #2750.