### PR TITLE
Remove already-deprecated support for "path" parameter in restRequest

### DIFF
--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -139,6 +139,9 @@ Other backwards incompatible changes affecting plugins
         def load(self, info):
             ModelImporter.registerModel('job', Job, 'jobs')
 
+* In the web client, ``girder.rest.restRequest`` no longer accepts the deprecated ``path``
+  parameter; callers should use the ``url`` parameter instead. Callers are also encouraged to use
+  the ``method`` parameter instead of ``type``.
 
 Client build changes
 ++++++++++++++++++++

--- a/girder/web_client/src/rest.js
+++ b/girder/web_client/src/rest.js
@@ -68,7 +68,8 @@ setApiRoot(
 let restRequest = function (opts) {
     opts = opts || {};
     const defaults = {
-        // the default `method` (aliased as `type`) is 'GET'
+        // the default 'method' is 'GET', as set by 'jquery.ajax'
+
         girderToken: getCurrentToken() || cookie.find('girderToken'),
 
         error: (error, status) => {
@@ -124,12 +125,6 @@ let restRequest = function (opts) {
 
     // Overwrite defaults with passed opts, but do not mutate opts
     const args = _.extend({}, defaults, opts);
-
-    if (args.path) {
-        console.warn('restRequest\'s "path" option is deprecated, use "url" instead');
-        args.url = args.url || args.path;
-        delete args.path;
-    }
 
     if (!args.url) {
         throw new Error('restRequest requires a "url" argument');

--- a/plugins/terms/plugin_tests/termsSpec.js
+++ b/plugins/terms/plugin_tests/termsSpec.js
@@ -11,8 +11,8 @@ describe('Create and log in to a user for testing', function () {
         runs(function () {
             settingSaved = false;
             girder.rest.restRequest({
-                path: 'system/setting',
-                type: 'PUT',
+                url: 'system/setting',
+                method: 'PUT',
                 data: {
                     key: 'core.collection_create_policy',
                     value: JSON.stringify({groups: [], open: true, users: []})


### PR DESCRIPTION
* Fix an outdated usage of restRequest arguments
* Remove already-deprecated support for "path" parameter in restRequest