### PR TITLE
Split the core web client into its own package.json

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -455,18 +455,21 @@ should be done:
 
        npm install -g 'npm@>=5.6'
 
-2. Update ``dependencies`` or ``devDependencies`` in ``girder/web_client/package.json.template``
-   to add a new *abstract* specifier for the package:
+2. Update ``girder/web_client/package.json.template`` or ``girder/web_client/src/package.json`` to
+   add a new *abstract* specifier for the package:
 
-  * Packages that are bundled into the web client should generally use the
+  * Packages that are bundled into the web client must be listed under the ``dependencies`` field
+    of ``girder/web_client/src/package.json`` and should generally use the
     `tilde range <https://www.npmjs.com/package/semver#tilde-ranges-123-12-1>`_
     to specify versions.
-  * Packages that are part of the build or testing process should generally use the
+  * Packages that are part of the build or testing process should be listed under either the
+    ``dependencies`` or ``devDependencies`` fields of ``girder/web_client/package.json.template``
+    and should generally use the
     `caret range <https://www.npmjs.com/package/semver#caret-ranges-123-025-004>`_
     to specify versions.
 
-If updating node libraries related to linting or documentation, you should instead modify
-the top-level ``package.json`` file, run ``npm update``, commit the modified files.
+If updating npm libraries related to linting or documentation, you should instead modify
+the top-level ``package.json`` file, run ``npm update``, then commit the modified files.
 
 Creating a new release
 ----------------------
@@ -477,7 +480,7 @@ are stored as releases inside the official
 `github repository <https://github.com/girder/girder/releases>`_. The
 recommended process for generating a new release is described here.
 
-1.  From the target commit, set the desired version number in ``girder/web_client/package.json.template``,
+1.  From the target commit, set the desired version number in ``girder/web_client/src/package.json``,
     and ``girder/__init__.py``. Create a new commit and note the SHA; this will
     become the release tag.
 
@@ -516,9 +519,9 @@ recommended process for generating a new release is described here.
 
         python setup.py sdist upload
 
-10. Publish the new girder source package on npm.
+10. Publish the new Girder core source package on npm.
 
-        cd girder/web_client && cp package.json.template package.json && npm publish
+        cd girder/web_client/src && npm publish
 
 .. _releasepythonclientpackage:
 

--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -152,12 +152,10 @@ build --dev`` will build a *development* install of Girder's static assets as
 well as building targets only necessary when running testing.
 
 The new build process works by generating a ``package.json`` file in ``girder/web_client``
-from the template (``girder/web_client/package.json.template``).  The generated
-``package.json`` includes all plugin web client dependencies as well as a list of
-npm packages containing web client extensions.  The build process is executed in
-place (in the Girder python package) in both development and production installs.
-The built assets are installed into a virtual environment specific static path
-``{sys.prefix}/share/girder``.
+from the template (``girder/web_client/package.json.template``). The generated ``package.json``
+itself depends on the core web client and all plugin web clients. The build process is executed in
+place (in the Girder Python package) in both development and production installs. The built assets
+are installed into a virtual environment specific static path ``{sys.prefix}/share/girder``.
 
 Static root is required during web client build
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/girder/cli/build.py
+++ b/girder/cli/build.py
@@ -110,6 +110,7 @@ def _generatePackageJSON(staging, source):
     with open(source, 'r') as f:
         sourceJSON = json.load(f)
     deps = sourceJSON['dependencies']
+    deps['@girder/core'] = 'file:%s' % os.path.join(os.path.dirname(source), 'src')
     plugins = _collectPluginDependencies()
     deps.update(plugins)
     sourceJSON['girder'] = {

--- a/girder/web_client/.gitignore
+++ b/girder/web_client/.gitignore
@@ -1,2 +1,2 @@
-package.json
+/package.json
 package-lock.json

--- a/girder/web_client/grunt_tasks/build.js
+++ b/girder/web_client/grunt_tasks/build.js
@@ -197,8 +197,6 @@ module.exports = function (grunt) {
         }
     });
 
-    const paths = require('./webpack.paths.js');
-
     // add coverage to all babel loader rules when in dev mode
     injectIstanbulCoverage(webpackConfig);
 
