### PR TITLE
Make event bindings with the same handler idempotent

### DIFF
--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -158,6 +158,45 @@ place (in the Girder python package) in both development and production installs
 The built assets are installed into a virtual environment specific static path
 ``{sys.prefix}/share/girder``.
 
+Server changes
+++++++++++++++
+
+Event bindings are now unique by handler name
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In Girder 2, it was possible to bind multiple handler callbacks to the same event with
+the same handler name. This has changed in Girder 3; for any given event identifier, each callback
+must be bound to it with a unique handler name. Example:
+
+.. code-block:: python
+
+    def cb(event):
+       print('hello')
+
+    for _ in range(5):
+      events.bind('an_event', 'my_handler', cb)
+
+    # Prints 'hello' five times in Girder 2, but only once in Girder 3
+    events.trigger('an_event')
+
+In the new behavior, a call to ``bind`` with the same event name and handler name as an existing
+handler will be ignored, and will emit a warning to the log. If you wish to overwrite the existing
+handler, you must call :py:func:`girder.events.unbind` on the existing mapping first.
+
+.. code-block:: python
+
+    def a(event):
+      print('a')
+
+    def b(event):
+      print('b')
+
+    events.bind('an_event', 'my_handler', a)
+    events.bind('an_event', 'my_handler', b)
+
+    # Prints 'a' and 'b' in Girder 2, but only 'a' in Girder 3
+    events.trigger('an_event')
+
 1.x |ra| 2.x
 ------------
 

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -785,10 +785,10 @@ class AccessControlledModel(Model):
         # Do the bindings before calling __init__(), in case a derived class
         # wants to change things in initialize()
         events.bind('model.user.remove',
-                    CoreEventHandler.ACCESS_CONTROL_CLEANUP,
+                    '.'.join((CoreEventHandler.ACCESS_CONTROL_CLEANUP, self.__class__.__name__)),
                     self._cleanupDeletedEntity)
         events.bind('model.group.remove',
-                    CoreEventHandler.ACCESS_CONTROL_CLEANUP,
+                    '.'.join((CoreEventHandler.ACCESS_CONTROL_CLEANUP, self.__class__.__name__)),
                     self._cleanupDeletedEntity)
         super(AccessControlledModel, self).__init__()
 

--- a/plugins/metadata_history/plugin_tests/provenance_test.py
+++ b/plugins/metadata_history/plugin_tests/provenance_test.py
@@ -382,17 +382,17 @@ class ProvenanceTestCase(base.TestCase):
             'unknown': True}
         for key in checkList:
             eventName = 'model.%s.save' % key
-            self.assertTrue((eventName in events._mapping and 'provenance' in
-                            [h['name'] for h in events._mapping[eventName]])
-                            is checkList[key])
+            self.assertTrue((
+                eventName in events._mapping and 'provenance' in events._mapping[eventName])
+                is checkList[key])
         # Setting a blank should be okay.  It should also remove all but item
         # event mappings
         Setting().set(constants.PluginSettings.PROVENANCE_RESOURCES, '')
         for key in checkList:
             eventName = 'model.%s.save' % key
-            self.assertTrue((eventName in events._mapping and 'provenance' in
-                            [h['name'] for h in events._mapping[eventName]])
-                            is (key == 'item'))
+            self.assertTrue((
+                eventName in events._mapping and 'provenance' in events._mapping[eventName])
+                is (key == 'item'))
 
     def testProvenanceFileWithoutItem(self):
         fileData = b'this is a test'


### PR DESCRIPTION
This makes it so that handler strings corresponding to event bindings are unique. Binding to the same event twice with the same handler previously would make the handler be invoked twice. After this change, it will instead overwrite the previous handler function, only making a single call, and emit a warning to the log. This will also cause the new binding to move to the end of the handler list for the given event.

@danlamanna PTAL