### PR TITLE
Fix girder client to work with pre 3.0 girder server

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -376,8 +376,14 @@ class GirderClient(object):
         :return: The API version as a list (e.g. ``['1', '0', '0']``)
         """
         if not self._serverVersion or not useCached:
-            # Include any more than 3 version components in the patch version
-            self._serverVersion = self.get('system/version')['release'].split('.', 3)
+            response = self.get('system/version')
+            if 'release' in response:
+                release = response['release']  # girder >= 3
+            else:
+                release = response['apiVersion']  # girder < 3
+
+            # Do not include any more than 3 version components in the patch version
+            self._serverVersion = release.split('.', 2)
 
         return self._serverVersion
 

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -378,6 +378,28 @@ class PythonClientTestCase(base.TestCase):
                     self.client, 'getServerVersion', return_value=version.split('.')):
                 self._testUploadMethod(expected_non_multipart_hits=0, expected_multipart_hits=1)
 
+    def testGetServerVersion2(self):
+        @httmock.urlmatch(path=r'.*/system/version')
+        def mock(url, request):
+            return {
+                'status_code': 200,
+                'content-type': 'application/json',
+                'content': {'apiVersion': '2.5.0'}
+            }
+        with httmock.HTTMock(mock):
+            self.assertEqual(self.client.getServerVersion(), ['2', '5', '0'])
+
+    def testGetServerVersion3(self):
+        @httmock.urlmatch(path=r'.*/system/version')
+        def mock(url, request):
+            return {
+                'status_code': 200,
+                'content-type': 'application/json',
+                'content': {'release': '3.0.0a5.dev1'}
+            }
+        with httmock.HTTMock(mock):
+            self.assertEqual(self.client.getServerVersion(), ['3', '0', '0a5.dev1'])
+
     def _testUploadMethod(self, expected_non_multipart_hits=0, expected_multipart_hits=0):
 
         # track API calls


### PR DESCRIPTION
This was reported in [discord](https://discourse.girder.org/t/girder-client-3-0-0a6-and-girder-2-5-keyerror-release-on-upload/231).  I don't know if we ever concluded that we would absolutely support pre 3.0 Girder servers in the client, but the fix here is trivial.