### PR TITLE
Fail early when trying to import a file to a non-folder.

### DIFF
--- a/girder/utility/filesystem_assetstore_adapter.py
+++ b/girder/utility/filesystem_assetstore_adapter.py
@@ -401,6 +401,12 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
             return
 
         listDir = os.listdir(importPath)
+
+        if parentType != 'folder' and any(
+                os.path.isfile(os.path.join(importPath, val)) for val in listDir):
+            raise ValidationException(
+                'Files cannot be imported directly underneath a %s.' % parentType)
+
         if leafFoldersAsItems and self._hasOnlyFiles(importPath, listDir):
             self._importDataAsItem(
                 os.path.basename(importPath.rstrip(os.sep)), user, parent, importPath,

--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -256,6 +256,18 @@ class AssetstoreTestCase(base.TestCase):
         self.assertIsNone(File().load(file['_id'], force=True))
         self.assertTrue(os.path.isfile(file['path']))
 
+        # Attempt to import a folder with an item directly into user; should fail
+        resp = self.request(
+            '/assetstore/%s/import' % self.assetstore['_id'], method='POST', params={
+                'importPath': os.path.join(
+                    ROOT_DIR, 'tests', 'cases', 'py_client', 'testdata'),
+                'destinationType': 'user',
+                'destinationId': self.admin['_id']
+            }, user=self.admin)
+        self.assertStatus(resp, 400)
+        self.assertEqual(
+            resp.json['message'], 'Files cannot be imported directly underneath a user.')
+
     def testFilesystemAssetstoreImportLeafFoldersAsItems(self):
         folder = six.next(Folder().childFolders(
             self.admin, parentType='user', force=True, filters={


### PR DESCRIPTION
Before, importing a mix of folders and files to a collection or user could import some of the folders before failing.  By failing immediately this removes some arbitrariness from the process.