### PR TITLE
Use universal-ctags to parse public symbols

### DIFF
--- a/.circleci/girder_test_py3/Dockerfile
+++ b/.circleci/girder_test_py3/Dockerfile
@@ -10,11 +10,9 @@ RUN curl --silent --location https://deb.nodesource.com/setup_10.x | bash - \
   && npm install --global npm
 
 # Install Girder system prereqs (including those for all plugins)
-# Note: ctags is installed for use in the public_names CI job.
 RUN apt-get update && apt-get install --assume-yes \
     libldap2-dev \
-    libsasl2-dev \
-    ctags
+    libsasl2-dev
 
 # Install Girder development prereqs
 # Get a very recent version of CMake
@@ -23,6 +21,15 @@ RUN mkdir --parents "/opt/cmake" \
     gunzip --stdout | \
     tar --extract --directory "/opt/cmake" --strip-components 1 \
   && ln --symbolic --force "/opt/cmake/bin/cmake" "/usr/local/bin/cmake" \
-  && ln --symbolic --force "/opt/cmake/bin/ctest" "/usr/local/bin/ctest"
+  && ln --symbolic --force "/opt/cmake/bin/ctest" "/usr/local/bin/ctest" \
+  # Note: universal-ctags is installed for use in the public_names CI job.
+  && git clone "https://github.com/universal-ctags/ctags.git" "./ctags" \
+  && cd ./ctags \
+  && ./autogen.sh \
+  && ./configure \
+  && make \
+  && make install \
+  && cd .. \
+  && rm -rf ./ctags
 
 USER circleci

--- a/scripts/publicNames.py
+++ b/scripts/publicNames.py
@@ -33,8 +33,15 @@ def addFileSymbols(filePath, symbolTree):
         'ctags',
         '-f', '-',
         '--languages=python',
-        # Skip imported symbols
-        '--python-kinds=-i',
+        '--python-kinds=%s' % ''.join([
+            # Skip imported symbols
+            '-i',
+            # Skip "as"-renamed imported modules
+            '-I'
+            # Skip unknown symbols (which are typically "as"-renamed imported symbols)
+            '-x',
+
+        ]),
         filePath
     ]).decode('utf-8')
 
@@ -50,8 +57,11 @@ def addFileSymbols(filePath, symbolTree):
             elif symbolScopeKind == 'function':
                 # Symbols defined inside functions are not visible
                 continue
+            elif symbolScopeKind == 'member':
+                # Symbols defined inside methods are not visible
+                continue
             else:
-                raise Exception('Unknown symbol scope')
+                raise Exception('Unknown symbol scope "%s" in %s' % (symbolScopeKind, filePath))
             symbolScope = symbolScope.split('.')
         else:
             symbolScope = []

--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -73,7 +73,6 @@ clients
             cli
                 GirderCli
                     sendRestRequest
-                help
                 main
 girder
     LogFormatter
@@ -343,9 +342,7 @@ girder
     auditLogger
     cli
         build
-            help
             main
-        context_settings
         main
         mount
             FUSELogError
@@ -363,17 +360,13 @@ girder
                 readdir
                 release
                 use_ns
-            help
             main
             mountServer
-            show_default
             unmountServer
         serve
             main
         sftpd
             DEFAULT_PORT
-            default
-            help
             main
         shell
             main
@@ -507,7 +500,9 @@ girder
         mongodb_proxy
             EXECUTABLE_MONGO_METHODS
             Executable
+            MongoClient
             MongoProxy
+            MongoReplicaSetClient
             get_methods
     getLogPaths
     logStdoutStderr


### PR DESCRIPTION
Unlike exuberant-ctags, universal-ctags is actively maintained and parses Python files more accurately. In particular, keyword arguments are no longer parsed as variable declarations.