### PR TITLE
Fix ansible role galaxy deployment on circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -466,6 +466,9 @@ jobs:
           path: girder
       # Since this cache must have been created in a previous step of this workflow, we can get
       # a virtualenv without having to create one or install anything.
+      - run:
+          name: Generate python environment checksum file
+          command: ./girder/.circleci/generatePyEnvChecksum.sh > girder/py-env-checksum
       - restore_cache:
           key: venv-py3.5-{{ arch }}-{{ checksum "girder/py-env-checksum" }}
       - run:

--- a/devops/ansible/roles/girder/tasks/girder.yml
+++ b/devops/ansible/roles/girder/tasks/girder.yml
@@ -66,3 +66,7 @@
 
 - set_fact:
     girder_files_updated: "{{ vc.changed }}"
+
+- name: Get Girder's major version
+  shell: sed -n "s/__version__ = '\([^.]*\).*'.*/\1/p" < "{{ girder_path }}/girder/__init__.py"
+  register: girder_major_version

--- a/devops/ansible/roles/girder/tasks/main.yml
+++ b/devops/ansible/roles/girder/tasks/main.yml
@@ -56,13 +56,18 @@
 - include: daemon.yml
   when: girder_daemonize
 
-- name: Install Girder Plugins
+- name: Install Girder 3 Plugins
   pip:
     name: "{{ item.path|default(item) }}"
     extra_args: "-e"
     chdir: "{{ girder_path }}"
     executable: "{{ girder_pip | default(omit) }}"
   with_items: "{{ girder_plugins }}"
+  when: girder_major_version == "3"
+
+- name: Install Girder 2 Plugins
+  command: "{{ girder_build_executable|default('girder-install') }} plugin {{ item.args|default('') }} {{ item.path|default(item) }}"
+  when: girder_major_version == "2"
 
 - name: Build Girder (web)
   command: "{{ girder_build_executable }} build {{ girder_web_extra_args }}"
@@ -70,4 +75,12 @@
     chdir: "{{ girder_path }}"
   # ensure that the install is one that uses web assets and
   # the assets are always supposed to be rebuilt, or the files have changed (from git)
-  when: girder_web and (girder_always_build_assets or girder_files_updated)
+  when: girder_major_version == "3" and girder_web and (girder_always_build_assets or girder_files_updated)
+
+- name: Build Girder (web)
+  command: "{{ girder_build_executable }} web {{ girder_web_extra_args }}"
+  args:
+    chdir: "{{ girder_path }}"
+  # ensure that the install is one that uses web assets and
+  # the assets are always supposed to be rebuilt, or the files have changed (from git)
+  when: girder_major_version == "2" and girder_web and (girder_always_build_assets or girder_files_updated)

--- a/devops/ansible/roles/girder/tasks/pip.yml
+++ b/devops/ansible/roles/girder/tasks/pip.yml
@@ -9,16 +9,32 @@
         - pip
         - setuptools
 
-    - name: Install Girder
+    - name: Install Girder 3
       pip:
         name: "."
         extra_args: "-e"
         chdir: "{{ girder_path }}"
         virtualenv: "{{ girder_virtualenv }}"
         virtualenv_python: "{{ girder_python | default(ansible_python.executable) }}"
+      when: girder_major_version == "3"
+
+    - name: Install Girder 2
+      pip:
+        name: ".[plugins]"
+        extra_args: "-e"
+        chdir: "{{ girder_path }}"
+        virtualenv: "{{ girder_virtualenv }}"
+        virtualenv_python: "{{ girder_python | default(ansible_python.executable) }}"
+      when: girder_major_version == "2"
 
     - set_fact:
         girder_build_executable: "{{ girder_virtualenv }}/bin/girder"
+      when: girder_major_version == "3"
+
+    - set_fact:
+        girder_install_executable: "{{ girder_virtualenv }}/bin/girder-install"
+      when: girder_major_version == "2"
+
   when: girder_virtualenv is defined
 
 - block:
@@ -40,18 +56,36 @@
         - six
         - requests
 
-    - name: Install Girder
+    - name: Install Girder 3
       pip:
         name: "."
         extra_args: "-e"
         executable: "{{ girder_pip | default(omit) }}"
+      when: girder_major_version == "3"
+
+    - name: Install Girder 2
+      pip:
+        name: "{{ girder_path }}[plugins]"
+        extra_args: "-e"
+        executable: "{{ girder_pip | default(omit) }}"
+      when: girder_major_version == "2"
 
     - name: Find girder executable
       shell: "which girder"
       register: executable
       environment:
         PATH: "{{ ansible_env.PATH }}:/usr/local/bin"
+      when: girder_major_version == "3"
+
+    - name: Find girder-install executable
+      shell: "which girder-install"
+      register: executable
+      environment:
+        PATH: "{{ ansible_env.PATH }}:/usr/local/bin"
+      when: girder_major_version == "2"
 
     - set_fact:
         girder_build_executable: "{{ executable.stdout_lines[0] }}"
+
+
   when: girder_virtualenv is not defined


### PR DESCRIPTION
The ansible role deployment failed after #2552 was merged.  This should fix that; however as we discovered yesterday, there are backwards incompatible changes in the ansible role as well.  I don't know if anything can/should be done to the deployment to handle that.