### PR TITLE
Print help for 'girder-install' with no args

### DIFF
--- a/girder/utility/install.py
+++ b/girder/utility/install.py
@@ -378,4 +378,8 @@ def main():
     ).set_defaults(func=print_web_root)
 
     parsed = parser.parse_args()
-    parsed.func(parsed)
+
+    if hasattr(parsed, 'func'):
+        parsed.func(parsed)
+    else:
+        parser.print_help()


### PR DESCRIPTION
Before, if you ran girder-install with no args, you would
get a cryptic error message such as this:

AttributeError: 'Namespace' object has no attribute 'func'

Now, the help message is printed instead, which indicates that
girder-install needs to be ran with args.