### PR TITLE
Reference static content more reliably from the API page

### DIFF
--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -467,7 +467,7 @@ class ApiDocs(WebrootBase):
     def _renderHTML(self):
         from girder.utility import server
         self.vars['apiRoot'] = server.getApiRoot()
-        self.vars['staticRoot'] = server.getApiStaticRoot()
+        self.vars['staticRoot'] = server.getStaticRoot()
         self.vars['brandName'] = Setting().get(SettingKey.BRAND_NAME)
         return super(ApiDocs, self)._renderHTML()
 

--- a/girder/utility/server.py
+++ b/girder/utility/server.py
@@ -21,7 +21,6 @@ import cherrypy
 import mako
 import mimetypes
 import os
-import posixpath
 import six
 
 import girder.events
@@ -55,24 +54,6 @@ def getApiRoot():
 def getStaticRoot():
     routeTable = loadRouteTable()
     return routeTable[constants.GIRDER_STATIC_ROUTE_ID]
-
-
-def getApiStaticRoot():
-    routeTable = loadRouteTable()
-
-    # If the static route is a URL, leave it alone
-    if '://' in routeTable[constants.GIRDER_STATIC_ROUTE_ID]:
-        return routeTable[constants.GIRDER_STATIC_ROUTE_ID]
-    else:
-        # Make the staticRoot relative to the api_root, if possible.  The api_root
-        # could be relative or absolute, but it needs to be in an absolute form for
-        # relpath to behave as expected.  We always expect the api_root to
-        # contain at least two components, but the reference from static needs to
-        # be from only the first component.
-        apiRootBase = posixpath.split(posixpath.join('/',
-                                                     config.getConfig()['server']['api_root']))[0]
-        return posixpath.relpath(routeTable[constants.GIRDER_STATIC_ROUTE_ID],
-                                 apiRootBase)
 
 
 def configureServer(test=False, plugins=None, curConfig=None):

--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -944,7 +944,6 @@ girder
         server
             configureServer
             getApiRoot
-            getApiStaticRoot
             getPlugins
             getStaticRoot
             loadRouteTable


### PR DESCRIPTION
Since the static root now must be an absolute path, there's no point to trying to determine it relative to the API page path, and the old implementation breaks in some cases (like accessing the API page from "/api/v1/" with a trailing slash).
