### PR TITLE
Fix showing plugin errors in the web client.

### DIFF
--- a/girder/web_client/src/templates/body/plugins.pug
+++ b/girder/web_client/src/templates/body/plugins.pug
@@ -31,9 +31,9 @@
                   "to breaking changes; use at your own risk.") Experimental
         if failed
           span.g-plugin-list-item-notice.g-plugin-list-item-failed-notice(
-              title='Click to see traceback',
+              native-title='Click to see traceback',
               data-title='Failed to load entrypoint "' + plugin.value.name + '"',
-              data-content=failed.traceback) Error
+              data-content=failed) Error
         if plugin.value.configRoute
           a.g-plugin-config-link(g-route=plugin.value.configRoute, title="Configure Plugin")
             i.icon-cog

--- a/girder/web_client/src/views/body/PluginsView.js
+++ b/girder/web_client/src/views/body/PluginsView.js
@@ -143,6 +143,9 @@ var PluginsView = View.extend({
             container: this.$el,
             template: PluginFailedNoticeTemplate()
         });
+        this.$('.g-plugin-list-item-failed-notice').each(function () {
+            $(this).attr('title', $(this).attr('native-title'));
+        });
 
         return this;
     },


### PR DESCRIPTION
This bug was due to a change between Girder 2 and 3.  The error button also showed the intended tooltip as a result title rather than as a tooltip.
