### PR TITLE
Pin fusepy to < 3.0 to prevent deadlocks in tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ extrasReqs['sftp'] = [
     'paramiko',
 ]
 extrasReqs['mount'] = [
-    'fusepy>=2.0.4',
+    'fusepy>=2.0.4,<3.0',
 ]
 
 init = os.path.join(os.path.dirname(__file__), 'girder', '__init__.py')


### PR DESCRIPTION
This fixes a deadlock in [py3_integrationTests](https://circleci.com/gh/girder/girder/13463).