### PR TITLE
Throw exception for interrupted file downloads

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -98,7 +98,7 @@ class HttpError(requests.HTTPError):
         return super(HttpError, self).__str__() + '\nResponse text: ' + self.responseText
 
 
-class IncompleteResponseError(requests.HTTPError):
+class IncompleteResponseError(requests.RequestException):
     def __init__(self, message, expected, received, response=None):
         super(IncompleteResponseError, self).__init__('%s (%d of %d bytes received)' % (
             message, received, expected

--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -67,6 +67,7 @@ clients
                 uploadFileToItem
                 uploadStreamToFolder
             HttpError
+            IncompleteResponseError
             IncorrectUploadLengthError
             REQ_BUFFER_SIZE
             cli


### PR DESCRIPTION
Prior to this change, if a connection was closed partway through a download, the python client code did not raise any exception, leaving downstream users to deal with the fallout of unknowingly having a partial file. See [this article](https://blog.petrzemek.net/2018/04/22/on-incomplete-http-reads-and-the-requests-library-in-python/) for more information about the counter-intuitive behavior of the requests library in this scenario.

Because this condition typically indicates ephemeral network or service failures, I think it's good to have it raise a distinct exception type that carries those semantics, allowing downstreams to catch this type and handle it differently than other types of HTTP errors, namely by adding retry logic, whereas we don't necessarily want to retry if we receive an HTTP error status but an otherwise intact response.