### PR TITLE
Pre-3.0 deprecated symbol cleanout

### DIFF
--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -304,7 +304,9 @@ handler, you must call :py:func:`girder.events.unbind` on the existing mapping f
 Async keyword arguments and properties changed to async\_ PR #2817
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In version 3.7 of python ``async`` is a `reserved keyword argument <https://www.python.org/dev/peps/pep-0492/#deprecation-plans/>`_. To mitigate any issues all instances of ``async`` in the codebase has changed to ``async_``. If the functions are called with ``async`` a deprecation warning will be given. This affects:
+In version 3.7 of python ``async`` is a `reserved keyword argument <https://www.python.org/dev/peps/pep-0492/#deprecation-plans/>`_.
+To mitigate any issues all instances of ``async`` in the codebase has changed to ``asynchronous``.
+If the functions are called with ``async`` a deprecation warning will be given. This affects:
 
  * The event framework ``girder/events.py``
  * The built-in job plugin ``plugins/jobs/girder_jobs/models/job.py``

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -825,6 +825,8 @@ class Resource(object):
                 handler = registeredHandler
                 del nLengthRoutes[i]
                 break
+        else:
+            raise GirderException('No such route: %s %s' % (method, '/'.join(route)))
 
         # Remove the api doc
         if resource is None:

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -805,11 +805,9 @@ class Resource(object):
                 'WARNING: No access level specified for route %s %s' % (
                     method, routePath))
 
-    def removeRoute(self, method, route, handler=None, resource=None):
+    def removeRoute(self, method, route, resource=None):
         """
         Remove a route from the handler and documentation.
-
-        .. deprecated :: 2.3.0
 
         :param method: The HTTP method, e.g. 'GET', 'POST', 'PUT'
         :type method: str
@@ -817,9 +815,6 @@ class Resource(object):
                       resource root. Elements of this list starting with ':'
                       are assumed to be wildcards.
         :type route: tuple[str]
-        :param handler: The method called for the route; this is necessary to
-                        remove the documentation.
-        :type handler: Function
         :param resource: the name of the resource at the root of this route.
         """
         self._ensureInit()

--- a/girder/events.py
+++ b/girder/events.py
@@ -44,7 +44,7 @@ class Event(object):
 
     # We might have a lot of events, so we use __slots__ to make them smaller
     __slots__ = (
-        'async_',
+        'asynchronous',
         'info',
         'name',
         'propagate',
@@ -53,14 +53,14 @@ class Event(object):
         'currentHandlerName'
     )
 
-    def __init__(self, name, info, async_=False):
+    def __init__(self, name, info, asynchronous=False):
         self.name = name
         self.info = info
         self.propagate = True
         self.defaultPrevented = False
         self.responses = []
         self.currentHandlerName = None
-        self.async_ = async_
+        self.asynchronous = asynchronous
 
     def preventDefault(self):
         """
@@ -109,9 +109,9 @@ class ForegroundEventsDaemon(object):
 
     def trigger(self, eventName=None, info=None, callback=None):
         if eventName is None:
-            event = Event(None, info, async_=False)
+            event = Event(None, info, asynchronous=False)
         else:
-            event = trigger(eventName, info, async_=False, daemon=True)
+            event = trigger(eventName, info, asynchronous=False, daemon=True)
 
         if callable(callback):
             callback(event)
@@ -143,9 +143,9 @@ class AsyncEventsThread(threading.Thread):
             try:
                 eventName, info, callback = self.eventQueue.get(block=False)
                 if eventName is None:
-                    event = Event(None, info, async_=True)
+                    event = Event(None, info, asynchronous=True)
                 else:
-                    event = trigger(eventName, info, async_=True, daemon=True)
+                    event = trigger(eventName, info, asynchronous=True, daemon=True)
 
                 if callable(callback):
                     callback(event)
@@ -259,7 +259,7 @@ def bound(eventName, handlerName, handler):
         unbind(eventName, handlerName)
 
 
-def trigger(eventName, info=None, pre=None, async_=False, daemon=False):
+def trigger(eventName, info=None, pre=None, asynchronous=False, daemon=False):
     """
     Fire an event with the given name. All listeners bound on that name will be
     called until they are exhausted or one of the handlers calls the
@@ -274,15 +274,15 @@ def trigger(eventName, info=None, pre=None, async_=False, daemon=False):
         "info" key (the info arg to this function), and "eventName" and
         "handlerName" values.
     :type pre: function or None
