### PR TITLE
Fix up vagrant and ansible

### DIFF
--- a/devops/ansible/roles/girder/tasks/pip.yml
+++ b/devops/ansible/roles/girder/tasks/pip.yml
@@ -33,9 +33,8 @@
 
     - name: Install Girder and plugin requirements
       pip:
-        name: ".[plugins]"
+        name: "{{ girder_path }}[plugins]"
         extra_args: "-e"
-        chdir: "{{ girder_path }}"
         executable: "{{ girder_pip | default(omit) }}"
 
     - name: Find girder-install executable

--- a/devops/ansible/roles/girder/tasks/pip.yml
+++ b/devops/ansible/roles/girder/tasks/pip.yml
@@ -31,6 +31,15 @@
         - pip
         - setuptools
 
+    - name: Force install of requests and six
+      pip:
+        name: "{{ item }}"
+        extra_args: "--ignore-installed"
+        executable: "{{ girder_pip | default(omit) }}"
+      with_items:
+        - six
+        - requests
+
     - name: Install Girder and plugin requirements
       pip:
         name: "{{ girder_path }}[plugins]"


### PR DESCRIPTION
I ran into two problems:

- The pip ansible module seem to have been [broken.](https://github.com/ansible/ansible/issues/37912). Added a workaround suggested in the issue. 
- On older distros such as our 14.04 image pip complains when trying to update six and requests. I have added a step to use the --ignore-installed option to reinstall these packages. It not particularly nice as it done regardless of the distro, but it seem alot of work to determine exactly which targets have this problem.