### PR TITLE
Work around vega having ES6 in node modules.

### DIFF
--- a/plugins/candela/webpack.helper.js
+++ b/plugins/candela/webpack.helper.js
@@ -1,0 +1,15 @@
+module.exports = function (config) {
+    config.module.rules.push({
+        resource: {
+            test: /\.js$/,
+            include: [/node_modules\/vega-.*/]
+        },
+        use: [{
+            loader: 'babel-loader',
+            options: {
+                presets: ['env']
+            }
+        }]
+    });
+    return config;
+};

--- a/plugins/jobs/webpack.helper.js
+++ b/plugins/jobs/webpack.helper.js
@@ -1,0 +1,15 @@
+module.exports = function (config) {
+    config.module.rules.push({
+        resource: {
+            test: /\.js$/,
+            include: [/node_modules\/vega-.*/]
+        },
+        use: [{
+            loader: 'babel-loader',
+            options: {
+                presets: ['env']
+            }
+        }]
+    });
+    return config;
+};

--- a/plugins/table_view/webpack.helper.js
+++ b/plugins/table_view/webpack.helper.js
@@ -1,0 +1,15 @@
+module.exports = function (config) {
+    config.module.rules.push({
+        resource: {
+            test: /\.js$/,
+            include: [/node_modules\/vega-.*/]
+        },
+        use: [{
+            loader: 'babel-loader',
+            options: {
+                presets: ['env']
+            }
+        }]
+    });
+    return config;
+};


### PR DESCRIPTION
For plugins that use vega, this transpiles the node modules.  If we don't do this, the web client tests fail since PhantomJS doesn't handle ES6.