### PR TITLE
Removed NODE_PATH addition to scripts from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,8 +73,8 @@
         "whatwg-fetch": "^2.0.4"
     },
     "scripts": {
-        "build": "NODE_PATH=$PWD/node_modules grunt",
-        "watch": "NODE_PATH=$PWD/node_modules grunt --watch",
+        "build": "grunt",
+        "watch": "grunt --watch",
         "lint": "eslint --cache clients/web Gruntfile.js grunt_tasks scripts clients/web/test && pug-lint clients/web/src/templates",
         "docs": "esdoc"
     },


### PR DESCRIPTION
NPM run already sets the local node_modules path when its run. Wasn't sure why this was in there as it's one of the few lines blocking windows compatibility.