@@ -207,7 +205,7 @@ module.exports = function (grunt) {
             options: webpackConfig,
             core_lib: {
                 entry: {
-                    girder_lib: [paths.web_src]
+                    girder_lib: [require.resolve('@girder/core')] // main is index.js
                 },
                 output: {
                     library: '[name]',
@@ -234,7 +232,7 @@ module.exports = function (grunt) {
             },
             core_app: {
                 entry: {
-                    girder_app: [path.join(paths.web_src, 'main.js')]
+                    girder_app: [require.resolve('@girder/core/main.js')]
                 },
                 output: {
                     path: grunt.config.get('builtPath')

--- a/girder/web_client/grunt_tasks/swagger.js
+++ b/girder/web_client/grunt_tasks/swagger.js
@@ -16,13 +16,13 @@
 
 const path = require('path');
 
-const webSrc = require('./webpack.paths').web_src;
-
 /**
  * Define tasks that copy and configure swagger API/doc files.
  */
 module.exports = function (grunt) {
     const builtPath = path.resolve(grunt.config.get('builtPath'), 'swagger');
+    // require.resolve('@girder/core') finds the main index.js
+    const webSrc = path.dirname(require.resolve('@girder/core'));
     grunt.config.merge({
         copy: {
             swagger: {

--- a/girder/web_client/grunt_tasks/webpack.config.js
+++ b/girder/web_client/grunt_tasks/webpack.config.js
@@ -24,7 +24,6 @@ var path = require('path');
 var webpack = require('webpack');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
-const webSrc = require('./webpack.paths').web_src;
 const nodeModules = require('./webpack.paths').node_modules;
 
 // Resolving the Babel presets here is required to support symlinking plugin directories from
@@ -41,7 +40,7 @@ function fileLoader() {
     };
 }
 
-var loaderPaths = [webSrc];
+var loaderPaths = [path.dirname(require.resolve('@girder/core'))];
 var loaderPathsNodeModules = loaderPaths.concat([nodeModules]);
 
 module.exports = {
@@ -203,7 +202,7 @@ module.exports = {
         extensions: ['.js'],
         symlinks: false,
         alias: {
-            'girder': path.resolve('src'),
+            'girder': '@girder/core',
             'jquery': require.resolve('jquery') // ensure that all plugins use the same "jquery"
         }
     },

--- a/girder/web_client/grunt_tasks/webpack.config.js
+++ b/girder/web_client/grunt_tasks/webpack.config.js
@@ -202,7 +202,9 @@ module.exports = {
         extensions: ['.js'],
         symlinks: false,
         alias: {
-            'girder': '@girder/core',
+            // Using "'girder': '@girder/core'" breaks the DllPlugin splitting, for some reason
+            'girder': path.dirname(require.resolve('@girder/core')),
+            '@girder/core': path.dirname(require.resolve('@girder/core')),
             'jquery': require.resolve('jquery') // ensure that all plugins use the same "jquery"
         }
     },

--- a/girder/web_client/grunt_tasks/webpack.paths.js
+++ b/girder/web_client/grunt_tasks/webpack.paths.js
@@ -18,7 +18,6 @@ var path = require('path');
 
 module.exports = {
     node_modules: path.resolve('node_modules'),
-    web_src: path.resolve('src'),
     plugins: path.resolve(__dirname, 'plugins'),
     static: path.resolve('static')
 };

--- a/girder/web_client/package.json.template
+++ b/girder/web_client/package.json.template
@@ -1,32 +1,16 @@
 {
-    "name": "girder",
-    "version": "3.0.0-alpha.1",
-    "description": "Extensible data management platform",
-    "homepage": "https://girder.readthedocs.org",
-    "bugs": {
-        "url": "https://github.com/girder/girder/issues"
-    },
-    "license": "Apache-2.0",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/girder/girder.git"
-    },
+    "name": "@girder/meta-build",
     "engines": {
         "node": ">=8.0",
         "npm": ">=5.2"
     },
     "dependencies": {
-        "as-jqplot": "~1.0.8",
         "babel-core": "^6.25.0",
         "babel-loader": "^7.1.1",
         "babel-preset-env": "^1.6.1",
-        "backbone": "~1.3.3",
-        "bootstrap": "~3.3.7",
-        "bootstrap-switch": "~3.3.4",
         "colors": "^1.1.2",
         "copy-webpack-plugin": "^4.5.2",
         "css-loader": "^0.26.1",
-        "eonasdan-bootstrap-datetimepicker": "~4.17",
         "extendify": "^1.0.0",
         "extract-text-webpack-plugin": "^2.1.2",
         "file-loader": "^0.11.2",
@@ -43,24 +27,15 @@
         "grunt-shell": "^2.1.0",
         "grunt-webpack": "^3.0.2",
         "grunt-zip": "^0.17.1",
-        "jquery": "~3.2.1",
-        "jsoneditor": "~5.9.3",
         "mkdirp": "^0.5.1",
-        "moment": "~2.20.1",
         "nib": "^1.1.2",
         "pug": "^2.0.0-rc.3",
         "pug-loader": "^2.3.0",
-        "qrcode": "~1.2.0",
-        "remarkable": "~1.7.1",
-        "sprintf-js": "~1.1.1",
         "style-loader": "^0.13.2",
         "stylus": "^0.54.5",
         "stylus-loader": "^3.0.1",
-        "swagger-ui": "~2.2.10",
         "toposort": "^1.0.3",
         "uglifyjs-webpack-plugin": "^1.1.6",
-        "underscore": "~1.8.3",
-        "url-otpauth": "~2.0.0",
         "webpack": "^2.7.0",
         "whatwg-fetch": "^2.0.4"
     },
@@ -73,14 +48,6 @@
         "build": "grunt",
         "watch": "grunt --watch"
     },
-    "files": [
-        "Gruntfile.js",
-        "grunt_tasks/",
-        "src/",
-        "static/",
-        "test/"
-    ],
-    "main": "./index.js",
     "girder": {
         "plugins": []
     }

--- a/girder/web_client/src/package.json
+++ b/girder/web_client/src/package.json
@@ -1,0 +1,31 @@
+{
+    "name": "@girder/core",
+    "version": "3.0.0-alpha.1",
+    "description": "Extensible data management platform",
+    "homepage": "https://girder.readthedocs.org",
+    "bugs": {
+        "url": "https://github.com/girder/girder/issues"
+    },
+    "license": "Apache-2.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/girder/girder.git"
+    },
+    "dependencies": {
+        "as-jqplot": "~1.0.8",
+        "backbone": "~1.3.3",
+        "bootstrap": "~3.3.7",
+        "bootstrap-switch": "~3.3.4",
+        "eonasdan-bootstrap-datetimepicker": "~4.17",
+        "jquery": "~3.2.1",
+        "jsoneditor": "~5.9.3",
+        "moment": "~2.20.1",
+        "qrcode": "~1.2.0",
+        "remarkable": "~1.7.1",
+        "sprintf-js": "~1.1.1",
+        "swagger-ui": "~2.2.10",
+        "underscore": "~1.8.3",
+        "url-otpauth": "~2.0.0"
+    },
+    "main": "./index.js"
+}


### PR DESCRIPTION
This will allow the code within the core web client to be published and reused by other projects with different build systems.