### PR TITLE
Remove static root setting

### DIFF
--- a/devops/ansible/roles/girder/library/test/test_setting.yml
+++ b/devops/ansible/roles/girder/library/test/test_setting.yml
@@ -60,7 +60,6 @@
           key: "core.route_table"
           value:
             core_girder: "/girder"
-            core_static_root: "/static"
 
     - name: Set multiple settings for email
       girder:

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -28,7 +28,6 @@ example, we have the following:
 
     [server]
     api_root = "/girder/api/v1"
-    static_root = "/girder/static"
 
 .. note:: If your chosen proxy server does not add the appropriate
    ``X-Forwarded-Host`` header (containing the host used in http requests,

--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -159,6 +159,23 @@ place (in the Girder python package) in both development and production installs
 The built assets are installed into a virtual environment specific static path
 ``{sys.prefix}/share/girder``.
 
+Static root is no longer dynamic
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The static root, indicating the base URL where web client files are served from,
+is no longer determined dynamcally via a setting. The static root now always assumes its previous
+default value of ``'/static'``. References to:
+
+* ``girder.rest.getStaticRoot()`` in the web client
+* ``girder.utility.server.getStaticRoot()`` in the server
+* ``girder.utility.server.getApiStaticRoot()`` in the server
+* ``info['staticRoot']`` in server plugin ``load`` functinos
+* ``${staticRoot}`` in server Mako templates
+* ``girder.constants.GIRDER_STATIC_ROUTE_ID`` or ``'core_static_root'`` in the server route table
+  (the ``'core.route_table'`` setting)
+
+should all be replaced with ``'/static'``.
+
+
 Server changes
 ++++++++++++++
 

--- a/girder/api/api_docs.mako
+++ b/girder/api/api_docs.mako
@@ -3,15 +3,15 @@
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>${brandName | h} - REST API Documentation</title>
-    <link rel="stylesheet" href="${staticRoot}/built/googlefonts.css">
-    <link rel="stylesheet" href="${staticRoot}/built/fontello/css/fontello.css">
-    <link rel="stylesheet" href="${staticRoot}/built/swagger/css/reset.css">
-    <link rel="stylesheet" href="${staticRoot}/built/swagger/css/screen.css">
-    <link rel="stylesheet" href="${staticRoot}/built/swagger/docs.css">
-    <link rel="icon" type="image/png" href="${staticRoot}/built/Girder_Favicon.png">
+    <link rel="stylesheet" href="/static/built/googlefonts.css">
+    <link rel="stylesheet" href="/static/built/fontello/css/fontello.css">
+    <link rel="stylesheet" href="/static/built/swagger/css/reset.css">
+    <link rel="stylesheet" href="/static/built/swagger/css/screen.css">
+    <link rel="stylesheet" href="/static/built/swagger/docs.css">
+    <link rel="icon" type="image/png" href="/static/built/Girder_Favicon.png">
     <style type="text/css">
       .response_throbber {
-        content: url("${staticRoot}/built/swagger/images/throbber.gif");
+        content: url("/static/built/swagger/images/throbber.gif");
       }
       #api_info {
         display: none;
@@ -47,22 +47,22 @@
           class="swagger-ui-wrap docs-swagger-container">
       </div>
     </div>
-    <script src="${staticRoot}/built/swagger/lib/object-assign-pollyfill.js"></script>
-    <script src="${staticRoot}/built/swagger/lib/jquery-1.8.0.min.js"></script>
-    <script src="${staticRoot}/built/swagger/lib/jquery.slideto.min.js"></script>
-    <script src="${staticRoot}/built/swagger/lib/jquery.wiggle.min.js"></script>
-    <script src="${staticRoot}/built/swagger/lib/jquery.ba-bbq.min.js"></script>
-    <script src="${staticRoot}/built/swagger/lib/handlebars-4.0.5.js"></script>
-    <script src="${staticRoot}/built/swagger/lib/lodash.min.js"></script>
-    <script src="${staticRoot}/built/swagger/lib/backbone-min.js"></script>
-    <script src="${staticRoot}/built/swagger/swagger-ui.min.js"></script>
-    <script src="${staticRoot}/built/swagger/lib/highlight.9.1.0.pack.js"></script>
-    <script src="${staticRoot}/built/swagger/lib/highlight.9.1.0.pack_extended.js"></script>
-    <script src='${staticRoot}/built/swagger/lib/jsoneditor.min.js'></script>
-    <script src='${staticRoot}/built/swagger/lib/marked.js'></script>
-    <script src="${staticRoot}/built/swagger/girder-swagger.js"></script>
+    <script src="/static/built/swagger/lib/object-assign-pollyfill.js"></script>
+    <script src="/static/built/swagger/lib/jquery-1.8.0.min.js"></script>
+    <script src="/static/built/swagger/lib/jquery.slideto.min.js"></script>
+    <script src="/static/built/swagger/lib/jquery.wiggle.min.js"></script>
+    <script src="/static/built/swagger/lib/jquery.ba-bbq.min.js"></script>
+    <script src="/static/built/swagger/lib/handlebars-4.0.5.js"></script>
+    <script src="/static/built/swagger/lib/lodash.min.js"></script>
+    <script src="/static/built/swagger/lib/backbone-min.js"></script>
+    <script src="/static/built/swagger/swagger-ui.min.js"></script>
+    <script src="/static/built/swagger/lib/highlight.9.1.0.pack.js"></script>
+    <script src="/static/built/swagger/lib/highlight.9.1.0.pack_extended.js"></script>
+    <script src='/static/built/swagger/lib/jsoneditor.min.js'></script>
+    <script src='/static/built/swagger/lib/marked.js'></script>
+    <script src="/static/built/swagger/girder-swagger.js"></script>
     % if mode == 'testing':
-    <script src="${staticRoot}/built/testing.min.js"></script>
+    <script src="/static/built/testing.min.js"></script>
     % endif
   </body>
 </html>

--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -469,14 +469,12 @@ class ApiDocs(WebrootBase):
 
         self.vars = {
             'apiRoot': '',
-            'staticRoot': '',
             'mode': mode
         }
 
     def _renderHTML(self):
         from girder.utility import server
         self.vars['apiRoot'] = server.getApiRoot()
-        self.vars['staticRoot'] = server.getApiStaticRoot()
         self.vars['brandName'] = Setting().get(SettingKey.BRAND_NAME)
         return super(ApiDocs, self)._renderHTML()
 

--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -28,8 +28,7 @@ import logging
 import traceback
 
 from girder.api import access
-from girder.constants import GIRDER_ROUTE_ID, GIRDER_STATIC_ROUTE_ID, \
-    SettingKey, TokenScope, ACCESS_FLAGS, VERSION
+from girder.constants import GIRDER_ROUTE_ID, SettingKey, TokenScope, ACCESS_FLAGS, VERSION
 from girder.exceptions import GirderException, ResourcePathNotFound, RestException
 from girder.models.collection import Collection
 from girder.models.file import File
@@ -215,7 +214,7 @@ class System(Resource):
         setting = Setting()
         routeTable = setting.get(SettingKey.ROUTE_TABLE)
         oldPlugins = setting.get(SettingKey.PLUGINS_ENABLED)
-        reservedRoutes = {GIRDER_ROUTE_ID, GIRDER_STATIC_ROUTE_ID}
+        reservedRoutes = {GIRDER_ROUTE_ID}
 
         routeTableChanged = False
         removedRoutes = (

--- a/girder/constants.py
+++ b/girder/constants.py
@@ -33,7 +33,6 @@ ACCESS_FLAGS = {}
 
 # Identifier for Girder's entry in the route table
 GIRDER_ROUTE_ID = 'core_girder'
-GIRDER_STATIC_ROUTE_ID = 'core_static_root'
 
 # Threshold below which text search results will be sorted by their text score.
 # Setting this too high causes mongodb to use too many resources for searches

--- a/girder/models/setting.py
+++ b/girder/models/setting.py
@@ -23,7 +23,7 @@ import pymongo
 import six
 import re
 
-from ..constants import GIRDER_ROUTE_ID, GIRDER_STATIC_ROUTE_ID, SettingDefault, SettingKey
+from ..constants import GIRDER_ROUTE_ID, SettingDefault, SettingKey
 from .model_base import Model
 from girder import logprint
 from girder.exceptions import ValidationException
@@ -380,19 +380,12 @@ class Setting(Model):
     @setting_utilities.validator(SettingKey.ROUTE_TABLE)
     def validateCoreRouteTable(doc):
         nonEmptyRoutes = [route for route in doc['value'].values() if route]
-        for key in [GIRDER_ROUTE_ID, GIRDER_STATIC_ROUTE_ID]:
-            if key not in doc['value'] or not doc['value'][key]:
-                raise ValidationException('Girder and static root must be routable.')
+        if GIRDER_ROUTE_ID not in doc['value'] or not doc['value'][GIRDER_ROUTE_ID]:
+            raise ValidationException('Girder root must be routable.')
 
         for key in doc['value']:
-            if (key != GIRDER_STATIC_ROUTE_ID and doc['value'][key] and
-                    not doc['value'][key].startswith('/')):
+            if (doc['value'][key] and not doc['value'][key].startswith('/')):
                 raise ValidationException('Routes must begin with a forward slash.')
-        if doc['value'].get(GIRDER_STATIC_ROUTE_ID):
-            if (not doc['value'][GIRDER_STATIC_ROUTE_ID].startswith('/') and
-                    '://' not in doc['value'][GIRDER_STATIC_ROUTE_ID]):
-                raise ValidationException(
-                    'Static root must begin with a forward slash or contain a URL scheme.')
 
         if len(nonEmptyRoutes) > len(set(nonEmptyRoutes)):
             raise ValidationException('Routes must be unique.')
@@ -401,8 +394,7 @@ class Setting(Model):
     @setting_utilities.default(SettingKey.ROUTE_TABLE)
     def defaultCoreRouteTable():
         return {
-            GIRDER_ROUTE_ID: '/',
-            GIRDER_STATIC_ROUTE_ID: '/static'
+            GIRDER_ROUTE_ID: '/'
         }
 
     @staticmethod

--- a/girder/utility/webroot.mako
+++ b/girder/utility/webroot.mako
@@ -3,20 +3,19 @@
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>${brandName | h}</title>
-    <link rel="stylesheet" href="${staticRoot}/built/googlefonts.css">
-    <link rel="stylesheet" href="${staticRoot}/built/fontello/css/fontello.css">
-    <link rel="stylesheet" href="${staticRoot}/built/fontello/css/animation.css">
-    <link rel="stylesheet" href="${staticRoot}/built/girder_lib.min.css">
-    <link rel="icon" type="image/png" href="${staticRoot}/built/Girder_Favicon.png">
+    <link rel="stylesheet" href="/static/built/googlefonts.css">
+    <link rel="stylesheet" href="/static/built/fontello/css/fontello.css">
+    <link rel="stylesheet" href="/static/built/fontello/css/animation.css">
+    <link rel="stylesheet" href="/static/built/girder_lib.min.css">
+    <link rel="icon" type="image/png" href="/static/built/Girder_Favicon.png">
     % for plugin in pluginCss:
-    <link rel="stylesheet" href="${staticRoot}/built/plugins/${plugin}/plugin.min.css">
+    <link rel="stylesheet" href="/static/built/plugins/${plugin}/plugin.min.css">
     % endfor
   </head>
   <body>
     <div id="g-global-info-apiroot" class="hide">${apiRoot}</div>
-    <div id="g-global-info-staticroot" class="hide">${staticRoot}</div>
-    <script src="${staticRoot}/built/girder_lib.min.js"></script>
-    <script src="${staticRoot}/built/girder_app.min.js"></script>
+    <script src="/static/built/girder_lib.min.js"></script>
+    <script src="/static/built/girder_app.min.js"></script>
     <script type="text/javascript">
         $(function () {
             girder.events.trigger('g:appload.before');
@@ -34,7 +33,7 @@
         });
     </script>
     % for plugin in pluginJs:
-    <script src="${staticRoot}/built/plugins/${plugin}/plugin.min.js"></script>
+    <script src="/static/built/plugins/${plugin}/plugin.min.js"></script>
     % endfor
   </body>
 </html>

--- a/girder/utility/webroot.py
+++ b/girder/utility/webroot.py
@@ -135,7 +135,6 @@ class Webroot(WebrootBase):
                 self.vars['pluginJs'].append(plugin)
 
         self.vars['apiRoot'] = server.getApiRoot()
-        self.vars['staticRoot'] = server.getStaticRoot()
         self.vars['brandName'] = Setting().get(SettingKey.BRAND_NAME)
         self.vars['contactEmail'] = Setting().get(
             SettingKey.CONTACT_EMAIL_ADDRESS)

--- a/girder/web_client/grunt_tasks/test.js
+++ b/girder/web_client/grunt_tasks/test.js
@@ -73,7 +73,6 @@ module.exports = function (grunt) {
                             '/static/built/girder_app.min.js',
                             '/static/built/testing.min.js'
                         ],
-                        staticRoot: '/static',
                         apiRoot: '/api/v1'
                     },
                     pretty: true

--- a/girder/web_client/grunt_tasks/webpack.config.js
+++ b/girder/web_client/grunt_tasks/webpack.config.js
@@ -47,10 +47,8 @@ var loaderPathsNodeModules = loaderPaths.concat([nodeModules]);
 module.exports = {
     output: {
         // pathinfo: true,  // for debugging
-        filename: '[name].min.js'
-        // publicPath must be set to Girder's externally-served static path for built outputs
-        // (typically '/static/built/'). This will be done at runtime with
-        // '__webpack_public_path__', since it's not always known at build-time.
+        filename: '[name].min.js',
+        publicPath: '/static/built/'
     },
     plugins: [
         // Exclude all of Moment.js's extra locale files except English

--- a/girder/web_client/src/rest.js
+++ b/girder/web_client/src/rest.js
@@ -6,7 +6,6 @@ import events from 'girder/events';
 import { getCurrentToken, cookie } from 'girder/auth';
 
 let apiRoot;
-let staticRoot;
 var uploadHandlers = {};
 var uploadChunkSize = 1024 * 1024 * 64; // 64MB
 
@@ -32,46 +31,11 @@ function setApiRoot(root) {
     apiRoot = root.replace(/\/$/, '');
 }
 
-/**
- * Get the root path to the static content.
- *
- * This may be an absolute path, or a path relative to the application root. It will never include
- * a trailing slash.
- *
- * @returns {string}
- */
-function getStaticRoot() {
-    return staticRoot;
-}
-
-/**
- * Set the root path to the static content.
- *
- * @param {string} root The root path for the static content.
- */
-function setStaticRoot(root) {
-    // Strip trailing slash
-    staticRoot = root.replace(/\/$/, '');
-    // publicPath would normally be set in the Webpack config file, but is not known at compile
-    // time.
-    __webpack_public_path__ = `${getStaticRoot()}/built/`; // eslint-disable-line no-undef, camelcase
-    // Note that in theory, an ES6-style import of a file asset that occurred earlier in the import
-    // resolution sequence than this module could fail to have its publicPath set at all, but the
-    // typical style rules for ordering ES6-style imports ensure that this module will be loaded
-    // very early in the import sequence. However, if App startup code modifies the staticRoot, then
-    // any ES6-style imports will probably have the incorrect path. Ultimately though, most file
-    // asset imports will occur in Pug files via require-style imports, which happen at runtime, so
-    // they will always succeed.
-}
-
-// Initialize the API and static roots (at JS load time)
+// Initialize the API root (at JS load time)
 // This could be overridden when the App is started, but we need sensible defaults so models, etc.
 // can be easily used without having to start an App or explicitly set these values
 setApiRoot(
     $('#g-global-info-apiroot').text().replace('%HOST%', window.location.origin) || '/api/v1'
-);
-setStaticRoot(
-    $('#g-global-info-staticroot').text().replace('%HOST%', window.location.origin) || '/static'
 );
 
 /**
@@ -264,11 +228,8 @@ function setUploadChunkSize(val) {
 
 export {
     apiRoot, // deprecated
-    staticRoot, // deprecated
     getApiRoot,
     setApiRoot,
-    getStaticRoot,
-    setStaticRoot,
     uploadHandlers,
     restRequest,
     numberOutstandingRestRequests,

--- a/girder/web_client/src/templates/body/systemConfiguration.pug
+++ b/girder/web_client/src/templates/body/systemConfiguration.pug
@@ -179,12 +179,6 @@ form.g-settings-form(role="form")
           value=routes['core_girder'] || '',
           data-webroot-name="core_girder",
           title="The path to place core_girder.")
-      label core_static_root
-      input.g-core-route-table.form-control.input-sm(
-          type="text",
-          value=routes['core_static_root'] || '',
-          data-webroot-name="core_static_root",
-          title="The path to place core_static_root.")
     if routeKeys.length > 2
       .form-group
         h5 Other Routes

--- a/girder/web_client/test/spec/setApiSpec.js
+++ b/girder/web_client/test/spec/setApiSpec.js
@@ -1,6 +1,6 @@
 girderTest.startApp();
 
-describe('Test setApiRoot() and setStaticRoot() functions', function () {
+describe('Test setApiRoot() function', function () {
     it('Check for default values and mutation', function () {
         waitsFor(function () {
             return $('.g-frontpage-body').length > 0;
@@ -9,15 +9,10 @@ describe('Test setApiRoot() and setStaticRoot() functions', function () {
         runs(function () {
             // Test the default values.
             expect(girder.rest.apiRoot.slice(girder.rest.apiRoot.indexOf('/', 7))).toBe('/api/v1');
-            expect(girder.rest.staticRoot.slice(girder.rest.staticRoot.indexOf('/', 7))).toBe('/static');
 
             var apiRootVal = '/foo/bar/v2';
             girder.rest.setApiRoot(apiRootVal);
             expect(girder.rest.apiRoot).toBe(apiRootVal);
-
-            var staticRootVal = 'dynamic';
-            girder.rest.setStaticRoot(staticRootVal);
-            expect(girder.rest.staticRoot).toBe(staticRootVal);
         });
     });
 });

--- a/girder/web_client/test/testEnv.pug
+++ b/girder/web_client/test/testEnv.pug
@@ -8,7 +8,6 @@ html(lang='en')
 
   body
     #g-global-info-apiroot.hide %HOST%#{apiRoot}
-    #g-global-info-staticroot.hide %HOST%#{staticRoot}
 
     each js in jsFiles
       script(src=js)

--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -398,7 +398,6 @@ girder
             USER_SELF_ACCESS
             WEBROOT_SETTING_CHANGE
         GIRDER_ROUTE_ID
-        GIRDER_STATIC_ROUTE_ID
         LOG_BACKUP_COUNT
         LOG_ROOT
         MAX_LOG_SIZE
@@ -950,9 +949,7 @@ girder
         server
             configureServer
             getApiRoot
-            getApiStaticRoot
             getPlugins
-            getStaticRoot
             loadRouteTable
             setup
             staticFile

--- a/test/test_route_table.py
+++ b/test/test_route_table.py
@@ -23,7 +23,7 @@ import pytest
 from pytest_girder.assertions import assertStatusOk
 from pytest_girder.utils import getResponseBody
 
-from girder.constants import GIRDER_ROUTE_ID, GIRDER_STATIC_ROUTE_ID, SettingKey
+from girder.constants import GIRDER_ROUTE_ID, SettingKey
 from girder.exceptions import ValidationException
 from girder.models.setting import Setting
 from girder.plugin import GirderPlugin, registerPluginWebroot
@@ -42,22 +42,16 @@ class HasWebroot(GirderPlugin):
 
 
 @pytest.mark.parametrize('value,err', [
-    ({}, r'Girder and static root must be routable\.$'),
-    ({GIRDER_ROUTE_ID: '/'}, r'Girder and static root must be routable\.$'),
+    ({}, r'Girder root must be routable\.$'),
+    ({'other': '/some_route'}, r'Girder root must be routable\.$'),
     ({
         GIRDER_ROUTE_ID: '/some_route',
-        GIRDER_STATIC_ROUTE_ID: '/static',
         'other': '/some_route'
     }, r'Routes must be unique\.$'),
     ({
         GIRDER_ROUTE_ID: '/',
-        GIRDER_STATIC_ROUTE_ID: '/static',
         'other': 'route_without_a_leading_slash'
-    }, r'Routes must begin with a forward slash\.$'),
-    ({
-        GIRDER_ROUTE_ID: '/',
-        GIRDER_STATIC_ROUTE_ID: 'relative/static'
-    }, r'Static root must begin with a forward slash or contain a URL scheme\.$')
+    }, r'Routes must begin with a forward slash\.$')
 ])
 def testRouteTableValidationFailure(value, err):
     with pytest.raises(ValidationException, match=err):
@@ -70,7 +64,6 @@ def testRouteTableValidationFailure(value, err):
 @pytest.mark.parametrize('value', [
     {
         GIRDER_ROUTE_ID: '/',
-        GIRDER_STATIC_ROUTE_ID: 'http://127.0.0.1/static'
     }
 ])
 def testRouteTableValidationSuccess(value):
@@ -84,7 +77,6 @@ def testRouteTableValidationSuccess(value):
 def testRouteTableBehavior(server, admin):
     Setting().set(SettingKey.ROUTE_TABLE, {
         GIRDER_ROUTE_ID: '/',
-        GIRDER_STATIC_ROUTE_ID: '/static',
         'has_webroot': '/has_webroot'
     })
 

--- a/test/test_webroot.py
+++ b/test/test_webroot.py
@@ -17,7 +17,7 @@
 #  limitations under the License.
 ###############################################################################
 
-from girder.constants import GIRDER_ROUTE_ID, GIRDER_STATIC_ROUTE_ID, SettingKey
+from girder.constants import GIRDER_ROUTE_ID, SettingKey
 from girder.models.setting import Setting
 from pytest_girder.assertions import assertStatusOk
 from pytest_girder.utils import getResponseBody
@@ -70,25 +70,6 @@ def testAccessWebRoot(server, db):
     assert WebrootBase._escapeJavascript(defaultEmailAddress) in body
     assert '<title>%s</title>' % defaultBrandName in body
 
-
-def testWebRootProperlyHandlesStaticRouteUrls(server, db):
-    Setting().set(SettingKey.ROUTE_TABLE, {
-        GIRDER_ROUTE_ID: '/',
-        GIRDER_STATIC_ROUTE_ID: 'http://my-cdn-url.com/static'
-    })
-
-    resp = server.request(path='/', method='GET', isJson=False, prefix='')
-    assertStatusOk(resp)
-    body = getResponseBody(resp)
-
-    assert 'href="http://my-cdn-url.com/static/built/Girder_Favicon.png"' in body
-
-    # Same assertion should hold true for Swagger
-    resp = server.request(path='/', method='GET', isJson=False)
-    assertStatusOk(resp)
-    body = getResponseBody(resp)
-
-    assert 'href="http://my-cdn-url.com/static/built/Girder_Favicon.png"' in body
 
 def testWebRootTemplateFilename():
     """


### PR DESCRIPTION
The base URL where static assets are served (known in Webpack as the `publicPath`) was never designed to be determined at Javascript runtime. While Webpack includes a limited tool (the magic `__webpack_public_path__` variable) to defer setting `publicPath` within the Webpack config, it intractably breaks several types of asset loading to try to set this value at JS runtime (as opposed to just within the JS build process).

Previous attempts to work around this are summed up within the code comment:
> `publicPath` would normally be set in the Webpack config file, but is not known at compile time. Note that in theory, an ES6-style import of a file asset that occurred earlier in the import resolution sequence than this module could fail to have its `publicPath` set at all, but the typical style rules for ordering ES6-style imports ensure that this module will be loaded very early in the import sequence. However, if `App` startup code modifies the `staticRoot`, then any ES6-style imports will probably have the incorrect path. Ultimately though, most file asset imports will occur in Pug files via require-style imports, which happen at runtime, so they will always succeed.

However, as mentioned in the comment, the previous strategy did not work for some types of asset imports. Worse, it fundamentally broke using the Girder JS code with any other build system (which would not expect an attempt to set `__webpack_public_path__` at runtime), making it impossible to reuse Girder's client components in externally-built projects or to modernize external projects with non-Girder build systems.

The static root setting was added very early in Girder's development, long before Webpack was introduced. At this point in time, it is likely that Webpack technology is simply not compatible with a dynamic `staticRoot` setting.

If Girder's static asset libraries need to be served from an alternative location (e.g. a CDN), then Webpack's `output.publicPath` value should be changed at JS build configuration time, ideally via a plugin that modifies the state of Grunt's config and the output of Girder's server-side Mako templates.

An alternative to this change would be to keep the `staticRoot` setting, but require that it be passed to Grunt on every build. However, this would require the client build process to have database or API server access for any build, and would require that the web client be rebuilt after any change of the setting's value. For a setting that is changed as rarely and infrequently as `staticRoot`, this extra complexity is likely not worthwhile.