### PR TITLE
Do not run pytest tests via CTest

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,8 +62,6 @@ if(RUN_CORE_TESTS)
   add_python_test(py_client.cli BIND_SERVER RESOURCE_LOCKS py_client_test_dir)
   add_python_test(py_client.lib BIND_SERVER RESOURCE_LOCKS py_client_test_dir)
 
-  add_pytest_test(core)
-
   add_web_client_test(data_filesystem "${PROJECT_SOURCE_DIR}/girder/web_client/test/spec/dataSpec.js" ASSETSTORE filesystem)
   add_web_client_test(data_gridfs "${PROJECT_SOURCE_DIR}/girder/web_client/test/spec/dataSpec.js" ASSETSTORE gridfs)
   add_web_client_test(data_gridfsrs "${PROJECT_SOURCE_DIR}/girder/web_client/test/spec/dataSpec.js" ASSETSTORE gridfsrs RESOURCE_LOCKS replicaset REQUIRED_FILES "${MONGOD_EXECUTABLE}")

--- a/tests/PythonTests.cmake
+++ b/tests/PythonTests.cmake
@@ -12,8 +12,6 @@ else()
   set(_separator ":")
 endif()
 
-find_program(PYTEST_EXECUTABLE NAMES pytest)
-
 function(python_tests_init)
   add_test(
     NAME py_coverage_reset
@@ -161,18 +159,5 @@ function(add_python_test case)
     girder_ExternalData_add_target("${name}_data")
   endif()
 
-  set_property(TEST ${name} PROPERTY LABELS girder_python)
-endfunction()
-
-function(add_pytest_test case)
-  set(name "server_pytest_${case}")
-
-  add_test(
-    NAME ${name}
-    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-    COMMAND "${PYTEST_EXECUTABLE}" --tb=long --cov-append
-  )
-  set_property(TEST ${name} APPEND PROPERTY DEPENDS py_coverage_reset)
-  set_property(TEST py_coverage_combine APPEND PROPERTY DEPENDS ${name})
   set_property(TEST ${name} PROPERTY LABELS girder_python)
 endfunction()


### PR DESCRIPTION
Reverts 56348ee549badd80ba0637b2d452cea005195ffb

@manthey what was the original rationale for doing this? It was causing our pytest suite to run twice in a row in CI.
