### PR TITLE
Add missing comma in migration guide example

### DIFF
--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -38,7 +38,7 @@ plugin:
     setup(
         name='example-plugin',            # The name registered on PyPI
         version='1.0.0',
-        description='An example plugin.'  # This text will be displayed on the plugin page
+        description='An example plugin.', # This text will be displayed on the plugin page
         packages=['example_plugin'],
         install_requires=['girder'],      # Add any plugin dependencies here
         entry_points={


### PR DESCRIPTION
Signed-off-by: Patrick Avery <patrick.avery@kitware.com>
