### PR TITLE
Explicitly set static root when building Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,6 @@ COPY requirements-dev.txt /girder/requirements-dev.txt
 # TODO: Do we want to create editable installs of plugins as well?  We
 # will need a plugin only requirements file for this.
 RUN pip install --upgrade --upgrade-strategy eager --editable .
-RUN girder build
+RUN girder build --static-root /static
 
 ENTRYPOINT ["girder", "serve"]

--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -34,6 +34,6 @@ ENV LANG=C.UTF-8
 # TODO: Do we want to create editable installs of plugins as well?  We
 # will need a plugin only requirements file for this.
 RUN pip install --upgrade --upgrade-strategy eager --editable .
-RUN girder build
+RUN girder build --static-root /static
 
 ENTRYPOINT ["girder", "serve"]

--- a/girder/cli/build.py
+++ b/girder/cli/build.py
@@ -49,7 +49,8 @@ _GIRDER_BUILD_ASSETS_PATH = os.path.realpath(resource_filename('girder', 'web_cl
               help='Full path to the npm executable to use.')
 @click.option('--reinstall/--no-reinstall', default=True,
               help='Force regenerate node_modules.')
-def main(dev, watch, watch_plugin, npm, reinstall):
+@click.option('--static-root', help='Runtime static root path in the web client.')
+def main(dev, watch, watch_plugin, npm, reinstall, static_root):
     if shutil.which(npm) is None:
         raise click.UsageError(
             'No npm executable was detected.  Please ensure the npm executable is in your '
@@ -81,7 +82,7 @@ def main(dev, watch, watch_plugin, npm, reinstall):
     buildCommand = [
         npm, 'run', 'build', '--',
         '--static-path=%s' % STATIC_ROOT_DIR,
-        '--static-url=%s' % getStaticRoot(),
+        '--static-url=%s' % static_root or getStaticRoot(),
         quiet
     ]
     if watch:


### PR DESCRIPTION
Prior to this change, the docker build was broken due to attempting a database lookup for the ROUTE_TABLE setting, in order to get the static path.

@jbeezley PTAL
