### PR TITLE
Restore some scripts that were deleted.

### DIFF
--- a/scripts/install_cmake.sh
+++ b/scripts/install_cmake.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+PREFIX="$CACHE/cmake-$CMAKE_VERSION"
+if [[ ! -f "$PREFIX/bin/cmake" || -n "$UPDATE_CACHE" ]] ; then
+    rm -fr "$PREFIX"
+    mkdir -p "$PREFIX"
+    curl -L "http://cmake.org/files/v${CMAKE_SHORT_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" | gunzip -c | tar -x -C "$PREFIX" --strip-components 1
+fi
+export PATH="$PREFIX/bin:$PATH"

--- a/scripts/install_mongo.sh
+++ b/scripts/install_mongo.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+PREFIX="$CACHE/mongo-$MONGO_VERSION"
+if [[ ! -f "$PREFIX/bin/mongod" || -n "$UPDATE_CACHE" ]] ; then
+    rm -fr "$PREFIX"
+    mkdir -p "$PREFIX"
+    curl -L "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGO_VERSION}.tgz" | gunzip -c | tar -x -C "$PREFIX" --strip-components 1
+fi
+export PATH="$PREFIX/bin:$PATH"


### PR DESCRIPTION
The install_cmake.sh and install_mongo.sh are convenience scripts for downstream CI.

These were removed as part of PR #2222.

Perhaps they shouldn't exist in Girder's repo, but they are being used in CI by both large_image and HistomicsTK.