### PR TITLE
When leaving the DICOM viewer, unbind vtk events.

### DIFF
--- a/plugins/dicom_viewer/web_client/views/DicomView.js
+++ b/plugins/dicom_viewer/web_client/views/DicomView.js
@@ -168,6 +168,13 @@ const DicomSliceImageWidget = View.extend({
         };
     },
 
+    destroy: function () {
+        if (this.vtk.interactor) {
+            this.vtk.interactor.unbindEvents(this.el);
+        }
+        View.prototype.destroy.apply(this, arguments);
+    },
+
     /**
      * Set the slice to use.
      *


### PR DESCRIPTION
Otherwise, keyboard events remain bound, which throw exceptions when the viewer has been destroyed and the keyboard is used in any way.  For instance, view a DICOM image, log out, and log back in; this throws exceptions in the console.