### PR TITLE
improve the girder-client authenticate method: return the id of the connected user

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -323,6 +323,12 @@ class GirderClient(object):
 
             self.setToken(resp['authToken']['token'])
 
+        if not 'user' in resp.keys():
+            print('Error trying to retrieve the user id during authentication')
+            return None
+
+        return resp['user']['_id']
+
     def setToken(self, token):
         """
         Set a token on the GirderClient instance. This is useful in the case

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -323,7 +323,7 @@ class GirderClient(object):
 
             self.setToken(resp['authToken']['token'])
 
-        return resp['user']['_id']
+        return resp['user']
 
     def setToken(self, token):
         """

--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -323,10 +323,6 @@ class GirderClient(object):
 
             self.setToken(resp['authToken']['token'])
 
-        if not 'user' in resp.keys():
-            print('Error trying to retrieve the user id during authentication')
-            return None
-
         return resp['user']['_id']
 
     def setToken(self, token):


### PR DESCRIPTION
This PR is linked to issue #2987 .

With this PR, the `authenticate` method (girder-client) returns the id of the connected user instead of nothing.
`authenticate` does not return the full user as response given by the server is not consistent between
login+passwd   &  apiKey authentication methods, which would be error prone.

