### PR TITLE
Sort imports when importing into a filesystem assetstore.

### DIFF
--- a/girder/utility/filesystem_assetstore_adapter.py
+++ b/girder/utility/filesystem_assetstore_adapter.py
@@ -407,12 +407,17 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
                 listDir, params=params)
             return
 
+        # Sort listDir to process files before directories.  Files and
+        # directories are alphabetized as well.
+        listDir = [entry[-1] for entry in sorted([
+            (not os.path.isfile(os.path.join(importPath, val)), val)
+            for val in listDir])]
         for name in listDir:
             progress.update(message=name)
             path = os.path.join(importPath, name)
 
             if os.path.isdir(path):
-                localListDir = os.listdir(path)
+                localListDir = sorted(os.listdir(path))
                 if leafFoldersAsItems and self._hasOnlyFiles(path, localListDir):
                     self._importDataAsItem(name, user, parent, path, localListDir, params=params)
                 else:


### PR DESCRIPTION
Sort files and directories when importing them into a filesystem assetstore.  Try to import files first, as if we are importing to a collection or user this will throw an exception right away instead of possibly importing some of the directories and then failing.

By having a predictable sort order, if the task is interrupted due to a failure or restart it is more obvious how far it got.