### PR TITLE
The DICOM reader throws an exception for some data.

### DIFF
--- a/plugins/dicom_viewer/plugin_tests/dicom_viewer_test.py
+++ b/plugins/dicom_viewer/plugin_tests/dicom_viewer_test.py
@@ -107,9 +107,8 @@ class DicomViewerTest(base.TestCase):
 
         # Check if the 'dicomItem' is well processed
         dicomItem = Item().load(item['_id'], force=True)
-        self.assertHasKeys(dicomItem, ['dicom'])
-        self.assertHasKeys(dicomItem['dicom'], ['meta'])
-        self.assertHasKeys(dicomItem['dicom'], ['files'])
+        self.assertIn('dicom', dicomItem)
+        self.assertHasKeys(dicomItem['dicom'], ['meta', 'files'])
 
         # Check if the files list contain the good keys and all the file are well sorted
         for i in range(0, 4):

--- a/plugins/dicom_viewer/plugin_tests/dicom_viewer_test.py
+++ b/plugins/dicom_viewer/plugin_tests/dicom_viewer_test.py
@@ -225,3 +225,38 @@ class DicomViewerTest(base.TestCase):
 
         # TODO: Add test to search for a private DICOM item with an other user
         # this test should not found anything
+
+    def testDicomWithIOError(self):
+        import pydicom
+        from girder.plugins.dicom_viewer.event_helper import _EventHelper
+
+        # One of the test files in the pydicom module will throw an IOError
+        # when parsing metadata.  We should work around that and still be able
+        # to import the file
+        samplePath = os.path.join(os.path.dirname(os.path.abspath(
+            pydicom.__file__)), 'data', 'test_files', 'CT_small.dcm')
+        admin, user = self.users
+        # Create a collection, folder, and item
+        collection = Collection().createCollection('collection4', admin, public=True)
+        folder = Folder().createFolder(collection, 'folder4', parentType='collection', public=True)
+        item = Item().createItem('item4', admin, folder)
+        # Upload this dicom file
+        with open(samplePath, 'rb') as fp, _EventHelper('dicom_viewer.upload.success') as helper:
+            dcmFile = Upload().uploadFromFile(
+                obj=fp,
+                size=os.path.getsize(samplePath),
+                name=os.path.basename(samplePath),
+                parentType='item',
+                parent=item,
+                mimeType='application/dicom',
+                user=user
+            )
+            self.assertIsNotNone(dcmFile)
+            # Wait for handler success event
+            handled = helper.wait()
+            self.assertTrue(handled)
+        # Check if the 'dicomItem' is well processed
+        dicomItem = Item().load(item['_id'], force=True)
+        self.assertHasKeys(dicomItem, ['dicom'])
+        self.assertHasKeys(dicomItem['dicom'], ['meta'])
+        self.assertHasKeys(dicomItem['dicom'], ['files'])

--- a/plugins/dicom_viewer/server/__init__.py
+++ b/plugins/dicom_viewer/server/__init__.py
@@ -166,9 +166,18 @@ def _coerceValue(value):
 def _coerceMetadata(dataset):
     metadata = {}
 
-    # Use simple iteration instead of "dataset.iterall", to prevent recursing into Sequiences, which
+    # Use simple iteration instead of "dataset.iterall", to prevent recursing into Sequences, which
     # are too complicated to flatten now
-    for dataElement in dataset:
+    # The dataset iterator is
+    #   for tag in sorted(dataset.keys()):
+    #       yield dataset[tag]
+    # but we want to ignore certain exceptions of delayed data loading, so
+    # we iterate through the dataset ourselves.
+    for tag in sorted(dataset.keys()):
+        try:
+            dataElement = dataset[tag]
+        except IOError:
+            continue
         if dataElement.tag.element == 0:
             # Skip Group Length tags, which are always element 0x0000
             continue

--- a/plugins/dicom_viewer/server/__init__.py
+++ b/plugins/dicom_viewer/server/__init__.py
@@ -173,7 +173,7 @@ def _coerceMetadata(dataset):
     #       yield dataset[tag]
     # but we want to ignore certain exceptions of delayed data loading, so
     # we iterate through the dataset ourselves.
-    for tag in sorted(dataset.keys()):
+    for tag in dataset.keys():
         try:
             dataElement = dataset[tag]
         except IOError:


### PR DESCRIPTION
This prevents it from working with some valid images that refer to delayed data, even though without that reference that would work.  When such a IOError occurs, ignore it.

The pydicom module has some test files that are installed along with it.  Use one of these files to test that we can work with this data.