### PR TITLE
Allow the S3 assetstore to work with google storage.

### DIFF
--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -134,7 +134,15 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
         """
         url = self.client.generate_presigned_url(*args, **kwargs)
         if getattr(self.client, '_useGoogleAccessId', False):
-            url = url.replace('AWSAccessKeyId', 'GoogleAccessId')
+            awskey, gskey = 'AWSAccessKeyId', 'GoogleAccessId'
+            parsed = urllib.parse.urlparse(url)
+            if awskey in urllib.parse.parse_qs(parsed.query):
+                qsl = urllib.parse.parse_qsl(parsed.query)
+                qsl = [(key if key != awskey else gskey, value) for key, value in qsl]
+                url = urllib.parse.urlunparse((
+                    parsed[0], parsed[1], parsed[2], parsed[3],
+                    urllib.parse.urlencode(qsl),
+                    parsed[5]))
         return url
 
     def initUpload(self, upload):

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -25,6 +25,7 @@ import re
 import requests
 import six
 import uuid
+from six.moves import urllib
 
 from girder import logger, events
 from girder.api.rest import setContentDisposition
@@ -52,7 +53,8 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
     def _s3Client(connectParams):
         try:
             client = boto3.client('s3', **connectParams)
-            if 'googleapis' in connectParams.get('endpoint_url', '').split('.'):
+            if 'googleapis' in urllib.parse.urlparse(connectParams.get(
+                    'endpoint_url', '')).netloc.split('.'):
                 client.meta.events.unregister(
                     'before-parameter-build.s3.ListObjects',
                     botocore.handlers.set_list_objects_encoding_type_url)

--- a/girder/web_client/src/templates/widgets/editAssetstoreWidget.pug
+++ b/girder/web_client/src/templates/widgets/editAssetstoreWidget.pug
@@ -48,7 +48,7 @@
               input#g-edit-s3-secret.input-sm.form-control(type="text", placeholder="Secret access key")
             .form-group
               label.control-label(for="g-edit-s3-service") Service
-              input#g-edit-s3-service.input-sm.form-control(type="text", placeholder="Service")
+              input#g-edit-s3-service.input-sm.form-control(type="text", placeholder="Service", title="The service if different from s3.amazonaws.com, such as storage.googleapis.com.")
             .form-group
               label.control-label(for="g-edit-s3-region") Region
               input#g-edit-s3-region.input-sm.form-control(type="text", placeholder="Region")

--- a/girder/web_client/src/templates/widgets/newAssetstore.pug
+++ b/girder/web_client/src/templates/widgets/newAssetstore.pug
@@ -101,7 +101,7 @@
             input#g-new-s3-secret.input-sm.form-control(type="text", placeholder="Secret access key")
           .form-group
             label.control-label(for="g-new-s3-service") Service
-            input#g-new-s3-service.input-sm.form-control(type="text", placeholder="Service")
+            input#g-new-s3-service.input-sm.form-control(type="text", placeholder="Service", title="The service if different from s3.amazonaws.com, such as storage.googleapis.com.")
           .form-group
             label.control-label(for="g-new-s3-region") Region
             input#g-new-s3-region.input-sm.form-control(type="text", placeholder="Region")


### PR DESCRIPTION
This works without credentials and in a read-only manner.

This also adjusts the presigned url, which may allow it to work with read/write or credentials, but those have not been tested.