### PR TITLE
Use the real path for web builds.

### DIFF
--- a/girder/cli/build.py
+++ b/girder/cli/build.py
@@ -35,7 +35,7 @@ from girder.utility.server import getStaticRoot
 if not six.PY3:
     import shutilwhich  # noqa
 
-_GIRDER_BUILD_ASSETS_PATH = os.path.realpath(resource_filename('girder', 'web_client'))
+_GIRDER_BUILD_ASSETS_PATH = resource_filename('girder', 'web_client')
 
 
 @click.command(name='build', help='Build web client static assets.')

--- a/girder/cli/build.py
+++ b/girder/cli/build.py
@@ -35,7 +35,7 @@ from girder.utility.server import getStaticRoot
 if not six.PY3:
     import shutilwhich  # noqa
 
-_GIRDER_BUILD_ASSETS_PATH = resource_filename('girder', 'web_client')
+_GIRDER_BUILD_ASSETS_PATH = os.path.realpath(resource_filename('girder', 'web_client'))
 
 
 @click.command(name='build', help='Build web client static assets.')

--- a/girder/web_client/package.json.template
+++ b/girder/web_client/package.json.template
@@ -21,7 +21,6 @@
         "grunt-contrib-uglify": "^3.0.1",
         "grunt-gitinfo": "^0.1.8",
         "grunt-webpack": "^3.0.2",
-        "jquery": "~3.2.1",
         "mkdirp": "^0.5.1",
         "nib": "^1.1.2",
         "pug": "^2.0.0-rc.3",
@@ -31,7 +30,6 @@
         "stylus-loader": "^3.0.1",
         "toposort": "^1.0.3",
         "uglifyjs-webpack-plugin": "^1.1.6",
-        "underscore": "~1.8.3",
         "webpack": "^2.7.0",
         "whatwg-fetch": "^2.0.4"
     },

--- a/girder/web_client/package.json.template
+++ b/girder/web_client/package.json.template
@@ -21,6 +21,7 @@
         "grunt-contrib-uglify": "^3.0.1",
         "grunt-gitinfo": "^0.1.8",
         "grunt-webpack": "^3.0.2",
+        "jquery": "~3.2.1",
         "mkdirp": "^0.5.1",
         "nib": "^1.1.2",
         "pug": "^2.0.0-rc.3",
@@ -30,6 +31,7 @@
         "stylus-loader": "^3.0.1",
         "toposort": "^1.0.3",
         "uglifyjs-webpack-plugin": "^1.1.6",
+        "underscore": "~1.8.3",
         "webpack": "^2.7.0",
         "whatwg-fetch": "^2.0.4"
     },


### PR DESCRIPTION
In a virtual Python 2.7 environment, with Girder installed in non-editable mode, the web_client path contains `<env root>/local/lib/python2.7/site-packages/girder/web_client`, but `local/lib` is a symlink to lib.  When npm installs packages, it fails to put the packages in the expect spot, so, for instance, underscore ends up in `.../web_client/node_modules/@girder/core/node_modules/underscore` rather
than at `.../web_client/node_modules/underscore`.  This causes the web client build to fail, as webpack fails to locate some modules.