### PR TITLE
Fix public_names CI job so it uses the correct docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -457,7 +457,7 @@ jobs:
 
   public_symbols:
     docker:
-      - image: kotfic/girder_test:latest-py3
+      - image: girder/girder_test:latest-py3
     working_directory: /home/circleci/project # as $CIRCLE_WORKING_DIRECTORY
     steps:
       - checkout:


### PR DESCRIPTION
Depends on https://github.com/girder/girder/pull/2827
