### PR TITLE
Start Girder in production mode by default

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -26,6 +26,13 @@ For more options for building the web client, run: ::
 
     girder build --help
 
+Finally, you'll want to set your server into development mode. Add the following entry into your
+local config file (see :ref:`Configuration <configuration>` for instructions):
+
+.. code-block:: ini
+
+    [server]
+    mode="development"
 
 Vagrant
 ^^^^^^^

--- a/girder/conf/girder.dist.cfg
+++ b/girder/conf/girder.dist.cfg
@@ -9,7 +9,7 @@ replica_set = None
 
 [server]
 # Set to "production" or "development"
-mode = "development"
+mode = "production"
 api_root = "api/v1"
 static_public_path = "/static"
 


### PR DESCRIPTION
This optimizes Girder for a production environment (via "pip install") over a development environment (via "git clone"). This should significant improve security by default.