### PR TITLE
Add a loaded plugin list to GET /system/plugins

### DIFF
--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -168,7 +168,8 @@ class System(Resource):
 
         plugins = {
             'all': {name: _pluginNameToResponse(name) for name in plugin.allPlugins()},
-            'enabled': plugin.loadedPlugins()
+            'enabled': Setting().get(SettingKey.PLUGINS_ENABLED),
+            'loaded': plugin.loadedPlugins()
         }
         failureInfo = {
             plugin: ''.join(traceback.format_exception(*exc_info))

--- a/girder/web_client/test/spec/adminSpec.js
+++ b/girder/web_client/test/spec/adminSpec.js
@@ -645,9 +645,7 @@ describe('Test the plugins page', function () {
     it('Disable a plugin', function () {
         runs(function () {
             $('.g-plugin-list-item:contains(Jobs) .g-plugin-switch').click();
-        });
-        runs(function () {
-            expect($('.g-plugin-list-item input[type=checkbox]:checked').length).toBe(1);
+            expect($('.g-plugin-list-item input[type=checkbox]:checked').length).toBe(0);
         });
         waitsFor(function () {
             var resp = girder.rest.restRequest({

--- a/pytest_girder/pytest_girder/fixtures.py
+++ b/pytest_girder/pytest_girder/fixtures.py
@@ -103,11 +103,13 @@ def server(db, request):
         if hasPluginMarkers:
             for pluginMarker in request.node.iter_markers('plugin'):
                 pluginName = pluginMarker.args[0]
+                shouldEnable = pluginMarker.kwargs.pop('enabled', True)
                 if len(pluginMarker.args) > 1:
                     pluginRegistry.registerTestPlugin(
                         *pluginMarker.args, **pluginMarker.kwargs
                     )
-                enabledPlugins.append(pluginName)
+                if shouldEnable:
+                    enabledPlugins.append(pluginName)
 
         Setting().set(SettingKey.PLUGINS_ENABLED, enabledPlugins)
 

--- a/test/test_system_rest.py
+++ b/test/test_system_rest.py
@@ -1,0 +1,39 @@
+import pytest
+
+from girder.plugin import getPlugin, GirderPlugin
+from pytest_girder.assertions import assertStatusOk
+
+
+class Plugin1(GirderPlugin):
+    def load(self, info):
+        pass
+
+
+class Plugin2(GirderPlugin):
+    def load(self, info):
+        getPlugin('plugin1').load(info)
+
+
+class Plugin3(GirderPlugin):
+    def load(self, info):
+        pass
+
+
+@pytest.mark.plugin('plugin1', Plugin1, enabled=False)
+@pytest.mark.plugin('plugin2', Plugin2, enabled=False)
+@pytest.mark.plugin('plugin3', Plugin3)
+def testGetEnabledPlugins(server, admin):
+    resp = server.request('/system/plugins', user=admin)
+    assertStatusOk(resp)
+    assert set(resp.json['enabled']) == {'plugin3'}
+    assert set(resp.json['loaded']) == {'plugin3'}
+
+
+@pytest.mark.plugin('plugin1', Plugin1, enabled=False)
+@pytest.mark.plugin('plugin2', Plugin2)
+@pytest.mark.plugin('plugin3', Plugin3, enabled=False)
+def testGetEnabledPluginsWithDependency(server, admin):
+    resp = server.request('/system/plugins', user=admin)
+    assertStatusOk(resp)
+    assert set(resp.json['enabled']) == {'plugin2'}
+    assert set(resp.json['loaded']) == {'plugin1', 'plugin2'}


### PR DESCRIPTION
Prior to this change, the enabled plugin list returned by this endpoint
was actually the list of currently loaded plugins.  Now, we return the
enabled list directly from the database setting and add a new key
containing the loaded list.  As a benefit, this would allow clients to
distinguish between plugins that were explicitly enabled vs. those that
were implicitly enabled by a dependency relationship.