### PR TITLE
Scripting mode for girder-shell

### DIFF
--- a/girder/cli/shell.py
+++ b/girder/cli/shell.py
@@ -61,7 +61,8 @@ def main(plugins, script, args):
             'appconf': appconf
         })
     else:
-        globals_ = {k: v for k, v in six.viewitems(globals()) if k != '__name__'}
+        globals_ = {k: v for k, v in six.viewitems(globals()) if k not in {'__file__', '__name__'}}
         sys.argv = [script] + list(args)
         six.exec_(open(script, 'rb').read(), dict(
-            webroot=webroot, appconf=appconf, __name__='__main__', **globals_))
+            webroot=webroot, appconf=appconf, __name__='__main__',
+            __file__=script, **globals_))


### PR DESCRIPTION
This allows a script to be passed into the `girder-shell` or
`girder shell` command which will execute with the same context
as though its code were run inside the interactive shell. Namely,
its `__name__` will be `'__main__'`, it will have the `appconf`
and `webroot` globals set, and the necessary plugins loaded. Its
`sys.argv` will be whatever was passed after `--` of the `girder-shell`
invocation, e.g.

    girder shell --plugins=audit_logs ./audit_report.py -- --format=csv


There may exist some `click` cleverness to make the `--` not necessary, but I wasn't able to find it if so.