### PR TITLE
Add "get metadata" endpoints for item and folder

### DIFF
--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -39,6 +39,7 @@ class Folder(Resource):
         self.route('DELETE', (':id', 'contents'), self.deleteContents)
         self.route('GET', (), self.find)
         self.route('GET', (':id',), self.getFolder)
+        self.route('GET', (':id', 'metadata'), self.getFolderMetadata)
         self.route('GET', (':id', 'details'), self.getFolderDetails)
         self.route('GET', (':id', 'access'), self.getFolderAccess)
         self.route('GET', (':id', 'download'), self.downloadFolder)
@@ -103,6 +104,17 @@ class Folder(Resource):
                 text, user=user, limit=limit, offset=offset, sort=sort)
         else:
             raise RestException('Invalid search mode.')
+
+
+    @access.public(scope=TokenScope.DATA_READ)
+    @autoDescribeRoute(
+        Description('Get folder metadata.')
+        .modelParam('id', model=FolderModel, level=AccessType.READ)
+        .errorResponse()
+        .errorResponse('Read access was denied on the folder.', 403)
+    )
+    def getFolderMetadata(self, folder):
+        return folder.get('meta', {})
 
     @access.public(scope=TokenScope.DATA_READ)
     @autoDescribeRoute(

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -38,6 +38,7 @@ class Item(Resource):
         self.route('DELETE', (':id',), self.deleteItem)
         self.route('GET', (), self.find)
         self.route('GET', (':id',), self.getItem)
+        self.route('GET', (':id', 'metadata'), self.getItemMetadata)
         self.route('GET', (':id', 'files'), self.getFiles)
         self.route('GET', (':id', 'download'), self.download)
         self.route('GET', (':id', 'rootpath'), self.rootpath)
@@ -220,6 +221,18 @@ class Item(Resource):
                     yield data
             yield zip.footer()
         return stream
+
+
+    @access.public(scope=TokenScope.DATA_READ)
+    @autoDescribeRoute(
+        Description('Get item metadata.')
+        .modelParam('id', model=ItemModel, level=AccessType.READ)
+        .errorResponse()
+        .errorResponse('Read access was denied on the folder.', 403)
+    )
+    def getItemMetadata(self, item):
+        return item.get('meta', {})
+
 
     @access.public(scope=TokenScope.DATA_READ)
     @filtermodel(model=File)

--- a/tests/cases/folder_test.py
+++ b/tests/cases/folder_test.py
@@ -305,6 +305,22 @@ class FolderTestCase(base.TestCase):
             resp.json['message'],
             'Parameter metadata must be valid JSON.')
 
+        resp = self.request(
+            path='/folder', method='POST', user=self.admin, params={
+                'name': 'My public subfolder without meta',
+                'parentId': publicFolder['_id']
+            }
+        )
+        self.assertStatusOk(resp)
+        folder = resp.json
+        self.assertNotHasKeys(folder, 'meta')
+
+        resp = self.request(
+            path='/folder/{}/metadata'.format(folder['_id']), method='GET', user=self.admin
+        )
+        receivedMetadata = resp.json
+        self.assertEqual(receivedMetadata, {})
+
         metadata = {
             'foo': 'bar',
             'test': 2
@@ -319,6 +335,15 @@ class FolderTestCase(base.TestCase):
         folder = resp.json
         self.assertEqual(folder['meta']['foo'], metadata['foo'])
         self.assertEqual(folder['meta']['test'], metadata['test'])
+
+        resp = self.request(
+            path='/folder/{}/metadata'.format(folder['_id']),
+                method='GET', user=self.admin
+        )
+        self.assertStatusOk(resp)
+        receivedMetadata = resp.json
+        self.assertEqual(receivedMetadata['foo'], metadata['foo'])
+        self.assertEqual(receivedMetadata['test'], metadata['test'])
 
         metadata = {
             'foo': None,

--- a/tests/cases/item_test.py
+++ b/tests/cases/item_test.py
@@ -353,6 +353,23 @@ class ItemTestCase(base.TestCase):
         self.assertEqual(
             resp.json['message'], 'Parameter metadata must be valid JSON.')
 
+        resp = self.request(
+            path='/item', method='POST', user=self.users[0], params={
+                'name': 'item without without meta via POST',
+                'description': ' a description ',
+                'folderId': self.privateFolder['_id']
+            }
+        )
+        self.assertStatusOk(resp)
+        item = resp.json
+        self.assertNotHasKeys(item, 'meta')
+
+        resp = self.request(
+            path='/item/{}/metadata'.format(item['_id']), method='GET', user=self.users[0]
+        )
+        receivedMetadata = resp.json
+        self.assertEqual(receivedMetadata, {})
+
         # Add some metadata
         metadata = {
             'foo': 'bar',
@@ -365,6 +382,15 @@ class ItemTestCase(base.TestCase):
         item = resp.json
         self.assertEqual(item['meta']['foo'], metadata['foo'])
         self.assertEqual(item['meta']['test'], metadata['test'])
+
+        resp = self.request(
+            path='/item/{}/metadata'.format(item['_id']),
+                method='GET', user=self.users[0]
+        )
+        self.assertStatusOk(resp)
+        receivedMetadata = resp.json
+        self.assertEqual(receivedMetadata['foo'], metadata['foo'])
+        self.assertEqual(receivedMetadata['test'], metadata['test'])
 
         metadata = {
             'foo': None,


### PR DESCRIPTION
This adds two new endpoints:
- `GET /folder/{id}/metadata`
- `GET /item/{id}/metadata`

along with tests.