### PR TITLE
Set the static root at JS build time

### DIFF
--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -159,6 +159,19 @@ place (in the Girder python package) in both development and production installs
 The built assets are installed into a virtual environment specific static path
 ``{sys.prefix}/share/girder``.
 
+Static root is required during web client build
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The static root, indicating the base URL where web client files are served from,
+is now required when the web client is built. The primary implication is that if the static root
+setting is changed, the web client must be immediately rebuilt. Also, note the API changes:
+
+* In the web client, ``girder.rest.staticRoot``, ``girder.rest.getStaticRoot``, and
+  ``girder.rest.setStaticRoot`` have been removed
+* The ability to set the web client static root via the special element
+  ``<div id="g-global-info-staticroot">`` has been removed
+* In the server, the ``girder.utility.server.getStaticRoot()`` function now returns an absolute path
+  unless set otherwise (which is not recommended).
+
 Server changes
 ++++++++++++++
 

--- a/girder/cli/build.py
+++ b/girder/cli/build.py
@@ -29,6 +29,7 @@ import six
 
 from girder.constants import STATIC_ROOT_DIR
 from girder.plugin import allPlugins, getPlugin
+from girder.utility.server import getStaticRoot
 
 # monkey patch shutil for python < 3
 if not six.PY3:
@@ -78,7 +79,11 @@ def main(dev, watch, watch_plugin, npm, reinstall):
 
     quiet = '--no-progress=false' if sys.stdout.isatty() else '--no-progress=true'
     buildCommand = [
-        npm, 'run', 'build', '--', '--static-path=%s' % STATIC_ROOT_DIR, quiet]
+        npm, 'run', 'build', '--',
+        '--static-path=%s' % STATIC_ROOT_DIR,
+        '--static-url=%s' % getStaticRoot(),
+        quiet
+    ]
     if watch:
         buildCommand.append('--watch')
     if watch_plugin:

--- a/girder/utility/server.py
+++ b/girder/utility/server.py
@@ -54,18 +54,7 @@ def getApiRoot():
 
 def getStaticRoot():
     routeTable = loadRouteTable()
-
-    # If the static route is a URL, leave it alone
-    if '://' in routeTable[constants.GIRDER_STATIC_ROUTE_ID]:
-        return routeTable[constants.GIRDER_STATIC_ROUTE_ID]
-    else:
-        # Make the staticRoot relative to the api_root, if possible.  The api_root
-        # could be relative or absolute, but it needs to be in an absolute form for
-        # relpath to behave as expected.  We always expect the api_root to
-        # contain at least two components, but the reference from static needs to
-        # be from only the first component.
-        return posixpath.relpath(routeTable[constants.GIRDER_STATIC_ROUTE_ID],
-                                 routeTable[constants.GIRDER_ROUTE_ID])
+    return routeTable[constants.GIRDER_STATIC_ROUTE_ID]
 
 
 def getApiStaticRoot():

--- a/girder/utility/webroot.mako
+++ b/girder/utility/webroot.mako
@@ -14,7 +14,6 @@
   </head>
   <body>
     <div id="g-global-info-apiroot" class="hide">${apiRoot}</div>
-    <div id="g-global-info-staticroot" class="hide">${staticRoot}</div>
     <script src="${staticRoot}/built/girder_lib.min.js"></script>
     <script src="${staticRoot}/built/girder_app.min.js"></script>
     <script type="text/javascript">

--- a/girder/web_client/Gruntfile.js
+++ b/girder/web_client/Gruntfile.js
@@ -53,6 +53,7 @@ module.exports = function (grunt) {
         pkg: grunt.file.readJSON('package.json'),
         staticDir: '.',
         builtPath: path.resolve(grunt.option('static-path') || '.', 'built'),
+        staticUrl: grunt.option('static-url') || '/static',
         default: {}
     });
 

