### PR TITLE
Pin to boto3 < 1.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,8 +59,8 @@ with open('README.rst') as f:
     readme = f.read()
 
 installReqs = [
-    'boto3>=1.7,<1.8',
-    'botocore<1.11.0',
+    'boto3>=1.7,<1.8',  # TODO: unpin once moto works with boto3>=1.8
+    'botocore<1.11.0',  # TODO: remove once moto works with boto3>=1.8
     # CherryPy version is restricted due to a bug in versions >=11.1
     # https://github.com/cherrypy/cherrypy/issues/1662
     'CherryPy<11.1',

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,8 @@ with open('README.rst') as f:
     readme = f.read()
 
 installReqs = [
-    'boto3',
+    'boto3>=1.7,<1.8',
+    'botocore<1.11.0',
     # CherryPy version is restricted due to a bug in versions >=11.1
     # https://github.com/cherrypy/cherrypy/issues/1662
     'CherryPy<11.1',


### PR DESCRIPTION
Boto3 1.8 breaks our tests using moto.  See https://github.com/spulec/moto/issues/1793 .  We can unpin when moto is updated.

This also has to add boto-core as a requirement to allow moto to install.