### PR TITLE
Publish python packages from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -492,6 +492,27 @@ jobs:
           command: tox -e public_names
           working_directory: girder
 
+  release:
+    docker:
+      - image: circleci/python:2.7
+    working_directory: /home/circleci/project
+    steps:
+      - checkout:
+          path: girder
+      - run:
+          name: Create virtual environment (if necessary)
+          command: if [ ! -d girder_env ]; then virtualenv girder_env; fi
+      - run:
+          name: Activate virtual environment
+          command: echo ". $CIRCLE_WORKING_DIRECTORY/girder_env/bin/activate" >> $BASH_ENV
+      - run:
+          name: Install twine
+          command: pip install --upgrade pip tox
+      - run:
+          name: Publish python packages
+          command: tox -e release
+          working_directory: girder
+
   deploy:
     docker:
       - image: girder/girder_test:latest-py3
@@ -544,10 +565,19 @@ workflows:
             - py3_webBuild_webTest
             - py3_integrationTests
       - public_symbols
-      - deploy:
+      - release:
           requires:
+            - public_symbols
             - py2_coverage
             - py3_coverage
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only: master
+      - deploy:
+          requires:
+            - release
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           command: pip install --upgrade pip setuptools virtualenv
       - run:
           name: Install Girder
-          command: pip install --upgrade --upgrade-strategy eager --editable .[sftp,mount] clients/python --requirement requirements-dev.txt
+          command: pip install --upgrade --upgrade-strategy eager --editable .[sftp,mount] --editable clients/python --requirement requirements-dev.txt
           # Until https://github.com/pypa/pip/pull/4208 is available in pip 10, the install of
           # "requirements-dev.txt" must be run from the "girder" working directory
           working_directory: girder
@@ -98,7 +98,7 @@ jobs:
           command: pip install --upgrade pip setuptools
       - run:
           name: Install Girder
-          command: pip install --upgrade --upgrade-strategy eager --editable .[sftp,mount] clients/python --requirement requirements-dev.txt
+          command: pip install --upgrade --upgrade-strategy eager --editable .[sftp,mount] --editable clients/python --requirement requirements-dev.txt
           working_directory: girder
       - run:
           name: Reduce workspace size
@@ -269,7 +269,7 @@ jobs:
       - run:
           name: Install all pip modules
           # sftp and python client aren't installed by the ansible example
-          command: pip install --upgrade --upgrade-strategy eager --editable .[sftp,mount] clients/python --requirement requirements-dev.txt
+          command: pip install --upgrade --upgrade-strategy eager --editable .[sftp,mount] --editable clients/python --requirement requirements-dev.txt
           working_directory: girder
       - run:
           name: Create Girder build directory
@@ -401,7 +401,7 @@ jobs:
       - run:
           name: Install all pip modules
           # sftp and python client aren't installed by the ansible example
-          command: pip install --upgrade --upgrade-strategy eager --editable .[sftp,mount] clients/python --requirement requirements-dev.txt
+          command: pip install --upgrade --upgrade-strategy eager --editable .[sftp,mount] --editable clients/python --requirement requirements-dev.txt
           working_directory: girder
       - run:
           name: Create Girder build directory

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Build outputs
 /build/
+**/dist/
+**/.eggs/
 girder-*.tar.gz
 node_modules/
 *.egg-info

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -17,6 +17,16 @@
 #  limitations under the License.
 ###############################################################################
 
+from pkg_resources import DistributionNotFound, get_distribution
+
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+    # package is not installed
+    __version__ = None
+
+__license__ = 'Apache 2.0'
+
 import diskcache
 import errno
 import getpass
@@ -33,9 +43,6 @@ import tempfile
 
 from contextlib import contextmanager
 from requests_toolbelt import MultipartEncoder
-
-__version__ = '3.0.0a4'
-__license__ = 'Apache 2.0'
 
 DEFAULT_PAGE_LIMIT = 50  # Number of results to fetch per request
 REQ_BUFFER_SIZE = 65536  # Chunk size when iterating a download body

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -18,8 +18,25 @@
 ###############################################################################
 
 import os
