### PR TITLE
Pin celery to < 4.2.

### DIFF
--- a/plugins/worker/requirements.txt
+++ b/plugins/worker/requirements.txt
@@ -1,1 +1,1 @@
-celery>=4
+celery>=4,<4.2


### PR DESCRIPTION
There is an issue with celery 4.2 that shows up in some places, such as travis builds.  Celery fails to maintain connections to rabbitmq, frequently (but not always) failing.  See, for instance, https://github.com/celery/celery/issues/4867.

Until celery resolves this or there is a clear workaround, avoid 4.2.