### PR TITLE
Bump versions of all built in plugins

### DIFF
--- a/plugins/audit_logs/setup.py
+++ b/plugins/audit_logs/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup, find_packages
 # perform the install
 setup(
     name='girder-audit-logs',
-    version='0.2.0a1',
+    version='0.2.0a2',
     description='Keeps detailed logs of every REST request and low-level file download event.',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',

--- a/plugins/authorized_upload/setup.py
+++ b/plugins/authorized_upload/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup, find_packages
 # perform the install
 setup(
     name='girder-authorized-upload',
-    version='0.2.0a1',
+    version='0.2.0a2',
     description='Allows registered users to authorize file uploads on their behalf '
     'via a secure one-use URL.',
     author='Kitware, Inc.',

--- a/plugins/autojoin/setup.py
+++ b/plugins/autojoin/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup, find_packages
 # perform the install
 setup(
     name='girder-autojoin',
-    version='0.2.0a1',
+    version='0.2.0a2',
     description='Automatically assign new users to groups based on their email domain',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',

--- a/plugins/dicom_viewer/setup.py
+++ b/plugins/dicom_viewer/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup, find_packages
 # perform the install
 setup(
     name='girder-dicom-viewer',
-    version='0.2.0a1',
+    version='0.2.0a2',
     description='View DICOM images in the browser',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',

--- a/plugins/download_statistics/setup.py
+++ b/plugins/download_statistics/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup, find_packages
 # perform the install
 setup(
     name='girder-download-statistics',
-    version='0.2.0a1',
+    version='0.2.0a2',
     description='Record file download statistics',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',

--- a/plugins/google_analytics/setup.py
+++ b/plugins/google_analytics/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup, find_packages
 # perform the install
 setup(
     name='girder-google-analytics',
-    version='0.2.0a1',
+    version='0.2.0a2',
     description='Allow the tracking of page views via Google Analytics.',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',

--- a/plugins/gravatar/setup.py
+++ b/plugins/gravatar/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup, find_packages
 # perform the install
 setup(
     name='girder-gravatar',
-    version='2.0.0a1',
+    version='2.0.0a2',
     description='Adds Gravatar URLs for users.',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',

--- a/plugins/hashsum_download/setup.py
+++ b/plugins/hashsum_download/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup, find_packages
 # perform the install
 setup(
     name='girder-hashsum-download',
-    version='0.2.0a1',
+    version='0.2.0a2',
     description='Allows download of a file by its hashsum.',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',

--- a/plugins/homepage/setup.py
+++ b/plugins/homepage/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup, find_packages
 # perform the install
 setup(
     name='girder-homepage',
-    version='2.0.0a1',
+    version='2.0.0a2',
     description='Customize the homepage using Markdown.',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',

--- a/plugins/item_licenses/setup.py
+++ b/plugins/item_licenses/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup, find_packages
 # perform the install
 setup(
     name='girder-item-licenses',
-    version='0.2.0a1',
+    version='0.2.0a2',
     description='Add a license field to items.',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',

--- a/plugins/jobs/setup.py
+++ b/plugins/jobs/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup, find_packages
 # perform the install
 setup(
     name='girder-jobs',
-    version='3.0.0a2',
+    version='3.0.0a3',
     description='A general purpose plugin for managing offline jobs.',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',

--- a/plugins/ldap/setup.py
+++ b/plugins/ldap/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup, find_packages
 # perform the install
 setup(
     name='girder-ldap',
-    version='0.2.0a1',
+    version='0.2.0a2',
     description='Authenticate user credentials against LDAP or Active Directory servers.',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',

--- a/plugins/oauth/setup.py
+++ b/plugins/oauth/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup, find_packages
 # perform the install
 setup(
     name='girder-oauth',
-    version='3.0.0a1',
+    version='3.0.0a2',
     description='Allow users to login via supported OAuth2 providers.',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',

--- a/plugins/terms/setup.py
+++ b/plugins/terms/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup, find_packages
 # perform the install
 setup(
     name='girder-terms',
-    version='0.2.0a1',
+    version='0.2.0a2',
     description='Allows Girder collections to require users to accept terms of '
     'use before browsing.',
     author='Kitware, Inc.',

--- a/plugins/thumbnails/setup.py
+++ b/plugins/thumbnails/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup, find_packages
 # perform the install
 setup(
     name='girder-thumbnails',
-    version='0.2.0a1',
+    version='0.2.0a2',
     description='Generate thumbnails from files.',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',

--- a/plugins/user_quota/setup.py
+++ b/plugins/user_quota/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup, find_packages
 # perform the install
 setup(
     name='girder-user-quota',
-    version='2.0.0a1',
+    version='2.0.0a2',
     description='Limits total file size stored for individual users and '
     'collections and can direct all files to a specific assetstore',
     author='Kitware, Inc.',

--- a/plugins/virtual_folders/setup.py
+++ b/plugins/virtual_folders/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup, find_packages
 # perform the install
 setup(
     name='girder-virtual-folders',
-    version='0.2.0a1',
+    version='0.2.0a2',
     description='Allows folders to list child items using arbitrary database queries',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',


### PR DESCRIPTION
New releases are necessary for compatibility with the latest Girder prerelease.