### PR TITLE
Use latest release of boto/botocore

### DIFF
--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -473,7 +473,7 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
         disp = 'attachment; filename="%s"' % file['name']
         mime = file.get('mimeType') or ''
 
-        if key['ContentType'] != mime or key['ContentDisposition'] != disp:
+        if key.get('ContentType') != mime or key.get('ContentDisposition') != disp:
             self.client.copy_object(
                 Bucket=bucket, Key=file['s3Key'], Metadata=key['Metadata'],
                 CopySource={'Bucket': bucket, 'Key': file['s3Key']}, ContentDisposition=disp,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,7 +30,7 @@ girder-worker
 httmock
 mock
 mongomock
-moto[server]
+moto[server]>=1.3.7
 pytest>=3.6
 pytest-cov<2.6
 pytest-xdist

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ with open('README.rst') as f:
     readme = f.read()
 
 installReqs = [
-    'boto3>=1.7,<1.8',  # TODO: unpin once moto works with boto3>=1.8
-    'botocore<1.11.0',  # TODO: remove once moto works with boto3>=1.8
+    'boto3',
+    'botocore',
     # CherryPy version is restricted due to a bug in versions >=11.1
     # https://github.com/cherrypy/cherrypy/issues/1662
     'CherryPy<11.1',

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -44,6 +44,14 @@ from girder.utility.filesystem_assetstore_adapter import DEFAULT_PERMS
 from girder.utility.s3_assetstore_adapter import makeBotoConnectParams, S3AssetstoreAdapter
 from six.moves import urllib
 
+# The latest moto/boto/botocore requires dummy credentials to function.  It is unclear if
+# this is a bug or intended behavior.
+#  https://github.com/spulec/moto/issues/1793#issuecomment-431459262
+#  https://github.com/spulec/moto/issues/1924
+os.environ['AWS_ACCESS_KEY_ID'] = "access"
+os.environ['AWS_SECRET_ACCESS_KEY'] = "secret"
+os.environ['AWS_DEFAULT_REGION'] = 'us-east-1'
+
 
 def setUpModule():
     base.startServer()
@@ -1099,5 +1107,5 @@ class FileTestCase(base.TestCase):
             self.assertTrue(self.finalizeUploadBeforeCalled)
             self.assertTrue(self.finalizeUploadAfterCalled)
 
-            events.unbind('model.file.finalizeUpload.before', '_testFinalizeUploadBefore')
-            events.unbind('model.file.finalizeUpload.after', '_testFinalizeUploadAfter')
+        events.unbind('model.file.finalizeUpload.before', '_testFinalizeUploadBefore')
+        events.unbind('model.file.finalizeUpload.after', '_testFinalizeUploadAfter')


### PR DESCRIPTION
After some experimenting I found the boto pinning to be mostly unnecessary with the latest moto.  It does appear that dummy credentials are now required (https://github.com/spulec/moto/issues/1924), but it's unclear if this is intentional or a bug.