### PR TITLE
Improve the browser widget in the assetstore import.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,10 @@ Python Client
 * Added a ``--verbose`` option to the girder-client command line interface to increase the verbosity
   of information dumped to stderr (`#2699 <https://github.com/girder/girder/pull/2699>`_).
 
+Web Client
+^^^^^^^^^^
+* Filesystem and S3 assetstore imports show the selected destination resource path next to the ID when selected via the browser widget (`#2775 <https://github.com/girder/girder/pull/2775>`_).
+
 Changes
 -------
 

--- a/clients/web/src/views/body/FilesystemImportView.js
+++ b/clients/web/src/views/body/FilesystemImportView.js
@@ -3,6 +3,7 @@ import $ from 'jquery';
 import BrowserWidget from 'girder/views/widgets/BrowserWidget';
 import router from 'girder/router';
 import View from 'girder/views/View';
+import { restRequest } from 'girder/rest';
 
 import FilesystemImportTemplate from 'girder/templates/body/filesystemImport.pug';
 
@@ -11,7 +12,7 @@ var FilesystemImportView = View.extend({
         'submit .g-filesystem-import-form': function (e) {
             e.preventDefault();
 
-            var destId = this.$('#g-filesystem-import-dest-id').val().trim(),
+            var destId = this.$('#g-filesystem-import-dest-id').val().trim().split(/\s/)[0],
                 destType = this.$('#g-filesystem-import-dest-type').val(),
                 foldersAsItems = this.$('#g-filesystem-import-leaf-items').val();
 
@@ -50,6 +51,17 @@ var FilesystemImportView = View.extend({
         });
         this.listenTo(this._browserWidgetView, 'g:saved', function (val) {
             this.$('#g-filesystem-import-dest-id').val(val.id);
+            this.$('#g-filesystem-import-dest-type').val(val.get('_modelType'));
+            restRequest({
+                url: `resource/${val.id}/path`,
+                method: 'GET',
+                data: {type: val.get('_modelType')}
+            }).done((result) => {
+                // Only add the resource path if the value wasn't altered
+                if (this.$('#g-filesystem-import-dest-id').val() === val.id) {
+                    this.$('#g-filesystem-import-dest-id').val(`${val.id} (${result})`);
+                }
+            });
         });
         this.assetstore = settings.assetstore;
         this.render();

--- a/clients/web/src/views/body/S3ImportView.js
+++ b/clients/web/src/views/body/S3ImportView.js
@@ -3,6 +3,7 @@ import $ from 'jquery';
 import BrowserWidget from 'girder/views/widgets/BrowserWidget';
 import router from 'girder/router';
 import View from 'girder/views/View';
+import { restRequest } from 'girder/rest';
 
 import S3ImportTemplate from 'girder/templates/body/s3Import.pug';
 
@@ -11,7 +12,7 @@ var S3ImportView = View.extend({
         'submit .g-s3-import-form': function (e) {
             e.preventDefault();
 
-            var destId = this.$('#g-s3-import-dest-id').val().trim(),
+            var destId = this.$('#g-s3-import-dest-id').val().trim().split(/\s/)[0],
                 destType = this.$('#g-s3-import-dest-type').val();
 
             this.$('.g-validation-failed-message').empty();
@@ -48,6 +49,17 @@ var S3ImportView = View.extend({
         });
         this.listenTo(this._browserWidgetView, 'g:saved', function (val) {
             this.$('#g-s3-import-dest-id').val(val.id);
+            this.$('#g-s3-import-dest-type').val(val.get('_modelType'));
+            restRequest({
+                url: `resource/${val.id}/path`,
+                method: 'GET',
+                data: {type: val.get('_modelType')}
+            }).done((result) => {
+                // Only add the resource path if the value wasn't altered
+                if (this.$('#g-s3-import-dest-id').val() === val.id) {
+                    this.$('#g-s3-import-dest-id').val(`${val.id} (${result})`);
+                }
+            });
         });
         this.assetstore = settings.assetstore;
         this.render();


### PR DESCRIPTION
Before, if you selected a user or collection as the destination for a filesystem or S3 assetstore import, the ID was placed in the appropriate field, but the type of resource was not changed.  This properly changes the resource to folder, user, or collection.

This also displays the resource path next to the destination ID to let the user know what they have selected.  Anything after the first whitespace in the ID field is ignored, so this is for information purposes only and has no effect on the import.