### PR TITLE
Pytest live server fixture

### DIFF
--- a/pytest_girder/pytest_girder/fixtures.py
+++ b/pytest_girder/pytest_girder/fixtures.py
@@ -6,6 +6,7 @@ import os
 import pytest
 import shutil
 
+import socket
 import time
 try:
     from urllib2 import urlopen
@@ -14,6 +15,16 @@ except ImportError:
     from urllib.request import urlopen
     from urllib import URLError
 from .utils import uploadFile, MockSmtpReceiver, request as restRequest
+
+
+def _getFreeTcpPort():
+    # Get a random free tcp port
+    # Taken from https://gist.github.com/gabrielfalcao/20e567e188f588b65ba2
+    tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    tcp.bind(('', 0))
+    addr, port = tcp.getsockname()
+    tcp.close()
+    return port
 
 
 def _uid(node):

--- a/pytest_girder/pytest_girder/fixtures.py
+++ b/pytest_girder/pytest_girder/fixtures.py
@@ -8,6 +8,7 @@ import shutil
 
 import socket
 import time
+import warnings
 try:
     from urllib2 import urlopen
     from urllib2 import URLError
@@ -35,13 +36,17 @@ def _uid(node):
 
 
 @pytest.fixture(autouse=True)
-def bcrypt():
+def bcrypt(request):
     """
     Mock out bcrypt password hashing to avoid unnecessary testing bottlenecks.
     """
-    with mock.patch('bcrypt.hashpw') as hashpw:
-        hashpw.side_effect = lambda x, y: x
-        yield hashpw
+    if 'liveServer' in request.node.fixturenames:
+        warnings.warn(UserWarning("Not using bicrypt mock, it is a live server"))
+        yield
+    else:
+        with mock.patch('bcrypt.hashpw') as hashpw:
+            hashpw.side_effect = lambda x, y: x
+            yield hashpw
 
 
 @pytest.fixture

--- a/pytest_girder/pytest_girder/fixtures.py
+++ b/pytest_girder/pytest_girder/fixtures.py
@@ -10,11 +10,9 @@ import subprocess
 import time
 import warnings
 try:
-    from urllib2 import urlopen
-    from urllib2 import URLError
+    from urllib2 import urlopen, URLError
 except ImportError:
-    from urllib.request import urlopen
-    from urllib import URLError
+    from urllib.request import urlopen, URLError
 
 from girder_client import GirderClient
 from .utils import uploadFile, MockSmtpReceiver, request as restRequest

--- a/pytest_girder/pytest_girder/fixtures.py
+++ b/pytest_girder/pytest_girder/fixtures.py
@@ -6,6 +6,13 @@ import os
 import pytest
 import shutil
 
+import time
+try:
+    from urllib2 import urlopen
+    from urllib2 import URLError
+except ImportError:
+    from urllib.request import urlopen
+    from urllib import URLError
 from .utils import uploadFile, MockSmtpReceiver, request as restRequest
 
 
@@ -147,6 +154,15 @@ def server(db, request):
     docs.routes.clear()
 
 
+    # Wait for girder to be up and running
+    timeout = 5
+    while timeout > 0:
+        time.sleep(1)
+        try:
+            urlopen(url)
+            timeout = 0
+        except URLError:
+            timeout -= 1
 @pytest.fixture
 def smtp(db, server):
     """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 -e pytest_girder
+-e clients/python
 coverage
 flake8
 flake8-blind-except


### PR DESCRIPTION
Adds a live server fixture to be used for integration tests. This fixture starts a girder server on a random
port and returns a girder client instance which points to the girder server. It also does not use any 
mocked fixtures such as bicrypt to test the real behavior of a live server.