### PR TITLE
Fix the order that slices are shown in the DICOM viewer.

### DIFF
--- a/plugins/dicom_viewer/girder_dicom_viewer/web_client/stylesheets/dicomItem.styl
+++ b/plugins/dicom_viewer/girder_dicom_viewer/web_client/stylesheets/dicomItem.styl
@@ -15,6 +15,8 @@
   .g-dicom-filename
     text-align center
     margin 5px 0
+    white-space nowrap
+    overflow hidden
 
   .g-dicom-controls
     .right

--- a/plugins/dicom_viewer/girder_dicom_viewer/web_client/views/DicomView.js
+++ b/plugins/dicom_viewer/girder_dicom_viewer/web_client/views/DicomView.js
@@ -48,6 +48,8 @@ const DicomFileCollection = FileCollection.extend({
         this._selectedIndex = null;
     },
 
+    sortField: 'none',
+
     selectIndex: function (index) {
         this._selectedIndex = index;
         this.trigger('g:selected', this.at(index), index);
@@ -412,7 +414,7 @@ const DicomItemView = View.extend({
 
         selectedFile.getSlice()
             .done((slice) => {
-                this.$('.g-dicom-filename').text(selectedFile.name());
+                this.$('.g-dicom-filename').text(selectedFile.name()).attr('title', selectedFile.name());
                 this.$('.g-dicom-slider').val(selectedIndex);
 
                 this._sliceMetadataView


### PR DESCRIPTION
This also stops wrapping long file names, as that causes the controls to jump around.