### PR TITLE
Add simple CI testing for OSX and Windows.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,33 @@
+environment:
+  matrix:
+    - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36-x64"
+    # - PYTHON: "C:\\Python37-x64"
+
+services:
+  - mongodb
+
+init:
+  - SET PROJDIR=%cd%
+  - SET ORIGPATH=%PATH%
+  # Print the build system version
+  - ver
+
+build_script:
+  # Use the specific python version for building
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%ORIGPATH%"
+  # We should output the results of 'where npm' for use in the build command
+  - where npm
+  - npm install -g npm
+  - pip install -U --upgrade-strategy eager .
+  - girder build --npm="C:\Program Files (x86)\nodejs\npm.cmd"
+
+test_script:
+  - ps: $GirderProcess = Start-Process -PassThru girder serve
+  # poll the version endpoint until it gets back a sensible response
+  - python .appveyor/waitforgirder.py
+  # This should be changed to more thorough testing
+  - curl --silent --show-error --fail "127.0.0.1:8080"
+  - curl --silent --show-error --fail -X POST "127.0.0.1:8080/api/v1/user?login=admin&email=admin@admin.admin&firstName=admin&lastName=admin&password=adminadmin&admin=true" --data ''
+  - ps: Stop-Process -Id $GirderProcess.Id

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,7 +3,7 @@ environment:
     - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
-    # - PYTHON: "C:\\Python37-x64"
+    - PYTHON: "C:\\Python37-x64"
 
 services:
   - mongodb

--- a/.appveyor/waitforgirder.py
+++ b/.appveyor/waitforgirder.py
@@ -1,0 +1,24 @@
+import json
+import os
+import pprint
+import sys
+import time
+
+cmd = 'curl --silent 127.0.0.1:8080/api/v1/system/version'
+maxWait = 60
+startTime = time.time()
+while time.time() - startTime < maxWait:
+    try:
+        output = json.loads(os.popen(cmd).read())
+        if 'apiVersion' in output:
+            break
+    except Exception:
+        pass
+    time.sleep(1)
+    sys.stderr.write('.')
+    sys.stderr.flush()
+else:
+    sys.stderr.write('Girder failed to start\n')
+    sys.exit(1)
+sys.stderr.write('\n')
+pprint.pprint(output)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+os: osx
+language: generic
+
+env:
+  matrix:
+    - PYTHON=2.7.15
+    - PYTHON=3.5.4
+    - PYTHON=3.6.5
+
+before_install: |
+  if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    # brew update
+    brew install openssl readline
+
+    brew install mongodb
+    sudo mkdir -p /data/db
+    brew services start mongodb
+
+    brew install node
+
+    brew outdated pyenv || brew upgrade pyenv
+    brew install pyenv-virtualenv
+    pyenv install $PYTHON
+    export PYENV_VERSION=$PYTHON
+    export PATH="/Users/travis/.pyenv/shims:${PATH}"
+    pyenv-virtualenv venv
+    source venv/bin/activate
+    # A manual check that the correct version of Python is running.
+    python --version
+    python -m pip install -U pip
+  fi
+
+install:
+  - npm install -g npm
+  - pip install -U --upgrade-strategy eager .
+
+script:
+  - girder serve &
+  # poll the version endpoint until it gets back a sensible response
+  - python .appveyor/waitforgirder.py
+  # This should be changed to more thorough testing
+  - curl --silent --show-error --fail "127.0.0.1:8080"
+  - curl --silent --show-error --fail -X POST "127.0.0.1:8080/api/v1/user?login=admin&email=admin@admin.admin&firstName=admin&lastName=admin&password=adminadmin&admin=true" --data ''

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
     - PYTHON=2.7.15
     - PYTHON=3.5.4
     - PYTHON=3.6.5
+    - PYTHON=3.7.0
 
 before_install: |
   if [ "$TRAVIS_OS_NAME" == "osx" ]; then

--- a/docs/installation-quickstart.rst
+++ b/docs/installation-quickstart.rst
@@ -71,6 +71,14 @@ Basic System Prerequisites
                 ``/usr/local/bin/python`` when invoking the server so that you use the version with the correct site
                 packages installed.
 
+   .. group-tab:: Windows
+
+      .. note:: Windows is not officially supported.
+
+      Install an appropriate version of `Python <https://www.python.org/downloads>`_.  It might be necessary to add Python and the Python\Scripts directory to the system path.
+
+      Some plugins will require additional packages to be installed.
+
 .. _virtualenv-install:
 
 Python Virtual Environment (optional)
@@ -170,6 +178,12 @@ MongoDB
 
         mongod -f /usr/local/etc/mongod.conf
 
+   .. group-tab:: Windows
+
+      .. note:: Windows is not officially supported.
+
+      Install `MongoDB <https://docs.mongodb.com/manual/tutorial/install-mongodb-on-windows>`_.
+
 .. _nodejs-install:
 
 Node.js
@@ -212,6 +226,12 @@ can also be used instead.
       .. code-block:: bash
 
          brew install node
+
+   .. group-tab:: Windows
+
+      .. note:: Windows is not officially supported.
+
+      Install an appropriate version of `NodeJS <https://nodejs.org/en/download>`_.  When building Girder, you may need to specify the npm path explicitly (.e.g, ``girder build --npm=<path to npm.com>``.
 
 Girder
 ------


### PR DESCRIPTION
This adds some minimal tests of Python 2.7, 3.5, 3.6 for OSX and Windows.

Tests of OSX are done using Travis-CI.

Tests of Windows are done using Appveyor.  A note has been added to the Quick-Start documentation cautioning that Windows is not officially supported.
