### PR TITLE
Remove the access.cookie decorator.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Changes
 * Move minimum node version to 8.x due to upstream packages using newer ES features.
   (`#2707 <https://github.com/girder/girder/pull/2707>`_).
 * Require MongoDB 3.4+ (`#2900 <https://github.com/girder/girder/pull/2900>`_)
+* Removed the `@access.cookie` decorator; this is now an option on the other access decorators.
 
 Bug Fixes
 ---------

--- a/docs/developer-cookbook.rst
+++ b/docs/developer-cookbook.rst
@@ -557,19 +557,16 @@ browser to a download endpoint that serves its content as an attachment.
 In such cases, you may allow specific REST API routes to authenticate using the
 Cookie. To avoid vulnerabilities to Cross-Site Request Forgery attacks, you
 should only do this if the endpoint is "read-only" (that is, the endpoint does
-not make modifications to data on the server). Accordingly, only routes for
-``HEAD`` and ``GET`` requests allow cookie authentication to be enabled (without
-an additional override).
+not make modifications to data on the server).
 
 In order to allow cookie authentication for your route, simply add the
-``cookie`` decorator to your route handler function. Example:
+``cookie=True`` option to the access decorator on your function. Example:
 
 .. code-block:: python
 
     from girder.api import access
 
-    @access.cookie
-    @access.public
+    @access.public(cookie=True)
     def download(self, params):
         ...
 

