### PR TITLE
Remove pinning of python-dateutil

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,6 +35,6 @@ moto[server]>=1.3.7
 pytest>=3.6
 pytest-cov<2.6
 pytest-xdist
-python-dateutil<2.7 # required for botocore=1.9.8
+python-dateutil
 tox
 virtualenv

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ installReqs = [
     'PyYAML',
     'psutil',
     'pyOpenSSL',
-    'python-dateutil<2.7',  # required for compatibility with botocore=1.9.8
+    'python-dateutil',
     'pytz',
     'requests',
     'shutilwhich ; python_version < \'3\'',


### PR DESCRIPTION
This effectively reverts https://github.com/girder/girder/pull/2663 since it is no longer necessary, see https://github.com/boto/botocore/pull/1433.