### PR TITLE
Add a resource/path/download/+path endpoint.

### DIFF
--- a/girder/api/docs.py
+++ b/girder/api/docs.py
@@ -36,7 +36,7 @@ def _toRoutePath(resource, route):
     """
     # Convert wildcard tokens from :foo form to {foo} form
     convRoute = [
-        '{%s}' % token[1:] if token[0] == ':' else token
+        '{%s}' % token[1:] if token[0] in (':', '+') else token
         for token in route
     ]
 

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -1011,6 +1011,20 @@ class Resource(object):
                     break
             else:
                 return route, handler, wildcards
+        # Handle routes with variable arguments
+        for routelen in range(len(path), 0, -1):
+            for route, handler in self._routes[method][routelen]:
+                wildcards = {}
+                if route[-1].startswith('+'):
+                    wildcards[route[-1][1:]] = path[routelen - 1:]
+                    for routeComponent, pathComponent in six.moves.zip(
+                            route[:-1], path[:routelen - 1]):
+                        if routeComponent[0] == ':':  # Wildcard token
+                            wildcards[routeComponent[1:]] = pathComponent
+                        elif routeComponent != pathComponent:  # Exact match token
+                            break
+                    else:
+                        return route, handler, wildcards
 
         raise RestException('No matching route for "%s %s"' % (method.upper(), '/'.join(path)))
 

--- a/girder/cli/mount.py
+++ b/girder/cli/mount.py
@@ -509,7 +509,7 @@ def mountServer(path, database=None, fuseOptions=None, quiet=False, plugins=None
 # will work.  If you specify a string that doesn't contain :// as the database
 # uri, then it will use the default girder configuration (e.g., use
 # "mount -t girder girder <path>").
-# If you have girder installed in a virtualenv, ifrequently prepending the
+# If you have girder installed in a virtualenv, frequently prepending the
 # virtualenv's bin directory to the path is enough to use it, so the
 # mount.girder file becomes
 #   #!/usr/bin/env bash

--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -283,6 +283,7 @@ girder
                     lookup
                     moveResources
                     path
+                    pathDownload
                     search
                     setTimestamp
                 allowedDeleteTypes


### PR DESCRIPTION
This adds the ability to have a path with a variable number of components at the end by making the last component +<name>.  Note that this shows up in swagger as a single parameters {name}, which doesn't
work properly in the swagger interface.
