### PR TITLE
Remove the "test" parameter from "resource/lookup"

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -533,17 +533,15 @@ class GirderClient(object):
 
         return self.get(route)
 
-    def resourceLookup(self, path, test=False):
+    def resourceLookup(self, path):
         """
         Look up and retrieve resource in the data hierarchy by path.
 
         :param path: The path of the resource. The path must be an absolute
             Unix path starting with either "/user/[user name]" or
             "/collection/[collection name]".
-        :param test: Whether or not to return None, if the path does not
-            exist, rather than throwing an exception.
         """
-        return self.get('resource/lookup', parameters={'path': path, 'test': test})
+        return self.get('resource/lookup', parameters={'path': path})
 
     def listResource(self, path, params=None, limit=None, offset=None):
         """
@@ -1703,7 +1701,9 @@ class GirderClient(object):
 
     def _checkResourcePath(self, objId):
         if isinstance(objId, six.string_types) and objId.startswith('/'):
-            obj = self.resourceLookup(objId, test=True)
-            if obj is not None:
-                return obj['_id']
+            try:
+                return self.resourceLookup(objId)['_id']
+            except requests.HTTPError:
+                return None
+
         return objId

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -110,16 +110,12 @@ class Resource(BaseResource):
                'path starting with either "/user/[user name]", for a user\'s '
                'resources or "/collection/[collection name]", for resources '
                'under a collection.')
-        .param('test',
-               'Specify whether to return None instead of throwing an '
-               'exception when path doesn\'t exist.',
-               required=False, dataType='boolean', default=False)
         .errorResponse('Path is invalid.')
         .errorResponse('Path refers to a resource that does not exist.')
         .errorResponse('Read access was denied for the resource.', 403)
     )
-    def lookup(self, path, test):
-        return path_util.lookUpPath(path, self.getCurrentUser(), test)['document']
+    def lookup(self, path):
+        return path_util.lookUpPath(path, self.getCurrentUser())['document']
 
     @access.public(scope=TokenScope.DATA_READ)
     @autoDescribeRoute(

--- a/girder/utility/path.py
+++ b/girder/utility/path.py
@@ -106,16 +106,12 @@ def lookUpToken(token, parentType, parent):
         parentType, parent.get('name', parent.get('_id')), token))
 
 
-def lookUpPath(path, user=None, test=False, filter=True, force=False):
+def lookUpPath(path, user=None, filter=True, force=False):
     """
     Look up a resource in the data hierarchy by path.
 
     :param path: path of the resource
     :param user: user with correct privileges to access path
-    :param test: defaults to false, when set to true
-        will return None instead of throwing exception when
-        path doesn't exist
-    :type test: bool
     :param filter: Whether the returned model should be filtered.
     :type filter: bool
     :param force: if True, don't validate the access.
@@ -130,26 +126,14 @@ def lookUpPath(path, user=None, test=False, filter=True, force=False):
         parent = User().findOne({'login': username})
 
         if parent is None:
-            if test:
-                return {
-                    'model': None,
-                    'document': None
-                }
-            else:
-                raise ResourcePathNotFound('User not found: %s' % username)
+            raise ResourcePathNotFound('User not found: %s' % username)
 
     elif model == 'collection':
         collectionName = pathArray[1]
         parent = Collection().findOne({'name': collectionName})
 
         if parent is None:
-            if test:
-                return {
-                    'model': None,
-                    'document': None
-                }
-            else:
-                raise ResourcePathNotFound('Collection not found: %s' % collectionName)
+            raise ResourcePathNotFound('Collection not found: %s' % collectionName)
 
     else:
         raise ValidationException('Invalid path format')
@@ -166,13 +150,7 @@ def lookUpPath(path, user=None, test=False, filter=True, force=False):
         # We should not distinguish the response between access and validation errors so that
         # adversarial users cannot discover the existence of data they don't have access to by
         # looking up a path.
-        if test:
-            return {
-                'model': None,
-                'document': None
-            }
-        else:
-            raise ResourcePathNotFound('Path not found: %s' % path)
+        raise ResourcePathNotFound('Path not found: %s' % path)
 
     if filter:
         document = ModelImporter.model(model).filter(document, user)

