### PR TITLE
Add pyOpenSSL to the requirements.

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,6 +1,6 @@
 # See tox.ini for documentation on this file.
 funcsigs ; python_version < '3'
 six
-Sphinx
+Sphinx<2
 sphinx_rtd_theme
 sphinx-tabs

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ installReqs = [
     'pymongo>=3.5',
     'PyYAML',
     'psutil',
+    'pyOpenSSL',
     'python-dateutil<2.7',  # required for compatibility with botocore=1.9.8
     'pytz',
     'requests',


### PR DESCRIPTION
We've already done this in master.  Without it, the requests library doesn't work.

Also, pin Sphinx for documentation builds.

Without this change, Circle is failing with `pkg_resources.DistributionNotFound: The 'pyOpenSSL>=0.14; extra == "security"' distribution was not found and is required by requests`.