### PR TITLE
Make bcrypt an explicit dependency

### DIFF
--- a/girder/models/password.py
+++ b/girder/models/password.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 ###############################################################################
 
+import bcrypt
 import cherrypy
 import hashlib
 import re
@@ -54,12 +55,6 @@ class Password(Model):
         if alg == 'sha512':
             return hashlib.sha512((password + salt).encode('utf8')).hexdigest()
         elif alg == 'bcrypt':
-            try:
-                import bcrypt
-            except ImportError:
-                raise Exception(
-                    'Bcrypt module is not installed. See girder.local.cfg.')
-
             password = password.encode('utf8')
 
             if salt is None:

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ with open('README.rst') as f:
     readme = f.read()
 
 installReqs = [
+    'bcrypt',
     'boto3',
     'botocore',
     # CherryPy version is restricted due to a bug in versions >=11.1


### PR DESCRIPTION
`bcrypt` is already being installed by `passlib` (see #2655) and it is the default implementation for hashing passwords.