### PR TITLE
Set cookie security from HTTPS status, not production mode

### DIFF
--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -1135,7 +1135,9 @@ class Resource(object):
         cookie['girderToken']['path'] = '/'
         cookie['girderToken']['expires'] = int(days * 3600 * 24)
 
-        if Setting().get(SettingKey.SECURE_COOKIE):
+        # CherryPy proxy tools modify the request.base, but not request.scheme, when receiving
+        # X-Forwarded-Proto headers from a reverse proxy
+        if cherrypy.request.scheme == 'https' or cherrypy.request.base.startswith('https'):
             cookie['girderToken']['secure'] = True
 
         return token

--- a/girder/settings.py
+++ b/girder/settings.py
@@ -8,7 +8,7 @@ import six
 
 from girder.constants import GIRDER_ROUTE_ID
 from girder.exceptions import ValidationException
-from girder.utility import config, setting_utilities
+from girder.utility import setting_utilities
 
 
 class SettingKey(object):
@@ -36,7 +36,6 @@ class SettingKey(object):
     PRIVACY_NOTICE = 'core.privacy_notice'
     REGISTRATION_POLICY = 'core.registration_policy'
     ROUTE_TABLE = 'core.route_table'
-    SECURE_COOKIE = 'core.secure_cookie'
     SERVER_ROOT = 'core.server_root'
     SMTP_ENCRYPTION = 'core.smtp.encryption'
     SMTP_HOST = 'core.smtp_host'
@@ -84,7 +83,6 @@ class SettingDefault(object):
         SettingKey.PRIVACY_NOTICE: 'https://www.kitware.com/privacy',
         SettingKey.REGISTRATION_POLICY: 'open',
         # SettingKey.ROUTE_TABLE is provided by a function
-        # SettingKey.SECURE_COOKIE is provided by a function
         SettingKey.SERVER_ROOT: '',
         SettingKey.SMTP_ENCRYPTION: 'none',
         SettingKey.SMTP_HOST: 'localhost',
@@ -110,11 +108,6 @@ class SettingDefault(object):
         return {
             GIRDER_ROUTE_ID: '/'
         }
-
-    @staticmethod
-    @setting_utilities.default(SettingKey.SECURE_COOKIE)
-    def _defaultSecureCookie():
-        return config.getConfig()['server']['mode'] == 'production'
 
 
 class SettingValidator(object):
@@ -303,12 +296,6 @@ class SettingValidator(object):
 
         if len(nonEmptyRoutes) > len(set(nonEmptyRoutes)):
             raise ValidationException('Routes must be unique.', 'value')
-
-    @staticmethod
-    @setting_utilities.validator(SettingKey.SECURE_COOKIE)
-    def _validateSecureCookie(doc):
-        if not isinstance(doc['value'], bool):
-            raise ValidationException('Secure cookie option must be boolean.', 'value')
 
     @staticmethod
     @setting_utilities.validator(SettingKey.SERVER_ROOT)

--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -749,7 +749,6 @@ girder
             PRIVACY_NOTICE
             REGISTRATION_POLICY
             ROUTE_TABLE
-            SECURE_COOKIE
             SERVER_ROOT
             SMTP_ENCRYPTION
             SMTP_HOST


### PR DESCRIPTION
First, this completely removes the SECURE_COOKIE setting from Girder. Since this setting never had a GUI for setting it, it is unlikely that most end users would have configured it.

Second, this no longer sets Girder's cookie "secure" attribute based on production vs development mode. Since Girder now starts in production mode by default, developers running Girder from a Git checkout for the first time will typically be in production mode with an HTTP connection.

Rather, this causes Girder to now auto-detect the scheme of the incoming request (for which the cookie is being set), and set the "secure" attribute accordingly. In production environments, this will by detected by CherryPy's proxy tools via the "X-Forwarded-Proto" header, which reverse proxies should set. In test mode, the HTTPS status must
simulated differently, since CherryPy proxy tools cannot be easily enabled.

From now on, an absent or misconfigured reverse proxy in production mode will cause Girder to gracefully degrade to using less secure cookies, rather than breaking.