### PR TITLE
Use the latest pre-built CTest in Python 3 testing

### DIFF
--- a/.circleci/girder_test_py3/Dockerfile
+++ b/.circleci/girder_test_py3/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install --assume-yes \
 # Install Girder development prereqs
 # Get a very recent version of CMake
 RUN mkdir --parents "/opt/cmake" \
-  && curl --location "https://cmake.org/files/v3.11/cmake-3.11.3.tar.gz" | \
+  && curl --location "https://cmake.org/files/v3.12/cmake-3.12.2-Linux-x86_64.tar.gz" | \
     gunzip --stdout | \
     tar --extract --directory "/opt/cmake" --strip-components 1 \
   && ln --symbolic --force "/opt/cmake/bin/cmake" "/usr/local/bin/cmake" \


### PR DESCRIPTION
The version added by #2222 was an older version and a source tarball, so binaries were not available.