### PR TITLE
Change the notification stream timeout used in tests.

### DIFF
--- a/girder/web_client/test/testEnv.pug
+++ b/girder/web_client/test/testEnv.pug
@@ -19,5 +19,5 @@ html(lang='en')
         window.jasmine_phantom_reporter = consoleReporter;
         jasmine.getEnv().addReporter(consoleReporter);
 
-        girder.utilities.eventStream.settings.timeout = 10;
+        girder.utilities.eventStream.settings.timeout = 100;
       })();


### PR DESCRIPTION
The existing value of 10 seconds will cause any client test to fail that takes that long without producing a notification.  This is probably a cause of occasional transient test failures.  These would manifest as failures at somewhat different points in tests, as the exact timing is not consistent.