-import re
+
 from setuptools import setup, find_packages
+
+
+def prerelease_local_scheme(version):
+    """Return local scheme version unless building on master in CircleCI.
+    This function returns the local scheme version number
+    (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
+    pre-release in which case it ignores the hash and produces a
+    PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
+    """
+
+    from setuptools_scm.version import get_local_node_and_date
+
+    if os.getenv('CIRCLE_BRANCH') == 'master':
+        return ''
+    else:
+        return get_local_node_and_date(version)
+
 
 install_reqs = [
     'click>=6.7',
@@ -31,16 +48,11 @@ install_reqs = [
 with open('README.rst') as f:
     readme = f.read()
 
-init = os.path.join(os.path.dirname(__file__), 'girder_client', '__init__.py')
-with open(init) as fd:
-    version = re.search(
-        r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
-        fd.read(), re.MULTILINE).group(1)
-
 # perform the install
 setup(
     name='girder-client',
-    version=version,
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    setup_requires=['setuptools-scm'],
     description='Python client for interacting with Girder servers',
     long_description=readme,
     author='Kitware, Inc.',

--- a/girder/__init__.py
+++ b/girder/__init__.py
@@ -17,7 +17,14 @@
 #  limitations under the License.
 ###############################################################################
 
-__version__ = '3.0.0a4'
+from pkg_resources import DistributionNotFound, get_distribution
+
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+    # package is not installed
+    __version__ = None
+
 __license__ = 'Apache 2.0'
 
 import cherrypy

--- a/plugins/audit_logs/setup.py
+++ b/plugins/audit_logs/setup.py
@@ -17,13 +17,32 @@
 #  limitations under the License.
 ###############################################################################
 
-from setuptools import setup, find_packages
+import os
+
+from setuptools import find_packages, setup
+
+
+def prerelease_local_scheme(version):
+    """Return local scheme version unless building on master in CircleCI.
+    This function returns the local scheme version number
+    (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
+    pre-release in which case it ignores the hash and produces a
+    PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
+    """
+
+    from setuptools_scm.version import get_local_node_and_date
+
+    if os.getenv('CIRCLE_BRANCH') == 'master':
+        return ''
+    else:
+        return get_local_node_and_date(version)
 
 
 # perform the install
 setup(
     name='girder-audit-logs',
-    version='3.0.0a4',
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    setup_requires=['setuptools-scm'],
     description='Keeps detailed logs of every REST request and low-level file download event.',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',

--- a/plugins/authorized_upload/setup.py
+++ b/plugins/authorized_upload/setup.py
@@ -16,14 +16,32 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ###############################################################################
+import os
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
+
+def prerelease_local_scheme(version):
+    """Return local scheme version unless building on master in CircleCI.
+    This function returns the local scheme version number
+    (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
+    pre-release in which case it ignores the hash and produces a
+    PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
+    """
+
+    from setuptools_scm.version import get_local_node_and_date
+
+    if os.getenv('CIRCLE_BRANCH') == 'master':
+        return ''
+    else:
+        return get_local_node_and_date(version)
 
 
 # perform the install
 setup(
     name='girder-authorized-upload',
-    version='3.0.0a4',
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Allows registered users to authorize file uploads on their behalf '
     'via a secure one-use URL.',
     author='Kitware, Inc.',
@@ -44,7 +62,6 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
-    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1'],
     entry_points={
         'girder.plugin': [

--- a/plugins/autojoin/setup.py
+++ b/plugins/autojoin/setup.py
@@ -16,14 +16,32 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ###############################################################################
+import os
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
+
+def prerelease_local_scheme(version):
+    """Return local scheme version unless building on master in CircleCI.
+    This function returns the local scheme version number
+    (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
+    pre-release in which case it ignores the hash and produces a
+    PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
+    """
+
+    from setuptools_scm.version import get_local_node_and_date
+
+    if os.getenv('CIRCLE_BRANCH') == 'master':
+        return ''
+    else:
+        return get_local_node_and_date(version)
 
 
 # perform the install
 setup(
     name='girder-autojoin',
-    version='3.0.0a4',
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Automatically assign new users to groups based on their email domain',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
@@ -43,7 +61,6 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
-    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1'],
     entry_points={
         'girder.plugin': [

--- a/plugins/dicom_viewer/setup.py
+++ b/plugins/dicom_viewer/setup.py
@@ -16,14 +16,32 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ###############################################################################
+import os
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
+
+def prerelease_local_scheme(version):
+    """Return local scheme version unless building on master in CircleCI.
+    This function returns the local scheme version number
+    (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
+    pre-release in which case it ignores the hash and produces a
+    PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
+    """
+
+    from setuptools_scm.version import get_local_node_and_date
+
+    if os.getenv('CIRCLE_BRANCH') == 'master':
+        return ''
+    else:
+        return get_local_node_and_date(version)
 
 
 # perform the install
 setup(
     name='girder-dicom-viewer',
-    version='3.0.0a4',
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    setup_requires=['setuptools-scm', 'setuptools-git'],
     description='View DICOM images in the browser',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
@@ -43,7 +61,6 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
-    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1', 'pydicom>=1.0.2'],
     entry_points={
         'girder.plugin': [

--- a/plugins/download_statistics/setup.py
+++ b/plugins/download_statistics/setup.py
@@ -16,14 +16,32 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ###############################################################################
+import os
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
+
+def prerelease_local_scheme(version):
+    """Return local scheme version unless building on master in CircleCI.
+    This function returns the local scheme version number
+    (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
+    pre-release in which case it ignores the hash and produces a
+    PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
+    """
+
+    from setuptools_scm.version import get_local_node_and_date
+
+    if os.getenv('CIRCLE_BRANCH') == 'master':
+        return ''
+    else:
+        return get_local_node_and_date(version)
 
 
 # perform the install
 setup(
     name='girder-download-statistics',
-    version='3.0.0a4',
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Record file download statistics',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
@@ -42,7 +60,6 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
-    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1'],
     entry_points={
         'girder.plugin': [

--- a/plugins/google_analytics/setup.py
+++ b/plugins/google_analytics/setup.py
@@ -16,14 +16,32 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ###############################################################################
+import os
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
+
+def prerelease_local_scheme(version):
+    """Return local scheme version unless building on master in CircleCI.
+    This function returns the local scheme version number
+    (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
+    pre-release in which case it ignores the hash and produces a
+    PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
+    """
+
+    from setuptools_scm.version import get_local_node_and_date
+
+    if os.getenv('CIRCLE_BRANCH') == 'master':
+        return ''
+    else:
+        return get_local_node_and_date(version)
 
 
 # perform the install
 setup(
     name='girder-google-analytics',
-    version='3.0.0a4',
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Allow the tracking of page views via Google Analytics.',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
@@ -43,7 +61,6 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
-    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1'],
     entry_points={
         'girder.plugin': [

--- a/plugins/gravatar/setup.py
+++ b/plugins/gravatar/setup.py
@@ -16,14 +16,32 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ###############################################################################
+import os
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
+
+def prerelease_local_scheme(version):
+    """Return local scheme version unless building on master in CircleCI.
+    This function returns the local scheme version number
+    (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
+    pre-release in which case it ignores the hash and produces a
+    PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
+    """
+
+    from setuptools_scm.version import get_local_node_and_date
+
+    if os.getenv('CIRCLE_BRANCH') == 'master':
+        return ''
+    else:
+        return get_local_node_and_date(version)
 
 
 # perform the install
 setup(
     name='girder-gravatar',
-    version='3.0.0a4',
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Adds Gravatar URLs for users.',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
@@ -43,7 +61,6 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
-    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1'],
     entry_points={
         'girder.plugin': [

--- a/plugins/hashsum_download/setup.py
+++ b/plugins/hashsum_download/setup.py
@@ -16,14 +16,32 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ###############################################################################
+import os
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
+
+def prerelease_local_scheme(version):
+    """Return local scheme version unless building on master in CircleCI.
+    This function returns the local scheme version number
+    (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
+    pre-release in which case it ignores the hash and produces a
+    PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
+    """
+
+    from setuptools_scm.version import get_local_node_and_date
+
+    if os.getenv('CIRCLE_BRANCH') == 'master':
+        return ''
+    else:
+        return get_local_node_and_date(version)
 
 
 # perform the install
 setup(
     name='girder-hashsum-download',
-    version='3.0.0a4',
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Allows download of a file by its hashsum.',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
@@ -43,7 +61,6 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
-    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1'],
     entry_points={
         'girder.plugin': [

--- a/plugins/homepage/setup.py
+++ b/plugins/homepage/setup.py
@@ -16,14 +16,32 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ###############################################################################
+import os
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
+
+def prerelease_local_scheme(version):
+    """Return local scheme version unless building on master in CircleCI.
+    This function returns the local scheme version number
+    (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
+    pre-release in which case it ignores the hash and produces a
+    PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
+    """
+
+    from setuptools_scm.version import get_local_node_and_date
+
+    if os.getenv('CIRCLE_BRANCH') == 'master':
+        return ''
+    else:
+        return get_local_node_and_date(version)
 
 
 # perform the install
 setup(
     name='girder-homepage',
-    version='3.0.0a4',
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Customize the homepage using Markdown.',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
@@ -43,7 +61,6 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
-    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1'],
     entry_points={
         'girder.plugin': [

--- a/plugins/item_licenses/setup.py
+++ b/plugins/item_licenses/setup.py
@@ -16,14 +16,32 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ###############################################################################
+import os
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
+
+def prerelease_local_scheme(version):
+    """Return local scheme version unless building on master in CircleCI.
+    This function returns the local scheme version number
+    (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
+    pre-release in which case it ignores the hash and produces a
+    PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
+    """
+
+    from setuptools_scm.version import get_local_node_and_date
+
+    if os.getenv('CIRCLE_BRANCH') == 'master':
+        return ''
+    else:
+        return get_local_node_and_date(version)
 
 
 # perform the install
 setup(
     name='girder-item-licenses',
-    version='3.0.0a4',
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Add a license field to items.',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
@@ -42,7 +60,6 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
-    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1'],
     entry_points={
         'girder.plugin': [

--- a/plugins/jobs/setup.py
+++ b/plugins/jobs/setup.py
@@ -16,14 +16,32 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ###############################################################################
+import os
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
+
+def prerelease_local_scheme(version):
+    """Return local scheme version unless building on master in CircleCI.
+    This function returns the local scheme version number
+    (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
+    pre-release in which case it ignores the hash and produces a
+    PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
+    """
+
+    from setuptools_scm.version import get_local_node_and_date
+
+    if os.getenv('CIRCLE_BRANCH') == 'master':
+        return ''
+    else:
+        return get_local_node_and_date(version)
 
 
 # perform the install
 setup(
     name='girder-jobs',
-    version='3.0.0a4',
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    setup_requires=['setuptools-scm', 'setuptools-git'],
     description='A general purpose plugin for managing offline jobs.',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
@@ -43,7 +61,6 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
-    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a2'],
     entry_points={
         'girder.plugin': [

--- a/plugins/ldap/setup.py
+++ b/plugins/ldap/setup.py
@@ -16,14 +16,32 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ###############################################################################
+import os
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
+
+def prerelease_local_scheme(version):
+    """Return local scheme version unless building on master in CircleCI.
+    This function returns the local scheme version number
+    (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
+    pre-release in which case it ignores the hash and produces a
+    PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
+    """
+
+    from setuptools_scm.version import get_local_node_and_date
+
+    if os.getenv('CIRCLE_BRANCH') == 'master':
+        return ''
+    else:
+        return get_local_node_and_date(version)
 
 
 # perform the install
 setup(
     name='girder-ldap',
-    version='3.0.0a4',
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Authenticate user credentials against LDAP or Active Directory servers.',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
@@ -42,7 +60,6 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
-    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1', 'pyldap'],
     entry_points={
         'girder.plugin': [

--- a/plugins/oauth/setup.py
+++ b/plugins/oauth/setup.py
@@ -16,14 +16,32 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ###############################################################################
+import os
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
+
+def prerelease_local_scheme(version):
+    """Return local scheme version unless building on master in CircleCI.
+    This function returns the local scheme version number
+    (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
+    pre-release in which case it ignores the hash and produces a
+    PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
+    """
+
+    from setuptools_scm.version import get_local_node_and_date
+
+    if os.getenv('CIRCLE_BRANCH') == 'master':
+        return ''
+    else:
+        return get_local_node_and_date(version)
 
 
 # perform the install
 setup(
     name='girder-oauth',
-    version='3.0.0a4',
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Allow users to login via supported OAuth2 providers.',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
@@ -43,7 +61,6 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
-    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1'],
     entry_points={
         'girder.plugin': [

--- a/plugins/terms/setup.py
+++ b/plugins/terms/setup.py
@@ -16,14 +16,32 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ###############################################################################
+import os
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
+
+def prerelease_local_scheme(version):
+    """Return local scheme version unless building on master in CircleCI.
+    This function returns the local scheme version number
+    (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
+    pre-release in which case it ignores the hash and produces a
+    PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
+    """
+
+    from setuptools_scm.version import get_local_node_and_date
+
+    if os.getenv('CIRCLE_BRANCH') == 'master':
+        return ''
+    else:
+        return get_local_node_and_date(version)
 
 
 # perform the install
 setup(
     name='girder-terms',
-    version='3.0.0a4',
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Allows Girder collections to require users to accept terms of '
     'use before browsing.',
     author='Kitware, Inc.',
@@ -44,7 +62,6 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
-    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1'],
     entry_points={
         'girder.plugin': [

--- a/plugins/thumbnails/setup.py
+++ b/plugins/thumbnails/setup.py
@@ -16,14 +16,32 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ###############################################################################
+import os
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
+
+def prerelease_local_scheme(version):
+    """Return local scheme version unless building on master in CircleCI.
+    This function returns the local scheme version number
+    (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
+    pre-release in which case it ignores the hash and produces a
+    PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
+    """
+
+    from setuptools_scm.version import get_local_node_and_date
+
+    if os.getenv('CIRCLE_BRANCH') == 'master':
+        return ''
+    else:
+        return get_local_node_and_date(version)
 
 
 # perform the install
 setup(
     name='girder-thumbnails',
-    version='3.0.0a4',
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Generate thumbnails from files.',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
@@ -42,7 +60,6 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
-    setup_requires=['setuptools-git'],
     install_requires=[
         'girder>=3.0.0a1',
         'girder-jobs>=3.0.0a1',

--- a/plugins/user_quota/setup.py
+++ b/plugins/user_quota/setup.py
@@ -16,14 +16,32 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ###############################################################################
+import os
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
+
+def prerelease_local_scheme(version):
+    """Return local scheme version unless building on master in CircleCI.
+    This function returns the local scheme version number
+    (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
+    pre-release in which case it ignores the hash and produces a
+    PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
+    """
+
+    from setuptools_scm.version import get_local_node_and_date
+
+    if os.getenv('CIRCLE_BRANCH') == 'master':
+        return ''
+    else:
+        return get_local_node_and_date(version)
 
 
 # perform the install
 setup(
     name='girder-user-quota',
-    version='3.0.0a4',
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Limits total file size stored for individual users and '
     'collections and can direct all files to a specific assetstore',
     author='Kitware, Inc.',
@@ -43,7 +61,6 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
-    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1'],
     entry_points={
         'girder.plugin': [

--- a/plugins/virtual_folders/setup.py
+++ b/plugins/virtual_folders/setup.py
@@ -16,14 +16,32 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ###############################################################################
+import os
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
+
+def prerelease_local_scheme(version):
+    """Return local scheme version unless building on master in CircleCI.
+    This function returns the local scheme version number
+    (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
+    pre-release in which case it ignores the hash and produces a
+    PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
+    """
+
+    from setuptools_scm.version import get_local_node_and_date
+
+    if os.getenv('CIRCLE_BRANCH') == 'master':
+        return ''
+    else:
+        return get_local_node_and_date(version)
 
 
 # perform the install
 setup(
     name='girder-virtual-folders',
-    version='3.0.0a4',
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Allows folders to list child items using arbitrary database queries',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
@@ -42,7 +60,6 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
-    setup_requires=['setuptools-git'],
     install_requires=['girder>=3.0.0a1'],
     entry_points={
         'girder.plugin': [

--- a/pytest_girder/setup.py
+++ b/pytest_girder/setup.py
@@ -1,8 +1,28 @@
+import os
+
 from setuptools import find_packages, setup
+
+
+def prerelease_local_scheme(version):
+    """Return local scheme version unless building on master in CircleCI.
+    This function returns the local scheme version number
+    (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
+    pre-release in which case it ignores the hash and produces a
+    PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
+    """
+
+    from setuptools_scm.version import get_local_node_and_date
+
+    if os.getenv('CIRCLE_BRANCH') == 'master':
+        return ''
+    else:
+        return get_local_node_and_date(version)
+
 
 setup(
     name='pytest-girder',
-    version='3.0.0a4',
+    use_scm_version={'root': '..', 'local_scheme': prerelease_local_scheme},
+    setup_requires=['setuptools-scm'],
     description='A set of pytest fixtures for testing Girder applications.',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',

--- a/scripts/pypi_publish.sh
+++ b/scripts/pypi_publish.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# build sdist's for all python packages in this repo
+for d in . plugins/* pytest_girder clients/python ; do
+    pushd $d
+    rm -fr dist
+    python setup.py sdist
+    popd
+done
+twine upload --skip-existing dist/* plugins/*/dist/* clients/python/dist/* pytest_girder/dist/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ show-source: True
 # Maximum cyclomatic complexity allowed
 max-complexity: 14
 format: pylint
-exclude: girder/external/* */web_client/*
+exclude: girder/external/* */web_client/* */.eggs/*
 # Ignore certain errors.
 #
 #   If an ignore line is not specified, the pep8 module defaults to

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,25 @@
 ###############################################################################
 
 import os
-import re
 import itertools
 
 from setuptools import setup, find_packages
+
+
+def prerelease_local_scheme(version):
+    """Return local scheme version unless building on master in CircleCI.
+    This function returns the local scheme version number
+    (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
+    pre-release in which case it ignores the hash and produces a
+    PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
+    """
+
+    from setuptools_scm.version import get_local_node_and_date
+
+    if os.getenv('CIRCLE_BRANCH') == 'master':
+        return ''
+    else:
+        return get_local_node_and_date(version)
 
 
 with open('README.rst') as f:
@@ -80,15 +95,10 @@ extrasReqs['mount'] = [
     'fusepy>=3.0',
 ]
 
-init = os.path.join(os.path.dirname(__file__), 'girder', '__init__.py')
-with open(init) as fd:
-    version = re.search(
-        r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
-        fd.read(), re.MULTILINE).group(1)
-
 setup(
     name='girder',
-    version=version,
+    use_scm_version={'local_scheme': prerelease_local_scheme},
+    setup_requires=['setuptools-scm'],
     description='Web-based data management platform',
     long_description=readme,
     author='Kitware, Inc.',

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,21 @@ commands =
         docs \
         build/docs/python
 
+[testenv:release]
+skip_install = true
+skipsdist = true
+basepython = python2.7
+passenv =
+  CIRCLE_BRANCH
+  TWINE_USERNAME
+  TWINE_PASSWORD
+deps =
+  setuptools-git
+  setuptools-scm
+  twine
+commands =
+  {toxinidir}/scripts/pypi_publish.sh
+
 [testenv:public_names]
 deps = six
 commands = {toxinidir}/scripts/test_names.sh


### PR DESCRIPTION
This is pretty straightforward.  It adds:
* a bunch of boilerplate added to each setup.py file
* a tox environment for generating and pushing the releases
* a CI step that is run after tests on master and tags matching `/^v.*/` that runs `tox -e release`

I also had to add my own pypi credentials to the circle ci environment... There doesn't seem to be any kind of api key or token based auth.  :(

I verified this works as well as I can, but the only test it is to merge.  