### PR TITLE
Redirect early in OAuth callback if any event prevents the default

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -266,6 +266,11 @@ if this is the first time logging in with these OAuth credentials).
     from girder import events
     events.bind('oauth.auth_callback.after', 'my_plugin', readCircles)
 
+.. note:: If ``event.preventDefault()`` is called in the event handler for
+  ``oauth.auth_callback.before`` or ``oauth.auth_callback.after``, the OAuth
+  callback does not create a new Girder Token, nor sets a new authentication
+  cookie.
+
 Gravatar Portraits
 ------------------
 

--- a/plugins/oauth/girder_oauth/rest.py
+++ b/plugins/oauth/girder_oauth/rest.py
@@ -133,18 +133,22 @@ class OAuth(Resource):
         providerObj = provider(cherrypy.url())
         token = providerObj.getToken(code)
 
-        events.trigger('oauth.auth_callback.before', {
+        event = events.trigger('oauth.auth_callback.before', {
             'provider': provider,
             'token': token
         })
+        if event.defaultPrevented:
+            raise cherrypy.HTTPRedirect(redirect)
 
         user = providerObj.getUser(token)
 
-        events.trigger('oauth.auth_callback.after', {
+        event = events.trigger('oauth.auth_callback.after', {
             'provider': provider,
             'token': token,
             'user': user
         })
+        if event.defaultPrevented:
+            raise cherrypy.HTTPRedirect(redirect)
 
         girderToken = self.sendAuthTokenCookie(user)
         try:


### PR DESCRIPTION
As per [Discourse discussion](https://discourse.girder.org/t/rfc-reusing-oauth-login-to-integrate-with-3rd-party-apps/236) this PR allows to break OAuth callback flow early if any of the `oauth.auth_callback.{after,before}` events prevents default behavior.