### PR TITLE
Update CI Docker image

### DIFF
--- a/.circleci/girder_test_py2/Dockerfile
+++ b/.circleci/girder_test_py2/Dockerfile
@@ -7,7 +7,7 @@ USER root
 # Install Node.js 8
 RUN curl --silent --location https://deb.nodesource.com/setup_8.x | bash - \
   && apt-get install --assume-yes nodejs \
-  && npm install --global npm
+  && npm install --global npm yarn
 
 # Install Girder system prereqs (including those for all plugins)
 RUN apt-get update && apt-get install --assume-yes \

--- a/.circleci/girder_test_py3/Dockerfile
+++ b/.circleci/girder_test_py3/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install --assume-yes \
 # Install Girder development prereqs
 # Get a very recent version of CMake
 RUN mkdir --parents "/opt/cmake" \
-  && curl --location "https://cmake.org/files/v3.12/cmake-3.12.2-Linux-x86_64.tar.gz" | \
+  && curl --location "https://github.com/Kitware/CMake/releases/download/v3.13.3/cmake-3.13.3-Linux-x86_64.tar.gz" | \
     gunzip --stdout | \
     tar --extract --directory "/opt/cmake" --strip-components 1 \
   && ln --symbolic --force "/opt/cmake/bin/cmake" "/usr/local/bin/cmake" \

--- a/.circleci/girder_test_py3/Dockerfile
+++ b/.circleci/girder_test_py3/Dockerfile
@@ -7,7 +7,7 @@ USER root
 # Install Node.js 10
 RUN curl --silent --location https://deb.nodesource.com/setup_10.x | bash - \
   && apt-get install --assume-yes nodejs \
-  && npm install --global npm
+  && npm install --global npm yarn
 
 # Install Girder system prereqs (including those for all plugins)
 # Note: ctags is installed for use in the public_names CI job.


### PR DESCRIPTION
* Fetch CMake from GitHub when building CI Docker image
* Install Yarn in CI docker image

GitHub is now the official location for new CMake releases and should have higher availability  then the existing cmake.org servers. Yarn can be useful as a tool for downstreams building CI on Girder's stack.