### PR TITLE
Move setup_database into the pytest_module.

### DIFF
--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -1340,6 +1340,8 @@ pytest_girder
                 generateEntrypoint
                 registerEntrypoint
                 registerTestPlugin
+        setup_database
+            setupDatabase
         utils
             MockSmtpReceiver
                 getMail

--- a/tests/base.py
+++ b/tests/base.py
@@ -50,7 +50,7 @@ from . import mongo_replicaset
 
 with warnings.catch_warnings():
     warnings.filterwarnings('ignore', 'setup_database.*')
-    from . import setup_database
+    from pytest_girder.setup_database import setupDatabase
 
 local = cherrypy.lib.httputil.Host('127.0.0.1', 30000)
 remote = cherrypy.lib.httputil.Host('127.0.0.1', 30001)
@@ -221,7 +221,7 @@ class TestCase(unittest.TestCase):
         settings.set(SettingKey.PLUGINS_ENABLED, enabledPlugins)
 
         if os.environ.get('GIRDER_TEST_DATABASE_CONFIG'):
-            setup_database.main(os.environ['GIRDER_TEST_DATABASE_CONFIG'])
+            setupDatabase(os.environ['GIRDER_TEST_DATABASE_CONFIG'])
 
     def tearDown(self):
         """


### PR DESCRIPTION
This renames most parameters to make them private.  This can still be used by non-pytest tests, but can now be used within a pytest.

For instance,
```
with warnings.catch_warnings():
    warnings.filterwarnings('ignore', 'setup_database.*')
    from pytest_girder.setup_database import setupDatabase

def testWebClientWithAnnotation(boundServer, fsAssetstore, db):
    spec = <path to specFile.js>
    setupFile = os.path.splitext(spec)[0] + '.yml'
    if os.path.exists(setupFile):
        setupDatabase(setupFile)
    runWebClientTest(boundServer, spec)

```