### PR TITLE
Change behavior of ModelImporter

### DIFF
--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -162,6 +162,36 @@ The built assets are installed into a virtual environment specific static path
 Server changes
 ++++++++++++++
 
+ModelImporter behavior changes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :py:class:`girder.utility.model_importer.ModelImporter` class allows model types to be mapped
+from strings, which is useful when model types must be provided by users via the REST API. In Girder
+2, there was logic to infer automatically where a model class resides without having to explicitly
+register it, but that logic was removed. If your plugin needs to expose a ``Model`` subclass for
+string-based lookup, it must be explicitly registered, e.g.
+
+.. code-block:: python
+
+  class MyModel(Model):
+     ...
+
+  ModelImporter.registerModel('my_plugin_model', MyModel, plugin='my_plugin')
+
+The ``load`` method of your plugin is a good place to register your plugin's models.
+
+In addition to explicitly requiring registration, the API of
+:py:meth:`~girder.utility.model_importer.ModelImporter.registerModel` has also changed. Before, one
+would pass the model *instance*, but now, one passes the model *class*.
+
+.. code-block:: python
+
+   # Girder 2:
+   ModelImporter.registerModel('my_thing', MyThing())
+
+   # Girder 3:
+   ModelImporter.registerModel('my_thing', MyThing)
+
 Event bindings are now unique by handler name
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -197,7 +227,7 @@ handler, you must call :py:func:`girder.events.unbind` on the existing mapping f
 
     # Prints 'a' and 'b' in Girder 2, but only 'a' in Girder 3
     events.trigger('an_event')
-	
+
 Async keyword arguments and properties changed to async\_ PR #2817
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -346,10 +346,9 @@ Adding a new model type in your plugin
 
 Most of the time, if you add a new resource type in your plugin, you'll have a
 ``Model`` class backing it. These model classes work just like the core model
-classes as described in the :ref:`models` section.  Because custom models in plugins
-cannot be automatically resolved, they should be registered with the :py:class:`girder.utility.model_importer.ModelImporter`
-class inside your load method.
-
+classes as described in the :ref:`models` section. If you need to use the
+:py:class:`~girder.utility.model_importer.ModelImporter` class with your model type,
+you will need to explicitly register the model type to a string, e.g.
 
 .. code-block:: python
 
@@ -359,7 +358,7 @@ class inside your load method.
 
     class CatsPlugin(GirderPlugin):
         def load(self, info):
-            ModelImporter.registerModel('cat', Cat(), 'cats')
+            ModelImporter.registerModel('cat', Cat, plugin='cats')
 
 
 Adding custom access flags

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -113,7 +113,7 @@ class Resource(BaseResource):
         """
         try:
             model = self.model(kind)
-        except ImportError:
+        except Exception:
             model = None
         if not model or (funcName and not hasattr(model, funcName)):
             raise RestException('Invalid resources format.')

--- a/girder/utility/model_importer.py
+++ b/girder/utility/model_importer.py
@@ -18,6 +18,33 @@
 ###############################################################################
 
 _modelClasses = {}
+_coreModelsRegistered = False
+
+
+def _registerCoreModels():
+    global _coreModelsRegistered
+    if _coreModelsRegistered:
+        return
+
+    from girder.models import (
+        api_key, assetstore, collection, file, folder, group, item, notification, password,
+        setting, token, upload, user)
+
+    ModelImporter.registerModel('api_key', api_key.ApiKey)
+    ModelImporter.registerModel('assetstore', assetstore.Assetstore)
+    ModelImporter.registerModel('collection', collection.Collection)
+    ModelImporter.registerModel('file', file.File)
+    ModelImporter.registerModel('folder', folder.Folder)
+    ModelImporter.registerModel('group', group.Group)
+    ModelImporter.registerModel('item', item.Item)
+    ModelImporter.registerModel('notification', notification.Notification)
+    ModelImporter.registerModel('password', password.Password)
+    ModelImporter.registerModel('setting', setting.Setting)
+    ModelImporter.registerModel('token', token.Token)
+    ModelImporter.registerModel('upload', upload.Upload)
+    ModelImporter.registerModel('user', user.User)
+
+    _coreModelsRegistered = True
 
 
 class ModelImporter(object):
@@ -38,6 +65,9 @@ class ModelImporter(object):
         :type plugin: str
         :returns: The instantiated model, which is a singleton.
         """
+        if not _coreModelsRegistered and plugin == '_core':
+            _registerCoreModels()
+
         if not _modelClasses.get(plugin, {}).get(model):
             raise Exception('Model "%s.%s" is not registered.' % (plugin, model))
 

--- a/girder/utility/model_importer.py
+++ b/girder/utility/model_importer.py
@@ -59,7 +59,7 @@ class ModelImporter(object):
         lazy-instantiated.
 
         :param model: The name of the model to get. This must have been
-            registered using the :py:ref
+            registered using the :py:meth:`registerModel` method.
         :type model: string
         :param plugin: Plugin identifier (if this is a plugin model).
         :type plugin: str

--- a/plugins/jobs/girder_jobs/__init__.py
+++ b/plugins/jobs/girder_jobs/__init__.py
@@ -52,6 +52,6 @@ class JobsPlugin(GirderPlugin):
     CLIENT_SOURCE_PATH = 'web_client'
 
     def load(self, info):
-        ModelImporter.registerModel('job', Job(), 'jobs')
+        ModelImporter.registerModel('job', Job, 'jobs')
         info['apiRoot'].job = job_rest.Job()
         events.bind('jobs.schedule', 'jobs', scheduleLocal)

--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -913,7 +913,6 @@ girder
                 model
                 registerModel
                 unregisterModel
-            reinitializeAll
         optionalArgumentDecorator
         parseTimestamp
         path

--- a/test/test_assetstore_model_override.py
+++ b/test/test_assetstore_model_override.py
@@ -22,7 +22,7 @@ class FakeAdapter(AbstractAssetstoreAdapter):
 
 @pytest.fixture
 def fakeModel(db):
-    ModelImporter.registerModel('fake', Fake(), plugin='fake_plugin')
+    ModelImporter.registerModel('fake', Fake, plugin='fake_plugin')
 
     yield Fake
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -242,7 +242,7 @@ class FakeModel(Model):
 
 @pytest.fixture
 def FakeAcMixModel(FakeAcModel):
-    model_importer._modelInstances.setdefault('_core', {})['fake_ac'] = FakeAcModel()
+    model_importer._modelClasses.setdefault('_core', {})['fake_ac'] = FakeAcModel
 
     class FakeAcMixModelClass(acl_mixin.AccessControlMixin, Model):
         def initialize(self):


### PR DESCRIPTION
Fixes #2377. This removes the ability of the ModelImporter to
infer the class of a model based on the string(s), instead requiring
each model to be explicitly registered to a string if it is needed
for model loading.

This also changes the API for registering models to the ModelImporter;
rather than registering the model instance, one now only registers the
model type. This is cleaner in that it can defer model instantiation,
and also makes the ModelImporter decoupled from the fact that models
are singletons.

This is a breaking change.

