### PR TITLE
Fix the ctest javascript coverage report.

### DIFF
--- a/tests/JavascriptTests.cmake
+++ b/tests/JavascriptTests.cmake
@@ -12,7 +12,7 @@ function(javascript_tests_init)
   add_test(
     NAME js_coverage_combine_report
     WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-    COMMAND npx nyc report
+    COMMAND npx nyc report -t "${PROJECT_SOURCE_DIR}/build/test/coverage/web_temp"
   )
   set_property(TEST js_coverage_reset PROPERTY LABELS girder_browser girder_integration)
   set_property(TEST js_coverage_combine_report PROPERTY LABELS girder_coverage)


### PR DESCRIPTION
Tell nyc where we stored the coverage data so the test passes.  With this change, ctest successfully passes locally.  Without it, it fails.