### PR TITLE
Fix python package install on readthedocs

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,6 @@
+build:
+  image: latest
+
+python:
+  version: 3.6
+  pip_install: true


### PR DESCRIPTION
By default, readthedocs runs `setup.py install` which is subtly
different than `pip install .`.  A recent change in click (I think)
broke the package install step on rtd's build machine.  This uses the
new `readthedocs.yml` config file to force installation with pip.  It seems to
be the only way to configure this option.

https://docs.readthedocs.io/en/latest/yaml-config.html

I also changed it to use python 3.6... because progress.