### PR TITLE
Add a setting to disable public access.

### DIFF
--- a/clients/web/src/templates/body/systemConfiguration.pug
+++ b/clients/web/src/templates/body/systemConfiguration.pug
@@ -231,6 +231,18 @@ form.g-settings-form(role="form")
                   defaults['core.enable_notification_stream'] :
                   settings['core.enable_notification_stream']))
                 | Enabled
+          .form-group
+            label Allow Public Access
+            br
+            span Disabling public access requires a user or access token to perform nearly all actions.  Altering this setting requires a #[a#g-restart-server restart of the Girder server] to take effect.
+            .checkbox
+              label(for="g-core-allow-public-access")
+                input#g-core-allow-public-access(
+                type="checkbox", checked=(
+                  settings['core.enable_notification_stream'] === null ?
+                  defaults['core.enable_notification_stream'] :
+                  settings['core.enable_notification_stream']))
+                | Allow
           .g-settings-form-container
             h4 CORS
             p.

--- a/clients/web/src/views/body/SystemConfigurationView.js
+++ b/clients/web/src/views/body/SystemConfigurationView.js
@@ -42,7 +42,8 @@ var SystemConfigurationView = View.extend({
                     [
                         'core.api_keys',
                         'core.enable_password_login',
-                        'core.enable_notification_stream'
+                        'core.enable_notification_stream',
+                        'core.allow_public_access'
                     ],
                     key
                 )) { // booleans via checkboxes
@@ -107,6 +108,7 @@ var SystemConfigurationView = View.extend({
             'core.smtp.password',
             'core.upload_minimum_chunk_size',
             'core.enable_notification_stream',
+            'core.allow_public_access',
             'core.cors.allow_origin',
             'core.cors.allow_methods',
             'core.cors.allow_headers',

--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -486,7 +486,7 @@ class Describe(Resource):
         super(Describe, self).__init__()
         self.route('GET', (), self.listResources, nodoc=True)
 
-    @access.public
+    @access.public(alwaysPublic=True)
     def listResources(self, params):
         # Paths Object
         paths = {}

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -87,7 +87,7 @@ class User(Resource):
     def getUser(self, user):
         return user
 
-    @access.public(scope=TokenScope.USER_INFO_READ)
+    @access.public(scope=TokenScope.USER_INFO_READ, alwaysPublic=True)
     @filtermodel(model=UserModel)
     @autoDescribeRoute(
         Description('Retrieve the currently logged-in user information.')
@@ -96,7 +96,7 @@ class User(Resource):
     def getMe(self):
         return self.getCurrentUser()
 
-    @access.public
+    @access.public(alwaysPublic=True)
     @autoDescribeRoute(
         Description('Log in to the system.')
         .notes('Pass your username and password using HTTP Basic Auth. Sends'
@@ -159,7 +159,7 @@ class User(Resource):
         self.deleteAuthTokenCookie()
         return {'message': 'Logged out.'}
 
-    @access.public
+    @access.public(alwaysPublic=True)
     @filtermodel(model=UserModel, addFields={'authToken'})
     @autoDescribeRoute(
         Description('Create a new user.')

--- a/girder/constants.py
+++ b/girder/constants.py
@@ -176,6 +176,7 @@ class SettingKey(object):
     ENABLE_PASSWORD_LOGIN = 'core.enable_password_login'
     GIRDER_MOUNT_INFORMATION = 'core.girder_mount_information'
     ENABLE_NOTIFICATION_STREAM = 'core.enable_notification_stream'
+    ALLOW_PUBLIC_ACCESS = 'core.allow_public_access'
     PLUGINS_ENABLED = 'core.plugins_enabled'
     REGISTRATION_POLICY = 'core.registration_policy'
     ROUTE_TABLE = 'core.route_table'
@@ -220,6 +221,7 @@ class SettingDefault(object):
         SettingKey.EMAIL_FROM_ADDRESS: 'Girder <no-reply@girder.org>',
         SettingKey.ENABLE_PASSWORD_LOGIN: True,
         SettingKey.ENABLE_NOTIFICATION_STREAM: True,
+        SettingKey.ALLOW_PUBLIC_ACCESS: True,
         SettingKey.PLUGINS_ENABLED: [],
         SettingKey.REGISTRATION_POLICY: 'open',
         SettingKey.SMTP_HOST: 'localhost',

--- a/girder/models/setting.py
+++ b/girder/models/setting.py
@@ -467,3 +467,10 @@ class Setting(Model):
         if not isinstance(doc['value'], bool):
             raise ValidationException(
                 'Enable notification stream option must be boolean.', 'value')
+
+    @staticmethod
+    @setting_utilities.validator(SettingKey.ALLOW_PUBLIC_ACCESS)
+    def validateAllowPublicAccess(doc):
+        if not isinstance(doc['value'], bool):
+            raise ValidationException(
+                'Allow public access option must be boolean.', 'value')

--- a/plugins/homepage/server/rest.py
+++ b/plugins/homepage/server/rest.py
@@ -34,7 +34,7 @@ class Homepage(Resource):
         self.route('GET', (), self.getSettings)
         self.route('GET', ('assets',), self.getAssets)
 
-    @access.public
+    @access.public(alwaysPublic=True)
     @autoDescribeRoute(
         Description('Public url for getting the homepage properties.')
     )


### PR DESCRIPTION
Note that plugins with @access.public endpoints may be broken if public access is disabled.  For those endpoints, it may be necessary to change to `@access.public(alwaysPublic=True)`.

The pytest access have been refactored to ensure that they use a clean database, as the setting for public access now affects endpoints marked public.