--- a/girder/web_client/grunt_tasks/build.js
+++ b/girder/web_client/grunt_tasks/build.js
@@ -72,7 +72,7 @@ module.exports = function (grunt) {
     const updateWebpackConfig = _.partial(
         extendify({
             inPlace: true,
-            isDeep: false,
+            isDeep: true,
             arrays: 'concat'
         }),
         webpackConfig

--- a/girder/web_client/grunt_tasks/build.js
+++ b/girder/web_client/grunt_tasks/build.js
@@ -190,6 +190,13 @@ module.exports = function (grunt) {
         progress: progress
     });
 
+    // Set the publicPath based on Girder's static root
+    updateWebpackConfig({
+        output: {
+            publicPath: path.join(grunt.config.get('staticUrl'), 'built/')
+        }
+    });
+
     const paths = require('./webpack.paths.js');
 
     // add coverage to all babel loader rules when in dev mode

--- a/girder/web_client/grunt_tasks/test.js
+++ b/girder/web_client/grunt_tasks/test.js
@@ -73,7 +73,6 @@ module.exports = function (grunt) {
                             '/static/built/girder_app.min.js',
                             '/static/built/testing.min.js'
                         ],
-                        staticRoot: '/static',
                         apiRoot: '/api/v1'
                     },
                     pretty: true