--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -279,6 +279,11 @@ In version 3.7 of python ``async`` is a `reserved keyword argument <https://www.
  * The event framework ``girder/events.py``
  * The built-in job plugin ``plugins/jobs/girder_jobs/models/job.py``
 
+The cookie access decorator has been removed
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``@access.cookie`` decorator has been removed.  To allow cookie authentication on an endpoint, include ``cookie=True`` as a parameter to one of the other access decorators (e.g., ``@access.user(cookie=True)``).
+
 Removed or moved plugins
 ++++++++++++++++++++++++
 

--- a/girder/api/access.py
+++ b/girder/api/access.py
@@ -26,7 +26,7 @@ from girder.utility import optionalArgumentDecorator
 
 
 @optionalArgumentDecorator
-def admin(fun, scope=None):
+def admin(fun, scope=None, cookie=False):
     """
     REST endpoints that require administrator access should be wrapped in this decorator.
 
@@ -35,6 +35,11 @@ def admin(fun, scope=None):
     :param scope: To also expose this endpoint for certain token scopes,
         pass those scopes here. If multiple are passed, all will be required.
     :type scope: str or list of str or None
+    :param cookie: if True, this rest endpoint allows the use of a cookie for
+        authentication.  If this is specified on routes that can alter the
+        system (those other than HEAD and GET), it can expose an application to
+        Cross-Site Request Forgery (CSRF) attacks.
+    :type cookie: bool
     """
     @six.wraps(fun)
     def wrapped(*args, **kwargs):
@@ -42,11 +47,13 @@ def admin(fun, scope=None):
         return fun(*args, **kwargs)
     wrapped.accessLevel = 'admin'
     wrapped.requiredScopes = scope
+    if cookie:
+        wrapped.cookieAuth = True
     return wrapped
 
 
 @optionalArgumentDecorator
-def user(fun, scope=None):
+def user(fun, scope=None, cookie=False):
     """
     REST endpoints that require a logged-in user should be wrapped with this access decorator.
 
@@ -55,6 +62,11 @@ def user(fun, scope=None):
     :param scope: To also expose this endpoint for certain token scopes,
         pass those scopes here. If multiple are passed, all will be required.
     :type scope: str or list of str or None
+    :param cookie: if True, this rest endpoint allows the use of a cookie for
+        authentication.  If this is specified on routes that can alter the
+        system (those other than HEAD and GET), it can expose an application to
+        Cross-Site Request Forgery (CSRF) attacks.
+    :type cookie: bool
     """
     @six.wraps(fun)
     def wrapped(*args, **kwargs):
@@ -63,11 +75,13 @@ def user(fun, scope=None):
         return fun(*args, **kwargs)
     wrapped.accessLevel = 'user'
     wrapped.requiredScopes = scope
+    if cookie:
+        wrapped.cookieAuth = True
     return wrapped
 
 
 @optionalArgumentDecorator
-def token(fun, scope=None, required=False):
+def token(fun, scope=None, required=False, cookie=False):
     """
     REST endpoints that require a token, but not necessarily a user authentication token, should use
     this access decorator.
@@ -78,6 +92,11 @@ def token(fun, scope=None, required=False):
     :type scope: str or list of str or None
     :param required: Whether all of the passed ``scope`` are required to access the endpoint at all.
     :type required: bool
+    :param cookie: if True, this rest endpoint allows the use of a cookie for
+        authentication.  If this is specified on routes that can alter the
+        system (those other than HEAD and GET), it can expose an application to
+        Cross-Site Request Forgery (CSRF) attacks.
+    :type cookie: bool
     """
     @six.wraps(fun)
     def wrapped(*args, **kwargs):
@@ -88,11 +107,13 @@ def token(fun, scope=None, required=False):
         return fun(*args, **kwargs)
     wrapped.accessLevel = 'token'
     wrapped.requiredScopes = scope
+    if cookie:
+        wrapped.cookieAuth = True
     return wrapped
 
 
 @optionalArgumentDecorator
-def public(fun, scope=None):
+def public(fun, scope=None, cookie=False):
     """
     Functions that allow any client access, including those that haven't logged
     in should be wrapped in this decorator.
@@ -101,30 +122,14 @@ def public(fun, scope=None):
     :type fun: callable
     :param scope: The scope or list of scopes required for this token.
     :type scope: str or list of str or None
+    :param cookie: if True, this rest endpoint allows the use of a cookie for
+        authentication.  If this is specified on routes that can alter the
+        system (those other than HEAD and GET), it can expose an application to
+        Cross-Site Request Forgery (CSRF) attacks.
+    :type cookie: bool
     """
     fun.accessLevel = 'public'
     fun.requiredScopes = scope
-    return fun
-
-
-@optionalArgumentDecorator
-def cookie(fun, force=False):
-    """
-    REST endpoints that allow the use of a cookie for authentication should be
-    wrapped in this decorator.
-
-    When used as a normal decorator, this is only effective on endpoints for
-    HEAD and GET routes (as these routes should be read-only in a RESTful API).
-
-    While allowing cookie authentication on other types of routes exposes an
-    application to Cross-Site Request Forgery (CSRF) attacks, an optional
-    ``force=True`` kwarg may be passed to the decorator to make it effective
-    on any type of route.
-
-    :param fun: A REST endpoint.
-    :type fun: callable
-    :param force: Allow this to apply to non-GET and non-HEAD endpoints.
-    :type force: bool
-    """
-    fun.cookieAuth = (True, force)
+    if cookie:
+        fun.cookieAuth = True
     return fun

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -822,16 +822,6 @@ class Resource(object):
                 'WARNING: No access level specified for route %s %s' % (
                     method, routePath))
 
-        if method.lower() not in ('head', 'get') \
-            and hasattr(handler, 'cookieAuth') \
-            and not (isinstance(handler.cookieAuth, tuple) and
-                     handler.cookieAuth[1]):
-            routePath = '/'.join([resource] + list(route))
-            logprint.warning(
-                'WARNING: Cannot allow cookie authentication for '
-                'route %s %s without specifying "force=True"' % (
-                    method, routePath))
-
     def removeRoute(self, method, route, handler=None, resource=None):
         """
         Remove a route from the handler and documentation.
@@ -937,18 +927,8 @@ class Resource(object):
         cherrypy.request.requiredScopes = getattr(
             handler, 'requiredScopes', None) or TokenScope.USER_AUTH
 
-        if hasattr(handler, 'cookieAuth'):
-            if isinstance(handler.cookieAuth, tuple):
-                cookieAuth, forceCookie = handler.cookieAuth
-            else:
-                # previously, cookieAuth was not set by a decorator, so the
-                # legacy way must be supported too
-                cookieAuth = handler.cookieAuth
-                forceCookie = False
-            if cookieAuth:
-                if forceCookie or method in ('head', 'get'):
-                    # Allow cookies for the rest of the request
-                    setattr(cherrypy.request, 'girderAllowCookie', True)
+        if getattr(handler, 'cookieAuth', False):
+            setattr(cherrypy.request, 'girderAllowCookie', True)
 
         kwargs['params'] = params
         # Add before call for the API method. Listeners can return

--- a/girder/api/v1/collection.py
+++ b/girder/api/v1/collection.py
@@ -106,8 +106,7 @@ class Collection(Resource):
                 collection, user=self.getCurrentUser(), level=AccessType.READ)
         }
 
-    @access.cookie
-    @access.public(scope=TokenScope.DATA_READ)
+    @access.public(scope=TokenScope.DATA_READ, cookie=True)
     @autoDescribeRoute(
         Description('Download an entire collection as a zip archive.')
         .modelParam('id', model=CollectionModel, level=AccessType.READ)

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -266,8 +266,7 @@ class File(Resource):
                 raise Exception('Failed to store upload.')
             raise
 
-    @access.cookie
-    @access.public(scope=TokenScope.DATA_READ)
+    @access.public(scope=TokenScope.DATA_READ, cookie=True)
     @autoDescribeRoute(
         Description('Download a file.')
         .notes('This endpoint also accepts the HTTP "Range" header for partial '
@@ -306,8 +305,7 @@ class File(Resource):
             file, offset, endByte=endByte, contentDisposition=contentDisposition,
             extraParameters=extraParameters)
 
-    @access.cookie
-    @access.public(scope=TokenScope.DATA_READ)
+    @access.public(scope=TokenScope.DATA_READ, cookie=True)
     @describeRoute(
         Description('Download a file.')
         .param('id', 'The ID of the file.', paramType='path')

--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -118,8 +118,7 @@ class Folder(Resource):
                 folder, user=self.getCurrentUser(), level=AccessType.READ)
         }
 
-    @access.cookie
-    @access.public(scope=TokenScope.DATA_READ)
+    @access.public(scope=TokenScope.DATA_READ, cookie=True)
     @autoDescribeRoute(
         Description('Download an entire folder as a zip archive.')
         .modelParam('id', model=FolderModel, level=AccessType.READ)

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -234,8 +234,7 @@ class Item(Resource):
     def getFiles(self, item, limit, offset, sort):
         return self._model.childFiles(item=item, limit=limit, offset=offset, sort=sort)
 
-    @access.cookie
-    @access.public(scope=TokenScope.DATA_READ)
+    @access.public(scope=TokenScope.DATA_READ, cookie=True)
     @autoDescribeRoute(
         Description('Download the contents of an item.')
         .modelParam('id', model=ItemModel, level=AccessType.READ)

--- a/girder/api/v1/notification.py
+++ b/girder/api/v1/notification.py
@@ -57,8 +57,7 @@ class Notification(Resource):
         self.route('GET', ('stream',), self.stream)
         self.route('GET', (), self.listNotifications)
 
-    @access.cookie
-    @access.token
+    @access.token(cookie=True)
     @autoDescribeRoute(
         Description('Stream notifications for a given user via the SSE protocol.')
         .notes('This uses long-polling to keep the connection open for '
@@ -107,8 +106,7 @@ class Notification(Resource):
                 time.sleep(wait)
         return streamGen
 
-    @access.cookie
-    @access.token
+    @access.token(cookie=True)
     @autoDescribeRoute(
         Description('List notification events')
         .notes('This endpoint can be used for manual long-polling when '

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -155,8 +155,7 @@ class Resource(BaseResource):
             raise RestException('Invalid resource id.')
         return path_util.getResourcePath(type, doc, user=user)
 
-    @access.cookie(force=True)
-    @access.public(scope=TokenScope.DATA_READ)
+    @access.public(scope=TokenScope.DATA_READ, cookie=True)
     @autoDescribeRoute(
         Description('Download a set of items, folders, collections, and users '
                     'as a zip archive.')

--- a/plugins/hashsum_download/girder_hashsum_download/__init__.py
+++ b/plugins/hashsum_download/girder_hashsum_download/__init__.py
@@ -59,8 +59,7 @@ class HashedFile(File):
         node.route('GET', (':id', 'hashsum_file', ':algo'), self.downloadKeyFile)
         node.route('POST', (':id', 'hashsum'), self.computeHashes)
 
-    @access.cookie
-    @access.public(scope=TokenScope.DATA_READ)
+    @access.public(scope=TokenScope.DATA_READ, cookie=True)
     @autoDescribeRoute(
         Description('Download the hashsum key file for a given file.')
         .modelParam('id', 'The ID of the file.', model=FileModel, level=AccessType.READ)
@@ -86,8 +85,7 @@ class HashedFile(File):
 
         return keyFileBody
 
-    @access.cookie
-    @access.public(scope=TokenScope.DATA_READ)
+    @access.public(scope=TokenScope.DATA_READ, cookie=True)
     @autoDescribeRoute(
         Description('Download a file by its hashsum.')
         .param('algo', 'The type of the given hashsum (case insensitive).',
@@ -103,8 +101,7 @@ class HashedFile(File):
 
         return self.download(id=file['_id'], params=params)
 
-    @access.cookie
-    @access.public(scope=TokenScope.DATA_READ)
+    @access.public(scope=TokenScope.DATA_READ, cookie=True)
     @filtermodel(FileModel)
     @autoDescribeRoute(
         Description('Return a list of files matching a hashsum.')

--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -85,7 +85,6 @@ girder
     api
         access
             admin
-            cookie
             public
             token
             user


### PR DESCRIPTION
There can be conflicts on how endpoints are authenticated when combining the cookie access decorator with other access decorators.  By incorporating this as an option to the other decorators, the problem is
avoided.

This fixes #2966 and adds a test for that case.

This resolves #2936.