-    :param async_: Whether this event is executing on the background thread
+    :param asynchronous: Whether this event is executing on the background thread
         (True) or on the request thread (False).
-    :type async_: bool
+    :type asynchronous: bool
     :param daemon: Whether this was triggered via ``girder.events.daemon``.
     :type daemon: bool
     """
-    e = Event(eventName, info, async_=async_)
+    e = Event(eventName, info, asynchronous=asynchronous)
     for name, handler in six.viewitems(_mapping.get(eventName, {})):
-        if daemon and not async_:
+        if daemon and not asynchronous:
             girder.logprint.warning(
                 'WARNING: Handler "%s" for event "%s" was triggered on the daemon, but is '
                 'actually running synchronously.' % (name, eventName))

--- a/girder/events.py
+++ b/girder/events.py
@@ -27,27 +27,10 @@ import contextlib
 import girder
 import six
 import threading
-from functools import wraps
-import warnings
 
 from collections import OrderedDict
 from girder.utility import config
 from six.moves import queue
-
-
-def _deprecatedAsync(func):
-    """A decorator, that let's us keep our old API, but deprecate it"""
-    @wraps(func)
-    def inner(*args, **kwargs):
-        if 'async' in kwargs:
-            if 'async_' in kwargs:
-                raise ValueError('cannot use both async and async_ '
-                                 'keyword arguments! the latter obsoletes the first.')
-            warnings.warn('async keyword argumnt is deprecated, '
-                          'use async_ instead', DeprecationWarning)
-            kwargs['async_'] = kwargs.pop('async')
-        return func(*args, **kwargs)
-    return inner
 
 
 class Event(object):
@@ -70,7 +53,6 @@ class Event(object):
         'currentHandlerName'
     )
 
-    @_deprecatedAsync
     def __init__(self, name, info, async_=False):
         self.name = name
         self.info = info
@@ -277,7 +259,6 @@ def bound(eventName, handlerName, handler):
         unbind(eventName, handlerName)
 
 
-@_deprecatedAsync
 def trigger(eventName, info=None, pre=None, async_=False, daemon=False):
     """
     Fire an event with the given name. All listeners bound on that name will be

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -9,7 +9,7 @@ import six
 from bson.objectid import ObjectId
 from bson.errors import InvalidId
 from pymongo.errors import WriteError
-from girder import events, logprint, auditLogger
+from girder import events, logprint, logger, auditLogger
 from girder.constants import AccessType, CoreEventHandler, ACCESS_FLAGS, TEXT_SCORE_SORT_MAX
 from girder.external.mongodb_proxy import MongoProxy
 from girder.models import getDbConnection
@@ -1416,7 +1416,10 @@ class AccessControlledModel(Model):
         :raises ValidationException: If an invalid ObjectId is passed.
         :returns: The matching document, or None if no match exists.
         """
+        # Warn of str type deprecation for `fields` param
         if isinstance(fields, six.string_types):
+            logger.warning('String data type for fields param is deprecated, '
+                           'use a list or dict instead.')
             fields = [fields]
 
         # Ensure we include access and public, they are needed by requireAccess

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -9,7 +9,7 @@ import six
 from bson.objectid import ObjectId
 from bson.errors import InvalidId
 from pymongo.errors import WriteError
-from girder import events, logprint, logger, auditLogger
+from girder import events, logprint, auditLogger
 from girder.constants import AccessType, CoreEventHandler, ACCESS_FLAGS, TEXT_SCORE_SORT_MAX
 from girder.external.mongodb_proxy import MongoProxy
 from girder.models import getDbConnection
