### PR TITLE
Fix setting notification stream option from system configuration view

### DIFF
--- a/clients/web/src/templates/body/systemConfiguration.pug
+++ b/clients/web/src/templates/body/systemConfiguration.pug
@@ -224,8 +224,8 @@ form.g-settings-form(role="form")
             br
             span Disabling this may improve server performance with many concurrent web client users.
             .checkbox
-              label(for="g-core-notification-stream-enabled")
-                input#g-core-notification-stream-enabled(
+              label(for="g-core-enable-notification-stream")
+                input#g-core-enable-notification-stream(
                 type="checkbox", checked=(
                   settings['core.enable_notification_stream'] === null ?
                   defaults['core.enable_notification_stream'] :


### PR DESCRIPTION
The system configuration view assumes that setting keys map to their
corresponding DOM element IDs in a standard way:
https://github.com/girder/girder/blob/7e6e09e/clients/web/src/views/body/SystemConfigurationView.js#L32

This commit changes the DOM element ID corresponding to the
'core.enable_notification_stream' setting to adhere to the convention.