--- a/scripts/midas/migrate.py
+++ b/scripts/midas/migrate.py
@@ -181,7 +181,10 @@ def skip(bc):
 
 def lookup_resource(bc):
     path = '/' + '/'.join(bc)
-    return gc.resourceLookup(path, True)
+    try:
+        return gc.resourceLookup(path)
+    except requests.HTTPError:
+        return None
 
 def get_or_create(type, id, timestamp, bc, func, args):
     newObj = created(type, id)

--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -187,11 +187,9 @@ class AssetstoreTestCase(base.TestCase):
         self.assertStatusOk(resp)
 
         resp = self.request('/resource/lookup', user=self.admin, params={
-            'path': '/user/admin/Public/world.txt/world.txt',
-            'test': True
+            'path': '/user/admin/Public/world.txt/world.txt'
         })
-        self.assertStatusOk(resp)
-        self.assertIsNone(resp.json)
+        self.assertStatus(resp, 400)
 
         # Do the import with the include regex on
         resp = self.request(
@@ -210,11 +208,9 @@ class AssetstoreTestCase(base.TestCase):
 
         # world.txt should not
         resp = self.request('/resource/lookup', user=self.admin, params={
-            'path': '/user/admin/Public/world.txt/world.txt',
-            'test': True
+            'path': '/user/admin/Public/world.txt/world.txt'
         })
-        self.assertStatusOk(resp)
-        self.assertIsNone(resp.json)
+        self.assertStatus(resp, 400)
 
         # Run import without any regexes specified, all files should be imported
         resp = self.request(path, method='POST', params=params, user=self.admin)
@@ -986,7 +982,7 @@ class AssetstoreTestCase(base.TestCase):
             progress=ProgressContext(False), user=self.admin, leafFoldersAsItems=False)
 
         file = path_util.lookUpPath('/user/admin/Public/world.txt/world.txt',
-                                    self.admin, False)['document']
+                                    self.admin)['document']
 
         # Move file
         params = {

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -718,24 +718,14 @@ class PythonClientTestCase(base.TestCase):
         self.assertEqual(resp['message'],
                          'Path not found: %s' % (testInvalidPath))
 
-        # Test valid path, test = True
+        # Test valid path
         self.assertEqual(
-            self.client.resourceLookup(testPath, test=True)['_id'],
+            self.client.resourceLookup(testPath)['_id'],
             item['_id'])
 
-        # Test invalid path, test = True
-        self.assertEqual(
-            self.client.resourceLookup(testInvalidPath, test=True),
-            None)
-
-        # Test valid path, test = False
-        self.assertEqual(
-            self.client.resourceLookup(testPath, test=False)['_id'],
-            item['_id'])
-
-        # Test invalid path, test = False
+        # Test invalid path
         with self.assertRaises(requests.HTTPError) as cm:
-            self.client.resourceLookup(testInvalidPath, test=False)
+            self.client.resourceLookup(testInvalidPath)
 
         self.assertEqual(cm.exception.response.status_code, 400)
         self.assertEqual(cm.exception.request.method, 'GET')

--- a/tests/cases/resource_test.py
+++ b/tests/cases/resource_test.py
@@ -424,26 +424,14 @@ class ResourceTestCase(base.TestCase):
                 str(resp.json['_id']), str(item['_id']))
 
         # test bogus path
-        # test is not set
         resp = self.request(path='/resource/lookup',
                             method='GET', user=self.user,
                             params={'path': '/bogus/path'})
         self.assertStatus(resp, 400)
-        # test is set to false, response code should be 400
         resp = self.request(path='/resource/lookup',
                             method='GET', user=self.user,
-                            params={'path': '/collection/bogus/path',
-                                    'test': False})
+                            params={'path': '/collection/bogus/path'})
         self.assertStatus(resp, 400)
-
-        # test is set to true, response code should be 200 and response body
-        # should be null (None)
-        resp = self.request(path='/resource/lookup',
-                            method='GET', user=self.user,
-                            params={'path': '/collection/bogus/path',
-                                    'test': True})
-        self.assertStatusOk(resp)
-        self.assertEqual(resp.json, None)
 
     def testGetResourcePath(self):
         self._createFiles()


### PR DESCRIPTION
This functionality violates RESTful design and can easily be provided by client-side logic.