### PR TITLE
Use "Authorization" as the default header for Basic Auth

### DIFF
--- a/docs/developer-cookbook.rst
+++ b/docs/developer-cookbook.rst
@@ -19,10 +19,9 @@ login process requires the client to make an HTTP ``GET`` request to the
 ``api/v1/user/authentication`` route, using HTTP Basic Auth to pass the user
 credentials. For example, for a user with login "john" and password "hello",
 first base-64 encode the string ``"john:hello"`` which yields ``"am9objpoZWxsbw=="``.
-Then take the base-64 encoded value and pass it via the ``Girder-Authorization``
-header (The ``Authorization`` header will also work): ::
+Then take the base-64 encoded value and pass it via the ``Authorization`` header: ::
 
-    Girder-Authorization: Basic am9objpoZWxsbw==
+    Authorization: Basic am9objpoZWxsbw==
 
 If the username and password are correct, you will receive a 200 status code and
 a JSON document from which you can extract the authentication token, e.g.:

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -97,10 +97,10 @@ class User(Resource):
 
         # Only create and send new cookie if user isn't already sending a valid one.
         if not user:
-            authHeader = cherrypy.request.headers.get('Girder-Authorization')
+            authHeader = cherrypy.request.headers.get('Authorization')
 
             if not authHeader:
-                authHeader = cherrypy.request.headers.get('Authorization')
+                authHeader = cherrypy.request.headers.get('Girder-Authorization')
 
             if not authHeader or not authHeader[0:6] == 'Basic ':
                 raise RestException('Use HTTP Basic Authentication', 401)

--- a/girder/web_client/src/auth.js
+++ b/girder/web_client/src/auth.js
@@ -84,7 +84,7 @@ function login(username, password, cors = corsAuth, otpToken = null) {
     var auth = 'Basic ' + window.btoa(username + ':' + password);
 
     const headers = {
-        'Girder-Authorization': auth
+        'Authorization': auth
     };
     if (_.isString(otpToken)) {
         // Use _.isString to send header with empty string

--- a/pytest_girder/pytest_girder/utils.py
+++ b/pytest_girder/pytest_girder/utils.py
@@ -142,7 +142,7 @@ def request(path='/', method='GET', params=None, user=None,
             prefix='/api/v1', isJson=True, basicAuth=None, body=None,
             type=None, exception=False, cookie=None, token=None,
             additionalHeaders=None, useHttps=False,
-            authHeader='Girder-Authorization', appPrefix=''):
+            authHeader='Authorization', appPrefix=''):
     """
     Make an HTTP request.
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -438,7 +438,7 @@ class TestCase(unittest.TestCase):
                 prefix='/api/v1', isJson=True, basicAuth=None, body=None,
                 type=None, exception=False, cookie=None, token=None,
                 additionalHeaders=None, useHttps=False,
-                authHeader='Girder-Authorization', appPrefix=''):
+                authHeader='Authorization', appPrefix=''):
         """
         Make an HTTP request.
 

--- a/tests/cases/user_test.py
+++ b/tests/cases/user_test.py
@@ -109,13 +109,13 @@ class UserTestCase(base.TestCase):
         # Bad authentication header
         resp = self.request(
             path='/user/authentication', method='GET',
-            additionalHeaders=[('Girder-Authorization', 'Basic Not-Valid-64')])
+            additionalHeaders=[('Authorization', 'Basic Not-Valid-64')])
         self.assertStatus(resp, 401)
         self.assertEqual('Invalid HTTP Authorization header',
                          resp.json['message'])
         resp = self.request(
             path='/user/authentication', method='GET',
-            additionalHeaders=[('Girder-Authorization', 'Basic NotValid')])
+            additionalHeaders=[('Authorization', 'Basic NotValid')])
         self.assertStatus(resp, 401)
         self.assertEqual('Invalid HTTP Authorization header',
                          resp.json['message'])
@@ -147,10 +147,10 @@ class UserTestCase(base.TestCase):
         self.assertStatus(resp, 401)
         self.assertEqual('Login failed.', resp.json['message'])
 
-        # Login successfully with fallback Authorization header
+        # Login successfully with fallback Girder-Authorization header
         resp = self.request(path='/user/authentication', method='GET',
                             basicAuth='goodlogin:good:password',
-                            authHeader='Authorization')
+                            authHeader='Girder-Authorization')
         self.assertStatusOk(resp)
 
         # Test secure cookie validation


### PR DESCRIPTION
"Authorization" is a standard RFC7235 header, which is automatically supported by nearly any third-party HTTP client. Using "Authorization" as the preferred header makes it easier and less surprising to use third-party clients to authenticate with Girder.

"Girder-Authorization" remains supported by the server for compatibility.