### PR TITLE
Accurately report size of chunks in uploadFromFile

### DIFF
--- a/girder/models/upload.py
+++ b/girder/models/upload.py
@@ -105,7 +105,7 @@ class Upload(Model):
             if not data:
                 break
 
-            upload = self.handleChunk(upload, RequestBodyStream(six.BytesIO(data), size))
+            upload = self.handleChunk(upload, RequestBodyStream(six.BytesIO(data), len(data)))
 
         return upload
 


### PR DESCRIPTION
I think this bug went undiscovered because we only use `uploadFromFile` in places where the files are smaller than the chunk size: in thumbnails, and in various automated tests.