### PR TITLE
Support passing unicode values to the pytest request method.

### DIFF
--- a/pytest_girder/pytest_girder/utils.py
+++ b/pytest_girder/pytest_girder/utils.py
@@ -182,7 +182,10 @@ def request(path='/', method='GET', params=None, user=None,
         body = body.encode('utf8')
 
     if params:
-        qs = urllib.parse.urlencode(params)
+        # Python2 can't urlencode unicode and this does no harm in Python3
+        qs = urllib.parse.urlencode({
+            k: v.encode('utf8') if isinstance(v, six.text_type) else v
+            for k, v in params.items()})
 
     if params and body:
         # In this case, we are forced to send params in query string

--- a/pytest_girder/setup.py
+++ b/pytest_girder/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='pytest-girder',
-    version='0.1.0a2',
+    version='0.1.0a3',
     description='A set of pytest fixtures for testing Girder applications.',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',


### PR DESCRIPTION
This is necessary to pass unicode values to the request method when testing in Python 2.7.
