### PR TITLE
Remove unused "logs" directory in package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ MAINTAINER Kitware, Inc. <kitware@kitware.com>
 EXPOSE 8080
 
 RUN mkdir /girder
-RUN mkdir /girder/logs
 
 RUN apt-get update && apt-get install -qy \
     gcc \

--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -4,7 +4,6 @@ MAINTAINER Kitware, Inc. <kitware@kitware.com>
 EXPOSE 8080
 
 RUN mkdir /girder
-RUN mkdir /girder/logs
 
 RUN apt-get update && apt-get install -qy \
     gcc \

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
Logs default to "~/.girder/logs", and no code tries to set LOG_ROOT to "girder/logs" within the package directory.