### PR TITLE
Don't try to get the assetstore adapter of url files.

### DIFF
--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -390,10 +390,13 @@ class File(acl_mixin.AccessControlMixin, Model):
 
     def getAssetstoreAdapter(self, file):
         """
-        Return the assetstore adapter for the given file.
+        Return the assetstore adapter for the given file.  Return None if the
+        file has no assetstore.
         """
         from girder.utility import assetstore_utilities
 
+        if not file.get('assetstoreId'):
+            return None
         assetstore = self._getAssetstoreModel(file).load(file['assetstoreId'])
         return assetstore_utilities.getAssetstoreAdapter(assetstore)
 

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -1102,6 +1102,10 @@ class FileTestCase(base.TestCase):
         extracted = zip.read('Private/My Link Item').decode('utf8')
         self.assertEqual(extracted, params['linkUrl'].strip())
 
+        # The file should report no assetstore adapter
+        fileDoc = File().load(file['_id'], force=True)
+        self.assertIsNone(File().getAssetstoreAdapter(fileDoc))
+
     def tearDown(self):
         if self.testForFinalizeUpload:
             self.assertTrue(self.finalizeUploadBeforeCalled)


### PR DESCRIPTION
Girder files that are just urls don't have an assetstore.  When we ask for a file's assetstore adapter, return None.

This is the backport of #2870.