--- a/girder/web_client/grunt_tasks/webpack.config.js
+++ b/girder/web_client/grunt_tasks/webpack.config.js
@@ -48,9 +48,6 @@ module.exports = {
     output: {
         // pathinfo: true,  // for debugging
         filename: '[name].min.js'
-        // publicPath must be set to Girder's externally-served static path for built outputs
-        // (typically '/static/built/'). This will be done at runtime with
-        // '__webpack_public_path__', since it's not always known at build-time.
     },
     plugins: [
         // Exclude all of Moment.js's extra locale files except English

--- a/girder/web_client/src/rest.js
+++ b/girder/web_client/src/rest.js
@@ -6,7 +6,6 @@ import events from 'girder/events';
 import { getCurrentToken, cookie } from 'girder/auth';
 
 let apiRoot;
-let staticRoot;
 var uploadHandlers = {};
 var uploadChunkSize = 1024 * 1024 * 64; // 64MB
 
@@ -32,46 +31,11 @@ function setApiRoot(root) {
     apiRoot = root.replace(/\/$/, '');
 }
 
-/**
- * Get the root path to the static content.
- *
- * This may be an absolute path, or a path relative to the application root. It will never include
- * a trailing slash.
- *
- * @returns {string}
- */
-function getStaticRoot() {
-    return staticRoot;
-}
-
-/**
- * Set the root path to the static content.
- *
- * @param {string} root The root path for the static content.
- */
-function setStaticRoot(root) {
-    // Strip trailing slash
-    staticRoot = root.replace(/\/$/, '');
-    // publicPath would normally be set in the Webpack config file, but is not known at compile
-    // time.
-    __webpack_public_path__ = `${getStaticRoot()}/built/`; // eslint-disable-line no-undef, camelcase
-    // Note that in theory, an ES6-style import of a file asset that occurred earlier in the import
-    // resolution sequence than this module could fail to have its publicPath set at all, but the
-    // typical style rules for ordering ES6-style imports ensure that this module will be loaded
-    // very early in the import sequence. However, if App startup code modifies the staticRoot, then
-    // any ES6-style imports will probably have the incorrect path. Ultimately though, most file
-    // asset imports will occur in Pug files via require-style imports, which happen at runtime, so
-    // they will always succeed.
-}
-
-// Initialize the API and static roots (at JS load time)
+// Initialize the API root (at JS load time)
 // This could be overridden when the App is started, but we need sensible defaults so models, etc.
 // can be easily used without having to start an App or explicitly set these values
 setApiRoot(
     $('#g-global-info-apiroot').text().replace('%HOST%', window.location.origin) || '/api/v1'
-);
-setStaticRoot(
-    $('#g-global-info-staticroot').text().replace('%HOST%', window.location.origin) || '/static'
 );
 
 /**
@@ -264,11 +228,8 @@ function setUploadChunkSize(val) {
 
 export {
     apiRoot, // deprecated
-    staticRoot, // deprecated
     getApiRoot,
     setApiRoot,
-    getStaticRoot,
-    setStaticRoot,
     uploadHandlers,
     restRequest,
     numberOutstandingRestRequests,

--- a/girder/web_client/test/spec/setApiSpec.js
+++ b/girder/web_client/test/spec/setApiSpec.js
@@ -1,6 +1,6 @@
 girderTest.startApp();
 
-describe('Test setApiRoot() and setStaticRoot() functions', function () {
+describe('Test setApiRoot() function', function () {
     it('Check for default values and mutation', function () {
         waitsFor(function () {
             return $('.g-frontpage-body').length > 0;
@@ -9,15 +9,10 @@ describe('Test setApiRoot() and setStaticRoot() functions', function () {
         runs(function () {
             // Test the default values.
             expect(girder.rest.apiRoot.slice(girder.rest.apiRoot.indexOf('/', 7))).toBe('/api/v1');
-            expect(girder.rest.staticRoot.slice(girder.rest.staticRoot.indexOf('/', 7))).toBe('/static');
 
             var apiRootVal = '/foo/bar/v2';
             girder.rest.setApiRoot(apiRootVal);
             expect(girder.rest.apiRoot).toBe(apiRootVal);
-
-            var staticRootVal = 'dynamic';
-            girder.rest.setStaticRoot(staticRootVal);
-            expect(girder.rest.staticRoot).toBe(staticRootVal);
         });
     });
 });

--- a/girder/web_client/test/testEnv.pug
+++ b/girder/web_client/test/testEnv.pug
@@ -8,7 +8,6 @@ html(lang='en')
 
   body
     #g-global-info-apiroot.hide %HOST%#{apiRoot}
-    #g-global-info-staticroot.hide %HOST%#{staticRoot}
 
     each js in jsFiles
       script(src=js)


### PR DESCRIPTION
This is a follow-up to #2893:
> The base URL where static assets are served (known in Webpack as the `publicPath`) was never designed to be determined at Javascript runtime. While Webpack includes a limited tool (the magic `__webpack_public_path__` variable) to defer setting `publicPath` within the Webpack config, it intractably breaks several types of asset loading to try to set this value at JS runtime (as opposed to just within the JS build process).
>
> Previous attempts to work around this are summed up within the code comment:
>> `publicPath` would normally be set in the Webpack config file, but is not known at compile time. Note that in theory, an ES6-style import of a file asset that occurred earlier in the import resolution sequence than this module could fail to have its `publicPath` set at all, but the typical style rules for ordering ES6-style imports ensure that this module will be loaded very early in the import sequence. However, if `App` startup code modifies the `staticRoot`, then any ES6-style imports will probably have the incorrect path. Ultimately though, most file asset imports will occur in Pug files via require-style imports, which happen at runtime, so they will always succeed.
>
> However, as mentioned in the comment, the previous strategy did not work for some types of asset imports. Worse, it fundamentally broke using the Girder JS code with any other build system (which would not expect an attempt to set `__webpack_public_path__` at runtime), making it impossible to reuse Girder's client components in externally-built projects or to modernize external projects with non-Girder build systems.

This PR now causes `girder build` to pass the static root (as determined by the Girder database setting) to Webpack at build time.

The ability to set the static root at JS run time (via the `setStaticRoot` API or via a `<div id="g-global-info-staticroot">`) has been removed.

Finally, the `girder.utility.server.getStaticRoot` method has been changed to return an absolute URL. This is necessary, since when Webpack's `publicPath` is a relative URL, assets referenced within CSS files (e.g. some of the JSON metadata editor assets) are incorrectly resolved relative to the referring file.