### PR TITLE
Prevent some false positive alerts in logs

### DIFF
--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -558,7 +558,6 @@ def _handleAccessException(e):
         cherrypy.response.status = 401
     else:
         cherrypy.response.status = 403
-        logger.exception('403 Error')
     val = {'message': e.message, 'type': 'access'}
     if e.extra is not None:
         val['extra'] = e.extra


### PR DESCRIPTION
This resolves some issues which can trigger false positive alerts with log analysis tools.

* ~~Move the logger to 'girder.app' and the audit logger to 'girder.audit'~~
* Don't create special log entries for AccessExceptions