### PR TITLE
When specifying an image in item tasks, return a single file

### DIFF
--- a/plugins/item_tasks/plugin_tests/cli_parser_test.py
+++ b/plugins/item_tasks/plugin_tests/cli_parser_test.py
@@ -69,11 +69,11 @@ class CliParserTest(base.TestCase):
 
         inputs = spec['inputs']
         for input in inputs:
-            if input['name'] == 'InputImage':
-                self.assertEqual(input['type'], 'image')
+            if input['name'] == 'InputFile':
+                self.assertEqual(input['type'], 'file')
                 break
         else:
-            raise Exception('InputImage not added to spec.')
+            raise Exception('InputFile not added to spec.')
 
     def test_output_directory(self):
         spec = self.parse_file('slicer_cli.xml')

--- a/plugins/item_tasks/plugin_tests/slicer_cli.xml
+++ b/plugins/item_tasks/plugin_tests/slicer_cli.xml
@@ -13,12 +13,12 @@
   </acknowledgements>
   <parameters>
     <label>Parameters</label>
-    <image type="scalar">
-      <longflag>InputImage</longflag>
-      <label>InputImage</label>
+    <file type="scalar">
+      <longflag>InputFile</longflag>
+      <label>InputFile</label>
       <channel>input</channel>
-      <description>Input image to be analysed.</description>
-    </image>
+      <description>Input file to be analysed.</description>
+    </file>
     <integer-enumeration>
       <longflag>SpheresPerPhantom</longflag>
       <label>SpheresPerPhantom</label>

--- a/plugins/item_tasks/plugin_tests/tasksSpec.js
+++ b/plugins/item_tasks/plugin_tests/tasksSpec.js
@@ -239,7 +239,7 @@ describe('Run the item task', function () {
 
         runs(function () {
             // Make sure item name displays properly
-            expect($('input[name="InputImage"]').val()).toBe('PET phantom detector CLI');
+            expect($('input[name="InputFile"]').val()).toBe('PET phantom detector CLI');
         });
     });
 });

--- a/plugins/item_tasks/plugin_tests/tasks_test.py
+++ b/plugins/item_tasks/plugin_tests/tasks_test.py
@@ -485,7 +485,7 @@ class TasksTest(base.TestCase):
             'mode': 'docker',
             'docker_image': 'johndoe/foo:v5',
             'container_args': [
-                '--foo', 'bar', '--InputImage=$input{--InputImage}',
+                '--foo', 'bar', '--InputFile=$input{--InputFile}',
                 '--MaximumLineStraightnessDeviation=$input{--MaximumLineStraightnessDeviation}',
                 '--MaximumRadius=$input{--MaximumRadius}',
                 '--MaximumSphereDistance=$input{--MaximumSphereDistance}',
@@ -498,9 +498,9 @@ class TasksTest(base.TestCase):
                 '--OutputDirectory=$output{--OutputDirectory}'
             ],
             'inputs': [{
-                'description': 'Input image to be analysed.',
-                'format': 'image',
-                'name': 'InputImage', 'type': 'image', 'id': '--InputImage',
+                'description': 'Input file to be analysed.',
+                'format': 'file',
+                'name': 'InputFile', 'type': 'file', 'id': '--InputFile',
                 'target': 'filepath'
             }, {
                 'description': 'Used for eliminating detections which are not in a straight line. '
@@ -595,7 +595,7 @@ class TasksTest(base.TestCase):
             flags=ACCESS_FLAG_EXECUTE_TASK, currentUser=self.admin, save=True)
 
         inputs = {
-            '--InputImage': {
+            '--InputFile': {
                 'mode': 'girder',
                 'resource_type': 'item',
                 'id': str(item['_id'])

--- a/plugins/item_tasks/web_client/views/TaskRunView.js
+++ b/plugins/item_tasks/web_client/views/TaskRunView.js
@@ -141,6 +141,12 @@ const TaskRunView = View.extend({
             let val = model.value();
             switch (model.get('type')) {
                 case 'image':
+                    return {
+                        mode: 'girder',
+                        resource_type: 'file',
+                        id: val.id,
+                        fileName: model.get('fileName') || null
+                    };
                 case 'file': // This is an input
                     return {
                         mode: 'girder',


### PR DESCRIPTION
For image types, the user picks an item, from which the first file is returned.  If the item contains metadata that includes a fileId in a subdictionary, that file is returned instead of the first one.