### PR TITLE
Don't call AsyncEventsThread's super's __del__.

### DIFF
--- a/girder/events.py
+++ b/girder/events.py
@@ -223,7 +223,9 @@ class AsyncEventsThread(threading.Thread):
     def __del__(self):
         # Make sure we stop this thread if it's getting GCed, i.e. daemon was reassigned
         self.stop()
-        super(AsyncEventsThread, self).__del__()
+        # We had been calling the super class's __del__, but it doesn't have
+        # such a method, so doing so would raise an AttributeError.
+        # super(AsyncEventsThread, self).__del__()
 
 
 def bind(eventName, handlerName, handler):


### PR DESCRIPTION
This was raising an exception: `Exception AttributeError: "'super' object has no attribute '__del__'" in <bound method AsyncEventsThread.__del__ of <AsyncEventsThread(Thread-7, initial
daemon)>> ignored`.  Neither Python 2.7 nor Python 3.x has a __del__ method on the threading.Thread class, so calling it was inappropriate.
