### PR TITLE
Update to fusepy 3.x.

### DIFF
--- a/girder/cli/mount.py
+++ b/girder/cli/mount.py
@@ -49,6 +49,8 @@ class ServerFuse(fuse.Operations):
     extended to expose metadata and other resources by extending the available
     paths.  Files can also be reached via a path shortcut of /file/<id>.
     """
+    use_ns = True
+
     def __init__(self, stat=None):
         """
         Instantiate the operations class.  This sets up tracking for open
@@ -141,9 +143,9 @@ class ServerFuse(fuse.Operations):
         attr['st_ino'] = -1
         attr['st_nlink'] = 1
         if 'updated' in doc:
-            attr['st_mtime'] = time.mktime(doc['updated'].timetuple())
+            attr['st_mtime'] = int(time.mktime(doc['updated'].timetuple()) * 1e9)
         elif 'created' in doc:
-            attr['st_mtime'] = time.mktime(doc['created'].timetuple())
+            attr['st_mtime'] = int(time.mktime(doc['created'].timetuple()) * 1e9)
         attr['st_ctime'] = attr['st_mtime']
 
         if model == 'file':
@@ -195,9 +197,10 @@ class ServerFuse(fuse.Operations):
                 entries.append(self._name(file, 'file'))
         return entries
 
-    # We don't handle extended attributes.
+    # We don't handle extended attributes or ioctl.
     getxattr = None
     listxattr = None
+    ioctl = None
 
     def access(self, path, mode):
         """

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ extrasReqs['sftp'] = [
     'paramiko',
 ]
 extrasReqs['mount'] = [
-    'fusepy>=2.0.4,<3.0',
+    'fusepy>=3.0',
 ]
 
 init = os.path.join(os.path.dirname(__file__), 'girder', '__init__.py')


### PR DESCRIPTION
fusepy 3 added support for ioctls, but this doesn't work in Python 3 without extra work.  Since we don't need to handle them, explicitly don't handle them.

Also, fusepy 3 has changed an internal time format for consistency with the base fuse library.  Before it coerced float epochs itself; that is now deprecated and it prefers nanosecond epochs instead.

Reference #2802.