@@ -1416,10 +1416,7 @@ class AccessControlledModel(Model):
         :raises ValidationException: If an invalid ObjectId is passed.
         :returns: The matching document, or None if no match exists.
         """
-        # Warn of str type deprecation for `fields` param
         if isinstance(fields, six.string_types):
-            logger.warning('String data type for fields param is deprecated, \
-                use a list or dict instead.')
             fields = [fields]
 
         # Ensure we include access and public, they are needed by requireAccess

--- a/girder/utility/webroot.py
+++ b/girder/utility/webroot.py
@@ -98,10 +98,7 @@ class Webroot(WebrootBase):
             templatePath = os.path.join(constants.PACKAGE_DIR, 'utility', 'webroot.mako')
         super(Webroot, self).__init__(templatePath)
 
-        self.vars = {
-            # 'title' is deprecated use brandName instead
-            'title': 'Girder'
-        }
+        self.vars = {}
 
     def _renderHTML(self):
         from girder.utility import server
@@ -119,8 +116,7 @@ class Webroot(WebrootBase):
         self.vars['apiRoot'] = server.getApiRoot()
         self.vars['staticPublicPath'] = server.getStaticPublicPath()
         self.vars['brandName'] = Setting().get(SettingKey.BRAND_NAME)
-        self.vars['contactEmail'] = Setting().get(
-            SettingKey.CONTACT_EMAIL_ADDRESS)
+        self.vars['contactEmail'] = Setting().get(SettingKey.CONTACT_EMAIL_ADDRESS)
         self.vars['privacyNoticeHref'] = Setting().get(SettingKey.PRIVACY_NOTICE)
         self.vars['bannerColor'] = Setting().get(SettingKey.BANNER_COLOR)
         self.vars['registrationPolicy'] = Setting().get(SettingKey.REGISTRATION_POLICY)

--- a/girder/web_client/src/rest.js
+++ b/girder/web_client/src/rest.js
@@ -137,27 +137,8 @@ let restRequest = function (opts) {
         delete args.girderToken;
     }
 
-    let jqXHR = Backbone.$.ajax(args);
-    jqXHR.error = function () {
-        console.warn('Use of restRequest.error is deprecated, use restRequest.fail instead.');
-        return jqXHR.fail.apply(jqXHR, arguments);
-    };
-    return jqXHR;
+    return Backbone.$.ajax(args);
 };
-
-const _originalRestRequest = restRequest;
-/**
- * @deprecated: will be removed in v3
- */
-function mockRestRequest(mock) {
-    restRequest = mock;
-}
-/**
- * @deprecated: will be removed in v3
- */
-function unmockRestRequest() {
-    restRequest = _originalRestRequest;
-}
 
 // All requests from Backbone should go through restRequest, adding authentication and the API root.
 Backbone.ajax = restRequest;
@@ -222,15 +203,12 @@ function setUploadChunkSize(val) {
 }
 
 export {
-    apiRoot, // deprecated
     getApiRoot,
     setApiRoot,
     uploadHandlers,
     restRequest,
     numberOutstandingRestRequests,
     cancelRestRequests,
-    mockRestRequest,
-    unmockRestRequest,
     getUploadChunkSize,
     setUploadChunkSize
 };

--- a/girder/web_client/src/views/widgets/EditCollectionWidget.js
+++ b/girder/web_client/src/views/widgets/EditCollectionWidget.js
@@ -81,16 +81,6 @@ const EditCollectionWidget = View.extend({
         return this;
     },
 
-    createCollection: function (fields) {
-        console.warn('The createCollection method is deprecated; use _saveCollection instead');
-        this._saveCollection(fields);
-    },
-
-    updateCollection: function (fields) {
-        console.warn('The updateCollection method is deprecated; use _saveCollection instead');
-        this._saveCollection(fields);
-    },
-
     _saveCollection: function (fields) {
         this.model.set(fields);
         return this.model.save()

--- a/girder/web_client/src/views/widgets/HierarchyWidget.js
+++ b/girder/web_client/src/views/widgets/HierarchyWidget.js
@@ -449,14 +449,6 @@ var HierarchyWidget = View.extend({
         confirm(params);
     },
 
-    /**
-     * Deprecated alias for showInfoDialog.
-     * @deprecated
-     */
-    folderInfoDialog: function () {
-        this.showInfoDialog();
-    },
-
     showInfoDialog: function () {
         var opts = {
             el: $('#g-dialog-container'),
@@ -921,14 +913,6 @@ var HierarchyWidget = View.extend({
                 this.refreshFolderList();
             }
         }, this);
-    },
-
-    /**
-     * Deprecated alias for editAccess.
-     * @deprecated
-     */
-    editFolderAccess: function () {
-        this.editAccess();
     },
 
     /**

--- a/girder/web_client/test/spec/folderSpec.js
+++ b/girder/web_client/test/spec/folderSpec.js
@@ -63,7 +63,7 @@ function _editFolder(button, buttonText, testValidation) {
 
         waitsFor(function () {
             return $('#g-dialog-container .g-markdown-text').val().indexOf(
-                '![fake.jpg](' + girder.rest.apiRoot) !== -1;
+                '![fake.jpg](' + girder.rest.getApiRoot()) !== -1;
         }, 'image to be attached to the markdown');
 
         runs(function () {

--- a/girder/web_client/test/spec/modelSpec.js
+++ b/girder/web_client/test/spec/modelSpec.js
@@ -120,8 +120,8 @@ describe('Test the model class', function () {
         triggerRestError = false;
 
         // test downloadUrl
-        expect(model.downloadUrl()).toBe(girder.rest.apiRoot + '/sampleResource/' + id + '/download');
-        expect(model.downloadUrl({foo: 'bar'})).toBe(girder.rest.apiRoot + '/sampleResource/' + id + '/download?foo=bar');
+        expect(model.downloadUrl()).toBe(girder.rest.getApiRoot() + '/sampleResource/' + id + '/download');
+        expect(model.downloadUrl({foo: 'bar'})).toBe(girder.rest.getApiRoot() + '/sampleResource/' + id + '/download?foo=bar');
 
         // test download
         window.location.assign.reset();

--- a/girder/web_client/test/spec/setApiSpec.js
+++ b/girder/web_client/test/spec/setApiSpec.js
@@ -8,11 +8,12 @@ describe('Test setApiRoot() function', function () {
 
         runs(function () {
             // Test the default values.
-            expect(girder.rest.apiRoot.slice(girder.rest.apiRoot.indexOf('/', 7))).toBe('/api/v1');
+            expect(girder.rest.getApiRoot().slice(
+                girder.rest.getApiRoot().indexOf('/', 7))).toBe('/api/v1');
 
             var apiRootVal = '/foo/bar/v2';
             girder.rest.setApiRoot(apiRootVal);
-            expect(girder.rest.apiRoot).toBe(apiRootVal);
+            expect(girder.rest.getApiRoot()).toBe(apiRootVal);
         });
     });
 });

--- a/girder/web_client/test/testUtils.js
+++ b/girder/web_client/test/testUtils.js
@@ -682,24 +682,6 @@ girderTest.importPlugin = function (pluginName) {
 };
 
 /**
- * An alias to addScript for backwards compatibility.
- * @deprecated
- */
-girderTest.addCoveredScript = function (url) {
-    console.warn('girderTest.addCoveredScript is deprecated, use girderTest.addScript instead');
-    girderTest.addScript(url);
-};
-
-/**
- * An alias to addScripts for backwards compatibility.
- * @deprecated
- */
-girderTest.addCoveredScripts = function (scripts) {
-    console.warn('girderTest.addCoveredScripts is deprecated, use girderTest.addScripts instead');
-    girderTest.addScripts(scripts);
-};
-
-/**
  * For the current folder, check if it is public or private and take an action.
  * :param current: either 'public' or 'private': expect this value to match.
  * :param action: if 'public' or 'private', switch to that setting.
@@ -1127,12 +1109,6 @@ girderTest.confirmDialog = function () {
     });
     girderTest.waitForLoad();
 };
-
-/**
- * @DEPRECATED TODO remove in major version
- * This is now a no-op since phantom 2.x has a Blob implementation
- */
-girderTest.shimBlobBuilder = $.noop;
 
 /*
  * Loads a particular fragment as anonymous and checks whether the login dialog

--- a/plugins/hashsum_download/plugin_tests/hashsumSpec.js
+++ b/plugins/hashsum_download/plugin_tests/hashsumSpec.js
@@ -39,7 +39,7 @@ describe('Unit test the file view augmentation', function () {
             expect(container.length).toBe(1);
             expect($('input.g-hash-textbox', container).val()).toBe(sha512);
             expect($('a.g-keyfile-download', container).attr('href')).toBe(
-                girder.rest.apiRoot + '/file/fake_id/hashsum_file/sha512'
+                girder.rest.getApiRoot() + '/file/fake_id/hashsum_file/sha512'
             );
         });
     });

--- a/plugins/jobs/girder_jobs/models/job.py
+++ b/plugins/jobs/girder_jobs/models/job.py
@@ -168,7 +168,6 @@ class Job(AccessControlledModel):
 
         return self.save(job)
 
-    @events._deprecatedAsync
     def createJob(self, title, type, args=(), kwargs=None, user=None, when=None,
                   interval=0, public=False, handler=None, async_=False,
                   save=True, parentJob=None, otherFields=None):

--- a/plugins/jobs/girder_jobs/models/job.py
+++ b/plugins/jobs/girder_jobs/models/job.py
@@ -29,7 +29,7 @@ class Job(AccessControlledModel):
 
         self.exposeFields(level=AccessType.READ, fields={
             'title', 'type', 'created', 'interval', 'when', 'status',
-            'progress', 'log', 'meta', '_id', 'public', 'parentId', 'async_',
+            'progress', 'log', 'meta', '_id', 'public', 'parentId', 'asynchronous',
             'updated', 'timestamps', 'handler', 'jobInfoSpec'})
 
         self.exposeFields(level=AccessType.SITE_ADMIN, fields={'args', 'kwargs'})
@@ -169,7 +169,7 @@ class Job(AccessControlledModel):
         return self.save(job)
 
     def createJob(self, title, type, args=(), kwargs=None, user=None, when=None,
-                  interval=0, public=False, handler=None, async_=False,
+                  interval=0, public=False, handler=None, asynchronous=False,
                   save=True, parentJob=None, otherFields=None):
         """
         Create a new job record.
