### PR TITLE
Add the mock dependency to pytest-girder

### DIFF
--- a/pytest_girder/setup.py
+++ b/pytest_girder/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='pytest-girder',
-    version='0.1.0a1',
+    version='0.1.0a2',
     description='A set of pytest fixtures for testing Girder applications.',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
@@ -13,6 +13,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'girder>=3.0.0a1',
+        'mock',
         'mongomock',
         'pytest>=3.6',
         'pytest-cov<2.6',


### PR DESCRIPTION
This was being brought in transitively, which was causing breakage in other scenarios.

@jbeezley 