### PR TITLE
Require that downstream plugins use '@girder/core' for JS imports

### DIFF
--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -101,17 +101,17 @@ plugin:
 * Migrate all imports in Python and Javascript source files.  The old plugin module paths are no longer
   valid.  Any import reference to:
 
-  * ``girder.plugins`` in Python should be changed to the actual installed module name
+  * ``girder.plugins`` in Python must be changed to the actual installed module name
 
     * For example, change ``from girder.plugins.jobs.models.job import Job`` to
       ``from girder_jobs.models.job import Job``
 
-  * ``girder_plugins`` in Javascript should be changed to the actual installed package name
+  * ``girder_plugins`` in Javascript must be changed to the actual installed package name
 
     * For example, change ``import { JobListWidget } from 'girder_plugins/jobs/views';`` to
       ``import { JobListWidget } from '@girder/jobs/views';``
 
-  * ``girder`` in Javascript should be changed to ``@girder/core``
+  * ``girder`` in Javascript must be changed to ``@girder/core``
 
     * For example, change ``import { restRequest } from 'girder/rest';`` to
       ``import { restRequest } from '@girder/core/rest';``

--- a/girder/web_client/grunt_tasks/build.js
+++ b/girder/web_client/grunt_tasks/build.js
@@ -282,12 +282,6 @@ module.exports = function (grunt) {
             module: {
                 rules: [babelRule]
             },
-            resolve: {
-                alias: {
-                    // This is deprecated, but kept in place for compatibility
-                    'girder': '@girder/core'
-                }
-            },
             plugins: [
                 new webpack.DllPlugin({
                     path: path.join(grunt.config.get('builtPath'), 'plugins', name, 'plugin-manifest.json'),


### PR DESCRIPTION
Previously, plugins building with Girder's JS build system could use the legacy `girder` package name for imports too.