### PR TITLE
Alias async to async_ to allow 3.7 compatibility

### DIFF
--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -197,9 +197,9 @@ handler, you must call :py:func:`girder.events.unbind` on the existing mapping f
     # Prints 'a' and 'b' in Girder 2, but only 'a' in Girder 3
     events.trigger('an_event')
 	
-Async keyword arguments and properties changed to async_ PR #2817
+Async keyword arguments and properties changed to async\_ PR #2817
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In version 3.7 of python ``async`` is a `reserved keyword argument <https://www.python.org/dev/peps/pep-0492/#deprecation-plans/>`_. To mitigate any issues all instances of ``async`` in the codebase has changed to ``async_``. If the functions are called with ``async`` a deprecation warning will be given. This affects:
+In version 3.7 of python ``async`` is a `reserved keyword argument <https://www.python.org/dev/peps/pep-0492/#deprecation-plans/>`_. To mitigate any issues all instances of ``async`` in the codebase has changed to ``async\_``. If the functions are called with ``async`` a deprecation warning will be given. This affects:
  * The event framework ``girder/events.py``
  * The built-in job plugin ``plugins/jobs/girder_jobs/models/job.py``
 

--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -198,8 +198,10 @@ handler, you must call :py:func:`girder.events.unbind` on the existing mapping f
     events.trigger('an_event')
 	
 Async keyword arguments and properties changed to async\_ PR #2817
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In version 3.7 of python ``async`` is a `reserved keyword argument <https://www.python.org/dev/peps/pep-0492/#deprecation-plans/>`_. To mitigate any issues all instances of ``async`` in the codebase has changed to ``async\_``. If the functions are called with ``async`` a deprecation warning will be given. This affects:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In version 3.7 of python ``async`` is a `reserved keyword argument <https://www.python.org/dev/peps/pep-0492/#deprecation-plans/>`_. To mitigate any issues all instances of ``async`` in the codebase has changed to ``async_``. If the functions are called with ``async`` a deprecation warning will be given. This affects:
+
  * The event framework ``girder/events.py``
  * The built-in job plugin ``plugins/jobs/girder_jobs/models/job.py``
 

--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -196,6 +196,12 @@ handler, you must call :py:func:`girder.events.unbind` on the existing mapping f
 
     # Prints 'a' and 'b' in Girder 2, but only 'a' in Girder 3
     events.trigger('an_event')
+	
+Async keyword arguments and properties changed to async_ #2817
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+In version 3.7 of python ``async`` is a `reserved keyword argument <https://www.python.org/dev/peps/pep-0492/#deprecation-plans/>`_. To mitigate any issues all instances of ``async`` in the codebase has changed to ``async_``. If the functions are called with ``async`` a deprecation warning will be given. This affects:
+ * The event framework ``girder/events.py``
+ * The built-in job plugin ``plugins/jobs/girder_jobs/models/job.py``
 
 1.x |ra| 2.x
 ------------

--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -197,8 +197,8 @@ handler, you must call :py:func:`girder.events.unbind` on the existing mapping f
     # Prints 'a' and 'b' in Girder 2, but only 'a' in Girder 3
     events.trigger('an_event')
 	
-Async keyword arguments and properties changed to async_ #2817
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Async keyword arguments and properties changed to async_ PR #2817
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In version 3.7 of python ``async`` is a `reserved keyword argument <https://www.python.org/dev/peps/pep-0492/#deprecation-plans/>`_. To mitigate any issues all instances of ``async`` in the codebase has changed to ``async_``. If the functions are called with ``async`` a deprecation warning will be given. This affects:
  * The event framework ``girder/events.py``
  * The built-in job plugin ``plugins/jobs/girder_jobs/models/job.py``

--- a/girder/events.py
+++ b/girder/events.py
@@ -315,7 +315,7 @@ def trigger(eventName, info=None, pre=None, async_=False, daemon=False):
     :param daemon: Whether this was triggered via ``girder.events.daemon``.
     :type daemon: bool
     """
-    e = Event(eventName, info, async=async)
+    e = Event(eventName, info, async_=async_)
     for name, handler in six.viewitems(_mapping.get(eventName, {})):
         if daemon and not async_:
             girder.logprint.warning(

--- a/girder/events.py
+++ b/girder/events.py
@@ -46,6 +46,7 @@ import girder
 import six
 import threading
 from functools import wraps
+import warnings
 
 from collections import OrderedDict
 from girder.utility import config

--- a/girder/events.py
+++ b/girder/events.py
@@ -52,6 +52,7 @@ from collections import OrderedDict
 from girder.utility import config
 from six.moves import queue
 
+
 def deprecated_async(func):
     """A decorator, that let's us keep our old API, but deprecate it"""
     @wraps(func)
@@ -290,6 +291,7 @@ def bound(eventName, handlerName, handler):
         yield
     finally:
         unbind(eventName, handlerName)
+
 
 @deprecated_async
 def trigger(eventName, info=None, pre=None, async_=False, daemon=False):

--- a/girder/events.py
+++ b/girder/events.py
@@ -62,7 +62,7 @@ def deprecated_async(func):
                                  'keyword arguments! the latter obsoletes the first.')
             warnings.warn('async keyword argumnt is deprecated, '
                           'use asynq instead', DeprecationWarning)
