### PR TITLE
Ignore notification stream timeouts in PhantomJS.

### DIFF
--- a/girder/web_client/test/specRunner.js
+++ b/girder/web_client/test/specRunner.js
@@ -217,6 +217,10 @@ page.onLoadFinished = function (status) {
 page.settings.resourceTimeout = 15000;
 
 page.onResourceTimeout = function (request) {
+    /* Ignore timeout of the notification stream */
+    if (request.url.indexOf('/api/v1/notification/stream') > 0) {
+        return;
+    }
     console.log('Resource timed out.  (#' + request.id + '): ' + JSON.stringify(request));
     console.log('PHANTOM_TIMEOUT');
     /* The exit code doesn't get sent back from here, so setting this to a

--- a/girder/web_client/test/testEnv.pug
+++ b/girder/web_client/test/testEnv.pug
@@ -19,5 +19,5 @@ html(lang='en')
         window.jasmine_phantom_reporter = consoleReporter;
         jasmine.getEnv().addReporter(consoleReporter);
 
-        girder.utilities.eventStream.settings.timeout = 100;
+        girder.utilities.eventStream.settings.timeout = 10;
       })();


### PR DESCRIPTION
This (along with previous PR #2921) attempts to make client tests more robust.  The previous PR set the timeout to try to avoid a 408 resource timeout from halting phantom.  A short notification stream timeout shouldn't trigger the 408 -- it should conclude the request and start another.  Although a long timeout anecdotally improved the test robustness, occasional 408 errors still occur.  This PR ignores such error from the notification stream.

There are probably better ways to do this (or to figure out when and why the 408 errors occur).