### PR TITLE
Skip asking for the git revision information in production mode.

### DIFF
--- a/girder/web_client/grunt_tasks/build.js
+++ b/girder/web_client/grunt_tasks/build.js
@@ -23,7 +23,6 @@ const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const GoogleFontsPlugin = require('google-fonts-webpack-plugin');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
-const GitRevisionPlugin = require('git-revision-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const webpackPlugins = require('./webpack.plugins.js');
@@ -135,7 +134,6 @@ module.exports = function (grunt) {
         });
     }
 
-    const gitRevision = new GitRevisionPlugin();
     let versionInfo = {
         git: false,
         SHA: null,
@@ -143,20 +141,21 @@ module.exports = function (grunt) {
         date: new Date().toISOString(),
         apiVersion: pkg.version
     };
-    try {
-        // inject git revision information if possible
-        const gitHash = gitRevision.commithash();
-        Object.assign(versionInfo, {
-            git: true,
-            SHA: gitHash,
-            shortSHA: gitHash.slice(0, 8)
-        });
-    } catch (err) {
-        // The above writes a fatal error line when not inside a git repo
-        // Let the user know this is not a problem for production/non-dev installs.
-        grunt.log.oklns(
-            'You are not running in a git repository.  This is normal for non-development builds of girder.'
-        );
+    if (isDev) {
+        const GitRevisionPlugin = require('git-revision-webpack-plugin');
+        const gitRevision = new GitRevisionPlugin();
+        try {
+            // inject git revision information if possible
+            const gitHash = gitRevision.commithash();
+            Object.assign(versionInfo, {
+                git: true,
+                SHA: gitHash,
+                shortSHA: gitHash.slice(0, 8)
+            });
+        } catch (err) {
+            // The above writes a fatal error line when not inside a git repo
+            grunt.log.oklns('You are not running in a git repository.');
+        }
     }
 
     // TODO: Eventually we should refactor the setup.py to use setuptools scm and avoid

--- a/girder/web_client/package.json.template
+++ b/girder/web_client/package.json.template
@@ -33,7 +33,6 @@
         "extendify": "^1.0.0",
         "extract-text-webpack-plugin": "^2.1.2",
         "file-loader": "^0.11.2",
-        "git-revision-webpack-plugin": "^2.5.1",
         "google-fonts-webpack-plugin": "^0.4.0",
         "grunt": "^1.0.1",
         "grunt-cli": "^1.2.0",
@@ -69,6 +68,7 @@
         "whatwg-fetch": "^2.0.4"
     },
     "devDependencies": {
+        "git-revision-webpack-plugin": "^2.5.1",
         "nyc": "^11.3.0",
         "phantomjs-prebuilt": "^2.1.14"
     },


### PR DESCRIPTION
This is cleaner than always failing and then reassuring the user that failure was expected.

