### PR TITLE
Remove the "plugins" pip extra

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -50,28 +50,6 @@ install these libraries for you. Just run the following command: ::
 Once this is done, you are ready to start using Girder as described in this
 section: :ref:`run-girder`.
 
-Installing extra dependencies with pip
->>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-
-Girder comes bundled with a number of :doc:`plugins` that require extra Python
-dependencies in order to use.  By default, none of these dependencies will be
-installed; however, you can tell pip to install them using pip's
-"`extras`_ " syntax.  Each girder plugin requiring extra Python dependencies
-can be specified during the pip install.  For example, installing girder with
-support for the ``ldap`` and ``dicom_viewer`` plugins can be done like this: ::
-
-   pip install girder[ldap,dicom_viewer]
-
-There is also an extra you can use to install the dependencies for all bundled
-plugins supported in the current Python environment called ``plugins``: ::
-
-   pip install girder[plugins]
-
-.. warning:: Not all plugins are available in every Python version and platform.
-   Specifying a plugin in an unsupported environment will raise an error.
-
-.. _extras: https://packaging.python.org/en/latest/installing/#installing-setuptools-extras
-
 Install from Git repository
 +++++++++++++++++++++++++++
 

--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -312,10 +312,9 @@ Removed or moved plugins
 ++++++++++++++++++++++++
 
 Many plugins were either deleted from the main repository, or moved to other repositories. Plugins
-that were moved to other repositories will no longer be installed via the ``[plugins]`` extra when
-installing the ``girder`` python package, but can be installed by
-``pip install girder-[plugin_name]``. If you were depending on a plugin that was deleted
-altogether, please reach out to us on Discourse for discussion of a path forward.
+are no longer installable via a ``[plugins]`` extra when installing the ``girder`` Python package;
+rather, all are installed by ``pip install girder-[plugin_name]``. If you were depending on a plugin
+that was deleted altogether, please reach out to us on Discourse for discussion of a path forward.
 
 The following plugins were **deleted**:
 

--- a/setup.py
+++ b/setup.py
@@ -69,32 +69,13 @@ installReqs = [
 ]
 
 extrasReqs = {
-    'authorized_upload': ['girder-authorized-upload'],
-    'autojoin': ['girder-autojoin'],
-    'dicom_viewer': ['girder-dicom-viewer'],
-    'download_statistics': ['girder-download-statistics'],
-    'google_analytics': ['girder-google-analytics'],
-    'gravatar': ['girder-gravatar'],
-    'hashsum_download': ['girder-hashsum-download'],
-    'homepage': ['girder-homepage'],
-    'item_licenses': ['girder-item-licenses'],
-    'jobs': ['girder-jobs'],
-    'ldap': ['girder-ldap'],
-    'oauth': ['girder-oauth'],
-    'terms': ['girder-terms'],
-    'thumbnails': ['girder-thumbnails'],
-    'quota': ['girder-user-quota'],
-    'worker': ['girder-worker'],
-    'virtual_folders': ['girder-virtual-folders']
+    'sftp': [
+        'paramiko'
+    ],
+    'mount': [
+        'fusepy>=3.0'
+    ]
 }
-
-extrasReqs['plugins'] = list(set(itertools.chain.from_iterable(extrasReqs.values())))
-extrasReqs['sftp'] = [
-    'paramiko',
-]
-extrasReqs['mount'] = [
-    'fusepy>=3.0',
-]
 
 setup(
     name='girder',


### PR DESCRIPTION
Now that plugins are loaded upon installation, attempting to install all plugins via the `[plugins]` extra is ill-advised. The other extras aliases are no longer necessary.