### PR TITLE
Replace Javascript imports of "girder" with "@girder/core"

### DIFF
--- a/docs/developer-cookbook.rst
+++ b/docs/developer-cookbook.rst
@@ -59,14 +59,14 @@ Upload a file
 ^^^^^^^^^^^^^
 
 If you are using the Girder javascript client library, you can simply call the ``upload``
-method of the ``girder/models/FileModel``. The first argument is the parent model
+method of the ``@girder/core/models/FileModel``. The first argument is the parent model
 object (an ``ItemModel`` or ``FolderModel`` instance) to upload into, and the second
 is a browser ``File`` object that was selected via a file input element. You can
 bind to several events of that model, as in the example below.
 
 .. code-block:: javascript
 
-    import FileModel from 'girder/models/FileModel';
+    import FileModel from '@girder/core/models/FileModel';
 
     var fileModel = new FileModel();
     fileModel.on('g:upload.complete', function () {
@@ -83,7 +83,7 @@ bind to several events of that model, as in the example below.
     fileModel.upload(parentFolder, fileObject);
 
 If you don't feel like making your own upload interface, you can simply use
-the ``girder/views/widgets/UploadWidget`` to provide a nice GUI interface for uploading.
+the ``@girder/core/views/widgets/UploadWidget`` to provide a nice GUI interface for uploading.
 It will prompt the user to drag and drop or browse for files, and then shows
 a current and overall progress bar and also provides controls for resuming a
 failed upload.
@@ -105,7 +105,7 @@ by passing in options like so:
 
 .. code-block:: javascript
 
-    import UploadWidget from 'girder/views/widgets/UploadWidget';
+    import UploadWidget from '@girder/core/views/widgets/UploadWidget';
 
     new UploadWidget({
         option: value,

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -142,7 +142,7 @@ expected, but a warning message will appear in the console to remind you. Exampl
 
 .. code-block:: javascript
 
-    import View from 'girder/views/View';
+    import View from '@girder/core/views/View';
 
     MySubView = View.extend({
        ...

--- a/docs/external-web-clients.rst
+++ b/docs/external-web-clients.rst
@@ -54,12 +54,12 @@ application bootstrapping
 
     import Backbone from 'backbone';
 
-    import { setCurrentUser } from 'girder/auth';
-    import UserModel from 'girder/models/UserModel';
-    import { setApiRoot } from 'girder/rest';
-    import router from 'girder/router';
-    import eventStream from 'girder/utilities/EventStream';
-    import App from 'girder/views/App';
+    import { setCurrentUser } from '@girder/core/auth';
+    import UserModel from '@girder/core/models/UserModel';
+    import { setApiRoot } from '@girder/core/rest';
+    import router from '@girder/core/router';
+    import eventStream from '@girder/core/utilities/EventStream';
+    import App from '@girder/core/views/App';
 
     // set the path where girder's API is mounted
     setApiRoot('/girder/api/v1');
@@ -135,12 +135,12 @@ In your JavaScript, perform callbacks such as the following:
 
 .. code-block:: javascript
 
-    import { getCurrentUser, setCurrentUser } from 'girder/auth';
-    import events from 'girder/events';
-    import UserModel from 'girder/models/UserModel';
-    import { restRequest } from 'girder/rest';
-    import LoginView from 'girder/views/layout/LoginView';
-    import RegisterView from 'girder/views/layout/RegisterView';
+    import { getCurrentUser, setCurrentUser } from '@girder/core/auth';
+    import events from '@girder/core/events';
+    import UserModel from '@girder/core/models/UserModel';
+    import { restRequest } from '@girder/core/rest';
+    import LoginView from '@girder/core/views/layout/LoginView';
+    import RegisterView from '@girder/core/views/layout/RegisterView';
 
     $('#login').click(function () {
         var loginView = new LoginView({

--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -98,9 +98,23 @@ plugin:
 .. warning:: The plugin name was removed from the info object.  Where previously used, plugins should
              replace references to ``info['name']`` with a hard-coded string.
 
-* Migrate all imports in python and javascript source files.  The old plugin module paths are no longer
-  valid.  Any reference to ``girder.plugins`` in python or ``girder.plugin`` in javascript should be changed
-  to the actual installed module names.
+* Migrate all imports in Python and Javascript source files.  The old plugin module paths are no longer
+  valid.  Any import reference to:
+
+  * ``girder.plugins`` in Python should be changed to the actual installed module name
+
+    * For example, change ``from girder.plugins.jobs.models.job import Job`` to
+      ``from girder_jobs.models.job import Job``
+
+  * ``girder_plugins`` in Javascript should be changed to the actual installed package name
+
+    * For example, change ``import { JobListWidget } from 'girder_plugins/jobs/views';`` to
+      ``import { JobListWidget } from '@girder/jobs/views';``
+
+  * ``girder`` in Javascript should be changed to ``@girder/core``
+
+    * For example, change ``import { restRequest } from 'girder/rest';`` to
+      ``import { restRequest } from '@girder/core/rest';``
 
 
 Other backwards incompatible changes affecting plugins

--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -700,8 +700,8 @@ Girder's client build system.  The important keys in the object are as follows:
     easy to include additional transpilation rules.  For an example of this in
     use, see the built in ``dicom_viewer`` plugin.
 
-Core Girder code can be imported relative to the path **girder**, for example
-``import View from 'girder/views/View';``. The entry point defined in your
+Core Girder code can be imported relative to the path **@girder/core**, for example
+``import View from '@girder/core/views/View';``. The entry point defined in your
 "main" file will be loaded into the browser after Girder's core library, but
 before the application is initialized.
 
@@ -715,7 +715,7 @@ events object that can be imported like so:
 
 .. code-block:: javascript
 
-    import events from 'girder/events';
+    import events from '@girder/core/events';
 
     ...
 
@@ -737,8 +737,8 @@ function to `wrap` the method of the core prototype with our own function.
 
 .. code-block:: javascript
 
-    import HierarchyWidget from 'girder/views/widgets/HierarchyWidget';
-    import { wrap } from 'girder/utilities/PluginUtils';
+    import HierarchyWidget from '@girder/core/views/widgets/HierarchyWidget';
+    import { wrap } from '@girder/core/utilities/PluginUtils';
 
     // Import our template file from our plugin using a relative path
     import myTemplate from './templates/hierachyWidgetExtension.pug';
@@ -807,11 +807,11 @@ route to your plugin.
 
 .. code-block:: javascript
 
-    import events from 'girder/events';
-    import router from 'girder/router';
-    import { Layout } from 'girder/constants';
-    import CollectionModel from 'girder/models/CollectionModel';
-    import CollectionView from 'girder/views/body/CollectionView';
+    import events from '@girder/core/events';
+    import router from '@girder/core/router';
+    import { Layout } from '@girder/core/constants';
+    import CollectionModel from '@girder/core/models/CollectionModel';
+    import CollectionView from '@girder/core/views/body/CollectionView';
 
     router.route('collection/:id/frontPage', 'collectionFrontPage', function (collectionId, params) {
         var collection = new CollectionModel();

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -295,7 +295,7 @@ internally. You can use it on any user model with the ``_id`` field set, as in t
 
 .. code-block:: javascript
 
-    import { getCurrentUser } from 'girder/auth';
+    import { getCurrentUser } from '@girder/core/auth';
 
     const currentUser = getCurrentUser();
     if (currentUser) {

--- a/girder/web_client/grunt_tasks/build.js
+++ b/girder/web_client/grunt_tasks/build.js
@@ -282,6 +282,12 @@ module.exports = function (grunt) {
             module: {
                 rules: [babelRule]
             },
+            resolve: {
+                alias: {
+                    // This is deprecated, but kept in place for compatibility
+                    'girder': '@girder/core'
+                }
+            },
             plugins: [
                 new webpack.DllPlugin({
                     path: path.join(grunt.config.get('builtPath'), 'plugins', name, 'plugin-manifest.json'),

--- a/girder/web_client/grunt_tasks/webpack.config.js
+++ b/girder/web_client/grunt_tasks/webpack.config.js
@@ -202,10 +202,9 @@ module.exports = {
         extensions: ['.js'],
         symlinks: false,
         alias: {
-            // Using "'girder': '@girder/core'" breaks the DllPlugin splitting, for some reason
-            'girder': path.dirname(require.resolve('@girder/core')),
-            '@girder/core': path.dirname(require.resolve('@girder/core')),
-            'jquery': require.resolve('jquery') // ensure that all plugins use the same "jquery"
+            'jquery': require.resolve('jquery'), // ensure that all plugins use the same "jquery"
+            // For some reason, this is necessary to ensure DllPlugin splitting works properly
+            '@girder/core': path.dirname(require.resolve('@girder/core'))
         }
     },
     node: {

--- a/girder/web_client/src/auth.js
+++ b/girder/web_client/src/auth.js
@@ -1,8 +1,8 @@
 import _ from 'underscore';
 
-import UserModel from 'girder/models/UserModel';
-import events from 'girder/events';
-import { restRequest } from 'girder/rest';
+import UserModel from '@girder/core/models/UserModel';
+import events from '@girder/core/events';
+import { restRequest } from '@girder/core/rest';
 
 // TODO: this might need some fixing/testing, as it seems that
 // girder.corsAuth could be an override. See login doc below.

--- a/girder/web_client/src/collections/ApiKeyCollection.js
+++ b/girder/web_client/src/collections/ApiKeyCollection.js
@@ -1,5 +1,5 @@
-import ApiKeyModel from 'girder/models/ApiKeyModel';
-import Collection from 'girder/collections/Collection';
+import ApiKeyModel from '@girder/core/models/ApiKeyModel';
+import Collection from '@girder/core/collections/Collection';
 
 var ApiKeyCollection = Collection.extend({
     resourceName: 'api_key',

--- a/girder/web_client/src/collections/AssetstoreCollection.js
+++ b/girder/web_client/src/collections/AssetstoreCollection.js
@@ -1,5 +1,5 @@
-import AssetstoreModel from 'girder/models/AssetstoreModel';
-import Collection from 'girder/collections/Collection';
+import AssetstoreModel from '@girder/core/models/AssetstoreModel';
+import Collection from '@girder/core/collections/Collection';
 
 var AssetstoreCollection = Collection.extend({
     resourceName: 'assetstore',

--- a/girder/web_client/src/collections/Collection.js
+++ b/girder/web_client/src/collections/Collection.js
@@ -1,10 +1,10 @@
 import _ from 'underscore';
 import Backbone from 'backbone';
 
-import { localeComparator } from 'girder/misc';
-import Model from 'girder/models/Model';
-import { restRequest } from 'girder/rest';
-import { SORT_ASC } from 'girder/constants';
+import { localeComparator } from '@girder/core/misc';
+import Model from '@girder/core/models/Model';
+import { restRequest } from '@girder/core/rest';
+import { SORT_ASC } from '@girder/core/constants';
 
 /**
  * All collections should descend from this collection base class, which

--- a/girder/web_client/src/collections/CollectionCollection.js
+++ b/girder/web_client/src/collections/CollectionCollection.js
@@ -1,5 +1,5 @@
-import Collection from 'girder/collections/Collection';
-import CollectionModel from 'girder/models/CollectionModel';
+import Collection from '@girder/core/collections/Collection';
+import CollectionModel from '@girder/core/models/CollectionModel';
 
 var CollectionCollection = Collection.extend({
     resourceName: 'collection',

--- a/girder/web_client/src/collections/FileCollection.js
+++ b/girder/web_client/src/collections/FileCollection.js
@@ -1,5 +1,5 @@
-import Collection from 'girder/collections/Collection';
-import FileModel from 'girder/models/FileModel';
+import Collection from '@girder/core/collections/Collection';
+import FileModel from '@girder/core/models/FileModel';
 
 var FileCollection = Collection.extend({
     resourceName: 'file',

--- a/girder/web_client/src/collections/FolderCollection.js
+++ b/girder/web_client/src/collections/FolderCollection.js
@@ -1,5 +1,5 @@
-import Collection from 'girder/collections/Collection';
-import FolderModel from 'girder/models/FolderModel';
+import Collection from '@girder/core/collections/Collection';
+import FolderModel from '@girder/core/models/FolderModel';
 
 var FolderCollection = Collection.extend({
     resourceName: 'folder',

--- a/girder/web_client/src/collections/GroupCollection.js
+++ b/girder/web_client/src/collections/GroupCollection.js
@@ -1,5 +1,5 @@
-import Collection from 'girder/collections/Collection';
-import GroupModel from 'girder/models/GroupModel';
+import Collection from '@girder/core/collections/Collection';
+import GroupModel from '@girder/core/models/GroupModel';
 
 var GroupCollection = Collection.extend({
     resourceName: 'group',

--- a/girder/web_client/src/collections/ItemCollection.js
+++ b/girder/web_client/src/collections/ItemCollection.js
@@ -1,5 +1,5 @@
-import Collection from 'girder/collections/Collection';
-import ItemModel from 'girder/models/ItemModel';
+import Collection from '@girder/core/collections/Collection';
+import ItemModel from '@girder/core/models/ItemModel';
 
 var ItemCollection = Collection.extend({
     resourceName: 'item',

--- a/girder/web_client/src/collections/UserCollection.js
+++ b/girder/web_client/src/collections/UserCollection.js
@@ -1,6 +1,6 @@
-import Collection from 'girder/collections/Collection';
-import UserModel from 'girder/models/UserModel';
-import { restRequest } from 'girder/rest';
+import Collection from '@girder/core/collections/Collection';
+import UserModel from '@girder/core/models/UserModel';
+import { restRequest } from '@girder/core/rest';
 
 var UserCollection = Collection.extend({
     resourceName: 'user',

--- a/girder/web_client/src/dialog.js
+++ b/girder/web_client/src/dialog.js
@@ -2,12 +2,12 @@ import $ from 'jquery';
 import _ from 'underscore';
 import Backbone from 'backbone';
 
-import router from 'girder/router';
-import { parseQueryString, splitRoute } from 'girder/misc';
+import router from '@girder/core/router';
+import { parseQueryString, splitRoute } from '@girder/core/misc';
 
-import ConfirmDialogTemplate from 'girder/templates/widgets/confirmDialog.pug';
+import ConfirmDialogTemplate from '@girder/core/templates/widgets/confirmDialog.pug';
 
-import 'girder/utilities/jquery/girderModal';
+import '@girder/core/utilities/jquery/girderModal';
 
 function handleClose(name, options, nameId) {
     if (!router.enabled()) {

--- a/girder/web_client/src/main.js
+++ b/girder/web_client/src/main.js
@@ -2,7 +2,7 @@ import $ from 'jquery';
 import _ from 'underscore';
 import Backbone from 'backbone';
 import moment from 'moment';
-import * as girder from 'girder';
+import * as girder from '@girder/core';
 
 window.girder = girder;
 

--- a/girder/web_client/src/misc.js
+++ b/girder/web_client/src/misc.js
@@ -2,7 +2,7 @@ import $ from 'jquery';
 import _ from 'underscore';
 import Remarkable from 'remarkable';
 
-import { MONTHS } from 'girder/constants';
+import { MONTHS } from '@girder/core/constants';
 
 /**
  * This file contains utility functions for general use in the application

--- a/girder/web_client/src/models/AccessControlledModel.js
+++ b/girder/web_client/src/models/AccessControlledModel.js
@@ -1,8 +1,8 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import Model from 'girder/models/Model';
-import { restRequest } from 'girder/rest';
+import Model from '@girder/core/models/Model';
+import { restRequest } from '@girder/core/rest';
 
 /**
  * Models corresponding to AccessControlledModels on the server should extend

--- a/girder/web_client/src/models/ApiKeyModel.js
+++ b/girder/web_client/src/models/ApiKeyModel.js
@@ -1,5 +1,5 @@
-import AccessControlledModel from 'girder/models/AccessControlledModel';
-import { restRequest } from 'girder/rest';
+import AccessControlledModel from '@girder/core/models/AccessControlledModel';
+import { restRequest } from '@girder/core/rest';
 
 var ApiKeyModel = AccessControlledModel.extend({
     resourceName: 'api_key',

--- a/girder/web_client/src/models/AssetstoreModel.js
+++ b/girder/web_client/src/models/AssetstoreModel.js
@@ -1,8 +1,8 @@
 import _ from 'underscore';
 
-import { formatSize } from 'girder/misc';
-import Model from 'girder/models/Model';
-import { restRequest } from 'girder/rest';
+import { formatSize } from '@girder/core/misc';
+import Model from '@girder/core/models/Model';
+import { restRequest } from '@girder/core/rest';
 
 var AssetstoreModel = Model.extend({
     resourceName: 'assetstore',

--- a/girder/web_client/src/models/CollectionCreationPolicyModel.js
+++ b/girder/web_client/src/models/CollectionCreationPolicyModel.js
@@ -1,5 +1,5 @@
-import AccessControlledModel from 'girder/models/AccessControlledModel';
-import { restRequest } from 'girder/rest';
+import AccessControlledModel from '@girder/core/models/AccessControlledModel';
+import { restRequest } from '@girder/core/rest';
 
 var CollectionCreationPolicyModel = AccessControlledModel.extend({
     resourceName: 'system/setting/collection_creation_policy',

--- a/girder/web_client/src/models/CollectionModel.js
+++ b/girder/web_client/src/models/CollectionModel.js
@@ -1,4 +1,4 @@
-import AccessControlledModel from 'girder/models/AccessControlledModel';
+import AccessControlledModel from '@girder/core/models/AccessControlledModel';
 
 var CollectionModel = AccessControlledModel.extend({
     resourceName: 'collection'

--- a/girder/web_client/src/models/FileModel.js
+++ b/girder/web_client/src/models/FileModel.js
@@ -1,10 +1,10 @@
 import _ from 'underscore';
 
-import FolderModel from 'girder/models/FolderModel';
-import ItemModel from 'girder/models/ItemModel';
-import Model from 'girder/models/Model';
-import { restRequest, uploadHandlers, getUploadChunkSize } from 'girder/rest';
-import 'girder/utilities/S3UploadHandler'; // imported for side effect
+import FolderModel from '@girder/core/models/FolderModel';
+import ItemModel from '@girder/core/models/ItemModel';
+import Model from '@girder/core/models/Model';
+import { restRequest, uploadHandlers, getUploadChunkSize } from '@girder/core/rest';
+import '@girder/core/utilities/S3UploadHandler'; // imported for side effect
 
 var FileModel = Model.extend({
     resourceName: 'file',

--- a/girder/web_client/src/models/FolderModel.js
+++ b/girder/web_client/src/models/FolderModel.js
@@ -1,8 +1,8 @@
 import _ from 'underscore';
 
-import AccessControlledModel from 'girder/models/AccessControlledModel';
-import MetadataMixin from 'girder/models/MetadataMixin';
-import { restRequest } from 'girder/rest';
+import AccessControlledModel from '@girder/core/models/AccessControlledModel';
+import MetadataMixin from '@girder/core/models/MetadataMixin';
+import { restRequest } from '@girder/core/rest';
 
 var FolderModel = AccessControlledModel.extend({
     resourceName: 'folder',

--- a/girder/web_client/src/models/GroupModel.js
+++ b/girder/web_client/src/models/GroupModel.js
@@ -1,9 +1,9 @@
 import _ from 'underscore';
 
-import AccessControlledModel from 'girder/models/AccessControlledModel';
-import { AccessType } from 'girder/constants';
-import { getCurrentUser } from 'girder/auth';
-import { restRequest } from 'girder/rest';
+import AccessControlledModel from '@girder/core/models/AccessControlledModel';
+import { AccessType } from '@girder/core/constants';
+import { getCurrentUser } from '@girder/core/auth';
+import { restRequest } from '@girder/core/rest';
 
 var GroupModel = AccessControlledModel.extend({
     resourceName: 'group',

--- a/girder/web_client/src/models/ItemModel.js
+++ b/girder/web_client/src/models/ItemModel.js
@@ -1,11 +1,11 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import FileCollection from 'girder/collections/FileCollection';
-import FolderModel from 'girder/models/FolderModel';
-import MetadataMixin from 'girder/models/MetadataMixin';
-import Model from 'girder/models/Model';
-import { restRequest } from 'girder/rest';
+import FileCollection from '@girder/core/collections/FileCollection';
+import FolderModel from '@girder/core/models/FolderModel';
+import MetadataMixin from '@girder/core/models/MetadataMixin';
+import Model from '@girder/core/models/Model';
+import { restRequest } from '@girder/core/rest';
 
 var ItemModel = Model.extend({
     resourceName: 'item',

--- a/girder/web_client/src/models/MetadataMixin.js
+++ b/girder/web_client/src/models/MetadataMixin.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 
-import { restRequest } from 'girder/rest';
+import { restRequest } from '@girder/core/rest';
 
 var MetadataMixin = {
     _sendMetadata: function (metadata, successCallback, errorCallback, opts) {

--- a/girder/web_client/src/models/Model.js
+++ b/girder/web_client/src/models/Model.js
@@ -2,7 +2,7 @@ import $ from 'jquery';
 import _ from 'underscore';
 import Backbone from 'backbone';
 
-import { restRequest, getApiRoot } from 'girder/rest';
+import { restRequest, getApiRoot } from '@girder/core/rest';
 
 /**
  * All models should descend from this base model, which provides a number

--- a/girder/web_client/src/models/UserModel.js
+++ b/girder/web_client/src/models/UserModel.js
@@ -1,10 +1,10 @@
 import _ from 'underscore';
 
-import { fetchCurrentUser, setCurrentToken, setCurrentUser } from 'girder/auth';
-import events from 'girder/events';
-import Model from 'girder/models/Model';
-import { restRequest } from 'girder/rest';
-import eventStream from 'girder/utilities/EventStream';
+import { fetchCurrentUser, setCurrentToken, setCurrentUser } from '@girder/core/auth';
+import events from '@girder/core/events';
+import Model from '@girder/core/models/Model';
+import { restRequest } from '@girder/core/rest';
+import eventStream from '@girder/core/utilities/EventStream';
 
 var UserModel = Model.extend({
     resourceName: 'user',

--- a/girder/web_client/src/rest.js
+++ b/girder/web_client/src/rest.js
@@ -2,8 +2,8 @@ import $ from 'jquery';
 import _ from 'underscore';
 import Backbone from 'backbone';
 
-import events from 'girder/events';
-import { getCurrentToken, cookie } from 'girder/auth';
+import events from '@girder/core/events';
+import { getCurrentToken, cookie } from '@girder/core/auth';
 
 let apiRoot;
 var uploadHandlers = {};

--- a/girder/web_client/src/router.js
+++ b/girder/web_client/src/router.js
@@ -1,10 +1,10 @@
 import $ from 'jquery';
 import Backbone from 'backbone';
 
-import events from 'girder/events';
-import { parseQueryString } from 'girder/misc';
+import events from '@girder/core/events';
+import { parseQueryString } from '@girder/core/misc';
 
-import 'girder/utilities/jquery/girderModal';
+import '@girder/core/utilities/jquery/girderModal';
 
 var Router = Backbone.Router.extend({
     initialize: function () {

--- a/girder/web_client/src/routes.js
+++ b/girder/web_client/src/routes.js
@@ -1,15 +1,15 @@
 /* eslint-disable import/first */
 
-import router from 'girder/router';
-import events from 'girder/events';
-import eventStream from 'girder/utilities/EventStream';
-import { getCurrentUser, setCurrentUser } from 'girder/auth';
-import { restRequest } from 'girder/rest';
+import router from '@girder/core/router';
+import events from '@girder/core/events';
+import eventStream from '@girder/core/utilities/EventStream';
+import { getCurrentUser, setCurrentUser } from '@girder/core/auth';
+import { restRequest } from '@girder/core/rest';
 
 /**
  * Admin
  */
-import AdminView from 'girder/views/body/AdminView';
+import AdminView from '@girder/core/views/body/AdminView';
 router.route('admin', 'admin', function () {
     events.trigger('g:navigateTo', AdminView);
 });
@@ -17,7 +17,7 @@ router.route('admin', 'admin', function () {
 /**
  * Assetstores
  */
-import AssetstoresView from 'girder/views/body/AssetstoresView';
+import AssetstoresView from '@girder/core/views/body/AssetstoresView';
 router.route('assetstores', 'assetstores', function (params) {
     events.trigger('g:navigateTo', AssetstoresView, {
         assetstoreEdit: params.dialog === 'assetstoreedit' ? params.dialogid : false
@@ -30,7 +30,7 @@ router.route('assetstore/:id/import', 'assetstoreImport', function (assetstoreId
 /**
  * Collections
  */
-import CollectionsView from 'girder/views/body/CollectionsView';
+import CollectionsView from '@girder/core/views/body/CollectionsView';
 router.route('collections', 'collections', function (params) {
     events.trigger('g:navigateTo', CollectionsView, params || {});
     events.trigger('g:highlightItem', 'CollectionsView');
@@ -39,7 +39,7 @@ router.route('collections', 'collections', function (params) {
 /**
  * Collection
  */
-import CollectionView from 'girder/views/body/CollectionView';
+import CollectionView from '@girder/core/views/body/CollectionView';
 router.route('collection/:id', 'collectionAccess', function (cid, params) {
     CollectionView.fetchAndInit(cid, {
         access: params.dialog === 'access',
@@ -64,7 +64,7 @@ router.route('collection/:id/folder/:id', 'collectionFolder', function (cid, fol
 /**
  * Folder
  */
-import FolderView from 'girder/views/body/FolderView';
+import FolderView from '@girder/core/views/body/FolderView';
 router.route('folder/:id', 'folder', function (id, params) {
     FolderView.fetchAndInit(id, {
         upload: params.dialog === 'upload',
@@ -78,7 +78,7 @@ router.route('folder/:id', 'folder', function (id, params) {
 /**
  * FrontPage
  */
-import FrontPageView from 'girder/views/body/FrontPageView';
+import FrontPageView from '@girder/core/views/body/FrontPageView';
 router.route('', 'index', function () {
     events.trigger('g:navigateTo', FrontPageView);
 });
@@ -86,7 +86,7 @@ router.route('', 'index', function () {
 /**
  * Groups
  */
-import GroupsView from 'girder/views/body/GroupsView';
+import GroupsView from '@girder/core/views/body/GroupsView';
 router.route('groups', 'groups', function (params) {
     events.trigger('g:navigateTo', GroupsView, params || {});
     events.trigger('g:highlightItem', 'GroupsView');
@@ -95,7 +95,7 @@ router.route('groups', 'groups', function (params) {
 /**
  * Group
  */
-import GroupView from 'girder/views/body/GroupView';
+import GroupView from '@girder/core/views/body/GroupView';
 router.route('group/:id', 'groupView', function (groupId, params) {
     GroupView.fetchAndInit(groupId, {
         edit: params.dialog === 'edit'
@@ -111,7 +111,7 @@ router.route('group/:id/:tab', 'groupView', function (groupId, tab, params) {
 /**
  * Item
  */
-import ItemView from 'girder/views/body/ItemView';
+import ItemView from '@girder/core/views/body/ItemView';
 router.route('item/:id', 'item', function (itemId, params) {
     ItemView.fetchAndInit(itemId, {
         edit: params.dialog === 'itemedit',
@@ -123,8 +123,8 @@ router.route('item/:id', 'item', function (itemId, params) {
 /**
  * Plugins
  */
-import PluginsView from 'girder/views/body/PluginsView';
-import UsersView from 'girder/views/body/UsersView';
+import PluginsView from '@girder/core/views/body/PluginsView';
+import UsersView from '@girder/core/views/body/UsersView';
 router.route('plugins', 'plugins', function () {
     events.trigger('g:navigateTo', PluginsView);
 });
@@ -132,7 +132,7 @@ router.route('plugins', 'plugins', function () {
 /**
  * SystemConfiguration
  */
-import SystemConfigurationView from 'girder/views/body/SystemConfigurationView';
+import SystemConfigurationView from '@girder/core/views/body/SystemConfigurationView';
 router.route('settings', 'settings', function () {
     events.trigger('g:navigateTo', SystemConfigurationView);
 });
@@ -140,8 +140,8 @@ router.route('settings', 'settings', function () {
 /**
  * UserAccount
  */
-import UserAccountView from 'girder/views/body/UserAccountView';
-import UserModel from 'girder/models/UserModel';
+import UserAccountView from '@girder/core/views/body/UserAccountView';
+import UserModel from '@girder/core/models/UserModel';
 router.route('useraccount/:id/:tab', 'accountTab', function (id, tab) {
     UserAccountView.fetchAndInit(id, tab);
 });
@@ -201,7 +201,7 @@ router.route('users', 'users', function (params) {
 /**
  * User
  */
-import UserView from 'girder/views/body/UserView';
+import UserView from '@girder/core/views/body/UserView';
 router.route('user/:id', 'user', function (userId, params) {
     UserView.fetchAndInit(userId, {
         folderCreate: params.dialog === 'foldercreate',
@@ -222,7 +222,7 @@ router.route('user/:id/folder/:id', 'userFolder', function (userId, folderId, pa
 /**
  * SearchResults
  */
-import SearchResultsView from 'girder/views/body/SearchResultsView';
+import SearchResultsView from '@girder/core/views/body/SearchResultsView';
 router.route('search/results', 'SearchResults', function (params) {
     events.trigger('g:navigateTo', SearchResultsView, {
         query: params.query,

--- a/girder/web_client/src/server.js
+++ b/girder/web_client/src/server.js
@@ -1,8 +1,8 @@
 import $ from 'jquery';
 
-import { confirm } from 'girder/dialog';
-import events from 'girder/events';
-import { restRequest } from 'girder/rest';
+import { confirm } from '@girder/core/dialog';
+import events from '@girder/core/events';
+import { restRequest } from '@girder/core/rest';
 
 /**
  * Periodically re-run a promise-returning function, until it is fulfilled.

--- a/girder/web_client/src/templates/body/frontPage.pug
+++ b/girder/web_client/src/templates/body/frontPage.pug
@@ -1,6 +1,6 @@
 .g-frontpage-header
   .g-frontpage-logo-container
-    img.g-frontpage-logo(src=require('girder/assets/Girder_Mark.png'))
+    img.g-frontpage-logo(src=require('@girder/core/assets/Girder_Mark.png'))
   .g-frontpage-title-container
     .g-frontpage-title #{brandName}
     .g-frontpage-subtitle Data management platform

--- a/girder/web_client/src/utilities/EventStream.js
+++ b/girder/web_client/src/utilities/EventStream.js
@@ -2,7 +2,7 @@ import $ from 'jquery';
 import _ from 'underscore';
 import Backbone from 'backbone';
 
-import { getApiRoot, restRequest } from 'girder/rest';
+import { getApiRoot, restRequest } from '@girder/core/rest';
 
 /**
  * The EventStream type wraps window.EventSource to listen to the unified

--- a/girder/web_client/src/utilities/S3UploadHandler.js
+++ b/girder/web_client/src/utilities/S3UploadHandler.js
@@ -1,7 +1,7 @@
 import _ from 'underscore';
 import Backbone from 'backbone';
 
-import { restRequest, uploadHandlers } from 'girder/rest';
+import { restRequest, uploadHandlers } from '@girder/core/rest';
 
 /**
  * This is the upload handler for the "s3" behavior, which is responsible for

--- a/girder/web_client/src/views/App.js
+++ b/girder/web_client/src/views/App.js
@@ -7,31 +7,31 @@ import 'bootstrap/js/alert';
 import '@girder/fontello/dist/css/animation.css';
 import '@girder/fontello/dist/css/fontello.css';
 
-import 'girder/utilities/jquery/girderModal';
+import '@girder/core/utilities/jquery/girderModal';
 
-import events from 'girder/events';
-import eventStream from 'girder/utilities/EventStream';
-import LayoutFooterView from 'girder/views/layout/FooterView';
-import LayoutGlobalNavView from 'girder/views/layout/GlobalNavView';
-import LayoutHeaderView from 'girder/views/layout/HeaderView';
-import LoginView from 'girder/views/layout/LoginView';
-import ProgressListView from 'girder/views/layout/ProgressListView';
-import RegisterView from 'girder/views/layout/RegisterView';
-import ResetPasswordView from 'girder/views/layout/ResetPasswordView';
-import router from 'girder/router';
-import UserModel from 'girder/models/UserModel';
-import View from 'girder/views/View';
-import { fetchCurrentUser, setCurrentUser, getCurrentUser } from 'girder/auth';
-import { Layout } from 'girder/constants';
-import { splitRoute } from 'girder/misc';
+import events from '@girder/core/events';
+import eventStream from '@girder/core/utilities/EventStream';
+import LayoutFooterView from '@girder/core/views/layout/FooterView';
+import LayoutGlobalNavView from '@girder/core/views/layout/GlobalNavView';
+import LayoutHeaderView from '@girder/core/views/layout/HeaderView';
+import LoginView from '@girder/core/views/layout/LoginView';
+import ProgressListView from '@girder/core/views/layout/ProgressListView';
+import RegisterView from '@girder/core/views/layout/RegisterView';
+import ResetPasswordView from '@girder/core/views/layout/ResetPasswordView';
+import router from '@girder/core/router';
+import UserModel from '@girder/core/models/UserModel';
+import View from '@girder/core/views/View';
+import { fetchCurrentUser, setCurrentUser, getCurrentUser } from '@girder/core/auth';
+import { Layout } from '@girder/core/constants';
+import { splitRoute } from '@girder/core/misc';
 
-import AlertTemplate from 'girder/templates/layout/alert.pug';
-import LayoutTemplate from 'girder/templates/layout/layout.pug';
+import AlertTemplate from '@girder/core/templates/layout/alert.pug';
+import LayoutTemplate from '@girder/core/templates/layout/layout.pug';
 
-import 'girder/routes';
+import '@girder/core/routes';
 
-import 'girder/stylesheets/layout/global.styl';
-import 'girder/stylesheets/layout/layout.styl';
+import '@girder/core/stylesheets/layout/global.styl';
+import '@girder/core/stylesheets/layout/layout.styl';
 
 var App = View.extend({
     /**

--- a/girder/web_client/src/views/View.js
+++ b/girder/web_client/src/views/View.js
@@ -1,8 +1,8 @@
 import _ from 'underscore';
 import Backbone from 'backbone';
 
-import events from 'girder/events';
-import eventStream from 'girder/utilities/EventStream';
+import events from '@girder/core/events';
+import eventStream from '@girder/core/utilities/EventStream';
 
 var View = Backbone.View.extend({
     constructor: function (opts) { // eslint-disable-line backbone/no-constructor

--- a/girder/web_client/src/views/body/AdminView.js
+++ b/girder/web_client/src/views/body/AdminView.js
@@ -1,10 +1,10 @@
-import View from 'girder/views/View';
-import { cancelRestRequests } from 'girder/rest';
-import { getCurrentUser } from 'girder/auth';
+import View from '@girder/core/views/View';
+import { cancelRestRequests } from '@girder/core/rest';
+import { getCurrentUser } from '@girder/core/auth';
 
-import AdminConsoleTemplate from 'girder/templates/body/adminConsole.pug';
+import AdminConsoleTemplate from '@girder/core/templates/body/adminConsole.pug';
 
-import 'girder/stylesheets/body/adminConsole.styl';
+import '@girder/core/stylesheets/body/adminConsole.styl';
 
 /**
  * This view shows the admin console, which links to all available admin pages.

--- a/girder/web_client/src/views/body/AssetstoresView.js
+++ b/girder/web_client/src/views/body/AssetstoresView.js
@@ -1,21 +1,21 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import AssetstoreCollection from 'girder/collections/AssetstoreCollection';
-import AssetstoreModel from 'girder/models/AssetstoreModel';
-import EditAssetstoreWidget from 'girder/views/widgets/EditAssetstoreWidget';
-import NewAssetstoreWidget from 'girder/views/widgets/NewAssetstoreWidget';
-import View from 'girder/views/View';
-import { AssetstoreType } from 'girder/constants';
-import { cancelRestRequests } from 'girder/rest';
-import { confirm } from 'girder/dialog';
-import events from 'girder/events';
-import { formatSize } from 'girder/misc';
-import { getCurrentUser } from 'girder/auth';
+import AssetstoreCollection from '@girder/core/collections/AssetstoreCollection';
+import AssetstoreModel from '@girder/core/models/AssetstoreModel';
+import EditAssetstoreWidget from '@girder/core/views/widgets/EditAssetstoreWidget';
+import NewAssetstoreWidget from '@girder/core/views/widgets/NewAssetstoreWidget';
+import View from '@girder/core/views/View';
+import { AssetstoreType } from '@girder/core/constants';
+import { cancelRestRequests } from '@girder/core/rest';
+import { confirm } from '@girder/core/dialog';
+import events from '@girder/core/events';
+import { formatSize } from '@girder/core/misc';
+import { getCurrentUser } from '@girder/core/auth';
 
-import AssetstoresTemplate from 'girder/templates/body/assetstores.pug';
+import AssetstoresTemplate from '@girder/core/templates/body/assetstores.pug';
 
-import 'girder/stylesheets/body/assetstores.styl';
+import '@girder/core/stylesheets/body/assetstores.styl';
 
 import 'as-jqplot/dist/jquery.jqplot.js';
 import 'as-jqplot/dist/jquery.jqplot.css'; // jquery.jqplot.min.css
@@ -25,8 +25,8 @@ import 'as-jqplot/dist/plugins/jqplot.pieRenderer.js';
  * This private data structure is a dynamic way to map assetstore types to the views
  * that should be rendered to import data into them.
  */
-import FilesystemImportView from 'girder/views/body/FilesystemImportView';
-import S3ImportView from 'girder/views/body/S3ImportView';
+import FilesystemImportView from '@girder/core/views/body/FilesystemImportView';
+import S3ImportView from '@girder/core/views/body/S3ImportView';
 var assetstoreImportViewMap = {};
 assetstoreImportViewMap[AssetstoreType.FILESYSTEM] = FilesystemImportView;
 assetstoreImportViewMap[AssetstoreType.S3] = S3ImportView;

--- a/girder/web_client/src/views/body/CollectionView.js
+++ b/girder/web_client/src/views/body/CollectionView.js
@@ -1,22 +1,22 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import AccessWidget from 'girder/views/widgets/AccessWidget';
-import CollectionModel from 'girder/models/CollectionModel';
-import EditCollectionWidget from 'girder/views/widgets/EditCollectionWidget';
-import FolderModel from 'girder/models/FolderModel';
-import HierarchyWidget from 'girder/views/widgets/HierarchyWidget';
-import router from 'girder/router';
-import View from 'girder/views/View';
-import { AccessType } from 'girder/constants';
-import { cancelRestRequests } from 'girder/rest';
-import { confirm } from 'girder/dialog';
-import { renderMarkdown, formatSize } from 'girder/misc';
-import events from 'girder/events';
+import AccessWidget from '@girder/core/views/widgets/AccessWidget';
+import CollectionModel from '@girder/core/models/CollectionModel';
+import EditCollectionWidget from '@girder/core/views/widgets/EditCollectionWidget';
+import FolderModel from '@girder/core/models/FolderModel';
+import HierarchyWidget from '@girder/core/views/widgets/HierarchyWidget';
+import router from '@girder/core/router';
+import View from '@girder/core/views/View';
+import { AccessType } from '@girder/core/constants';
+import { cancelRestRequests } from '@girder/core/rest';
+import { confirm } from '@girder/core/dialog';
+import { renderMarkdown, formatSize } from '@girder/core/misc';
+import events from '@girder/core/events';
 
-import CollectionPageTemplate from 'girder/templates/body/collectionPage.pug';
+import CollectionPageTemplate from '@girder/core/templates/body/collectionPage.pug';
 
-import 'girder/stylesheets/body/collectionPage.styl';
+import '@girder/core/stylesheets/body/collectionPage.styl';
 
 import 'bootstrap/js/dropdown';
 

--- a/girder/web_client/src/views/body/CollectionsView.js
+++ b/girder/web_client/src/views/body/CollectionsView.js
@@ -1,19 +1,19 @@
 import $ from 'jquery';
 
-import CollectionCollection from 'girder/collections/CollectionCollection';
-import CollectionModel from 'girder/models/CollectionModel';
-import EditCollectionWidget from 'girder/views/widgets/EditCollectionWidget';
-import PaginateWidget from 'girder/views/widgets/PaginateWidget';
-import router from 'girder/router';
-import SearchFieldWidget from 'girder/views/widgets/SearchFieldWidget';
-import View from 'girder/views/View';
-import { cancelRestRequests } from 'girder/rest';
-import { formatDate, formatSize, renderMarkdown, DATE_MINUTE } from 'girder/misc';
-import { getCurrentUser } from 'girder/auth';
+import CollectionCollection from '@girder/core/collections/CollectionCollection';
+import CollectionModel from '@girder/core/models/CollectionModel';
+import EditCollectionWidget from '@girder/core/views/widgets/EditCollectionWidget';
+import PaginateWidget from '@girder/core/views/widgets/PaginateWidget';
+import router from '@girder/core/router';
+import SearchFieldWidget from '@girder/core/views/widgets/SearchFieldWidget';
+import View from '@girder/core/views/View';
+import { cancelRestRequests } from '@girder/core/rest';
+import { formatDate, formatSize, renderMarkdown, DATE_MINUTE } from '@girder/core/misc';
+import { getCurrentUser } from '@girder/core/auth';
 
-import CollectionListTemplate from 'girder/templates/body/collectionList.pug';
+import CollectionListTemplate from '@girder/core/templates/body/collectionList.pug';
 
-import 'girder/stylesheets/body/collectionList.styl';
+import '@girder/core/stylesheets/body/collectionList.styl';
 
 /**
  * This view lists the collections.

--- a/girder/web_client/src/views/body/FilesystemImportView.js
+++ b/girder/web_client/src/views/body/FilesystemImportView.js
@@ -1,11 +1,11 @@
 import $ from 'jquery';
 
-import BrowserWidget from 'girder/views/widgets/BrowserWidget';
-import router from 'girder/router';
-import View from 'girder/views/View';
-import { restRequest } from 'girder/rest';
+import BrowserWidget from '@girder/core/views/widgets/BrowserWidget';
+import router from '@girder/core/router';
+import View from '@girder/core/views/View';
+import { restRequest } from '@girder/core/rest';
 
-import FilesystemImportTemplate from 'girder/templates/body/filesystemImport.pug';
+import FilesystemImportTemplate from '@girder/core/templates/body/filesystemImport.pug';
 
 var FilesystemImportView = View.extend({
     events: {

--- a/girder/web_client/src/views/body/FolderView.js
+++ b/girder/web_client/src/views/body/FolderView.js
@@ -1,10 +1,10 @@
 import _ from 'underscore';
 
-import FolderModel from 'girder/models/FolderModel';
-import HierarchyWidget from 'girder/views/widgets/HierarchyWidget';
-import View from 'girder/views/View';
-import { cancelRestRequests } from 'girder/rest';
-import events from 'girder/events';
+import FolderModel from '@girder/core/models/FolderModel';
+import HierarchyWidget from '@girder/core/views/widgets/HierarchyWidget';
+import View from '@girder/core/views/View';
+import { cancelRestRequests } from '@girder/core/rest';
+import events from '@girder/core/events';
 
 /**
  * This view shows a single folder as a hierarchy widget.

--- a/girder/web_client/src/views/body/FrontPageView.js
+++ b/girder/web_client/src/views/body/FrontPageView.js
@@ -1,14 +1,14 @@
 import $ from 'jquery';
 
-import versionInfo from 'girder/version';
-import View from 'girder/views/View';
-import { cancelRestRequests, getApiRoot } from 'girder/rest';
-import events from 'girder/events';
-import { getCurrentUser } from 'girder/auth';
+import versionInfo from '@girder/core/version';
+import View from '@girder/core/views/View';
+import { cancelRestRequests, getApiRoot } from '@girder/core/rest';
+import events from '@girder/core/events';
+import { getCurrentUser } from '@girder/core/auth';
 
-import FrontPageTemplate from 'girder/templates/body/frontPage.pug';
+import FrontPageTemplate from '@girder/core/templates/body/frontPage.pug';
 
-import 'girder/stylesheets/body/frontPage.styl';
+import '@girder/core/stylesheets/body/frontPage.styl';
 
 /**
  * This is the view for the front page of the app.

--- a/girder/web_client/src/views/body/GroupView.js
+++ b/girder/web_client/src/views/body/GroupView.js
@@ -1,25 +1,25 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import EditGroupWidget from 'girder/views/widgets/EditGroupWidget';
-import GroupAdminsWidget from 'girder/views/widgets/GroupAdminsWidget';
-import GroupInvitesWidget from 'girder/views/widgets/GroupInvitesWidget';
-import GroupMembersWidget from 'girder/views/widgets/GroupMembersWidget';
-import GroupModel from 'girder/models/GroupModel';
-import GroupModsWidget from 'girder/views/widgets/GroupModsWidget';
-import LoadingAnimation from 'girder/views/widgets/LoadingAnimation';
-import router from 'girder/router';
-import UserCollection from 'girder/collections/UserCollection';
-import View from 'girder/views/View';
-import { AccessType } from 'girder/constants';
-import { cancelRestRequests } from 'girder/rest';
-import { confirm } from 'girder/dialog';
-import events from 'girder/events';
-import { getCurrentUser } from 'girder/auth';
+import EditGroupWidget from '@girder/core/views/widgets/EditGroupWidget';
+import GroupAdminsWidget from '@girder/core/views/widgets/GroupAdminsWidget';
+import GroupInvitesWidget from '@girder/core/views/widgets/GroupInvitesWidget';
+import GroupMembersWidget from '@girder/core/views/widgets/GroupMembersWidget';
+import GroupModel from '@girder/core/models/GroupModel';
+import GroupModsWidget from '@girder/core/views/widgets/GroupModsWidget';
+import LoadingAnimation from '@girder/core/views/widgets/LoadingAnimation';
+import router from '@girder/core/router';
+import UserCollection from '@girder/core/collections/UserCollection';
+import View from '@girder/core/views/View';
+import { AccessType } from '@girder/core/constants';
+import { cancelRestRequests } from '@girder/core/rest';
+import { confirm } from '@girder/core/dialog';
+import events from '@girder/core/events';
+import { getCurrentUser } from '@girder/core/auth';
 
-import GroupPageTemplate from 'girder/templates/body/groupPage.pug';
+import GroupPageTemplate from '@girder/core/templates/body/groupPage.pug';
 
-import 'girder/stylesheets/body/groupPage.styl';
+import '@girder/core/stylesheets/body/groupPage.styl';
 
 import 'bootstrap/js/dropdown';
 import 'bootstrap/js/tab';

--- a/girder/web_client/src/views/body/GroupsView.js
+++ b/girder/web_client/src/views/body/GroupsView.js
@@ -1,19 +1,19 @@
 import $ from 'jquery';
 
-import EditGroupWidget from 'girder/views/widgets/EditGroupWidget';
-import GroupCollection from 'girder/collections/GroupCollection';
-import GroupModel from 'girder/models/GroupModel';
-import PaginateWidget from 'girder/views/widgets/PaginateWidget';
-import router from 'girder/router';
-import SearchFieldWidget from 'girder/views/widgets/SearchFieldWidget';
-import View from 'girder/views/View';
-import { cancelRestRequests } from 'girder/rest';
-import { formatDate, DATE_DAY } from 'girder/misc';
-import { getCurrentUser } from 'girder/auth';
+import EditGroupWidget from '@girder/core/views/widgets/EditGroupWidget';
+import GroupCollection from '@girder/core/collections/GroupCollection';
+import GroupModel from '@girder/core/models/GroupModel';
+import PaginateWidget from '@girder/core/views/widgets/PaginateWidget';
+import router from '@girder/core/router';
+import SearchFieldWidget from '@girder/core/views/widgets/SearchFieldWidget';
+import View from '@girder/core/views/View';
+import { cancelRestRequests } from '@girder/core/rest';
+import { formatDate, DATE_DAY } from '@girder/core/misc';
+import { getCurrentUser } from '@girder/core/auth';
 
-import GroupListTemplate from 'girder/templates/body/groupList.pug';
+import GroupListTemplate from '@girder/core/templates/body/groupList.pug';
 
-import 'girder/stylesheets/body/groupList.styl';
+import '@girder/core/stylesheets/body/groupList.styl';
 
 /**
  * This view lists groups.

--- a/girder/web_client/src/views/body/ItemView.js
+++ b/girder/web_client/src/views/body/ItemView.js
@@ -1,23 +1,23 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import EditItemWidget from 'girder/views/widgets/EditItemWidget';
-import FileListWidget from 'girder/views/widgets/FileListWidget';
-import ItemBreadcrumbWidget from 'girder/views/widgets/ItemBreadcrumbWidget';
-import ItemModel from 'girder/models/ItemModel';
-import MetadataWidget from 'girder/views/widgets/MetadataWidget';
-import router from 'girder/router';
-import UploadWidget from 'girder/views/widgets/UploadWidget';
-import View from 'girder/views/View';
-import { AccessType } from 'girder/constants';
-import { cancelRestRequests } from 'girder/rest';
-import { confirm, handleClose } from 'girder/dialog';
-import events from 'girder/events';
-import { formatSize, formatDate, renderMarkdown, DATE_SECOND } from 'girder/misc';
+import EditItemWidget from '@girder/core/views/widgets/EditItemWidget';
+import FileListWidget from '@girder/core/views/widgets/FileListWidget';
+import ItemBreadcrumbWidget from '@girder/core/views/widgets/ItemBreadcrumbWidget';
+import ItemModel from '@girder/core/models/ItemModel';
+import MetadataWidget from '@girder/core/views/widgets/MetadataWidget';
+import router from '@girder/core/router';
+import UploadWidget from '@girder/core/views/widgets/UploadWidget';
+import View from '@girder/core/views/View';
+import { AccessType } from '@girder/core/constants';
+import { cancelRestRequests } from '@girder/core/rest';
+import { confirm, handleClose } from '@girder/core/dialog';
+import events from '@girder/core/events';
+import { formatSize, formatDate, renderMarkdown, DATE_SECOND } from '@girder/core/misc';
 
-import ItemPageTemplate from 'girder/templates/body/itemPage.pug';
+import ItemPageTemplate from '@girder/core/templates/body/itemPage.pug';
 
-import 'girder/stylesheets/body/itemPage.styl';
+import '@girder/core/stylesheets/body/itemPage.styl';
 
 import 'bootstrap/js/dropdown';
 

--- a/girder/web_client/src/views/body/PluginsView.js
+++ b/girder/web_client/src/views/body/PluginsView.js
@@ -4,19 +4,19 @@ import _ from 'underscore';
 import 'bootstrap/js/tooltip';
 import 'bootstrap/js/popover';
 
-import events from 'girder/events';
-import router from 'girder/router';
-import View from 'girder/views/View';
-import { confirm } from 'girder/dialog';
-import { getPluginConfigRoute } from 'girder/utilities/PluginUtils';
-import { restartServer } from 'girder/server';
-import { restRequest, cancelRestRequests } from 'girder/rest';
+import events from '@girder/core/events';
+import router from '@girder/core/router';
+import View from '@girder/core/views/View';
+import { confirm } from '@girder/core/dialog';
+import { getPluginConfigRoute } from '@girder/core/utilities/PluginUtils';
+import { restartServer } from '@girder/core/server';
+import { restRequest, cancelRestRequests } from '@girder/core/rest';
 
-import PluginFailedNoticeTemplate from 'girder/templates/widgets/pluginFailedNotice.pug';
-import PluginsTemplate from 'girder/templates/body/plugins.pug';
+import PluginFailedNoticeTemplate from '@girder/core/templates/widgets/pluginFailedNotice.pug';
+import PluginsTemplate from '@girder/core/templates/body/plugins.pug';
 
-import 'girder/utilities/jquery/girderEnable';
-import 'girder/stylesheets/body/plugins.styl';
+import '@girder/core/utilities/jquery/girderEnable';
+import '@girder/core/stylesheets/body/plugins.styl';
 
 import 'bootstrap-switch'; // /dist/js/bootstrap-switch.js',
 import 'bootstrap-switch/dist/css/bootstrap3/bootstrap-switch.css';

--- a/girder/web_client/src/views/body/S3ImportView.js
+++ b/girder/web_client/src/views/body/S3ImportView.js
@@ -1,11 +1,11 @@
 import $ from 'jquery';
 
-import BrowserWidget from 'girder/views/widgets/BrowserWidget';
-import router from 'girder/router';
-import View from 'girder/views/View';
-import { restRequest } from 'girder/rest';
+import BrowserWidget from '@girder/core/views/widgets/BrowserWidget';
+import router from '@girder/core/router';
+import View from '@girder/core/views/View';
+import { restRequest } from '@girder/core/rest';
 
-import S3ImportTemplate from 'girder/templates/body/s3Import.pug';
+import S3ImportTemplate from '@girder/core/templates/body/s3Import.pug';
 
 var S3ImportView = View.extend({
     events: {

--- a/girder/web_client/src/views/body/SearchResultsView.js
+++ b/girder/web_client/src/views/body/SearchResultsView.js
@@ -1,13 +1,13 @@
 import _ from 'underscore';
 
-import View from 'girder/views/View';
-import { restRequest } from 'girder/rest';
-import SearchPaginateWidget from 'girder/views/widgets/SearchPaginateWidget';
-import SearchFieldWidget from 'girder/views/widgets/SearchFieldWidget';
+import View from '@girder/core/views/View';
+import { restRequest } from '@girder/core/rest';
+import SearchPaginateWidget from '@girder/core/views/widgets/SearchPaginateWidget';
+import SearchFieldWidget from '@girder/core/views/widgets/SearchFieldWidget';
 
-import SearchResultsTemplate from 'girder/templates/body/searchResults.pug';
-import SearchResultsTypeTemplate from 'girder/templates/body/searchResultsType.pug';
-import 'girder/stylesheets/body/searchResultsList.styl';
+import SearchResultsTemplate from '@girder/core/templates/body/searchResults.pug';
+import SearchResultsTypeTemplate from '@girder/core/templates/body/searchResultsType.pug';
+import '@girder/core/stylesheets/body/searchResultsList.styl';
 
 /**
  * This view display all the search results by instantiating a subview

--- a/girder/web_client/src/views/body/SystemConfigurationView.js
+++ b/girder/web_client/src/views/body/SystemConfigurationView.js
@@ -1,16 +1,16 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import AccessWidget from 'girder/views/widgets/AccessWidget';
-import View from 'girder/views/View';
-import events from 'girder/events';
-import { restRequest, cancelRestRequests } from 'girder/rest';
-import { restartServerPrompt } from 'girder/server';
-import CollectionCreationPolicyModel from 'girder/models/CollectionCreationPolicyModel';
+import AccessWidget from '@girder/core/views/widgets/AccessWidget';
+import View from '@girder/core/views/View';
+import events from '@girder/core/events';
+import { restRequest, cancelRestRequests } from '@girder/core/rest';
+import { restartServerPrompt } from '@girder/core/server';
+import CollectionCreationPolicyModel from '@girder/core/models/CollectionCreationPolicyModel';
 
-import SystemConfigurationTemplate from 'girder/templates/body/systemConfiguration.pug';
+import SystemConfigurationTemplate from '@girder/core/templates/body/systemConfiguration.pug';
 
-import 'girder/stylesheets/body/systemConfig.styl';
+import '@girder/core/stylesheets/body/systemConfig.styl';
 
 import 'bootstrap/js/collapse';
 import 'bootstrap/js/transition';

--- a/girder/web_client/src/views/body/UserAccountView.js
+++ b/girder/web_client/src/views/body/UserAccountView.js
@@ -1,19 +1,19 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import ApiKeyListWidget from 'girder/views/widgets/ApiKeyListWidget';
-import UserOtpManagementWidget from 'girder/views/widgets/UserOtpManagementWidget';
-import router from 'girder/router';
-import UserModel from 'girder/models/UserModel';
-import View from 'girder/views/View';
-import { AccessType } from 'girder/constants';
-import events from 'girder/events';
-import { getCurrentUser } from 'girder/auth';
-import { cancelRestRequests } from 'girder/rest';
+import ApiKeyListWidget from '@girder/core/views/widgets/ApiKeyListWidget';
+import UserOtpManagementWidget from '@girder/core/views/widgets/UserOtpManagementWidget';
+import router from '@girder/core/router';
+import UserModel from '@girder/core/models/UserModel';
+import View from '@girder/core/views/View';
+import { AccessType } from '@girder/core/constants';
+import events from '@girder/core/events';
+import { getCurrentUser } from '@girder/core/auth';
+import { cancelRestRequests } from '@girder/core/rest';
 
-import UserAccountTemplate from 'girder/templates/body/userAccount.pug';
+import UserAccountTemplate from '@girder/core/templates/body/userAccount.pug';
 
-import 'girder/stylesheets/body/userAccount.styl';
+import '@girder/core/stylesheets/body/userAccount.styl';
 
 import 'bootstrap/js/tab';
 

--- a/girder/web_client/src/views/body/UserView.js
+++ b/girder/web_client/src/views/body/UserView.js
@@ -1,19 +1,19 @@
 import _ from 'underscore';
 
-import FolderModel from 'girder/models/FolderModel';
-import HierarchyWidget from 'girder/views/widgets/HierarchyWidget';
-import router from 'girder/router';
-import UserModel from 'girder/models/UserModel';
-import UsersView from 'girder/views/body/UsersView';
-import View from 'girder/views/View';
-import { AccessType } from 'girder/constants';
-import { cancelRestRequests } from 'girder/rest';
-import { confirm } from 'girder/dialog';
-import events from 'girder/events';
+import FolderModel from '@girder/core/models/FolderModel';
+import HierarchyWidget from '@girder/core/views/widgets/HierarchyWidget';
+import router from '@girder/core/router';
+import UserModel from '@girder/core/models/UserModel';
+import UsersView from '@girder/core/views/body/UsersView';
+import View from '@girder/core/views/View';
+import { AccessType } from '@girder/core/constants';
+import { cancelRestRequests } from '@girder/core/rest';
+import { confirm } from '@girder/core/dialog';
+import events from '@girder/core/events';
 
-import UserPageTemplate from 'girder/templates/body/userPage.pug';
+import UserPageTemplate from '@girder/core/templates/body/userPage.pug';
 
-import 'girder/stylesheets/body/userPage.styl';
+import '@girder/core/stylesheets/body/userPage.styl';
 
 import 'bootstrap/js/dropdown';
 

--- a/girder/web_client/src/views/body/UsersView.js
+++ b/girder/web_client/src/views/body/UsersView.js
@@ -1,20 +1,20 @@
 import $ from 'jquery';
 
-import PaginateWidget from 'girder/views/widgets/PaginateWidget';
-import RegisterView from 'girder/views/layout/RegisterView';
-import router from 'girder/router';
-import SearchFieldWidget from 'girder/views/widgets/SearchFieldWidget';
-import SortCollectionWidget from 'girder/views/widgets/SortCollectionWidget';
-import UserCollection from 'girder/collections/UserCollection';
-import UserModel from 'girder/models/UserModel';
-import View from 'girder/views/View';
-import { cancelRestRequests } from 'girder/rest';
-import { formatDate, formatSize, DATE_DAY } from 'girder/misc';
-import { getCurrentUser } from 'girder/auth';
+import PaginateWidget from '@girder/core/views/widgets/PaginateWidget';
+import RegisterView from '@girder/core/views/layout/RegisterView';
+import router from '@girder/core/router';
+import SearchFieldWidget from '@girder/core/views/widgets/SearchFieldWidget';
+import SortCollectionWidget from '@girder/core/views/widgets/SortCollectionWidget';
+import UserCollection from '@girder/core/collections/UserCollection';
+import UserModel from '@girder/core/models/UserModel';
+import View from '@girder/core/views/View';
+import { cancelRestRequests } from '@girder/core/rest';
+import { formatDate, formatSize, DATE_DAY } from '@girder/core/misc';
+import { getCurrentUser } from '@girder/core/auth';
 
-import UserListTemplate from 'girder/templates/body/userList.pug';
+import UserListTemplate from '@girder/core/templates/body/userList.pug';
 
-import 'girder/stylesheets/body/userList.styl';
+import '@girder/core/stylesheets/body/userList.styl';
 
 /**
  * This view lists users.

--- a/girder/web_client/src/views/layout/FooterView.js
+++ b/girder/web_client/src/views/layout/FooterView.js
@@ -1,9 +1,9 @@
-import View from 'girder/views/View';
-import { getApiRoot } from 'girder/rest';
+import View from '@girder/core/views/View';
+import { getApiRoot } from '@girder/core/rest';
 
-import LayoutFooterTemplate from 'girder/templates/layout/layoutFooter.pug';
+import LayoutFooterTemplate from '@girder/core/templates/layout/layoutFooter.pug';
 
-import 'girder/stylesheets/layout/footer.styl';
+import '@girder/core/stylesheets/layout/footer.styl';
 
 /**
  * This view shows the footer in the layout.

--- a/girder/web_client/src/views/layout/GlobalNavView.js
+++ b/girder/web_client/src/views/layout/GlobalNavView.js
@@ -1,14 +1,14 @@
 import $ from 'jquery';
 import Backbone from 'backbone';
 
-import router from 'girder/router';
-import View from 'girder/views/View';
-import events from 'girder/events';
-import { getCurrentUser } from 'girder/auth';
+import router from '@girder/core/router';
+import View from '@girder/core/views/View';
+import events from '@girder/core/events';
+import { getCurrentUser } from '@girder/core/auth';
 
-import LayoutGlobalNavTemplate from 'girder/templates/layout/layoutGlobalNav.pug';
+import LayoutGlobalNavTemplate from '@girder/core/templates/layout/layoutGlobalNav.pug';
 
-import 'girder/stylesheets/layout/globalNav.styl';
+import '@girder/core/stylesheets/layout/globalNav.styl';
 
 /**
  * This view shows a list of global navigation links that should be

--- a/girder/web_client/src/views/layout/HeaderUserView.js
+++ b/girder/web_client/src/views/layout/HeaderUserView.js
@@ -1,10 +1,10 @@
-import View from 'girder/views/View';
-import events from 'girder/events';
-import { logout, getCurrentUser } from 'girder/auth';
+import View from '@girder/core/views/View';
+import events from '@girder/core/events';
+import { logout, getCurrentUser } from '@girder/core/auth';
 
-import LayoutHeaderUserTemplate from 'girder/templates/layout/layoutHeaderUser.pug';
+import LayoutHeaderUserTemplate from '@girder/core/templates/layout/layoutHeaderUser.pug';
 
-import 'girder/stylesheets/layout/headerUser.styl';
+import '@girder/core/stylesheets/layout/headerUser.styl';
 
 import 'bootstrap/js/dropdown';
 

--- a/girder/web_client/src/views/layout/HeaderView.js
+++ b/girder/web_client/src/views/layout/HeaderView.js
@@ -1,13 +1,13 @@
 import _ from 'underscore';
 
-import LayoutHeaderUserView from 'girder/views/layout/HeaderUserView';
-import router from 'girder/router';
-import SearchFieldWidget from 'girder/views/widgets/SearchFieldWidget';
-import View from 'girder/views/View';
+import LayoutHeaderUserView from '@girder/core/views/layout/HeaderUserView';
+import router from '@girder/core/router';
+import SearchFieldWidget from '@girder/core/views/widgets/SearchFieldWidget';
+import View from '@girder/core/views/View';
 
-import LayoutHeaderTemplate from 'girder/templates/layout/layoutHeader.pug';
+import LayoutHeaderTemplate from '@girder/core/templates/layout/layoutHeader.pug';
 
-import 'girder/stylesheets/layout/header.styl';
+import '@girder/core/stylesheets/layout/header.styl';
 
 /**
  * This view shows the header in the layout.

--- a/girder/web_client/src/views/layout/LoginView.js
+++ b/girder/web_client/src/views/layout/LoginView.js
@@ -1,16 +1,16 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import View from 'girder/views/View';
-import events from 'girder/events';
-import { handleClose, handleOpen } from 'girder/dialog';
-import { login } from 'girder/auth';
-import UserModel from 'girder/models/UserModel';
+import View from '@girder/core/views/View';
+import events from '@girder/core/events';
+import { handleClose, handleOpen } from '@girder/core/dialog';
+import { login } from '@girder/core/auth';
+import UserModel from '@girder/core/models/UserModel';
 
-import LoginDialogTemplate from 'girder/templates/layout/loginDialog.pug';
+import LoginDialogTemplate from '@girder/core/templates/layout/loginDialog.pug';
 
-import 'girder/utilities/jquery/girderEnable';
-import 'girder/utilities/jquery/girderModal';
+import '@girder/core/utilities/jquery/girderEnable';
+import '@girder/core/utilities/jquery/girderModal';
 
 /**
  * This view shows a login modal dialog.

--- a/girder/web_client/src/views/layout/ProgressListView.js
+++ b/girder/web_client/src/views/layout/ProgressListView.js
@@ -1,11 +1,11 @@
 import _ from 'underscore';
 
-import TaskProgressWidget from 'girder/views/widgets/TaskProgressWidget';
-import View from 'girder/views/View';
+import TaskProgressWidget from '@girder/core/views/widgets/TaskProgressWidget';
+import View from '@girder/core/views/View';
 
-import LayoutProgressAreaTemplate from 'girder/templates/layout/layoutProgressArea.pug';
+import LayoutProgressAreaTemplate from '@girder/core/templates/layout/layoutProgressArea.pug';
 
-import 'girder/stylesheets/layout/progressArea.styl';
+import '@girder/core/stylesheets/layout/progressArea.styl';
 
 /**
  * Container showing list of active tasks that are reporting progress

--- a/girder/web_client/src/views/layout/RegisterView.js
+++ b/girder/web_client/src/views/layout/RegisterView.js
@@ -1,13 +1,13 @@
-import UserModel from 'girder/models/UserModel';
-import View from 'girder/views/View';
-import events from 'girder/events';
-import { getCurrentUser, setCurrentUser, getCurrentToken, setCurrentToken, corsAuth } from 'girder/auth';
-import { handleClose, handleOpen } from 'girder/dialog';
+import UserModel from '@girder/core/models/UserModel';
+import View from '@girder/core/views/View';
+import events from '@girder/core/events';
+import { getCurrentUser, setCurrentUser, getCurrentToken, setCurrentToken, corsAuth } from '@girder/core/auth';
+import { handleClose, handleOpen } from '@girder/core/dialog';
 
-import RegisterDialogTemplate from 'girder/templates/layout/registerDialog.pug';
+import RegisterDialogTemplate from '@girder/core/templates/layout/registerDialog.pug';
 
-import 'girder/utilities/jquery/girderEnable';
-import 'girder/utilities/jquery/girderModal';
+import '@girder/core/utilities/jquery/girderEnable';
+import '@girder/core/utilities/jquery/girderModal';
 
 /**
  * This view shows a register modal dialog.

--- a/girder/web_client/src/views/layout/ResetPasswordView.js
+++ b/girder/web_client/src/views/layout/ResetPasswordView.js
@@ -1,12 +1,12 @@
-import View from 'girder/views/View';
-import events from 'girder/events';
-import { handleClose, handleOpen } from 'girder/dialog';
-import { restRequest } from 'girder/rest';
+import View from '@girder/core/views/View';
+import events from '@girder/core/events';
+import { handleClose, handleOpen } from '@girder/core/dialog';
+import { restRequest } from '@girder/core/rest';
 
-import ResetPasswordDialogTemplate from 'girder/templates/layout/resetPasswordDialog.pug';
+import ResetPasswordDialogTemplate from '@girder/core/templates/layout/resetPasswordDialog.pug';
 
-import 'girder/utilities/jquery/girderEnable';
-import 'girder/utilities/jquery/girderModal';
+import '@girder/core/utilities/jquery/girderEnable';
+import '@girder/core/utilities/jquery/girderModal';
 
 /**
  * This view shows a modal dialog for resetting a forgotten password.

--- a/girder/web_client/src/views/widgets/AccessWidget.js
+++ b/girder/web_client/src/views/widgets/AccessWidget.js
@@ -4,22 +4,22 @@ import _ from 'underscore';
 import 'bootstrap/js/tooltip';
 import 'bootstrap/js/popover';
 
-import accessEditorNonModalTemplate from 'girder/templates/widgets/accessEditorNonModal.pug';
-import accessEditorTemplate from 'girder/templates/widgets/accessEditor.pug';
-import accessEntryTemplate from 'girder/templates/widgets/accessEntry.pug';
-import GroupModel from 'girder/models/GroupModel';
-import LoadingAnimation from 'girder/views/widgets/LoadingAnimation';
-import SearchFieldWidget from 'girder/views/widgets/SearchFieldWidget';
-import UserModel from 'girder/models/UserModel';
-import View from 'girder/views/View';
-import { getCurrentUser } from 'girder/auth';
-import { AccessType } from 'girder/constants';
-import { handleClose, handleOpen } from 'girder/dialog';
-import { restRequest } from 'girder/rest';
+import accessEditorNonModalTemplate from '@girder/core/templates/widgets/accessEditorNonModal.pug';
+import accessEditorTemplate from '@girder/core/templates/widgets/accessEditor.pug';
+import accessEntryTemplate from '@girder/core/templates/widgets/accessEntry.pug';
+import GroupModel from '@girder/core/models/GroupModel';
+import LoadingAnimation from '@girder/core/views/widgets/LoadingAnimation';
+import SearchFieldWidget from '@girder/core/views/widgets/SearchFieldWidget';
+import UserModel from '@girder/core/models/UserModel';
+import View from '@girder/core/views/View';
+import { getCurrentUser } from '@girder/core/auth';
+import { AccessType } from '@girder/core/constants';
+import { handleClose, handleOpen } from '@girder/core/dialog';
+import { restRequest } from '@girder/core/rest';
 
-import 'girder/stylesheets/widgets/accessWidget.styl';
+import '@girder/core/stylesheets/widgets/accessWidget.styl';
 
-import 'girder/utilities/jquery/girderModal';
+import '@girder/core/utilities/jquery/girderModal';
 
 /**
  * This view allows users to see and control access on a resource.

--- a/girder/web_client/src/views/widgets/ApiKeyListWidget.js
+++ b/girder/web_client/src/views/widgets/ApiKeyListWidget.js
@@ -4,14 +4,14 @@ import moment from 'moment';
 import 'bootstrap/js/tooltip';
 import 'bootstrap/js/popover';
 
-import ApiKeyCollection from 'girder/collections/ApiKeyCollection';
-import EditApiKeyWidget from 'girder/views/widgets/EditApiKeyWidget';
-import PaginateWidget from 'girder/views/widgets/PaginateWidget';
-import View from 'girder/views/View';
-import { confirm } from 'girder/dialog';
-import events from 'girder/events';
+import ApiKeyCollection from '@girder/core/collections/ApiKeyCollection';
+import EditApiKeyWidget from '@girder/core/views/widgets/EditApiKeyWidget';
+import PaginateWidget from '@girder/core/views/widgets/PaginateWidget';
+import View from '@girder/core/views/View';
+import { confirm } from '@girder/core/dialog';
+import events from '@girder/core/events';
 
-import ApiKeyListTemplate from 'girder/templates/widgets/apiKeyList.pug';
+import ApiKeyListTemplate from '@girder/core/templates/widgets/apiKeyList.pug';
 
 var ApiKeyListWidget = View.extend({
     events: {

--- a/girder/web_client/src/views/widgets/BrowserWidget.js
+++ b/girder/web_client/src/views/widgets/BrowserWidget.js
@@ -1,13 +1,13 @@
 import _ from 'underscore';
 
-import HierarchyWidget from 'girder/views/widgets/HierarchyWidget';
-import RootSelectorWidget from 'girder/views/widgets/RootSelectorWidget';
-import View from 'girder/views/View';
+import HierarchyWidget from '@girder/core/views/widgets/HierarchyWidget';
+import RootSelectorWidget from '@girder/core/views/widgets/RootSelectorWidget';
+import View from '@girder/core/views/View';
 
-import BrowserWidgetTemplate from 'girder/templates/widgets/browserWidget.pug';
+import BrowserWidgetTemplate from '@girder/core/templates/widgets/browserWidget.pug';
 
-import 'girder/stylesheets/widgets/browserWidget.styl';
-import 'girder/utilities/jquery/girderModal';
+import '@girder/core/stylesheets/widgets/browserWidget.styl';
+import '@girder/core/utilities/jquery/girderModal';
 
 /**
  * This widget provides the user with an interface similar to a filesystem

--- a/girder/web_client/src/views/widgets/CheckedMenuWidget.js
+++ b/girder/web_client/src/views/widgets/CheckedMenuWidget.js
@@ -1,10 +1,10 @@
-import HierarchyWidget from 'girder/views/widgets/HierarchyWidget';
-import View from 'girder/views/View';
-import { AccessType } from 'girder/constants';
+import HierarchyWidget from '@girder/core/views/widgets/HierarchyWidget';
+import View from '@girder/core/views/View';
+import { AccessType } from '@girder/core/constants';
 
-import CheckedActionsMenuTemplate from 'girder/templates/widgets/checkedActionsMenu.pug';
+import CheckedActionsMenuTemplate from '@girder/core/templates/widgets/checkedActionsMenu.pug';
 
-import 'girder/utilities/jquery/girderEnable';
+import '@girder/core/utilities/jquery/girderEnable';
 
 /**
  * This widget presents a list of available batch actions

--- a/girder/web_client/src/views/widgets/CollectionInfoWidget.js
+++ b/girder/web_client/src/views/widgets/CollectionInfoWidget.js
@@ -1,9 +1,9 @@
-import View from 'girder/views/View';
-import { formatDate, DATE_SECOND, renderMarkdown, formatSize } from 'girder/misc';
+import View from '@girder/core/views/View';
+import { formatDate, DATE_SECOND, renderMarkdown, formatSize } from '@girder/core/misc';
 
-import CollectionInfoDialogTemplate from 'girder/templates/widgets/collectionInfoDialog.pug';
+import CollectionInfoDialogTemplate from '@girder/core/templates/widgets/collectionInfoDialog.pug';
 
-import 'girder/utilities/jquery/girderModal';
+import '@girder/core/utilities/jquery/girderModal';
 
 /**
  * This view shows a dialog containing detailed collection information.

--- a/girder/web_client/src/views/widgets/DateTimeRangeWidget.js
+++ b/girder/web_client/src/views/widgets/DateTimeRangeWidget.js
@@ -1,9 +1,9 @@
 import _ from 'underscore';
 import moment from 'moment';
 
-import View from 'girder/views/View';
+import View from '@girder/core/views/View';
 
-import dateTimeRangeWidgetTemplate from 'girder/templates/widgets/dateTimeRangeWidget.pug';
+import dateTimeRangeWidgetTemplate from '@girder/core/templates/widgets/dateTimeRangeWidget.pug';
 
 import 'eonasdan-bootstrap-datetimepicker'; // /src/js/bootstrap-datetimepicker.js'
 import 'eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.css';

--- a/girder/web_client/src/views/widgets/DateTimeWidget.js
+++ b/girder/web_client/src/views/widgets/DateTimeWidget.js
@@ -1,9 +1,9 @@
 import _ from 'underscore';
 import moment from 'moment';
 
-import View from 'girder/views/View';
+import View from '@girder/core/views/View';
 
-import dateTimeWidgetTemplate from 'girder/templates/widgets/dateTimeWidget.pug';
+import dateTimeWidgetTemplate from '@girder/core/templates/widgets/dateTimeWidget.pug';
 
 import 'eonasdan-bootstrap-datetimepicker'; // /src/js/bootstrap-datetimepicker.js'
 import 'eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.css';

--- a/girder/web_client/src/views/widgets/EditApiKeyWidget.js
+++ b/girder/web_client/src/views/widgets/EditApiKeyWidget.js
@@ -1,15 +1,15 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import ApiKeyModel from 'girder/models/ApiKeyModel';
-import View from 'girder/views/View';
-import { getCurrentUser } from 'girder/auth';
-import { restRequest } from 'girder/rest';
+import ApiKeyModel from '@girder/core/models/ApiKeyModel';
+import View from '@girder/core/views/View';
+import { getCurrentUser } from '@girder/core/auth';
+import { restRequest } from '@girder/core/rest';
 
-import EditApiKeyWidgetTemplate from 'girder/templates/widgets/editApiKeyWidget.pug';
+import EditApiKeyWidgetTemplate from '@girder/core/templates/widgets/editApiKeyWidget.pug';
 
-import 'girder/utilities/jquery/girderEnable';
-import 'girder/utilities/jquery/girderModal';
+import '@girder/core/utilities/jquery/girderEnable';
+import '@girder/core/utilities/jquery/girderModal';
 
 /**
  * This widget is used to create a new API key or edit an existing one.

--- a/girder/web_client/src/views/widgets/EditAssetstoreWidget.js
+++ b/girder/web_client/src/views/widgets/EditAssetstoreWidget.js
@@ -1,14 +1,14 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import View from 'girder/views/View';
-import { AssetstoreType } from 'girder/constants';
-import { handleClose, handleOpen } from 'girder/dialog';
+import View from '@girder/core/views/View';
+import { AssetstoreType } from '@girder/core/constants';
+import { handleClose, handleOpen } from '@girder/core/dialog';
 
-import EditAssetstoreWidgetTemplate from 'girder/templates/widgets/editAssetstoreWidget.pug';
+import EditAssetstoreWidgetTemplate from '@girder/core/templates/widgets/editAssetstoreWidget.pug';
 
-import 'girder/utilities/jquery/girderEnable';
-import 'girder/utilities/jquery/girderModal';
+import '@girder/core/utilities/jquery/girderEnable';
+import '@girder/core/utilities/jquery/girderModal';
 
 /**
  * This widget is used to edit an existing assetstore.

--- a/girder/web_client/src/views/widgets/EditCollectionWidget.js
+++ b/girder/web_client/src/views/widgets/EditCollectionWidget.js
@@ -1,14 +1,14 @@
 import $ from 'jquery';
 
-import CollectionModel from 'girder/models/CollectionModel';
-import View from 'girder/views/View';
-import MarkdownWidget from 'girder/views/widgets/MarkdownWidget';
-import { handleClose, handleOpen } from 'girder/dialog';
+import CollectionModel from '@girder/core/models/CollectionModel';
+import View from '@girder/core/views/View';
+import MarkdownWidget from '@girder/core/views/widgets/MarkdownWidget';
+import { handleClose, handleOpen } from '@girder/core/dialog';
 
-import EditCollectionWidgetTemplate from 'girder/templates/widgets/editCollectionWidget.pug';
+import EditCollectionWidgetTemplate from '@girder/core/templates/widgets/editCollectionWidget.pug';
 
-import 'girder/utilities/jquery/girderEnable';
-import 'girder/utilities/jquery/girderModal';
+import '@girder/core/utilities/jquery/girderEnable';
+import '@girder/core/utilities/jquery/girderModal';
 
 /**
  * This widget is used to create a new collection or edit an existing one.

--- a/girder/web_client/src/views/widgets/EditFileWidget.js
+++ b/girder/web_client/src/views/widgets/EditFileWidget.js
@@ -1,10 +1,10 @@
-import View from 'girder/views/View';
-import { handleClose, handleOpen } from 'girder/dialog';
+import View from '@girder/core/views/View';
+import { handleClose, handleOpen } from '@girder/core/dialog';
 
-import EditFileWidgetTemplate from 'girder/templates/widgets/editFileWidget.pug';
+import EditFileWidgetTemplate from '@girder/core/templates/widgets/editFileWidget.pug';
 
-import 'girder/utilities/jquery/girderEnable';
-import 'girder/utilities/jquery/girderModal';
+import '@girder/core/utilities/jquery/girderEnable';
+import '@girder/core/utilities/jquery/girderModal';
 
 /**
  * This widget is used to edit file information.

--- a/girder/web_client/src/views/widgets/EditFolderWidget.js
+++ b/girder/web_client/src/views/widgets/EditFolderWidget.js
@@ -1,15 +1,15 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import FolderModel from 'girder/models/FolderModel';
-import MarkdownWidget from 'girder/views/widgets/MarkdownWidget';
-import View from 'girder/views/View';
-import { handleClose, handleOpen } from 'girder/dialog';
+import FolderModel from '@girder/core/models/FolderModel';
+import MarkdownWidget from '@girder/core/views/widgets/MarkdownWidget';
+import View from '@girder/core/views/View';
+import { handleClose, handleOpen } from '@girder/core/dialog';
 
-import EditFolderWidgetTemplate from 'girder/templates/widgets/editFolderWidget.pug';
+import EditFolderWidgetTemplate from '@girder/core/templates/widgets/editFolderWidget.pug';
 
-import 'girder/utilities/jquery/girderEnable';
-import 'girder/utilities/jquery/girderModal';
+import '@girder/core/utilities/jquery/girderEnable';
+import '@girder/core/utilities/jquery/girderModal';
 
 /**
  * This widget is used to create a new folder or edit an existing one.

--- a/girder/web_client/src/views/widgets/EditGroupWidget.js
+++ b/girder/web_client/src/views/widgets/EditGroupWidget.js
@@ -1,13 +1,13 @@
 import $ from 'jquery';
 
-import GroupModel from 'girder/models/GroupModel';
-import View from 'girder/views/View';
-import { getCurrentUser } from 'girder/auth';
-import { handleClose, handleOpen } from 'girder/dialog';
+import GroupModel from '@girder/core/models/GroupModel';
+import View from '@girder/core/views/View';
+import { getCurrentUser } from '@girder/core/auth';
+import { handleClose, handleOpen } from '@girder/core/dialog';
 
-import EditGroupWidgetTemplate from 'girder/templates/widgets/editGroupWidget.pug';
+import EditGroupWidgetTemplate from '@girder/core/templates/widgets/editGroupWidget.pug';
 
-import 'girder/utilities/jquery/girderModal';
+import '@girder/core/utilities/jquery/girderModal';
 
 /**
  * This widget is used to create a new group or edit an existing one.

--- a/girder/web_client/src/views/widgets/EditItemWidget.js
+++ b/girder/web_client/src/views/widgets/EditItemWidget.js
@@ -1,15 +1,15 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import ItemModel from 'girder/models/ItemModel';
-import MarkdownWidget from 'girder/views/widgets/MarkdownWidget';
-import View from 'girder/views/View';
-import { handleClose, handleOpen } from 'girder/dialog';
+import ItemModel from '@girder/core/models/ItemModel';
+import MarkdownWidget from '@girder/core/views/widgets/MarkdownWidget';
+import View from '@girder/core/views/View';
+import { handleClose, handleOpen } from '@girder/core/dialog';
 
-import EditItemWidgetTemplate from 'girder/templates/widgets/editItemWidget.pug';
+import EditItemWidgetTemplate from '@girder/core/templates/widgets/editItemWidget.pug';
 
-import 'girder/utilities/jquery/girderEnable';
-import 'girder/utilities/jquery/girderModal';
+import '@girder/core/utilities/jquery/girderEnable';
+import '@girder/core/utilities/jquery/girderModal';
 
 /**
  * This widget is used to create a new item or edit an existing one.

--- a/girder/web_client/src/views/widgets/FileInfoWidget.js
+++ b/girder/web_client/src/views/widgets/FileInfoWidget.js
@@ -1,9 +1,9 @@
-import View from 'girder/views/View';
-import { formatDate, DATE_SECOND } from 'girder/misc';
+import View from '@girder/core/views/View';
+import { formatDate, DATE_SECOND } from '@girder/core/misc';
 
-import FileInfoDialogTemplate from 'girder/templates/widgets/fileInfoDialog.pug';
+import FileInfoDialogTemplate from '@girder/core/templates/widgets/fileInfoDialog.pug';
 
-import 'girder/utilities/jquery/girderModal';
+import '@girder/core/utilities/jquery/girderModal';
 
 /**
  * This widget shows information about a single file in a modal dialog.

--- a/girder/web_client/src/views/widgets/FileListWidget.js
+++ b/girder/web_client/src/views/widgets/FileListWidget.js
@@ -1,16 +1,16 @@
 import $ from 'jquery';
 
-import EditFileWidget from 'girder/views/widgets/EditFileWidget';
-import FileCollection from 'girder/collections/FileCollection';
-import FileInfoWidget from 'girder/views/widgets/FileInfoWidget';
-import UploadWidget from 'girder/views/widgets/UploadWidget';
-import View from 'girder/views/View';
-import { AccessType } from 'girder/constants';
-import { confirm } from 'girder/dialog';
-import { formatSize } from 'girder/misc';
-import events from 'girder/events';
+import EditFileWidget from '@girder/core/views/widgets/EditFileWidget';
+import FileCollection from '@girder/core/collections/FileCollection';
+import FileInfoWidget from '@girder/core/views/widgets/FileInfoWidget';
+import UploadWidget from '@girder/core/views/widgets/UploadWidget';
+import View from '@girder/core/views/View';
+import { AccessType } from '@girder/core/constants';
+import { confirm } from '@girder/core/dialog';
+import { formatSize } from '@girder/core/misc';
+import events from '@girder/core/events';
 
-import FileListTemplate from 'girder/templates/widgets/fileList.pug';
+import FileListTemplate from '@girder/core/templates/widgets/fileList.pug';
 
 /**
  * This widget shows a list of files in a given item.

--- a/girder/web_client/src/views/widgets/FolderInfoWidget.js
+++ b/girder/web_client/src/views/widgets/FolderInfoWidget.js
@@ -1,9 +1,9 @@
-import View from 'girder/views/View';
-import { formatDate, formatSize, DATE_SECOND, renderMarkdown } from 'girder/misc';
+import View from '@girder/core/views/View';
+import { formatDate, formatSize, DATE_SECOND, renderMarkdown } from '@girder/core/misc';
 
-import FolderInfoDialogTemplate from 'girder/templates/widgets/folderInfoDialog.pug';
+import FolderInfoDialogTemplate from '@girder/core/templates/widgets/folderInfoDialog.pug';
 
-import 'girder/utilities/jquery/girderModal';
+import '@girder/core/utilities/jquery/girderModal';
 
 /**
  * This view shows a dialog container detailed folder information.

--- a/girder/web_client/src/views/widgets/FolderListWidget.js
+++ b/girder/web_client/src/views/widgets/FolderListWidget.js
@@ -1,11 +1,11 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import FolderCollection from 'girder/collections/FolderCollection';
-import LoadingAnimation from 'girder/views/widgets/LoadingAnimation';
-import View from 'girder/views/View';
+import FolderCollection from '@girder/core/collections/FolderCollection';
+import LoadingAnimation from '@girder/core/views/widgets/LoadingAnimation';
+import View from '@girder/core/views/View';
 
-import FolderListTemplate from 'girder/templates/widgets/folderList.pug';
+import FolderListTemplate from '@girder/core/templates/widgets/folderList.pug';
 
 /**
  * This widget shows a list of folders under a given parent.

--- a/girder/web_client/src/views/widgets/GroupAdminsWidget.js
+++ b/girder/web_client/src/views/widgets/GroupAdminsWidget.js
@@ -1,14 +1,14 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import UserModel from 'girder/models/UserModel';
-import UserView from 'girder/views/body/UserView';
-import View from 'girder/views/View';
-import { AccessType } from 'girder/constants';
-import { confirm } from 'girder/dialog';
-import events from 'girder/events';
+import UserModel from '@girder/core/models/UserModel';
+import UserView from '@girder/core/views/body/UserView';
+import View from '@girder/core/views/View';
+import { AccessType } from '@girder/core/constants';
+import { confirm } from '@girder/core/dialog';
+import events from '@girder/core/events';
 
-import GroupAdminListTemplate from 'girder/templates/widgets/groupAdminList.pug';
+import GroupAdminListTemplate from '@girder/core/templates/widgets/groupAdminList.pug';
 
 import 'bootstrap/js/dropdown';
 

--- a/girder/web_client/src/views/widgets/GroupInvitesWidget.js
+++ b/girder/web_client/src/views/widgets/GroupInvitesWidget.js
@@ -1,12 +1,12 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import router from 'girder/router';
-import View from 'girder/views/View';
-import { AccessType } from 'girder/constants';
-import { confirm } from 'girder/dialog';
+import router from '@girder/core/router';
+import View from '@girder/core/views/View';
+import { AccessType } from '@girder/core/constants';
+import { confirm } from '@girder/core/dialog';
 
-import GroupInviteListTemplate from 'girder/templates/widgets/groupInviteList.pug';
+import GroupInviteListTemplate from '@girder/core/templates/widgets/groupInviteList.pug';
 
 /**
  * This view shows a list of pending invitations to the group.

--- a/girder/web_client/src/views/widgets/GroupMembersWidget.js
+++ b/girder/web_client/src/views/widgets/GroupMembersWidget.js
@@ -1,22 +1,22 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import PaginateWidget from 'girder/views/widgets/PaginateWidget';
-import router from 'girder/router';
-import SearchFieldWidget from 'girder/views/widgets/SearchFieldWidget';
-import UserCollection from 'girder/collections/UserCollection';
-import View from 'girder/views/View';
-import { AccessType } from 'girder/constants';
-import { confirm } from 'girder/dialog';
+import PaginateWidget from '@girder/core/views/widgets/PaginateWidget';
+import router from '@girder/core/router';
+import SearchFieldWidget from '@girder/core/views/widgets/SearchFieldWidget';
+import UserCollection from '@girder/core/collections/UserCollection';
+import View from '@girder/core/views/View';
+import { AccessType } from '@girder/core/constants';
+import { confirm } from '@girder/core/dialog';
 
-import GroupInviteDialogTemplate from 'girder/templates/widgets/groupInviteDialog.pug';
-import GroupMemberListTemplate from 'girder/templates/widgets/groupMemberList.pug';
+import GroupInviteDialogTemplate from '@girder/core/templates/widgets/groupInviteDialog.pug';
+import GroupMemberListTemplate from '@girder/core/templates/widgets/groupMemberList.pug';
 
 import 'bootstrap/js/collapse';
 import 'bootstrap/js/dropdown';
 import 'bootstrap/js/transition';
 
-import 'girder/utilities/jquery/girderModal';
+import '@girder/core/utilities/jquery/girderModal';
 
 var InviteUserDialog = View.extend({
     events: {

--- a/girder/web_client/src/views/widgets/GroupModsWidget.js
+++ b/girder/web_client/src/views/widgets/GroupModsWidget.js
@@ -1,14 +1,14 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import UserModel from 'girder/models/UserModel';
-import UserView from 'girder/views/body/UserView';
-import View from 'girder/views/View';
-import { AccessType } from 'girder/constants';
-import { confirm } from 'girder/dialog';
-import events from 'girder/events';
+import UserModel from '@girder/core/models/UserModel';
+import UserView from '@girder/core/views/body/UserView';
+import View from '@girder/core/views/View';
+import { AccessType } from '@girder/core/constants';
+import { confirm } from '@girder/core/dialog';
+import events from '@girder/core/events';
 
-import GroupModListTemplate from 'girder/templates/widgets/groupModList.pug';
+import GroupModListTemplate from '@girder/core/templates/widgets/groupModList.pug';
 
 /**
  * This view shows a list of moderators of a group.

--- a/girder/web_client/src/views/widgets/HierarchyWidget.js
+++ b/girder/web_client/src/views/widgets/HierarchyWidget.js
@@ -1,31 +1,31 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import * as allModels from 'girder/models';
-import AccessWidget from 'girder/views/widgets/AccessWidget';
-import CheckedMenuWidget from 'girder/views/widgets/CheckedMenuWidget';
-import CollectionInfoWidget from 'girder/views/widgets/CollectionInfoWidget';
-import EditCollectionWidget from 'girder/views/widgets/EditCollectionWidget';
-import EditFolderWidget from 'girder/views/widgets/EditFolderWidget';
-import EditItemWidget from 'girder/views/widgets/EditItemWidget';
-import FolderInfoWidget from 'girder/views/widgets/FolderInfoWidget';
-import FolderListWidget from 'girder/views/widgets/FolderListWidget';
-import ItemListWidget from 'girder/views/widgets/ItemListWidget';
-import ItemModel from 'girder/models/ItemModel';
-import MetadataWidget from 'girder/views/widgets/MetadataWidget';
-import router from 'girder/router';
-import UploadWidget from 'girder/views/widgets/UploadWidget';
-import View from 'girder/views/View';
-import { AccessType } from 'girder/constants';
-import { confirm, handleClose } from 'girder/dialog';
-import events from 'girder/events';
-import { getModelClassByName, renderMarkdown, formatCount, capitalize, formatSize } from 'girder/misc';
-import { restRequest, getApiRoot } from 'girder/rest';
+import * as allModels from '@girder/core/models';
+import AccessWidget from '@girder/core/views/widgets/AccessWidget';
+import CheckedMenuWidget from '@girder/core/views/widgets/CheckedMenuWidget';
+import CollectionInfoWidget from '@girder/core/views/widgets/CollectionInfoWidget';
+import EditCollectionWidget from '@girder/core/views/widgets/EditCollectionWidget';
+import EditFolderWidget from '@girder/core/views/widgets/EditFolderWidget';
+import EditItemWidget from '@girder/core/views/widgets/EditItemWidget';
+import FolderInfoWidget from '@girder/core/views/widgets/FolderInfoWidget';
+import FolderListWidget from '@girder/core/views/widgets/FolderListWidget';
+import ItemListWidget from '@girder/core/views/widgets/ItemListWidget';
+import ItemModel from '@girder/core/models/ItemModel';
+import MetadataWidget from '@girder/core/views/widgets/MetadataWidget';
+import router from '@girder/core/router';
+import UploadWidget from '@girder/core/views/widgets/UploadWidget';
+import View from '@girder/core/views/View';
+import { AccessType } from '@girder/core/constants';
+import { confirm, handleClose } from '@girder/core/dialog';
+import events from '@girder/core/events';
+import { getModelClassByName, renderMarkdown, formatCount, capitalize, formatSize } from '@girder/core/misc';
+import { restRequest, getApiRoot } from '@girder/core/rest';
 
-import HierarchyBreadcrumbTemplate from 'girder/templates/widgets/hierarchyBreadcrumb.pug';
-import HierarchyWidgetTemplate from 'girder/templates/widgets/hierarchyWidget.pug';
+import HierarchyBreadcrumbTemplate from '@girder/core/templates/widgets/hierarchyBreadcrumb.pug';
+import HierarchyWidgetTemplate from '@girder/core/templates/widgets/hierarchyWidget.pug';
 
-import 'girder/stylesheets/widgets/hierarchyWidget.styl';
+import '@girder/core/stylesheets/widgets/hierarchyWidget.styl';
 
 import 'bootstrap/js/dropdown';
 

--- a/girder/web_client/src/views/widgets/ItemBreadcrumbWidget.js
+++ b/girder/web_client/src/views/widgets/ItemBreadcrumbWidget.js
@@ -1,9 +1,9 @@
 import $ from 'jquery';
 
-import router from 'girder/router';
-import View from 'girder/views/View';
+import router from '@girder/core/router';
+import View from '@girder/core/views/View';
 
-import ItemBreadcrumbTemplate from 'girder/templates/widgets/itemBreadcrumb.pug';
+import ItemBreadcrumbTemplate from '@girder/core/templates/widgets/itemBreadcrumb.pug';
 
 /**
  * Renders the a breadcrumb for the item page

--- a/girder/web_client/src/views/widgets/ItemListWidget.js
+++ b/girder/web_client/src/views/widgets/ItemListWidget.js
@@ -1,12 +1,12 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import ItemCollection from 'girder/collections/ItemCollection';
-import LoadingAnimation from 'girder/views/widgets/LoadingAnimation';
-import View from 'girder/views/View';
-import { formatSize } from 'girder/misc';
+import ItemCollection from '@girder/core/collections/ItemCollection';
+import LoadingAnimation from '@girder/core/views/widgets/LoadingAnimation';
+import View from '@girder/core/views/View';
+import { formatSize } from '@girder/core/misc';
 
-import ItemListTemplate from 'girder/templates/widgets/itemList.pug';
+import ItemListTemplate from '@girder/core/templates/widgets/itemList.pug';
 
 /**
  * This widget shows a list of items under a given folder.

--- a/girder/web_client/src/views/widgets/LoadingAnimation.js
+++ b/girder/web_client/src/views/widgets/LoadingAnimation.js
@@ -1,8 +1,8 @@
-import View from 'girder/views/View';
+import View from '@girder/core/views/View';
 
-import LoadingAnimationTemplate from 'girder/templates/widgets/loadingAnimation.pug';
+import LoadingAnimationTemplate from '@girder/core/templates/widgets/loadingAnimation.pug';
 
-import 'girder/stylesheets/layout/loading.styl';
+import '@girder/core/stylesheets/layout/loading.styl';
 
 /**
  * This widget can be used to display a small loading animation.

--- a/girder/web_client/src/views/widgets/MarkdownWidget.js
+++ b/girder/web_client/src/views/widgets/MarkdownWidget.js
@@ -1,15 +1,15 @@
 import _ from 'underscore';
 
-import FileModel from 'girder/models/FileModel';
-import View from 'girder/views/View';
-import events from 'girder/events';
-import { renderMarkdown, formatSize } from 'girder/misc';
+import FileModel from '@girder/core/models/FileModel';
+import View from '@girder/core/views/View';
+import events from '@girder/core/events';
+import { renderMarkdown, formatSize } from '@girder/core/misc';
 
-import MarkdownWidgetTemplate from 'girder/templates/widgets/markdownWidget.pug';
+import MarkdownWidgetTemplate from '@girder/core/templates/widgets/markdownWidget.pug';
 
-import 'girder/stylesheets/widgets/markdownWidget.styl';
+import '@girder/core/stylesheets/widgets/markdownWidget.styl';
 
-import 'girder/utilities/jquery/girderEnable';
+import '@girder/core/utilities/jquery/girderEnable';
 
 import 'bootstrap/js/tab';
 

--- a/girder/web_client/src/views/widgets/MetadataWidget.js
+++ b/girder/web_client/src/views/widgets/MetadataWidget.js
@@ -1,19 +1,19 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import View from 'girder/views/View';
-import { AccessType } from 'girder/constants';
-import { confirm } from 'girder/dialog';
-import events from 'girder/events';
-import { localeSort } from 'girder/misc';
+import View from '@girder/core/views/View';
+import { AccessType } from '@girder/core/constants';
+import { confirm } from '@girder/core/dialog';
+import events from '@girder/core/events';
+import { localeSort } from '@girder/core/misc';
 
-import JsonMetadatumEditWidgetTemplate from 'girder/templates/widgets/jsonMetadatumEditWidget.pug';
-import JsonMetadatumViewTemplate from 'girder/templates/widgets/jsonMetadatumView.pug';
-import MetadataWidgetTemplate from 'girder/templates/widgets/metadataWidget.pug';
-import MetadatumEditWidgetTemplate from 'girder/templates/widgets/metadatumEditWidget.pug';
-import MetadatumViewTemplate from 'girder/templates/widgets/metadatumView.pug';
+import JsonMetadatumEditWidgetTemplate from '@girder/core/templates/widgets/jsonMetadatumEditWidget.pug';
+import JsonMetadatumViewTemplate from '@girder/core/templates/widgets/jsonMetadatumView.pug';
+import MetadataWidgetTemplate from '@girder/core/templates/widgets/metadataWidget.pug';
+import MetadatumEditWidgetTemplate from '@girder/core/templates/widgets/metadatumEditWidget.pug';
+import MetadatumViewTemplate from '@girder/core/templates/widgets/metadatumView.pug';
 
-import 'girder/stylesheets/widgets/metadataWidget.styl';
+import '@girder/core/stylesheets/widgets/metadataWidget.styl';
 
 import JSONEditor from 'jsoneditor/dist/jsoneditor.js'; // can't 'jsoneditor'
 import 'jsoneditor/dist/jsoneditor.css';

--- a/girder/web_client/src/views/widgets/NewAssetstoreWidget.js
+++ b/girder/web_client/src/views/widgets/NewAssetstoreWidget.js
@@ -1,13 +1,13 @@
-import AssetstoreModel from 'girder/models/AssetstoreModel';
-import View from 'girder/views/View';
-import { AssetstoreType } from 'girder/constants';
+import AssetstoreModel from '@girder/core/models/AssetstoreModel';
+import View from '@girder/core/views/View';
+import { AssetstoreType } from '@girder/core/constants';
 
-import NewAssetstoreTemplate from 'girder/templates/widgets/newAssetstore.pug';
+import NewAssetstoreTemplate from '@girder/core/templates/widgets/newAssetstore.pug';
 
 import 'bootstrap/js/collapse';
 import 'bootstrap/js/transition';
 
-import 'girder/utilities/jquery/girderEnable';
+import '@girder/core/utilities/jquery/girderEnable';
 
 /**
  * This widget is for creating new assetstores. The parent view is responsible

--- a/girder/web_client/src/views/widgets/PaginateWidget.js
+++ b/girder/web_client/src/views/widgets/PaginateWidget.js
@@ -1,6 +1,6 @@
-import View from 'girder/views/View';
+import View from '@girder/core/views/View';
 
-import PaginateWidgetTemplate from 'girder/templates/widgets/paginateWidget.pug';
+import PaginateWidgetTemplate from '@girder/core/templates/widgets/paginateWidget.pug';
 
 /**
  * This widget is used to provide a consistent widget for iterating amongst

--- a/girder/web_client/src/views/widgets/PluginConfigBreadcrumbWidget.js
+++ b/girder/web_client/src/views/widgets/PluginConfigBreadcrumbWidget.js
@@ -1,7 +1,7 @@
-import router from 'girder/router';
-import View from 'girder/views/View';
+import router from '@girder/core/router';
+import View from '@girder/core/views/View';
 
-import PluginConfigBreadcrumbTemplate from 'girder/templates/widgets/pluginConfigBreadcrumb.pug';
+import PluginConfigBreadcrumbTemplate from '@girder/core/templates/widgets/pluginConfigBreadcrumb.pug';
 
 /**
  * This widget provides a consistent breadcrumb to be displayed on the admin

--- a/girder/web_client/src/views/widgets/RootSelectorWidget.js
+++ b/girder/web_client/src/views/widgets/RootSelectorWidget.js
@@ -1,12 +1,12 @@
 import _ from 'underscore';
 
-import CollectionCollection from 'girder/collections/CollectionCollection';
-import UserCollection from 'girder/collections/UserCollection';
-import View from 'girder/views/View';
-import events from 'girder/events';
-import { getCurrentUser } from 'girder/auth';
+import CollectionCollection from '@girder/core/collections/CollectionCollection';
+import UserCollection from '@girder/core/collections/UserCollection';
+import View from '@girder/core/views/View';
+import events from '@girder/core/events';
+import { getCurrentUser } from '@girder/core/auth';
 
-import RootSelectorWidgetTemplate from 'girder/templates/widgets/rootSelectorWidget.pug';
+import RootSelectorWidgetTemplate from '@girder/core/templates/widgets/rootSelectorWidget.pug';
 
 /**
  * This widget creates a dropdown box allowing the user to select

--- a/girder/web_client/src/views/widgets/SearchFieldWidget.js
+++ b/girder/web_client/src/views/widgets/SearchFieldWidget.js
@@ -4,15 +4,15 @@ import _ from 'underscore';
 import 'bootstrap/js/tooltip';
 import 'bootstrap/js/popover';
 
-import View from 'girder/views/View';
-import { restRequest } from 'girder/rest';
-import router from 'girder/router';
+import View from '@girder/core/views/View';
+import { restRequest } from '@girder/core/rest';
+import router from '@girder/core/router';
 
-import SearchFieldTemplate from 'girder/templates/widgets/searchField.pug';
-import SearchHelpTemplate from 'girder/templates/widgets/searchHelp.pug';
-import SearchModeSelectTemplate from 'girder/templates/widgets/searchModeSelect.pug';
-import SearchResultsTemplate from 'girder/templates/widgets/searchResults.pug';
-import 'girder/stylesheets/widgets/searchFieldWidget.styl';
+import SearchFieldTemplate from '@girder/core/templates/widgets/searchField.pug';
+import SearchHelpTemplate from '@girder/core/templates/widgets/searchHelp.pug';
+import SearchModeSelectTemplate from '@girder/core/templates/widgets/searchModeSelect.pug';
+import SearchResultsTemplate from '@girder/core/templates/widgets/searchResults.pug';
+import '@girder/core/stylesheets/widgets/searchFieldWidget.styl';
 
 /**
  * This widget provides a text field that will search any set of data types

--- a/girder/web_client/src/views/widgets/SearchPaginateWidget.js
+++ b/girder/web_client/src/views/widgets/SearchPaginateWidget.js
@@ -1,10 +1,10 @@
 import _ from 'underscore';
 
-import View from 'girder/views/View';
-import { restRequest } from 'girder/rest';
+import View from '@girder/core/views/View';
+import { restRequest } from '@girder/core/rest';
 
-import PaginateWidgetTemplate from 'girder/templates/widgets/paginateWidget.pug';
-import SearchFieldWidget from 'girder/views/widgets/SearchFieldWidget';
+import PaginateWidgetTemplate from '@girder/core/templates/widgets/paginateWidget.pug';
+import SearchFieldWidget from '@girder/core/views/widgets/SearchFieldWidget';
 /**
  * This widget is used to provide a consistent widget for iterating amongst
  * pages of a list of search results (using a search mode, a query, an unique type,

--- a/girder/web_client/src/views/widgets/SortCollectionWidget.js
+++ b/girder/web_client/src/views/widgets/SortCollectionWidget.js
@@ -1,7 +1,7 @@
-import View from 'girder/views/View';
-import { SORT_ASC, SORT_DESC } from 'girder/constants';
+import View from '@girder/core/views/View';
+import { SORT_ASC, SORT_DESC } from '@girder/core/constants';
 
-import SortCollectionWidgetTemplate from 'girder/templates/widgets/sortCollectionWidget.pug';
+import SortCollectionWidgetTemplate from '@girder/core/templates/widgets/sortCollectionWidget.pug';
 
 import 'bootstrap/js/dropdown';
 

--- a/girder/web_client/src/views/widgets/TaskProgressWidget.js
+++ b/girder/web_client/src/views/widgets/TaskProgressWidget.js
@@ -1,10 +1,10 @@
 import { sprintf } from 'sprintf-js';
 
-import View from 'girder/views/View';
+import View from '@girder/core/views/View';
 
-import TaskProgressTemplate from 'girder/templates/widgets/taskProgress.pug';
+import TaskProgressTemplate from '@girder/core/templates/widgets/taskProgress.pug';
 
-import 'girder/stylesheets/widgets/taskProgress.styl';
+import '@girder/core/stylesheets/widgets/taskProgress.styl';
 
 /**
  * This widget renders the state of a progress notification.

--- a/girder/web_client/src/views/widgets/TimelineWidget.js
+++ b/girder/web_client/src/views/widgets/TimelineWidget.js
@@ -1,10 +1,10 @@
 import _ from 'underscore';
 
-import View from 'girder/views/View';
+import View from '@girder/core/views/View';
 
-import TimelineTemplate from 'girder/templates/widgets/timeline.pug';
+import TimelineTemplate from '@girder/core/templates/widgets/timeline.pug';
 
-import 'girder/stylesheets/widgets/timelineWidget.styl';
+import '@girder/core/stylesheets/widgets/timelineWidget.styl';
 
 /**
  * This widget displays a timeline of events. This is visualized as a line (a bar)

--- a/girder/web_client/src/views/widgets/UploadWidget.js
+++ b/girder/web_client/src/views/widgets/UploadWidget.js
@@ -1,18 +1,18 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import FileModel from 'girder/models/FileModel';
-import View from 'girder/views/View';
-import { formatSize } from 'girder/misc';
-import { handleClose, handleOpen } from 'girder/dialog';
+import FileModel from '@girder/core/models/FileModel';
+import View from '@girder/core/views/View';
+import { formatSize } from '@girder/core/misc';
+import { handleClose, handleOpen } from '@girder/core/dialog';
 
-import UploadWidgetTemplate from 'girder/templates/widgets/uploadWidget.pug';
-import UploadWidgetNonModalTemplate from 'girder/templates/widgets/uploadWidgetNonModal.pug';
+import UploadWidgetTemplate from '@girder/core/templates/widgets/uploadWidget.pug';
+import UploadWidgetNonModalTemplate from '@girder/core/templates/widgets/uploadWidgetNonModal.pug';
 
-import 'girder/stylesheets/widgets/uploadWidget.styl';
+import '@girder/core/stylesheets/widgets/uploadWidget.styl';
 
-import 'girder/utilities/jquery/girderEnable';
-import 'girder/utilities/jquery/girderModal';
+import '@girder/core/utilities/jquery/girderEnable';
+import '@girder/core/utilities/jquery/girderModal';
 
 /**
  * This widget is used to upload files to a folder. Pass a folder model

--- a/girder/web_client/src/views/widgets/UserOtpManagementWidget.js
+++ b/girder/web_client/src/views/widgets/UserOtpManagementWidget.js
@@ -1,12 +1,12 @@
 import QRCode from 'qrcode';
 import OTPAuth from 'url-otpauth';
 
-import View from 'girder/views/View';
+import View from '@girder/core/views/View';
 
-import UserOtpBeginTemplate from 'girder/templates/widgets/userOtpBegin.pug';
-import UserOtpEnableTemplate from 'girder/templates/widgets/userOtpEnable.pug';
-import UserOtpDisableTemplate from 'girder/templates/widgets/userOtpDisable.pug';
-import 'girder/stylesheets/widgets/userOtpManagementWidget.styl';
+import UserOtpBeginTemplate from '@girder/core/templates/widgets/userOtpBegin.pug';
+import UserOtpEnableTemplate from '@girder/core/templates/widgets/userOtpEnable.pug';
+import UserOtpDisableTemplate from '@girder/core/templates/widgets/userOtpDisable.pug';
+import '@girder/core/stylesheets/widgets/userOtpManagementWidget.styl';
 
 const UserOtpManagementWidget = View.extend({
     events: {

--- a/plugins/authorized_upload/girder_authorized_upload/web_client/main.js
+++ b/plugins/authorized_upload/girder_authorized_upload/web_client/main.js
@@ -1,8 +1,8 @@
 import './routes.js';
 
-import HierarchyWidget from 'girder/views/widgets/HierarchyWidget';
-import { AccessType } from 'girder/constants';
-import { wrap } from 'girder/utilities/PluginUtils';
+import HierarchyWidget from '@girder/core/views/widgets/HierarchyWidget';
+import { AccessType } from '@girder/core/constants';
+import { wrap } from '@girder/core/utilities/PluginUtils';
 
 import template from './templates/folderActions.pug';
 

--- a/plugins/authorized_upload/girder_authorized_upload/web_client/routes.js
+++ b/plugins/authorized_upload/girder_authorized_upload/web_client/routes.js
@@ -1,9 +1,9 @@
 /* eslint-disable import/first */
 
-import router from 'girder/router';
-import events from 'girder/events';
-import FolderModel from 'girder/models/FolderModel';
-import { Layout } from 'girder/constants';
+import router from '@girder/core/router';
+import events from '@girder/core/events';
+import FolderModel from '@girder/core/models/FolderModel';
+import { Layout } from '@girder/core/constants';
 
 import AuthorizeUploadView from './views/AuthorizeUploadView';
 import AuthorizedUploadView from './views/AuthorizedUploadView';

--- a/plugins/authorized_upload/girder_authorized_upload/web_client/views/AuthorizeUploadView.js
+++ b/plugins/authorized_upload/girder_authorized_upload/web_client/views/AuthorizeUploadView.js
@@ -1,5 +1,5 @@
-import View from 'girder/views/View';
-import { restRequest } from 'girder/rest';
+import View from '@girder/core/views/View';
+import { restRequest } from '@girder/core/rest';
 
 import template from '../templates/authorizeUpload.pug';
 import '../stylesheets/authorizeUpload.styl';

--- a/plugins/authorized_upload/girder_authorized_upload/web_client/views/AuthorizedUploadView.js
+++ b/plugins/authorized_upload/girder_authorized_upload/web_client/views/AuthorizedUploadView.js
@@ -1,7 +1,7 @@
-import FolderModel from 'girder/models/FolderModel';
-import View from 'girder/views/View';
-import UploadWidget from 'girder/views/widgets/UploadWidget';
-import { setCurrentToken } from 'girder/auth';
+import FolderModel from '@girder/core/models/FolderModel';
+import View from '@girder/core/views/View';
+import UploadWidget from '@girder/core/views/widgets/UploadWidget';
+import { setCurrentToken } from '@girder/core/auth';
 
 import template from '../templates/authorizedUpload.pug';
 import '../stylesheets/authorizedUpload.styl';

--- a/plugins/autojoin/girder_autojoin/web_client/routes.js
+++ b/plugins/autojoin/girder_autojoin/web_client/routes.js
@@ -1,8 +1,8 @@
 /* eslint-disable import/first */
 
-import router from 'girder/router';
-import events from 'girder/events';
-import { exposePluginConfig } from 'girder/utilities/PluginUtils';
+import router from '@girder/core/router';
+import events from '@girder/core/events';
+import { exposePluginConfig } from '@girder/core/utilities/PluginUtils';
 
 exposePluginConfig('autojoin', 'plugins/autojoin/config');
 

--- a/plugins/autojoin/girder_autojoin/web_client/views/ConfigView.js
+++ b/plugins/autojoin/girder_autojoin/web_client/views/ConfigView.js
@@ -1,11 +1,11 @@
 import $ from 'jquery';
 
-import GroupCollection from 'girder/collections/GroupCollection';
-import PluginConfigBreadcrumbWidget from 'girder/views/widgets/PluginConfigBreadcrumbWidget';
-import router from 'girder/router';
-import View from 'girder/views/View';
-import events from 'girder/events';
-import { restRequest } from 'girder/rest';
+import GroupCollection from '@girder/core/collections/GroupCollection';
+import PluginConfigBreadcrumbWidget from '@girder/core/views/widgets/PluginConfigBreadcrumbWidget';
+import router from '@girder/core/router';
+import View from '@girder/core/views/View';
+import events from '@girder/core/events';
+import { restRequest } from '@girder/core/rest';
 
 import ConfigViewTemplate from '../templates/configView.pug';
 import '../stylesheets/configView.styl';

--- a/plugins/dicom_viewer/girder_dicom_viewer/web_client/main.js
+++ b/plugins/dicom_viewer/girder_dicom_viewer/web_client/main.js
@@ -1,12 +1,12 @@
 
-import { getCurrentUser } from 'girder/auth';
-import { AccessType } from 'girder/constants';
-import events from 'girder/events';
-import { restRequest } from 'girder/rest';
-import { wrap } from 'girder/utilities/PluginUtils';
+import { getCurrentUser } from '@girder/core/auth';
+import { AccessType } from '@girder/core/constants';
+import events from '@girder/core/events';
+import { restRequest } from '@girder/core/rest';
+import { wrap } from '@girder/core/utilities/PluginUtils';
 
-import ItemView from 'girder/views/body/ItemView';
-import SearchFieldWidget from 'girder/views/widgets/SearchFieldWidget';
+import ItemView from '@girder/core/views/body/ItemView';
+import SearchFieldWidget from '@girder/core/views/widgets/SearchFieldWidget';
 
 import DicomItemView from './views/DicomView';
 import ParseDicomItemTemplate from './templates/parseDicomItem.pug';

--- a/plugins/dicom_viewer/girder_dicom_viewer/web_client/views/DicomView.js
+++ b/plugins/dicom_viewer/girder_dicom_viewer/web_client/views/DicomView.js
@@ -10,10 +10,10 @@ import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderWindowInteractor from 'vtk.js/Sources/Rendering/Core/RenderWindowInteractor';
 
-import { restRequest } from 'girder/rest';
-import FileModel from 'girder/models/FileModel';
-import FileCollection from 'girder/collections/FileCollection';
-import View from 'girder/views/View';
+import { restRequest } from '@girder/core/rest';
+import FileModel from '@girder/core/models/FileModel';
+import FileCollection from '@girder/core/collections/FileCollection';
+import View from '@girder/core/views/View';
 
 import DicomItemTemplate from '../templates/dicomItem.pug';
 import '../stylesheets/dicomItem.styl';

--- a/plugins/google_analytics/girder_google_analytics/web_client/main.js
+++ b/plugins/google_analytics/girder_google_analytics/web_client/main.js
@@ -1,5 +1,5 @@
-import events from 'girder/events';
-import { restRequest } from 'girder/rest';
+import events from '@girder/core/events';
+import { restRequest } from '@girder/core/rest';
 
 import './lib/backbone.analytics';
 import './routes';

--- a/plugins/google_analytics/girder_google_analytics/web_client/routes.js
+++ b/plugins/google_analytics/girder_google_analytics/web_client/routes.js
@@ -1,8 +1,8 @@
 /* eslint-disable import/first */
 
-import router from 'girder/router';
-import events from 'girder/events';
-import { exposePluginConfig } from 'girder/utilities/PluginUtils';
+import router from '@girder/core/router';
+import events from '@girder/core/events';
+import { exposePluginConfig } from '@girder/core/utilities/PluginUtils';
 
 exposePluginConfig('google_analytics', 'plugins/google_analytics/config');
 

--- a/plugins/google_analytics/girder_google_analytics/web_client/views/ConfigView.js
+++ b/plugins/google_analytics/girder_google_analytics/web_client/views/ConfigView.js
@@ -1,7 +1,7 @@
-import PluginConfigBreadcrumbWidget from 'girder/views/widgets/PluginConfigBreadcrumbWidget';
-import View from 'girder/views/View';
-import events from 'girder/events';
-import { restRequest } from 'girder/rest';
+import PluginConfigBreadcrumbWidget from '@girder/core/views/widgets/PluginConfigBreadcrumbWidget';
+import View from '@girder/core/views/View';
+import events from '@girder/core/events';
+import { restRequest } from '@girder/core/rest';
 
 import ConfigViewTemplate from '../templates/configView.pug';
 import '../stylesheets/configView.styl';

--- a/plugins/gravatar/girder_gravatar/web_client/models/UserModel.js
+++ b/plugins/gravatar/girder_gravatar/web_client/models/UserModel.js
@@ -1,5 +1,5 @@
-import UserModel from 'girder/models/UserModel';
-import { getApiRoot } from 'girder/rest';
+import UserModel from '@girder/core/models/UserModel';
+import { getApiRoot } from '@girder/core/rest';
 
 UserModel.prototype.getGravatarUrl = function (size) {
     size = size || 64;

--- a/plugins/gravatar/girder_gravatar/web_client/routes.js
+++ b/plugins/gravatar/girder_gravatar/web_client/routes.js
@@ -1,8 +1,8 @@
 /* eslint-disable import/first */
 
-import router from 'girder/router';
-import events from 'girder/events';
-import { exposePluginConfig } from 'girder/utilities/PluginUtils';
+import router from '@girder/core/router';
+import events from '@girder/core/events';
+import { exposePluginConfig } from '@girder/core/utilities/PluginUtils';
 
 exposePluginConfig('gravatar', 'plugins/gravatar/config');
 

--- a/plugins/gravatar/girder_gravatar/web_client/views/ConfigView.js
+++ b/plugins/gravatar/girder_gravatar/web_client/views/ConfigView.js
@@ -1,7 +1,7 @@
-import PluginConfigBreadcrumbWidget from 'girder/views/widgets/PluginConfigBreadcrumbWidget';
-import View from 'girder/views/View';
-import events from 'girder/events';
-import { restRequest } from 'girder/rest';
+import PluginConfigBreadcrumbWidget from '@girder/core/views/widgets/PluginConfigBreadcrumbWidget';
+import View from '@girder/core/views/View';
+import events from '@girder/core/events';
+import { restRequest } from '@girder/core/rest';
 
 import ConfigViewTemplate from '../templates/configView.pug';
 

--- a/plugins/hashsum_download/girder_hashsum_download/web_client/main.js
+++ b/plugins/hashsum_download/girder_hashsum_download/web_client/main.js
@@ -3,9 +3,9 @@
 // Extends and overrides API
 import './views/FileInfoWidget';
 
-import router from 'girder/router';
-import events from 'girder/events';
-import { exposePluginConfig } from 'girder/utilities/PluginUtils';
+import router from '@girder/core/router';
+import events from '@girder/core/events';
+import { exposePluginConfig } from '@girder/core/utilities/PluginUtils';
 
 exposePluginConfig('hashsum_download', 'plugins/hashsum_download/config');
 

--- a/plugins/hashsum_download/girder_hashsum_download/web_client/views/ConfigView.js
+++ b/plugins/hashsum_download/girder_hashsum_download/web_client/views/ConfigView.js
@@ -1,7 +1,7 @@
-import PluginConfigBreadcrumbWidget from 'girder/views/widgets/PluginConfigBreadcrumbWidget';
-import View from 'girder/views/View';
-import events from 'girder/events';
-import { restRequest } from 'girder/rest';
+import PluginConfigBreadcrumbWidget from '@girder/core/views/widgets/PluginConfigBreadcrumbWidget';
+import View from '@girder/core/views/View';
+import events from '@girder/core/events';
+import { restRequest } from '@girder/core/rest';
 
 import template from '../templates/config.pug';
 

--- a/plugins/hashsum_download/girder_hashsum_download/web_client/views/FileInfoWidget.js
+++ b/plugins/hashsum_download/girder_hashsum_download/web_client/views/FileInfoWidget.js
@@ -1,7 +1,7 @@
-import FileInfoWidget from 'girder/views/widgets/FileInfoWidget';
-import { getApiRoot, restRequest } from 'girder/rest';
-import { AccessType } from 'girder/constants';
-import { wrap } from 'girder/utilities/PluginUtils';
+import FileInfoWidget from '@girder/core/views/widgets/FileInfoWidget';
+import { getApiRoot, restRequest } from '@girder/core/rest';
+import { AccessType } from '@girder/core/constants';
+import { wrap } from '@girder/core/utilities/PluginUtils';
 
 import template from '../templates/hashsumDownloadFileInfoWidget.pug';
 

--- a/plugins/homepage/girder_homepage/web_client/routes.js
+++ b/plugins/homepage/girder_homepage/web_client/routes.js
@@ -1,8 +1,8 @@
 /* eslint-disable import/first */
 
-import router from 'girder/router';
-import events from 'girder/events';
-import { exposePluginConfig } from 'girder/utilities/PluginUtils';
+import router from '@girder/core/router';
+import events from '@girder/core/events';
+import { exposePluginConfig } from '@girder/core/utilities/PluginUtils';
 
 exposePluginConfig('homepage', 'plugins/homepage/config');
 

--- a/plugins/homepage/girder_homepage/web_client/views/ConfigView.js
+++ b/plugins/homepage/girder_homepage/web_client/views/ConfigView.js
@@ -1,10 +1,10 @@
-import FolderModel from 'girder/models/FolderModel';
-import MarkdownWidget from 'girder/views/widgets/MarkdownWidget';
-import PluginConfigBreadcrumbWidget from 'girder/views/widgets/PluginConfigBreadcrumbWidget';
-import View from 'girder/views/View';
-import UploadWidget from 'girder/views/widgets/UploadWidget';
-import events from 'girder/events';
-import { restRequest, getApiRoot } from 'girder/rest';
+import FolderModel from '@girder/core/models/FolderModel';
+import MarkdownWidget from '@girder/core/views/widgets/MarkdownWidget';
+import PluginConfigBreadcrumbWidget from '@girder/core/views/widgets/PluginConfigBreadcrumbWidget';
+import View from '@girder/core/views/View';
+import UploadWidget from '@girder/core/views/widgets/UploadWidget';
+import events from '@girder/core/events';
+import { restRequest, getApiRoot } from '@girder/core/rest';
 
 import ConfigViewTemplate from '../templates/configView.pug';
 import '../stylesheets/configView.styl';
@@ -115,7 +115,7 @@ const ConfigView = View.extend({
         if (this.logoFileId) {
             logoUrl = `${getApiRoot()}/file/${this.logoFileId}/download?contentDisposition=inline`;
         } else {
-            logoUrl = require('girder/assets/Girder_Mark.png');
+            logoUrl = require('@girder/core/assets/Girder_Mark.png');
         }
         this.$('.g-homepage-logo-preview img').attr('src', logoUrl);
     },

--- a/plugins/homepage/girder_homepage/web_client/views/FrontPageView.js
+++ b/plugins/homepage/girder_homepage/web_client/views/FrontPageView.js
@@ -1,7 +1,7 @@
-import FrontPageView from 'girder/views/body/FrontPageView';
-import { renderMarkdown } from 'girder/misc';
-import { restRequest, getApiRoot } from 'girder/rest';
-import { wrap } from 'girder/utilities/PluginUtils';
+import FrontPageView from '@girder/core/views/body/FrontPageView';
+import { renderMarkdown } from '@girder/core/misc';
+import { restRequest, getApiRoot } from '@girder/core/rest';
+import { wrap } from '@girder/core/utilities/PluginUtils';
 
 wrap(FrontPageView, 'render', function (render) {
     restRequest({

--- a/plugins/item_licenses/girder_item_licenses/web_client/routes.js
+++ b/plugins/item_licenses/girder_item_licenses/web_client/routes.js
@@ -1,8 +1,8 @@
 /* eslint-disable import/first */
 
-import router from 'girder/router';
-import events from 'girder/events';
-import { exposePluginConfig } from 'girder/utilities/PluginUtils';
+import router from '@girder/core/router';
+import events from '@girder/core/events';
+import { exposePluginConfig } from '@girder/core/utilities/PluginUtils';
 
 exposePluginConfig('item_licenses', 'plugins/item_licenses/config');
 

--- a/plugins/item_licenses/girder_item_licenses/web_client/views/ConfigView.js
+++ b/plugins/item_licenses/girder_item_licenses/web_client/views/ConfigView.js
@@ -1,7 +1,7 @@
-import PluginConfigBreadcrumbWidget from 'girder/views/widgets/PluginConfigBreadcrumbWidget';
-import View from 'girder/views/View';
-import events from 'girder/events';
-import { restRequest } from 'girder/rest';
+import PluginConfigBreadcrumbWidget from '@girder/core/views/widgets/PluginConfigBreadcrumbWidget';
+import View from '@girder/core/views/View';
+import events from '@girder/core/events';
+import { restRequest } from '@girder/core/rest';
 
 import ConfigViewTemplate from '../templates/configView.pug';
 import '../stylesheets/configView.styl';

--- a/plugins/item_licenses/girder_item_licenses/web_client/views/EditItemWidget.js
+++ b/plugins/item_licenses/girder_item_licenses/web_client/views/EditItemWidget.js
@@ -1,8 +1,8 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import EditItemWidget from 'girder/views/widgets/EditItemWidget';
-import { wrap } from 'girder/utilities/PluginUtils';
+import EditItemWidget from '@girder/core/views/widgets/EditItemWidget';
+import { wrap } from '@girder/core/utilities/PluginUtils';
 
 import SelectLicenseWidget from './SelectLicenseWidget';
 

--- a/plugins/item_licenses/girder_item_licenses/web_client/views/HierarchyWidget.js
+++ b/plugins/item_licenses/girder_item_licenses/web_client/views/HierarchyWidget.js
@@ -1,6 +1,6 @@
-import HierarchyWidget from 'girder/views/widgets/HierarchyWidget';
-import { restRequest } from 'girder/rest';
-import { wrap } from 'girder/utilities/PluginUtils';
+import HierarchyWidget from '@girder/core/views/widgets/HierarchyWidget';
+import { restRequest } from '@girder/core/rest';
+import { wrap } from '@girder/core/utilities/PluginUtils';
 
 /**
  * Allow selecting license when uploading an item.

--- a/plugins/item_licenses/girder_item_licenses/web_client/views/ItemLicenseWidget.js
+++ b/plugins/item_licenses/girder_item_licenses/web_client/views/ItemLicenseWidget.js
@@ -1,4 +1,4 @@
-import View from 'girder/views/View';
+import View from '@girder/core/views/View';
 
 import ItemLicenseWidgetTemplate from '../templates/itemLicenseWidget.pug';
 

--- a/plugins/item_licenses/girder_item_licenses/web_client/views/ItemView.js
+++ b/plugins/item_licenses/girder_item_licenses/web_client/views/ItemView.js
@@ -1,8 +1,8 @@
 import $ from 'jquery';
 
-import ItemView from 'girder/views/body/ItemView';
-import { restRequest } from 'girder/rest';
-import { wrap } from 'girder/utilities/PluginUtils';
+import ItemView from '@girder/core/views/body/ItemView';
+import { restRequest } from '@girder/core/rest';
+import { wrap } from '@girder/core/utilities/PluginUtils';
 
 import ItemLicenseWidget from './ItemLicenseWidget';
 

--- a/plugins/item_licenses/girder_item_licenses/web_client/views/SelectLicenseWidget.js
+++ b/plugins/item_licenses/girder_item_licenses/web_client/views/SelectLicenseWidget.js
@@ -1,4 +1,4 @@
-import View from 'girder/views/View';
+import View from '@girder/core/views/View';
 
 import SelectLicenseWidgetTemplate from '../templates/selectLicenseWidget.pug';
 

--- a/plugins/item_licenses/girder_item_licenses/web_client/views/UploadWidget.js
+++ b/plugins/item_licenses/girder_item_licenses/web_client/views/UploadWidget.js
@@ -1,9 +1,9 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import ItemModel from 'girder/models/ItemModel';
-import UploadWidget from 'girder/views/widgets/UploadWidget';
-import { wrap } from 'girder/utilities/PluginUtils';
+import ItemModel from '@girder/core/models/ItemModel';
+import UploadWidget from '@girder/core/views/widgets/UploadWidget';
+import { wrap } from '@girder/core/utilities/PluginUtils';
 
 import SelectLicenseWidget from './SelectLicenseWidget';
 

--- a/plugins/jobs/girder_jobs/web_client/collections/JobCollection.js
+++ b/plugins/jobs/girder_jobs/web_client/collections/JobCollection.js
@@ -1,4 +1,4 @@
-import Collection from 'girder/collections/Collection';
+import Collection from '@girder/core/collections/Collection';
 
 import JobModel from '../models/JobModel';
 

--- a/plugins/jobs/girder_jobs/web_client/main.js
+++ b/plugins/jobs/girder_jobs/web_client/main.js
@@ -1,4 +1,4 @@
-import { registerPluginNamespace } from 'girder/pluginUtils';
+import { registerPluginNamespace } from '@girder/core/pluginUtils';
 
 import './routes';
 

--- a/plugins/jobs/girder_jobs/web_client/models/JobModel.js
+++ b/plugins/jobs/girder_jobs/web_client/models/JobModel.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 
-import AccessControlledModel from 'girder/models/AccessControlledModel';
+import AccessControlledModel from '@girder/core/models/AccessControlledModel';
 
 import JobStatus from '../JobStatus';
 

--- a/plugins/jobs/girder_jobs/web_client/routes.js
+++ b/plugins/jobs/girder_jobs/web_client/routes.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/first */
 
-import router from 'girder/router';
-import events from 'girder/events';
+import router from '@girder/core/router';
+import events from '@girder/core/events';
 
 import JobModel from './models/JobModel';
 import JobDetailsWidget from './views/JobDetailsWidget';

--- a/plugins/jobs/girder_jobs/web_client/views/AdminView.js
+++ b/plugins/jobs/girder_jobs/web_client/views/AdminView.js
@@ -1,5 +1,5 @@
-import { wrap } from 'girder/utilities/PluginUtils';
-import AdminView from 'girder/views/body/AdminView';
+import { wrap } from '@girder/core/utilities/PluginUtils';
+import AdminView from '@girder/core/views/body/AdminView';
 
 import adminViewMenuItemTemplate from '../templates/adminViewMenuItem.pug';
 

--- a/plugins/jobs/girder_jobs/web_client/views/CheckBoxMenu.js
+++ b/plugins/jobs/girder_jobs/web_client/views/CheckBoxMenu.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 
-import View from 'girder/views/View';
+import View from '@girder/core/views/View';
 
 import JobCheckBoxMenuTemplate from '../templates/jobCheckBoxMenu.pug';
 import JobCheckBoxContentTemplate from '../templates/jobCheckBoxContent.pug';

--- a/plugins/jobs/girder_jobs/web_client/views/HeaderUserView.js
+++ b/plugins/jobs/girder_jobs/web_client/views/HeaderUserView.js
@@ -1,6 +1,6 @@
-import HeaderUserView from 'girder/views/layout/HeaderUserView';
-import { getCurrentUser } from 'girder/auth';
-import { wrap } from 'girder/utilities/PluginUtils';
+import HeaderUserView from '@girder/core/views/layout/HeaderUserView';
+import { getCurrentUser } from '@girder/core/auth';
+import { wrap } from '@girder/core/utilities/PluginUtils';
 
 import HeaderUserViewMenuTemplate from '../templates/headerUserViewMenu.pug';
 

--- a/plugins/jobs/girder_jobs/web_client/views/JobDetailsWidget.js
+++ b/plugins/jobs/girder_jobs/web_client/views/JobDetailsWidget.js
@@ -1,11 +1,11 @@
 import _ from 'underscore';
 
-import { restRequest } from 'girder/rest';
-import TimelineWidget from 'girder/views/widgets/TimelineWidget';
-import View from 'girder/views/View';
-import eventStream from 'girder/utilities/EventStream';
-import { formatDate, DATE_SECOND } from 'girder/misc';
-import events from 'girder/events';
+import { restRequest } from '@girder/core/rest';
+import TimelineWidget from '@girder/core/views/widgets/TimelineWidget';
+import View from '@girder/core/views/View';
+import eventStream from '@girder/core/utilities/EventStream';
+import { formatDate, DATE_SECOND } from '@girder/core/misc';
+import events from '@girder/core/events';
 
 import JobDetailsWidgetTemplate from '../templates/jobDetailsWidget.pug';
 import JobStatus from '../JobStatus';

--- a/plugins/jobs/girder_jobs/web_client/views/JobGraphWidget.js
+++ b/plugins/jobs/girder_jobs/web_client/views/JobGraphWidget.js
@@ -4,7 +4,7 @@ import { parse,
     View as VegaView } from 'vega-lib/build/vega';
 import moment from 'moment';
 
-import View from 'girder/views/View';
+import View from '@girder/core/views/View';
 
 import JobStatus from '../JobStatus';
 import JobsGraphWidgetTemplate from '../templates/jobsGraphWidget.pug';

--- a/plugins/jobs/girder_jobs/web_client/views/JobListWidget.js
+++ b/plugins/jobs/girder_jobs/web_client/views/JobListWidget.js
@@ -1,15 +1,15 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import PaginateWidget from 'girder/views/widgets/PaginateWidget';
-import View from 'girder/views/View';
-import router from 'girder/router';
-import events from 'girder/events';
-import { restRequest } from 'girder/rest';
-import { defineFlags, formatDate, DATE_SECOND, _whenAll } from 'girder/misc';
-import eventStream from 'girder/utilities/EventStream';
-import { getCurrentUser } from 'girder/auth';
-import { SORT_DESC } from 'girder/constants';
+import PaginateWidget from '@girder/core/views/widgets/PaginateWidget';
+import View from '@girder/core/views/View';
+import router from '@girder/core/router';
+import events from '@girder/core/events';
+import { restRequest } from '@girder/core/rest';
+import { defineFlags, formatDate, DATE_SECOND, _whenAll } from '@girder/core/misc';
+import eventStream from '@girder/core/utilities/EventStream';
+import { getCurrentUser } from '@girder/core/auth';
+import { SORT_DESC } from '@girder/core/constants';
 
 import JobCollection from '../collections/JobCollection';
 import JobStatus from '../JobStatus';

--- a/plugins/ldap/girder_ldap/web_client/routes.js
+++ b/plugins/ldap/girder_ldap/web_client/routes.js
@@ -1,8 +1,8 @@
 /* eslint-disable import/first */
 
-import events from 'girder/events';
-import router from 'girder/router';
-import { exposePluginConfig } from 'girder/utilities/PluginUtils';
+import events from '@girder/core/events';
+import router from '@girder/core/router';
+import { exposePluginConfig } from '@girder/core/utilities/PluginUtils';
 
 exposePluginConfig('ldap', 'plugins/ldap/config');
 

--- a/plugins/ldap/girder_ldap/web_client/views/ConfigView.js
+++ b/plugins/ldap/girder_ldap/web_client/views/ConfigView.js
@@ -2,15 +2,15 @@ import $ from 'jquery';
 import _ from 'underscore';
 import sortable from 'sortablejs';
 
-import PluginConfigBreadcrumbWidget from 'girder/views/widgets/PluginConfigBreadcrumbWidget';
-import View from 'girder/views/View';
-import { restRequest } from 'girder/rest';
-import events from 'girder/events';
+import PluginConfigBreadcrumbWidget from '@girder/core/views/widgets/PluginConfigBreadcrumbWidget';
+import View from '@girder/core/views/View';
+import { restRequest } from '@girder/core/rest';
+import events from '@girder/core/events';
 
 import template from '../templates/configView.pug';
 import newServerTemplate from '../templates/newServerTemplate.pug';
 import '../stylesheets/configView.styl';
-import 'girder/utilities/jquery/girderEnable';
+import '@girder/core/utilities/jquery/girderEnable';
 
 const FIELDS = ['uri', 'bindName', 'baseDn', 'password', 'searchField'];
 

--- a/plugins/oauth/girder_oauth/web_client/routes.js
+++ b/plugins/oauth/girder_oauth/web_client/routes.js
@@ -1,8 +1,8 @@
 /* eslint-disable import/first */
 
-import events from 'girder/events';
-import router from 'girder/router';
-import { exposePluginConfig } from 'girder/utilities/PluginUtils';
+import events from '@girder/core/events';
+import router from '@girder/core/router';
+import { exposePluginConfig } from '@girder/core/utilities/PluginUtils';
 
 exposePluginConfig('oauth', 'plugins/oauth/config');
 

--- a/plugins/oauth/girder_oauth/web_client/views/ConfigView.js
+++ b/plugins/oauth/girder_oauth/web_client/views/ConfigView.js
@@ -1,10 +1,10 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import PluginConfigBreadcrumbWidget from 'girder/views/widgets/PluginConfigBreadcrumbWidget';
-import View from 'girder/views/View';
-import { getApiRoot, restRequest } from 'girder/rest';
-import events from 'girder/events';
+import PluginConfigBreadcrumbWidget from '@girder/core/views/widgets/PluginConfigBreadcrumbWidget';
+import View from '@girder/core/views/View';
+import { getApiRoot, restRequest } from '@girder/core/rest';
+import events from '@girder/core/events';
 
 import ConfigViewTemplate from '../templates/configView.pug';
 import '../stylesheets/configView.styl';

--- a/plugins/oauth/girder_oauth/web_client/views/LoginView.js
+++ b/plugins/oauth/girder_oauth/web_client/views/LoginView.js
@@ -1,5 +1,5 @@
-import LoginView from 'girder/views/layout/LoginView';
-import { wrap } from 'girder/utilities/PluginUtils';
+import LoginView from '@girder/core/views/layout/LoginView';
+import { wrap } from '@girder/core/utilities/PluginUtils';
 
 import OAuthLoginView from './OAuthLoginView';
 

--- a/plugins/oauth/girder_oauth/web_client/views/OAuthLoginView.js
+++ b/plugins/oauth/girder_oauth/web_client/views/OAuthLoginView.js
@@ -1,9 +1,9 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import View from 'girder/views/View';
-import { restRequest } from 'girder/rest';
-import { splitRoute } from 'girder/misc';
+import View from '@girder/core/views/View';
+import { restRequest } from '@girder/core/rest';
+import { splitRoute } from '@girder/core/misc';
 
 import OAuthLoginViewTemplate from '../templates/oauthLoginView.pug';
 import '../stylesheets/oauthLoginView.styl';

--- a/plugins/oauth/girder_oauth/web_client/views/RegisterView.js
+++ b/plugins/oauth/girder_oauth/web_client/views/RegisterView.js
@@ -1,6 +1,6 @@
-import RegisterView from 'girder/views/layout/RegisterView';
-import { getCurrentUser } from 'girder/auth';
-import { wrap } from 'girder/utilities/PluginUtils';
+import RegisterView from '@girder/core/views/layout/RegisterView';
+import { getCurrentUser } from '@girder/core/auth';
+import { wrap } from '@girder/core/utilities/PluginUtils';
 
 import OAuthLoginView from './OAuthLoginView';
 

--- a/plugins/terms/girder_terms/web_client/models/CollectionModel.js
+++ b/plugins/terms/girder_terms/web_client/models/CollectionModel.js
@@ -1,9 +1,9 @@
 import $ from 'jquery';
 import createHash from 'sha.js';
 
-import { getCurrentUser } from 'girder/auth';
-import CollectionModel from 'girder/models/CollectionModel';
-import { restRequest } from 'girder/rest';
+import { getCurrentUser } from '@girder/core/auth';
+import CollectionModel from '@girder/core/models/CollectionModel';
+import { restRequest } from '@girder/core/rest';
 
 const termsAcceptedFallback = {};
 

--- a/plugins/terms/girder_terms/web_client/routes.js
+++ b/plugins/terms/girder_terms/web_client/routes.js
@@ -1,12 +1,12 @@
 import _ from 'underscore';
 
-import events from 'girder/events';
-import CollectionModel from 'girder/models/CollectionModel';
-import FolderModel from 'girder/models/FolderModel';
-import ItemModel from 'girder/models/ItemModel';
-import CollectionView from 'girder/views/body/CollectionView';
-import FolderView from 'girder/views/body/FolderView';
-import ItemView from 'girder/views/body/ItemView';
+import events from '@girder/core/events';
+import CollectionModel from '@girder/core/models/CollectionModel';
+import FolderModel from '@girder/core/models/FolderModel';
+import ItemModel from '@girder/core/models/ItemModel';
+import CollectionView from '@girder/core/views/body/CollectionView';
+import FolderView from '@girder/core/views/body/FolderView';
+import ItemView from '@girder/core/views/body/ItemView';
 
 import TermsAcceptanceView from './views/TermsAcceptanceView';
 

--- a/plugins/terms/girder_terms/web_client/views/CollectionInfoWidget.js
+++ b/plugins/terms/girder_terms/web_client/views/CollectionInfoWidget.js
@@ -1,8 +1,8 @@
 import $ from 'jquery';
 
-import { renderMarkdown } from 'girder/misc';
-import CollectionInfoWidget from 'girder/views/widgets/CollectionInfoWidget';
-import { wrap } from 'girder/utilities/PluginUtils';
+import { renderMarkdown } from '@girder/core/misc';
+import CollectionInfoWidget from '@girder/core/views/widgets/CollectionInfoWidget';
+import { wrap } from '@girder/core/utilities/PluginUtils';
 
 import CollectionInfoWidgetTemplate from '../templates/collectionInfoWidget.pug';
 import '../stylesheets/collectionInfoWidget.styl';

--- a/plugins/terms/girder_terms/web_client/views/EditCollectionWidget.js
+++ b/plugins/terms/girder_terms/web_client/views/EditCollectionWidget.js
@@ -1,9 +1,9 @@
 import $ from 'jquery';
 
-import { AccessType } from 'girder/constants';
-import EditCollectionWidget from 'girder/views/widgets/EditCollectionWidget';
-import MarkdownWidget from 'girder/views/widgets/MarkdownWidget';
-import { wrap } from 'girder/utilities/PluginUtils';
+import { AccessType } from '@girder/core/constants';
+import EditCollectionWidget from '@girder/core/views/widgets/EditCollectionWidget';
+import MarkdownWidget from '@girder/core/views/widgets/MarkdownWidget';
+import { wrap } from '@girder/core/utilities/PluginUtils';
 
 import EditCollectionTermsWidgetTemplate from '../templates/editCollectionTermsWidget.pug';
 import '../stylesheets/editCollectionTermsWidget.styl';

--- a/plugins/terms/girder_terms/web_client/views/TermsAcceptanceView.js
+++ b/plugins/terms/girder_terms/web_client/views/TermsAcceptanceView.js
@@ -1,8 +1,8 @@
 import Backbone from 'backbone';
 
-import { renderMarkdown } from 'girder/misc';
-import router from 'girder/router';
-import View from 'girder/views/View';
+import { renderMarkdown } from '@girder/core/misc';
+import router from '@girder/core/router';
+import View from '@girder/core/views/View';
 
 import TermsAcceptanceTemplate from '../templates/termsAcceptance.pug';
 import '../stylesheets/termsAcceptance.styl';

--- a/plugins/thumbnails/girder_thumbnails/web_client/models/ThumbnailModel.js
+++ b/plugins/thumbnails/girder_thumbnails/web_client/models/ThumbnailModel.js
@@ -1,4 +1,4 @@
-import Model from 'girder/models/Model';
+import Model from '@girder/core/models/Model';
 
 var ThumbnailModel = Model.extend({
     resourceName: 'thumbnail'

--- a/plugins/thumbnails/girder_thumbnails/web_client/views/CreateThumbnailView.js
+++ b/plugins/thumbnails/girder_thumbnails/web_client/views/CreateThumbnailView.js
@@ -1,8 +1,8 @@
-import SearchFieldWidget from 'girder/views/widgets/SearchFieldWidget';
-import View from 'girder/views/View';
+import SearchFieldWidget from '@girder/core/views/widgets/SearchFieldWidget';
+import View from '@girder/core/views/View';
 
-import 'girder/utilities/jquery/girderEnable';
-import 'girder/utilities/jquery/girderModal';
+import '@girder/core/utilities/jquery/girderEnable';
+import '@girder/core/utilities/jquery/girderModal';
 
 import ThumbnailModel from '../models/ThumbnailModel';
 

--- a/plugins/thumbnails/girder_thumbnails/web_client/views/FileListWidget.js
+++ b/plugins/thumbnails/girder_thumbnails/web_client/views/FileListWidget.js
@@ -1,10 +1,10 @@
 import $ from 'jquery';
 import Backbone from 'backbone';
 
-import FileListWidget from 'girder/views/widgets/FileListWidget';
-import router from 'girder/router';
-import { AccessType } from 'girder/constants';
-import { wrap } from 'girder/utilities/PluginUtils';
+import FileListWidget from '@girder/core/views/widgets/FileListWidget';
+import router from '@girder/core/router';
+import { AccessType } from '@girder/core/constants';
+import { wrap } from '@girder/core/utilities/PluginUtils';
 
 import FileListWidgetCreateButtonTemplate from '../templates/fileListWidgetCreateButton.pug';
 

--- a/plugins/thumbnails/girder_thumbnails/web_client/views/FlowView.js
+++ b/plugins/thumbnails/girder_thumbnails/web_client/views/FlowView.js
@@ -1,10 +1,10 @@
 import $ from 'jquery';
 
-import FileModel from 'girder/models/FileModel';
-import View from 'girder/views/View';
-import { AccessType } from 'girder/constants';
-import { confirm } from 'girder/dialog';
-import events from 'girder/events';
+import FileModel from '@girder/core/models/FileModel';
+import View from '@girder/core/views/View';
+import { AccessType } from '@girder/core/constants';
+import { confirm } from '@girder/core/dialog';
+import events from '@girder/core/events';
 
 import FlowViewTemplate from '../templates/flowView.pug';
 

--- a/plugins/thumbnails/girder_thumbnails/web_client/views/ItemView.js
+++ b/plugins/thumbnails/girder_thumbnails/web_client/views/ItemView.js
@@ -1,8 +1,8 @@
 import _ from 'underscore';
 
-import FileCollection from 'girder/collections/FileCollection';
-import ItemView from 'girder/views/body/ItemView';
-import { wrap } from 'girder/utilities/PluginUtils';
+import FileCollection from '@girder/core/collections/FileCollection';
+import ItemView from '@girder/core/views/body/ItemView';
+import { wrap } from '@girder/core/utilities/PluginUtils';
 
 import ItemViewTemplate from '../templates/itemView.pug';
 

--- a/plugins/user_quota/girder_user_quota/web_client/models/CollectionModel.js
+++ b/plugins/user_quota/girder_user_quota/web_client/models/CollectionModel.js
@@ -1,4 +1,4 @@
-import CollectionModel from 'girder/models/CollectionModel';
+import CollectionModel from '@girder/core/models/CollectionModel';
 
 import extendModel from './extendModel';
 

--- a/plugins/user_quota/girder_user_quota/web_client/models/UserModel.js
+++ b/plugins/user_quota/girder_user_quota/web_client/models/UserModel.js
@@ -1,4 +1,4 @@
-import UserModel from 'girder/models/UserModel';
+import UserModel from '@girder/core/models/UserModel';
 
 import extendModel from './extendModel';
 

--- a/plugins/user_quota/girder_user_quota/web_client/models/extendModel.js
+++ b/plugins/user_quota/girder_user_quota/web_client/models/extendModel.js
@@ -1,6 +1,6 @@
-import AssetstoreCollection from 'girder/collections/AssetstoreCollection';
-import { getCurrentUser } from 'girder/auth';
-import { restRequest } from 'girder/rest';
+import AssetstoreCollection from '@girder/core/collections/AssetstoreCollection';
+import { getCurrentUser } from '@girder/core/auth';
+import { restRequest } from '@girder/core/rest';
 
 function extendModel(Model, modelType) {
     /* Saves the quota policy on this model to the server.  Saves the

--- a/plugins/user_quota/girder_user_quota/web_client/routes.js
+++ b/plugins/user_quota/girder_user_quota/web_client/routes.js
@@ -1,8 +1,8 @@
 /* eslint-disable import/first */
 
-import router from 'girder/router';
-import events from 'girder/events';
-import { exposePluginConfig } from 'girder/utilities/PluginUtils';
+import router from '@girder/core/router';
+import events from '@girder/core/events';
+import { exposePluginConfig } from '@girder/core/utilities/PluginUtils';
 
 exposePluginConfig('user_quota', 'plugins/user_quota/config');
 

--- a/plugins/user_quota/girder_user_quota/web_client/views/CollectionView.js
+++ b/plugins/user_quota/girder_user_quota/web_client/views/CollectionView.js
@@ -1,4 +1,4 @@
-import CollectionView from 'girder/views/body/CollectionView';
+import CollectionView from '@girder/core/views/body/CollectionView';
 
 import CollectionViewPoliciesMenuTemplate from '../templates/collectionViewPoliciesMenu.pug';
 

--- a/plugins/user_quota/girder_user_quota/web_client/views/ConfigView.js
+++ b/plugins/user_quota/girder_user_quota/web_client/views/ConfigView.js
@@ -1,7 +1,7 @@
-import PluginConfigBreadcrumbWidget from 'girder/views/widgets/PluginConfigBreadcrumbWidget';
-import View from 'girder/views/View';
-import events from 'girder/events';
-import { restRequest } from 'girder/rest';
+import PluginConfigBreadcrumbWidget from '@girder/core/views/widgets/PluginConfigBreadcrumbWidget';
+import View from '@girder/core/views/View';
+import events from '@girder/core/events';
+import { restRequest } from '@girder/core/rest';
 
 import { valueAndUnitsToSize, sizeToValueAndUnits } from '../utilities/Conversions';
 import ConfigViewTemplate from '../templates/configView.pug';

--- a/plugins/user_quota/girder_user_quota/web_client/views/QuotaPoliciesWidget.js
+++ b/plugins/user_quota/girder_user_quota/web_client/views/QuotaPoliciesWidget.js
@@ -1,12 +1,12 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import View from 'girder/views/View';
-import { formatSize } from 'girder/misc';
-import { getCurrentUser } from 'girder/auth';
-import { handleOpen, handleClose } from 'girder/dialog';
-import 'girder/utilities/jquery/girderEnable';
-import 'girder/utilities/jquery/girderModal';
+import View from '@girder/core/views/View';
+import { formatSize } from '@girder/core/misc';
+import { getCurrentUser } from '@girder/core/auth';
+import { handleOpen, handleClose } from '@girder/core/dialog';
+import '@girder/core/utilities/jquery/girderEnable';
+import '@girder/core/utilities/jquery/girderModal';
 
 import { valueAndUnitsToSize, sizeToValueAndUnits } from '../utilities/Conversions';
 import QuotaPoliciesWidgetTemplate from '../templates/quotaPoliciesWidget.pug';

--- a/plugins/user_quota/girder_user_quota/web_client/views/UploadWidget.js
+++ b/plugins/user_quota/girder_user_quota/web_client/views/UploadWidget.js
@@ -1,5 +1,5 @@
-import { wrap } from 'girder/utilities/PluginUtils';
-import UploadWidget from 'girder/views/widgets/UploadWidget';
+import { wrap } from '@girder/core/utilities/PluginUtils';
+import UploadWidget from '@girder/core/views/widgets/UploadWidget';
 
 wrap(UploadWidget, 'uploadNextFile', function (uploadNextFile) {
     this.$('.g-drop-zone').addClass('hide');

--- a/plugins/user_quota/girder_user_quota/web_client/views/UserView.js
+++ b/plugins/user_quota/girder_user_quota/web_client/views/UserView.js
@@ -1,4 +1,4 @@
-import UserView from 'girder/views/body/UserView';
+import UserView from '@girder/core/views/body/UserView';
 
 import UserViewPoliciesMenuTemplate from '../templates/userViewPoliciesMenu.pug';
 

--- a/plugins/user_quota/girder_user_quota/web_client/views/extendView.js
+++ b/plugins/user_quota/girder_user_quota/web_client/views/extendView.js
@@ -1,8 +1,8 @@
 import $ from 'jquery';
 
-import { AccessType } from 'girder/constants';
-import { getCurrentUser } from 'girder/auth';
-import { wrap } from 'girder/utilities/PluginUtils';
+import { AccessType } from '@girder/core/constants';
+import { getCurrentUser } from '@girder/core/auth';
+import { wrap } from '@girder/core/utilities/PluginUtils';
 
 import QuotaPoliciesWidget from './QuotaPoliciesWidget';
 


### PR DESCRIPTION
* Replace Javascript imports of "girder" with "@girder/core"
* Document the change of "girder" to "@girder/core"
* Update the client to only use the "girder": "@girder/core" alias for plugins

Since the npm package containing the Girder core Javascript code is now named `@girder/core`, all internal references should use this new name. Otherwise, third party packages which depend on `@girder/core` will fail to build it without adding their own alias rules.

However, note that for now, the rule aliasing `girder` to `@girder/core` remains in place for plugins, making this a deprecation and not a breaking change for downstreams. New Javascript code within core Girder will have to use the new syntax, which is intended.

Considering that downstream plugins already have to change the JS import syntax for other plugins, perhaps it's better to force all of the changes at once in the Girder 3 release, in which case we should remove the alias for plugins now too.