### PR TITLE
Move the login regex out of the config file

### DIFF
--- a/girder/conf/girder.dist.cfg
+++ b/girder/conf/girder.dist.cfg
@@ -40,12 +40,6 @@ disable_event_daemon = False
 # log_max_info_level = "CRITICAL"
 
 [users]
-# Regular expression that logins must match. All logins are lower()ed before validation.
-login_regex = "^[a-z][\da-z\-\.]{3,}$"
-# Text that will be presented to the user if their login fails the regex
-login_description = "Login must be at least 4 characters, start with a letter, and may only contain \
-                     letters, numbers, dashes, and dots."
-
 # Regular expression that passwords must match
 password_regex = ".{6}.*"
 # Text that will be presented to the user if their password fails the regex

--- a/plugins/oauth/girder_oauth/providers/base.py
+++ b/plugins/oauth/girder_oauth/providers/base.py
@@ -4,11 +4,10 @@ import re
 import requests
 import six
 
-from girder.exceptions import RestException
+from girder.exceptions import RestException, ValidationException
 from girder.models.setting import Setting
 from girder.models.user import User
 from girder.settings import SettingKey
-from girder.utility import config
 
 from ..settings import PluginSettings
 
@@ -241,10 +240,10 @@ class ProviderBase(object):
         When attempting to generate a username, use this to test if the given
         name is valid.
         """
-        regex = config.getConfig()['users']['login_regex']
-
-        # Still doesn't match regex, we're hosed
-        if not re.match(regex, login):
+        try:
+            User()._validateLogin(login)
+        except ValidationException:
+            # Still doesn't match regex, we're hosed
             return False
 
         # See if this is already taken.

--- a/tests/cases/user_test.py
+++ b/tests/cases/user_test.py
@@ -83,8 +83,6 @@ class UserTestCase(base.TestCase):
         params['login'] = ' '
         resp = self.request(path='/user', method='POST', params=params)
         self.assertValidationError(resp, 'login')
-        self.assertEqual(cherrypy.config['users']['login_description'],
-                         resp.json['message'])
 
         params['login'] = 'goodlogin'
         resp = self.request(path='/user', method='POST', params=params)


### PR DESCRIPTION
This also fixes a Pytest warning from the CherryPy config file:
"DeprecationWarning: invalid escape sequence \d"