### PR TITLE
Make audit log separate from girder log

### DIFF
--- a/girder/__init__.py
+++ b/girder/__init__.py
@@ -226,6 +226,7 @@ def _setupLogger():
 
 logger = _setupLogger()
 auditLogger = logging.getLogger('girder_audit')
+auditLogger.setLevel(logging.INFO)
 
 
 def logStdoutStderr(force=False):

--- a/girder/__init__.py
+++ b/girder/__init__.py
@@ -225,7 +225,7 @@ def _setupLogger():
 
 
 logger = _setupLogger()
-auditLogger = logging.getLogger('girder.audit')
+auditLogger = logging.getLogger('girder_audit')
 
 
 def logStdoutStderr(force=False):


### PR DESCRIPTION
Prior to this, everything sent to the audit log was also logged to the girder log because we registered the audit log as a sub-log of the girder log by virtue of their names. This change makes the audit log separate from the main girder log.