### PR TITLE
Include the full git repository in Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,14 +17,7 @@ RUN apt-get update && apt-get install -qy \
 RUN wget https://bootstrap.pypa.io/get-pip.py && python get-pip.py
 
 WORKDIR /girder
-COPY girder /girder/girder
-COPY clients /girder/clients
-COPY plugins /girder/plugins
-COPY scripts /girder/scripts
-COPY setup.py /girder/setup.py
-COPY package.json /girder/package.json
-COPY README.rst /girder/README.rst
-COPY requirements-dev.txt /girder/requirements-dev.txt
+COPY . /girder/
 
 # TODO: Do we want to create editable installs of plugins as well?  We
 # will need a plugin only requirements file for this.

--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -17,14 +17,7 @@ RUN apt-get update && apt-get install -qy \
 RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
 
 WORKDIR /girder
-COPY girder /girder/girder
-COPY clients /girder/clients
-COPY plugins /girder/plugins
-COPY scripts /girder/scripts
-COPY setup.py /girder/setup.py
-COPY package.json /girder/package.json
-COPY README.rst /girder/README.rst
-COPY requirements-dev.txt /girder/requirements-dev.txt
+COPY . /girder/
 
 # See http://click.pocoo.org/5/python3/#python-3-surrogate-handling for more detail on
 # why this is necessary.


### PR DESCRIPTION
This is the most straightforward solution to the currently broken Docker images with minimal overhead.  I think we can discuss more radical changes as an enhancement in a future PR if necessary.
