### PR TITLE
If a DICOM metadata has a binary value, it could prevent parsing.

### DIFF
--- a/plugins/dicom_viewer/plugin_tests/dicom_viewer_test.py
+++ b/plugins/dicom_viewer/plugin_tests/dicom_viewer_test.py
@@ -140,9 +140,8 @@ class DicomViewerTest(base.TestCase):
         resp = self.request(path=path, method='POST', user=admin)
         self.assertStatusOk(resp)
         dicomItem = Item().load(item['_id'], force=True)
-        self.assertHasKeys(dicomItem, ['dicom'])
-        self.assertHasKeys(dicomItem['dicom'], ['meta'])
-        self.assertHasKeys(dicomItem['dicom'], ['files'])
+        self.assertIn('dicom', dicomItem)
+        self.assertHasKeys(dicomItem['dicom'], ['meta', 'files'])
 
         # Check the endpoint 'parseDicom' for an non admin user
         dicomItem = Item().load(item['_id'], force=True)
@@ -256,6 +255,39 @@ class DicomViewerTest(base.TestCase):
             self.assertTrue(handled)
         # Check if the 'dicomItem' is well processed
         dicomItem = Item().load(item['_id'], force=True)
-        self.assertHasKeys(dicomItem, ['dicom'])
-        self.assertHasKeys(dicomItem['dicom'], ['meta'])
-        self.assertHasKeys(dicomItem['dicom'], ['files'])
+        self.assertIn('dicom', dicomItem)
+        self.assertHasKeys(dicomItem['dicom'], ['meta', 'files'])
+
+    def testDicomWithBinaryValues(self):
+        import pydicom
+        from girder.plugins.dicom_viewer.event_helper import _EventHelper
+
+        # One of the test files in the pydicom module will throw an IOError
+        # when parsing metadata.  We should work around that and still be able
+        # to import the file
+        samplePath = os.path.join(os.path.dirname(os.path.abspath(
+            pydicom.__file__)), 'data', 'test_files', 'OBXXXX1A.dcm')
+        admin, user = self.users
+        # Create a collection, folder, and item
+        collection = Collection().createCollection('collection5', admin, public=True)
+        folder = Folder().createFolder(collection, 'folder5', parentType='collection', public=True)
+        item = Item().createItem('item5', admin, folder)
+        # Upload this dicom file
+        with open(samplePath, 'rb') as fp, _EventHelper('dicom_viewer.upload.success') as helper:
+            dcmFile = Upload().uploadFromFile(
+                obj=fp,
+                size=os.path.getsize(samplePath),
+                name=os.path.basename(samplePath),
+                parentType='item',
+                parent=item,
+                mimeType='application/dicom',
+                user=user
+            )
+            self.assertIsNotNone(dcmFile)
+            # Wait for handler success event
+            handled = helper.wait()
+            self.assertTrue(handled)
+        # Check if the 'dicomItem' is well processed
+        dicomItem = Item().load(item['_id'], force=True)
+        self.assertIn('dicom', dicomItem)
+        self.assertHasKeys(dicomItem['dicom'], ['meta', 'files'])

--- a/plugins/dicom_viewer/server/__init__.py
+++ b/plugins/dicom_viewer/server/__init__.py
@@ -134,6 +134,15 @@ def _removeUniqueMetadata(dicomMeta, additionalMeta):
 
 
 def _coerceValue(value):
+    # For binary data, see if it can be coerced further into utf8 data.  If
+    # not, mongo won't store it, so don't accept it here.
+    if isinstance(value, six.binary_type):
+        if b'\x00' in value:
+            raise ValueError('Binary data with null')
+        try:
+            value.decode('utf-8')
+        except UnicodeDecodeError:
+            raise ValueError('Binary data that cannot be stored as utf-8')
     # Many pydicom value types are subclasses of base types; to ensure the value can be serialized
     # to MongoDB, cast the value back to its base type
     for knownBaseType in {


### PR DESCRIPTION
We don't store values we don't understand, but we were trying to store arbitrary binary values.  This fails if we can't coerce the value to UTF-8 to stick it in Mongo.  If we actually want to store binary data, we need to encode it different.  This skips such binary data, including any data that doesn't encode to UTF-8 or has a null in it.

This uses a pydicom test file for testing.