### PR TITLE
Fix test for latest moto version

### DIFF
--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -878,11 +878,11 @@ class FileTestCase(base.TestCase):
     @moto.mock_s3
     def testS3Assetstore(self):
         botoParams = makeBotoConnectParams('access', 'secret')
-        mock_s3.createBucket(botoParams, 'b')
+        mock_s3.createBucket(botoParams, 'bname')
 
         Assetstore().remove(Assetstore().getCurrent())
         assetstore = Assetstore().createS3Assetstore(
-            name='test', bucket='b', accessKeyId='access', secret='secret',
+            name='test', bucket='bname', accessKeyId='access', secret='secret',
             prefix='test', serverSideEncryption=True)
         self.assetstore = assetstore
 
@@ -932,7 +932,7 @@ class FileTestCase(base.TestCase):
             S3, however we now no longer use the boto API to do so internally,
             and must mock this out at the level of requests.
             """
-            if url.netloc != 's3.amazonaws.com':
+            if url.netloc != 'bname.s3.amazonaws.com':
                 raise Exception('Unexpected request to host ' + url.netloc)
 
             body = request.body.read(65536)  # sufficient for now, we have short bodies
@@ -942,9 +942,9 @@ class FileTestCase(base.TestCase):
                 initRequests.append(request)
 
             # Actually set the key in moto
-            self.assertEqual(url.path[:3], '/b/')
+            self.assertTrue(url.path.startswith('/test/'))
             client = boto3.client('s3')
-            client.put_object(Bucket='b', Key=url.path[3:], Body=body)
+            client.put_object(Bucket='bname', Key=url.path[1:], Body=body)
 
             return {
                 'status_code': 200
@@ -995,7 +995,7 @@ class FileTestCase(base.TestCase):
         self.assertStatusOk(resp)
 
         # Make sure our metadata got updated in S3
-        obj = boto3.client('s3').get_object(Bucket='b', Key=file['s3Key'])
+        obj = boto3.client('s3').get_object(Bucket='bname', Key=file['s3Key'])
         self.assertEqual(obj['ContentDisposition'], 'attachment; filename="new name"')
         self.assertEqual(obj['ContentType'], 'application/csv')
 
@@ -1083,7 +1083,7 @@ class FileTestCase(base.TestCase):
         file = File().load(file['_id'], force=True)
 
         # Mock Serve range requests
-        @httmock.urlmatch(netloc=r'^s3.amazonaws.com')
+        @httmock.urlmatch(netloc=r'^bname.s3.amazonaws.com')
         def s3_range_mock(url, request):
             data = chunk1 + chunk2
             if request.headers.get('range', '').startswith('bytes='):


### PR DESCRIPTION
This fixes the broken test that is currently on master.

This accommodates two changes in the behavior of moto that changed in v1.3.8. First, it enforces bucket name minimum length. Second, it uses domain-name addressing for buckets.