@@ -197,9 +197,9 @@ class Job(AccessControlledModel):
         :param externalToken: If an external token was created for updating this
         job, pass it in and it will have the job-specific scope set.
         :type externalToken: token (dict) or None.
-        :param async_: Whether the job is to be run asynchronously. For now this
+        :param asynchronous: Whether the job is to be run asynchronously. For now this
             only applies to jobs that are scheduled to run locally.
-        :type async_: bool
+        :type asynchronous: bool
         :param save: Whether the documented should be saved to the database.
         :type save: bool
         :param parentJob: The job which will be set as a parent
@@ -233,7 +233,7 @@ class Job(AccessControlledModel):
             'log': [],
             'meta': {},
             'handler': handler,
-            'async_': async_,
+            'asynchronous': asynchronous,
             'timestamps': [],
             'parentId': parentId
         }
@@ -309,7 +309,7 @@ class Job(AccessControlledModel):
         actually scheduling and/or executing the job, except in the case when
         the handler is 'local'.
         """
-        if job.get('async_', job.get('async')) is True:
+        if job.get('asynchronous', job.get('async')) is True:
             events.daemon.trigger('jobs.schedule', info=job)
         else:
             events.trigger('jobs.schedule', info=job)

--- a/plugins/jobs/girder_jobs/models/job.py
+++ b/plugins/jobs/girder_jobs/models/job.py
@@ -127,20 +127,6 @@ class Job(AccessControlledModel):
             query, offset=offset, limit=limit, timeout=timeout, fields=fields,
             sort=sort, user=user, level=level, **kwargs)
 
-    def listAll(self, limit=0, offset=0, sort=None, currentUser=None):
-        """
-        List all jobs.
-
-        :param limit: The page limit.
-        :param offset: The page offset
-        :param sort: The sort field.
-        :param currentUser: User for access filtering.
-        .. deprecated :: 2.3.0
-           Use :func:`job.list` instead
-        """
-        return self.list(user='all', types=None, statuses=None, limit=limit,
-                         offset=offset, sort=sort, currentUser=currentUser)
-
     def cancelJob(self, job):
         """
         Revoke/cancel a job. This simply triggers the jobs.cancel event and

--- a/plugins/jobs/plugin_tests/jobs_test.py
+++ b/plugins/jobs/plugin_tests/jobs_test.py
@@ -187,10 +187,6 @@ class JobsTestCase(base.TestCase):
         self.assertStatusOk(resp)
         self.assertEqual(len(resp.json), 6)
 
-        # Test deprecated listAll method
-        jobs = list(self.jobModel.listAll(limit=0, offset=0, sort=None, currentUser=self.users[0]))
-        self.assertEqual(len(jobs), 6)
-
         # get with filter
         resp = self.request('/job/all', user=self.users[0], params={
             'types': json.dumps(['t']),

--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -1117,7 +1117,6 @@ plugins
                         getAllTypesAndStatuses
                         initialize
                         list
-                        listAll
                         listChildJobs
                         load
                         save


### PR DESCRIPTION
`git grep -i deprecate` was used to find lingering deprecations. This does not remove *all* deprecated things comprehensively, and in one case, actually un-deprecates a behavior, which may be controversial.

Most of these things won't be missed, but this should be looked over carefully.