### PR TITLE
Vagrant improvements

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,6 +37,7 @@ eos
 
   config.vm.provision "ansible_local" do |ansible|
     ansible.compatibility_mode = '2.0'
+    ansible.config_file = 'devops/vagrant/ansible.cfg'
     ansible.galaxy_role_file = 'devops/vagrant/vagrant-requirements.yml'
     ansible.playbook = "devops/vagrant/vagrant-playbook.yml"
     ansible.provisioning_path = "/home/vagrant/girder"

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,0 @@
-[defaults]
-roles_path = devops/

--- a/devops/vagrant/ansible.cfg
+++ b/devops/vagrant/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = ..

--- a/devops/vagrant/vagrant-requirements.yml
+++ b/devops/vagrant/vagrant-requirements.yml
@@ -1,2 +1,3 @@
 ---
 - src: girder.mongodb
+  version: master


### PR DESCRIPTION
* Move the Vagrant Ansible config to the "devops/vagrant" folder
* Use the latest version of "girder.mongodb" to provision with Vagrant