### PR TITLE
Mention changing allowed host when running in docker

### DIFF
--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -117,7 +117,7 @@ information, see the
 `Docker Hub Page <https://registry.hub.docker.com/u/girder/girder/>`_. Since the
 container does not run a database, you'll need to run a command in the form: ::
 
-   $ docker run -p 8080:8080 girder/girder -d mongodb://db-server-external-ip:27017/girder
+   $ docker run -p 8080:8080 girder/girder -d mongodb://db-server-external-ip:27017/girder --host 0.0.0.0
 
 Google Container Engine
 -----------------------


### PR DESCRIPTION
`-p 8080:8080` isn't a useful flag without `--host 0.0.0.0`


