### PR TITLE
Fix some client build warnings

### DIFF
--- a/girder/web_client/src/package.json
+++ b/girder/web_client/src/package.json
@@ -20,6 +20,7 @@
         "jquery": "~3.2.1",
         "jsoneditor": "~5.9.3",
         "moment": "~2.20.1",
+        "moment-timezone": "~0.4.1",
         "qrcode": "~1.2.0",
         "remarkable": "~1.7.1",
         "sprintf-js": "~1.1.1",

--- a/girder/web_client/src/stylesheets/layout/global.styl
+++ b/girder/web_client/src/stylesheets/layout/global.styl
@@ -125,10 +125,10 @@ textarea
     width 45px
     position absolute
     right 0
-    background linear-gradient(left, rgba(250, 250, 252, 0), rgba(250, 250, 252, 1))
+    background linear-gradient(to right, rgba(250, 250, 252, 0), rgba(250, 250, 252, 1))
 
     &[public="false"]
-      background linear-gradient(left, rgba(255, 249, 234, 0), rgba(255, 249, 234, 1))
+      background linear-gradient(to right, rgba(255, 249, 234, 0), rgba(255, 249, 234, 1))
 
 .g-list-public-status-icon
   display inline-block

--- a/girder/web_client/src/stylesheets/widgets/accessWidget.styl
+++ b/girder/web_client/src/stylesheets/widgets/accessWidget.styl
@@ -44,7 +44,7 @@ i.g-flag-icon
 .g-ac-list
   border 1px solid #d7d7d7
   border-top none
-  background linear-gradient(top, #d3d3d3 0, #f0f0f0 6px)
+  background linear-gradient(to bottom, #d3d3d3 0, #f0f0f0 6px)
   padding 1px 4px
 
   .g-group-access-entry, .g-user-access-entry

--- a/girder/web_client/src/stylesheets/widgets/hierarchyWidget.styl
+++ b/girder/web_client/src/stylesheets/widgets/hierarchyWidget.styl
@@ -2,7 +2,7 @@
   border 1px solid #eaeaea
 
   .g-hierarchy-actions-header
-    background linear-gradient(top, #e6e6e6 0, #f7f7f7 8px)
+    background linear-gradient(to bottom, #e6e6e6 0, #f7f7f7 8px)
     padding 4px 5px 3px
     background-color #f6f6f6
     border-top 1px solid #ddd
@@ -91,7 +91,7 @@
           background-color #f4eedf
 
     >.g-show-more
-      background-image linear-gradient(top, #f6f6f6 0, #fff 10px)
+      background-image linear-gradient(to bottom, #f6f6f6 0, #fff 10px)
 
     .g-list-checkbox
       font-size 16px

--- a/plugins/authorized_upload/girder_authorized_upload/web_client/stylesheets/authorizedUpload.styl
+++ b/plugins/authorized_upload/girder_authorized_upload/web_client/stylesheets/authorizedUpload.styl
@@ -26,7 +26,7 @@
 
       &:hover
         background-color #6cc8a7
-        background linear-gradient(top, #6cc8a7 50%, #5cb897 100%)
+        background linear-gradient(to bottom, #6cc8a7 50%, #5cb897 100%)
 
       &:active
         background #6cc8a7


### PR DESCRIPTION
* Use updated CSS syntax for "linear-gradient"
  * The old direction syntax is deprecated.
* Add a peerDependency "moment-timezone" for "eonasdan-bootstrap-datetimepicker"