### PR TITLE
Remove the ability to store girder configuration inside the package

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,6 +1,8 @@
 Configuration
 =============
 
+.. _configuration:
+
 In many cases, Girder will work with default configuration whether installed via
 pip or from a source checkout or tarball. That said, the Girder config file can
 be set at the following locations (ordered by precedent):
@@ -8,8 +10,6 @@ be set at the following locations (ordered by precedent):
 #. The path specified by the environment variable `GIRDER_CONFIG`.
 #. ~/.girder/girder.cfg
 #. /etc/girder.cfg
-#. /path/to/girder/package/conf/girder.local.cfg
-#. /path/to/girder/package/conf/girder.dist.cfg
 
 Logging
 -------

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -16,7 +16,7 @@ server.  For example, if you have a server accepting requests at
 
 Anytime you deploy behind a proxy, Girder must be configured properly in order to serve
 content correctly.  This can be accomplished by setting a few parameters in
-your local configuration file at ``girder/conf/girder.local.cfg``.  In this
+your local configuration file (see :ref:`Configuration <configuration>`).  In this
 example, we have the following:
 
 .. code-block:: ini

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -92,9 +92,10 @@ object is: ::
 There is a configuration file for Girder located in **girder/conf**. The file
 **girder.dist.cfg** is the file distributed with the repository and containing
 the default configuration values. This file should not be edited when deploying
-Girder. Rather, edit the **girder.local.cfg** file. You only need to edit the
+Girder. Rather, create a custom **girder.cfg** file and place it in one of the supported
+locations (see :ref:`Configuration <configuration>`). You only need to edit the
 values in the file that you wish to change from their default values; the system
-loads the **dist** file first, then the **local** file, so your local settings
+loads the **dist** file first, then the custom file, so your local settings
 will override the defaults.
 
 .. _client_development_js:

--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -293,6 +293,13 @@ The cookie access decorator has been removed
 
 The ``@access.cookie`` decorator has been removed.  To allow cookie authentication on an endpoint, include ``cookie=True`` as a parameter to one of the other access decorators (e.g., ``@access.user(cookie=True)``).
 
+Storing girder.local.cfg inside the package directory is no longer supported
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+In order to facilitate the ability to upgrade Girder using ``pip``, the user configuration file
+can no longer be stored inside the package directory since it would be deleted on upgrade. Users must
+now store their configuration in one of the approved locations, or use ``GIRDER_CONFIG`` to specify
+the exact location. See :ref:`the configuration documentation <configuration>` for more details.
+
 Removed or moved plugins
 ++++++++++++++++++++++++
 


### PR DESCRIPTION
This will allow Girder to be upgraded via `pip install --upgrade` without concerns that it would overwrite custom configuration.