### PR TITLE
Remove path from auth token cookies

### DIFF
--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -1132,7 +1132,6 @@ class Resource(object):
 
         cookie = cherrypy.response.cookie
         cookie['girderToken'] = str(token['_id'])
-        cookie['girderToken']['path'] = '/'
         cookie['girderToken']['expires'] = int(days * 3600 * 24)
 
         if Setting().get(SettingKey.SECURE_COOKIE):
@@ -1146,7 +1145,6 @@ class Resource(object):
         """
         cookie = cherrypy.response.cookie
         cookie['girderToken'] = ''
-        cookie['girderToken']['path'] = '/'
         cookie['girderToken']['expires'] = 0
 
     # This is NOT wrapped in an endpoint decorator; we don't want that behavior


### PR DESCRIPTION
Somehow I only just ran into this bug, possibly a result of a recent Chrome update.

On my localhost:8080 domain, I had a girderToken cookie set *without* a path field, and the ones sent by the server on login did contain a path field. The one without the path field (the old, expired one) was taking precedence when reading `document.cookie`, which means that a hard page refresh reverted to a logged out state every time.

The correct behavior is not to set a path value at all.