### PR TITLE
RFC: Always remove node_modules after building the client

### DIFF
--- a/girder/cli/build.py
+++ b/girder/cli/build.py
@@ -74,7 +74,8 @@ def main(dev, watch, watch_plugin):
     try:
         check_call(buildCommand, cwd=staging)
     finally:
-        shutil.rmtree(os.path.join(staging, 'node_modules'), ignore_errors=True)
+        if not dev:
+            shutil.rmtree(os.path.join(staging, 'node_modules'), ignore_errors=True)
 
 
 def _collectPluginDependencies():


### PR DESCRIPTION
There is a problem with how we do the web client build that manifests itself when trying to uninstall Girder.  Try running the following:
```
pip install --pre girder
girder build
pip uninstall girder
```
The last command will take several minutes.  This is caused because the `node_modules` directory created by `girder build` is not tracked by pip, and it lists every non-tracked file as a warning.

I wanted to see what others thought about this.  The solution in this PR just removes `node_modules` on every build... This mean that every `girder build` command needs to regenerate it from scratch.  I just ran a test and `npm install` from scratch is about 1 minute vs. 6 seconds the second time.  This extra time includes the `--watch` commands which used to be nearly instant.

Possible other solutions:
1.  Only delete `node_modules` after a production build.
2.  Leave it as is and tell people to use `pip uninstall -y girder`, which is fast but still leaves the untracked files around.
3.  Move `node_modules` elsewhere and set the `--prefix` flag (and maybe `NODE_PATH` environment vars).  This option is somewhat likely to cause problems with edge cases in module path resolution.
4.  Use a staging area outside of the Girder python package.  This is what I wanted to do originally, but it caused too many problems.  See my commit message in 517f7e668c0398ece3bebc7c13adfbe43ddef50f for some details about this.