### PR TITLE
Reduce npm warnings with girder-build

### DIFF
--- a/girder/web_client/package.json.template
+++ b/girder/web_client/package.json.template
@@ -1,7 +1,7 @@
 {
     "name": "@girder/meta-build",
     "description": "Girder meta-build",
-    "license": "SEE LICENSE IN OTHER MODULES",
+    "license": "Apache-2.0",
     "repository": {},
     "engines": {
         "node": ">=8.0",

--- a/girder/web_client/package.json.template
+++ b/girder/web_client/package.json.template
@@ -1,5 +1,8 @@
 {
     "name": "@girder/meta-build",
+    "description": "Girder meta-build",
+    "license": "SEE LICENSE IN OTHER MODULES",
+    "repository": {},
     "engines": {
         "node": ">=8.0",
         "npm": ">=5.2"


### PR DESCRIPTION
Every time we run girder build, npm warns that various fields aren't set in girder/meta-build.  This sets those fields to get rid of the warnings.