### PR TITLE
UID for each request

### DIFF
--- a/girder/__init__.py
+++ b/girder/__init__.py
@@ -66,10 +66,10 @@ class LogFormatter(logging.Formatter):
     """
     def formatException(self, exc):
         info = '\n'.join((
-            '  Request URL: %s %s' % (cherrypy.request.method.upper(),
-                                      cherrypy.url()),
+            '  Request URL: %s %s' % (cherrypy.request.method.upper(), cherrypy.url()),
             '  Query string: ' + cherrypy.request.query_string,
-            '  Remote IP: ' + cherrypy.request.remote.ip
+            '  Remote IP: ' + cherrypy.request.remote.ip,
+            '  Request UID: ' + getattr(cherrypy.request, 'girderRequestUid', '[none]')
         ))
         return ('%s\n'
                 'Additional info:\n'

--- a/test/test_rest_exception_handling.py
+++ b/test/test_rest_exception_handling.py
@@ -1,4 +1,6 @@
+import cherrypy
 import contextlib
+import mock
 import pytest
 from girder import config
 from girder.api import access
@@ -18,20 +20,31 @@ def serverMode(mode):
 def exceptionServer(server):
     @access.public
     def _raiseException(*args, **kwargs):
-        raise Exception('Specific message')
+        raise Exception('Specific message ' + cherrypy.request.girderRequestUid)
 
     server.root.api.v1.item.route('GET', ('exception',), _raiseException)
     yield server
     server.root.api.v1.item.removeRoute('GET', ('exception',))
 
 
+@pytest.fixture
+def uuidMock():
+    val = '1234'
+    with mock.patch('uuid.uuid4', return_value=val):
+        yield val
+
+
 @pytest.mark.parametrize('mode,msg,hasTrace', [
     ('production', 'An unexpected error occurred on the server.', False),
-    ('development', 'Exception: Exception(\'Specific message\',)', True)
+    ('development', 'Exception: Exception(\'Specific message 1234\',)', True)
 ])
-def testExceptionHandlingBasedOnServerMode(exceptionServer, mode, msg, hasTrace):
+def testExceptionHandlingBasedOnServerMode(exceptionServer, uuidMock, mode, msg, hasTrace):
     with serverMode(mode):
         resp = exceptionServer.request('/item/exception', exception=True)
-        assertStatus(resp, 500)
-        assert resp.json['message'] == msg
-        assert ('trace' in resp.json) is hasTrace
+
+    assertStatus(resp, 500)
+    assert resp.json['message'] == msg
+    assert resp.json['type'] == 'internal'
+    assert resp.json['uid'] == uuidMock
+    assert ('trace' in resp.json) is hasTrace
+    assert resp.headers['Girder-Request-Uid'] == uuidMock


### PR DESCRIPTION
Depends on #2853 

For every REST request, a UID is generated at the beginning and returned to the user as the `Girder-Request-Uid` header. It's also set as a thread-local variable on the request thread so that it can be generally used within request handlers.

In Girder core, this field is now included in all exception log messages.