### PR TITLE
Add an endpoint to poll for notifications

### DIFF
--- a/girder/api/v1/notification.py
+++ b/girder/api/v1/notification.py
@@ -121,6 +121,8 @@ class Notification(Resource):
     def listNotifications(self, params):
         user, token = self.getCurrentUser(returnToken=True)
         since = params.get('since')
+        setResponseHeader('Date', str(time.time()))
+
         if since is not None:
             since = datetime.utcfromtimestamp(since)
         return list(NotificationModel().get(user, since, token=token))

--- a/girder/api/v1/notification.py
+++ b/girder/api/v1/notification.py
@@ -55,7 +55,7 @@ class Notification(Resource):
         super(Notification, self).__init__()
         self.resourceName = 'notification'
         self.route('GET', ('stream',), self.stream)
-        self.route('GET', (), self.list)
+        self.route('GET', (), self.listNotifications)
 
     @access.cookie
     @access.token
@@ -118,7 +118,7 @@ class Notification(Resource):
         .errorResponse()
         .errorResponse('You are not logged in.', 403)
     )
-    def list(self, params):
+    def listNotifications(self, params):
         user, token = self.getCurrentUser(returnToken=True)
         since = params.get('since')
         if since is not None:

--- a/girder/api/v1/notification.py
+++ b/girder/api/v1/notification.py
@@ -121,13 +121,13 @@ class Notification(Resource):
     def listNotifications(self, params):
         user, token = self.getCurrentUser(returnToken=True)
         since = params.get('since')
+        timestamp = time.time()
 
         if since is not None:
             since = datetime.utcfromtimestamp(since)
         notifications = list(NotificationModel().get(user, since, token=token))
-        if not notifications:
-            timestamp = time.time()
-        else:
+
+        if notifications:
             timestamp = notifications[0]['updatedTime']
             for notification in notifications:
                 timestamp = max(timestamp, notification['updatedTime'])

--- a/girder/api/v1/notification.py
+++ b/girder/api/v1/notification.py
@@ -118,9 +118,8 @@ class Notification(Resource):
         .errorResponse()
         .errorResponse('You are not logged in.', 403)
     )
-    def listNotifications(self, params):
+    def listNotifications(self, since):
         user, token = self.getCurrentUser(returnToken=True)
-        since = params.get('since')
         timestamp = time.time()
 
         if since is not None:
@@ -128,9 +127,7 @@ class Notification(Resource):
         notifications = list(NotificationModel().get(user, since, token=token))
 
         if notifications:
-            timestamp = notifications[0]['updatedTime']
-            for notification in notifications:
-                timestamp = max(timestamp, notification['updatedTime'])
+            timestamp = max(n['updatedTime'] for n in notifications)
 
         setResponseHeader('Date', str(timestamp))
         return notifications

--- a/girder/api/v1/notification.py
+++ b/girder/api/v1/notification.py
@@ -121,8 +121,16 @@ class Notification(Resource):
     def listNotifications(self, params):
         user, token = self.getCurrentUser(returnToken=True)
         since = params.get('since')
-        setResponseHeader('Date', str(time.time()))
 
         if since is not None:
             since = datetime.utcfromtimestamp(since)
-        return list(NotificationModel().get(user, since, token=token))
+        notifications = list(NotificationModel().get(user, since, token=token))
+        if not notifications:
+            timestamp = time.time()
+        else:
+            timestamp = notifications[0]['updatedTime']
+            for notification in notifications:
+                timestamp = max(timestamp, notification['updatedTime'])
+
+        setResponseHeader('Date', str(timestamp))
+        return notifications

--- a/test/test_notification.py
+++ b/test/test_notification.py
@@ -38,12 +38,14 @@ def notifications(user):
 def testListAllNotifications(server, user, notifications):
     resp = server.request(path='/notification', user=user)
     assertStatusOk(resp)
+    assert 'Date' in resp.headers
     assert {m['_id'] for m in resp.json} == {str(m['_id']) for m in notifications}
 
 
 def testListNotificationsSinceTime(server, user, notifications):
     resp = server.request(path='/notification', user=user, params={'since': 10})
     assertStatusOk(resp)
+    assert 'Date' in resp.headers
     assert {m['_id'] for m in resp.json} == {str(notifications[-1]['_id'])}
 
 

--- a/test/test_notification.py
+++ b/test/test_notification.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+import pytest
+from pytest_girder.assertions import assertStatus, assertStatusOk
+
+from girder.models.notification import Notification
+
+
+@pytest.fixture
+def notifications(user):
+    model = Notification()
+    doc1 = model.createNotification('type', {}, user)
+    doc1['updated'] = 1
+    doc1['time'] = 1
+    model.save(doc1)
+    doc2 = model.createNotification('type', {}, user)
+    yield [doc1, doc2]
+    model.remove(doc1)
+    model.remove(doc2)
+
+
+def testListAllNotifications(server, user, notifications):
+    resp = server.request(path='/notification', user=user)
+    assertStatusOk(resp)
+    assert {m['_id'] for m in resp.json} == {str(m['_id']) for m in notifications}
+
+
+def testListNotificationsSinceTime(server, user, notifications):
+    resp = server.request(path='/notification', user=user, params={'since': 10})
+    assertStatusOk(resp)
+    assert {m['_id'] for m in resp.json} == {str(notifications[-1]['_id'])}
+
+
+def testListNotificationsAuthError(server, notifications):
+    resp = server.request(path='/notification')
+    assertStatus(resp, 401)


### PR DESCRIPTION
This adds a notification listing endpoint at `/notification`.  It returns the same information provided by `/notification/stream`, but without the issues with long-lived request threads.  It would be up to the client to fall back to manual long polling.

The implementation is simple, but I'll add a test if everyone agrees this is a good idea.