### PR TITLE
Add a guard around getting a local file path.

### DIFF
--- a/plugins/worker/server/utils.py
+++ b/plugins/worker/server/utils.py
@@ -21,6 +21,7 @@ import celery
 
 from .constants import PluginSettings
 from girder.api.rest import getApiUrl
+from girder.exceptions import FilePathException
 from girder.models.file import File
 from girder.models.setting import Setting
 from girder.utility import setting_utilities
@@ -111,7 +112,10 @@ def girderInputSpec(resource, resourceType='file', name=None, token=None,
         # If we are adding a file and it exists on the local filesystem include
         # that location.  This can permit the user of the specification to
         # access the file directly instead of downloading the file.
-        direct_path = File().getLocalFilePath(resource)
+        try:
+            direct_path = File().getLocalFilePath(resource)
+        except FilePathException:
+            direct_path = None
         if direct_path is not None:
             result['direct_path'] = direct_path
     return result


### PR DESCRIPTION
This is necessary for old-style girder_worker jobs using non-filesystem assetstores.

This only applies to the 2.x-maintenance branch, as the companion Girder-3 change is in the girder_worker repo.  See https://github.com/girder/girder_worker/pull/322.
