### PR TITLE
Add setuptools-git as an install time requirement for plugins

### DIFF
--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -60,9 +60,9 @@ package we are going to create.
         'License :: OSI Approved :: Apache Software License'
       ],
       include_package_data=True,
-      package_data={ '': ['web_client'] },
       packages=find_packages(exclude=['plugin_tests']),
       zip_safe=False,
+      setup_requires=['setuptools-git'],
       install_requires=['girder>=3', 'girder-jobs'],
       entry_points={
           'girder.plugin': [ 'cats = girder_cats.CatsPlugin' ]
@@ -80,6 +80,11 @@ in this example are specific to a Girder plugin.  These are as follows:
     in the package distribution.  See the
     `setuptools documentation <https://setuptools.readthedocs.io/en/latest/setuptools.html#including-data-files>`_
     for details.
+
+``setup_requires=['setuptools-git']``
+    This works with the ``include_package_data`` option to automatically include all non-python
+    files that are checked into your git repository.  Alternatively, you can generate a
+    ``MANIFEST.in`` for more fine-grained control over which files are included.
 
 ``packages=find_packages(exclude=['plugin_tests'])``
     This will include all python "packages" found inside the local path in the distribution

--- a/plugins/authorized_upload/setup.py
+++ b/plugins/authorized_upload/setup.py
@@ -44,6 +44,7 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
+    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1'],
     entry_points={
         'girder.plugin': [

--- a/plugins/autojoin/setup.py
+++ b/plugins/autojoin/setup.py
@@ -43,6 +43,7 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
+    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1'],
     entry_points={
         'girder.plugin': [

--- a/plugins/dicom_viewer/setup.py
+++ b/plugins/dicom_viewer/setup.py
@@ -43,6 +43,7 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
+    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1', 'pydicom>=1.0.2'],
     entry_points={
         'girder.plugin': [

--- a/plugins/download_statistics/setup.py
+++ b/plugins/download_statistics/setup.py
@@ -42,6 +42,7 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
+    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1'],
     entry_points={
         'girder.plugin': [

--- a/plugins/google_analytics/setup.py
+++ b/plugins/google_analytics/setup.py
@@ -43,6 +43,7 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
+    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1'],
     entry_points={
         'girder.plugin': [

--- a/plugins/gravatar/setup.py
+++ b/plugins/gravatar/setup.py
@@ -43,6 +43,7 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
+    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1'],
     entry_points={
         'girder.plugin': [

--- a/plugins/hashsum_download/setup.py
+++ b/plugins/hashsum_download/setup.py
@@ -43,6 +43,7 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
+    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1'],
     entry_points={
         'girder.plugin': [

--- a/plugins/homepage/setup.py
+++ b/plugins/homepage/setup.py
@@ -43,6 +43,7 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
+    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1'],
     entry_points={
         'girder.plugin': [

--- a/plugins/item_licenses/setup.py
+++ b/plugins/item_licenses/setup.py
@@ -42,6 +42,7 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
+    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1'],
     entry_points={
         'girder.plugin': [

--- a/plugins/jobs/setup.py
+++ b/plugins/jobs/setup.py
@@ -43,6 +43,7 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
+    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a2'],
     entry_points={
         'girder.plugin': [

--- a/plugins/ldap/setup.py
+++ b/plugins/ldap/setup.py
@@ -42,6 +42,7 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
+    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1', 'pyldap'],
     entry_points={
         'girder.plugin': [

--- a/plugins/oauth/setup.py
+++ b/plugins/oauth/setup.py
@@ -43,6 +43,7 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
+    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1'],
     entry_points={
         'girder.plugin': [

--- a/plugins/terms/setup.py
+++ b/plugins/terms/setup.py
@@ -44,6 +44,7 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
+    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1'],
     entry_points={
         'girder.plugin': [

--- a/plugins/thumbnails/setup.py
+++ b/plugins/thumbnails/setup.py
@@ -42,6 +42,7 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
+    setup_requires=['setuptools-git'],
     install_requires=[
         'girder>=3.0.0a1',
         'girder-jobs>=3.0.0a1',

--- a/plugins/user_quota/setup.py
+++ b/plugins/user_quota/setup.py
@@ -43,6 +43,7 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
+    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1'],
     entry_points={
         'girder.plugin': [

--- a/plugins/virtual_folders/setup.py
+++ b/plugins/virtual_folders/setup.py
@@ -42,6 +42,7 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
+    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1'],
     entry_points={
         'girder.plugin': [


### PR DESCRIPTION
This ensures that web_client assets are always installed with the python package.  Alternatively, we could recommend a package_data kwarg to setup, but IMO that option is confusing.  With this change, using `include_package_data` with `setuptools-git` (or an explicit manifest) is the recommended method for including web client assets for external plugins.

As a side note, I'm not sure why this was working before.  Possibly some third party library was bringing in `setuptools-git`.