### PR TITLE
Change behavior of notification polling endpoint

### DIFF
--- a/girder/api/v1/notification.py
+++ b/girder/api/v1/notification.py
@@ -18,7 +18,6 @@
 ###############################################################################
 
 import cherrypy
-import dateutil.parser
 import json
 import time
 from datetime import datetime
@@ -115,23 +114,11 @@ class Notification(Resource):
         .notes('This endpoint can be used for manual long-polling when '
                'SSE support is disabled or otherwise unavailable. The events are always '
                'returned in chronological order.')
-        .param('since', 'Filter out events before this date. Pass as either epoch seconds or '
-               'an ISO-8601 formatted datetime.', required=False)
+        .param('since', 'Filter out events before this date.', required=False, dataType='dateTime')
         .errorResponse()
         .errorResponse('You are not logged in.', 403)
     )
     def listNotifications(self, since):
         user, token = self.getCurrentUser(returnToken=True)
-
-        if since is not None:
-            try:
-                since = dateutil.parser.parse(since)
-            except ValueError:
-                try:
-                    since = datetime.utcfromtimestamp(float(since))
-                except ValueError:
-                    raise RestException(
-                        'The "since" parameter must be a valid date string or epoch timestamp.')
-
         return list(NotificationModel().get(
             user, since, token=token, sort=[('updated', SortDir.ASCENDING)]))

--- a/girder/models/notification.py
+++ b/girder/models/notification.py
@@ -204,7 +204,7 @@ class Notification(Model):
         else:
             return record
 
-    def get(self, user, since=None, token=None):
+    def get(self, user, since=None, token=None, sort=None):
         """
         Get outstanding notifications for the given user.
 
@@ -214,6 +214,7 @@ class Notification(Model):
             since a certain timestamp.
         :type since: datetime
         :param token: if the user is None, the token requesting updated.
+        :param sort: Sort field for the database query.
         """
         q = {}
         if user:
@@ -224,4 +225,4 @@ class Notification(Model):
         if since is not None:
             q['updated'] = {'$gt': since}
 
-        return self.find(q)
+        return self.find(q, sort=sort)

--- a/test/test_notification.py
+++ b/test/test_notification.py
@@ -19,12 +19,11 @@
 
 import datetime
 import pytest
-import time
 from pytest_girder.assertions import assertStatus, assertStatusOk
 from girder.models.notification import Notification
 
 OLD_TIME = datetime.datetime.utcnow() - datetime.timedelta(days=3)
-SINCE_TIME = OLD_TIME + datetime.timedelta(days=1)
+SINCE = OLD_TIME + datetime.timedelta(days=1)
 
 
 @pytest.fixture
@@ -47,12 +46,8 @@ def testListAllNotifications(server, user, notifications):
     assert [n['_id'] for n in resp.json] == [str(n2['_id']), str(n1['_id'])]
 
 
-@pytest.mark.parametrize('since', [
-    SINCE_TIME.isoformat(),
-    time.mktime(SINCE_TIME.timetuple())
-])
-def testListNotificationsSinceTime(server, user, notifications, since):
-    resp = server.request(path='/notification', user=user, params={'since': since})
+def testListNotificationsSinceTime(server, user, notifications):
+    resp = server.request(path='/notification', user=user, params={'since': SINCE.isoformat()})
     assertStatusOk(resp)
     assert len(resp.json) == 1
     assert resp.json[0]['_id'] == str(notifications[0]['_id'])

--- a/test/test_notification.py
+++ b/test/test_notification.py
@@ -16,54 +16,48 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ###############################################################################
-import time
 
+import datetime
 import pytest
+import time
 from pytest_girder.assertions import assertStatus, assertStatusOk
-
 from girder.models.notification import Notification
 
-
-def assertApproximateTimestamp(time1, time2, delta=1):
-    __tracebackhide__ = True
-    assert abs(float(time1) - float(time2)) < delta
+OLD_TIME = datetime.datetime.utcnow() - datetime.timedelta(days=3)
+SINCE_TIME = OLD_TIME + datetime.timedelta(days=1)
 
 
 @pytest.fixture
 def notifications(user):
     model = Notification()
     doc1 = model.createNotification('type', {}, user)
-    doc1['updated'] = 1
-    doc1['time'] = 1
-    model.save(doc1)
     doc2 = model.createNotification('type', {}, user)
+    doc2['updated'] = OLD_TIME
+    doc2['time'] = OLD_TIME
+    model.save(doc2)
+
     yield [doc1, doc2]
-    model.remove(doc1)
-    model.remove(doc2)
 
 
 def testListAllNotifications(server, user, notifications):
     resp = server.request(path='/notification', user=user)
     assertStatusOk(resp)
-    assert {m['_id'] for m in resp.json} == {str(m['_id']) for m in notifications}
-    assertApproximateTimestamp(resp.headers.get('Date'), notifications[1]['updatedTime'])
+    n1, n2 = notifications
+    # Make sure we get results back in chronological order
+    assert [n['_id'] for n in resp.json] == [str(n2['_id']), str(n1['_id'])]
 
 
-def testListNotificationsSinceTime(server, user, notifications):
-    resp = server.request(path='/notification', user=user, params={'since': 10})
+@pytest.mark.parametrize('since', [
+    SINCE_TIME.isoformat(),
+    time.mktime(SINCE_TIME.timetuple())
+])
+def testListNotificationsSinceTime(server, user, notifications, since):
+    resp = server.request(path='/notification', user=user, params={'since': since})
     assertStatusOk(resp)
-    assert {m['_id'] for m in resp.json} == {str(notifications[-1]['_id'])}
-    assertApproximateTimestamp(resp.headers.get('Date'), notifications[1]['updatedTime'])
+    assert len(resp.json) == 1
+    assert resp.json[0]['_id'] == str(notifications[0]['_id'])
 
 
-def testDefaultDateHeader(server, user, notifications):
-    resp = server.request(path='/notification', user=user,
-                          params={'since': int(time.time()) + 1000})
-    assertStatusOk(resp)
-    assert resp.json == []
-    assertApproximateTimestamp(resp.headers.get('Date'), time.time(), 10)
-
-
-def testListNotificationsAuthError(server, notifications):
+def testListNotificationsAuthError(server):
     resp = server.request(path='/notification')
     assertStatus(resp, 401)


### PR DESCRIPTION
* Rather than pass an HTTP header to clients indicating the next
  "since" parameter to poll with, it's left to clients to infer
  it from the response.
* The "since" parameter for this endpoint now supports date strings
  in addition to epoch timestamps.
* The results of the endpoint are now guaranteed to be returned
  sorted chronologically; this means clients can discover the next
  "since" value to use in O(1) time rather than O(n).

@brianhelba @jbeezley let me know what you think, I'll write tests when we agree on the behavior.