### PR TITLE
Remove pinning of pytest-cov

### DIFF
--- a/pytest_girder/setup.py
+++ b/pytest_girder/setup.py
@@ -16,7 +16,7 @@ setup(
         'mock',
         'mongomock',
         'pytest>=3.6',
-        'pytest-cov<2.6',
+        'pytest-cov',
         'pymongo'
     ],
     entry_points={


### PR DESCRIPTION
Can someone confirm that coverage looks sane on this branch: https://codecov.io/gh/girder/girder/commit/0b4186cdaff53dc92d06b97f3f79bf60c00a71d7.

This removes the pinning of pytest-cov from the setup.py, but leaves it in requirements-dev, so it shouldn't affect Girder but will allow downstreams to use newer versions.