-            kwargs['asynchronous'] = kwargs.pop('async')
+            kwargs['asynq'] = kwargs.pop('async')
         return func(*args, **kwargs)
     return inner
 

--- a/plugins/jobs/girder_jobs/models/job.py
+++ b/plugins/jobs/girder_jobs/models/job.py
@@ -342,7 +342,7 @@ class Job(AccessControlledModel):
         actually scheduling and/or executing the job, except in the case when
         the handler is 'local'.
         """
-        if job.get('async_') is True:
+        if job.get('async_', job.get('async')) is True:
             events.daemon.trigger('jobs.schedule', info=job)
         else:
             events.trigger('jobs.schedule', info=job)

--- a/plugins/jobs/girder_jobs/models/job.py
+++ b/plugins/jobs/girder_jobs/models/job.py
@@ -31,7 +31,6 @@ from girder.models.user import User
 
 from ..constants import JobStatus, JOB_HANDLER_LOCAL
 
-
 class Job(AccessControlledModel):
 
     def initialize(self):
@@ -47,7 +46,7 @@ class Job(AccessControlledModel):
 
         self.exposeFields(level=AccessType.READ, fields={
             'title', 'type', 'created', 'interval', 'when', 'status',
-            'progress', 'log', 'meta', '_id', 'public', 'parentId', 'async',
+            'progress', 'log', 'meta', '_id', 'public', 'parentId', 'asynq',
             'updated', 'timestamps', 'handler', 'jobInfoSpec'})
 
         self.exposeFields(level=AccessType.SITE_ADMIN, fields={'args', 'kwargs'})
@@ -200,6 +199,7 @@ class Job(AccessControlledModel):
 
         return self.save(job)
 
+	@events.deprecated_async
     def createJob(self, title, type, args=(), kwargs=None, user=None, when=None,
                   interval=0, public=False, handler=None, async=False,
                   save=True, parentJob=None, otherFields=None):
@@ -341,7 +341,7 @@ class Job(AccessControlledModel):
         actually scheduling and/or executing the job, except in the case when
         the handler is 'local'.
         """
-        if job.get('async') is True:
+        if job.get('asynq') is True:
             events.daemon.trigger('jobs.schedule', info=job)
         else:
             events.trigger('jobs.schedule', info=job)

--- a/plugins/jobs/girder_jobs/models/job.py
+++ b/plugins/jobs/girder_jobs/models/job.py
@@ -46,7 +46,7 @@ class Job(AccessControlledModel):
 
         self.exposeFields(level=AccessType.READ, fields={
             'title', 'type', 'created', 'interval', 'when', 'status',
-            'progress', 'log', 'meta', '_id', 'public', 'parentId', 'asynq',
+            'progress', 'log', 'meta', '_id', 'public', 'parentId', 'async_',
             'updated', 'timestamps', 'handler', 'jobInfoSpec'})
 
         self.exposeFields(level=AccessType.SITE_ADMIN, fields={'args', 'kwargs'})
@@ -199,9 +199,9 @@ class Job(AccessControlledModel):
 
         return self.save(job)
 
-	@events.deprecated_async
+    @events.deprecated_async
     def createJob(self, title, type, args=(), kwargs=None, user=None, when=None,
-                  interval=0, public=False, handler=None, async=False,
+                  interval=0, public=False, handler=None, async_=False,
                   save=True, parentJob=None, otherFields=None):
         """
         Create a new job record.
@@ -229,9 +229,9 @@ class Job(AccessControlledModel):
         :param externalToken: If an external token was created for updating this
         job, pass it in and it will have the job-specific scope set.
         :type externalToken: token (dict) or None.
-        :param async: Whether the job is to be run asynchronously. For now this
+        :param async_: Whether the job is to be run asynchronously. For now this
             only applies to jobs that are scheduled to run locally.
-        :type async: bool
+        :type async_: bool
         :param save: Whether the documented should be saved to the database.
         :type save: bool
         :param parentJob: The job which will be set as a parent
@@ -265,7 +265,7 @@ class Job(AccessControlledModel):
             'log': [],
             'meta': {},
             'handler': handler,
-            'async': async,
+            'async_': async_,
             'timestamps': [],
             'parentId': parentId
         }
@@ -341,7 +341,7 @@ class Job(AccessControlledModel):
         actually scheduling and/or executing the job, except in the case when
         the handler is 'local'.
         """
-        if job.get('asynq') is True:
+        if job.get('async_') is True:
             events.daemon.trigger('jobs.schedule', info=job)
         else:
             events.trigger('jobs.schedule', info=job)

--- a/plugins/jobs/girder_jobs/models/job.py
+++ b/plugins/jobs/girder_jobs/models/job.py
@@ -31,6 +31,7 @@ from girder.models.user import User
 
 from ..constants import JobStatus, JOB_HANDLER_LOCAL
 
+
 class Job(AccessControlledModel):
 
     def initialize(self):


### PR DESCRIPTION
In 3.7 async and await are protected keywords.
Renamed async to asynq and added an alias so changes shouldn't be breaking for users using <3.7