### PR TITLE
Remove duplicated MetadataWidget from collection view

### DIFF
--- a/girder/web_client/src/templates/body/collectionPage.pug
+++ b/girder/web_client/src/templates/body/collectionPage.pug
@@ -34,5 +34,3 @@
   .g-clear-right
 
 .g-collection-hierarchy-container
-
-.g-collection-metadata

--- a/girder/web_client/src/views/body/CollectionView.js
+++ b/girder/web_client/src/views/body/CollectionView.js
@@ -119,13 +119,6 @@ var CollectionView = View.extend({
         this.folderCreate = false;
         this.itemCreate = false;
 
-        this.metadataWidget = new MetadataWidget({
-            el: this.$('.g-collection-metadata'),
-            item: this.model,
-            accessLevel: this.model.getAccessLevel(),
-            parentView: this
-        });
-
         if (this.edit) {
             this.editCollection();
         } else if (this.access) {

--- a/girder/web_client/src/views/body/CollectionView.js
+++ b/girder/web_client/src/views/body/CollectionView.js
@@ -3,7 +3,6 @@ import _ from 'underscore';
 
 import AccessWidget from '@girder/core/views/widgets/AccessWidget';
 import CollectionModel from '@girder/core/models/CollectionModel';
-import MetadataWidget from '@girder/core/views/widgets/MetadataWidget';
 import EditCollectionWidget from '@girder/core/views/widgets/EditCollectionWidget';
 import FolderModel from '@girder/core/models/FolderModel';
 import HierarchyWidget from '@girder/core/views/widgets/HierarchyWidget';

--- a/girder/web_client/src/views/widgets/HierarchyWidget.js
+++ b/girder/web_client/src/views/widgets/HierarchyWidget.js
@@ -294,6 +294,19 @@ var HierarchyWidget = View.extend({
             }
         }
 
+        if (this.parentModel.resourceName === 'collection' && this._showMetadata) {
+            if (!this.metadataWidget) {
+                this.metadataWidget = new MetadataWidget({
+                    item: this.parentModel,
+                    parentView: this,
+                    accessLevel: this.parentModel.getAccessLevel()
+                });
+            }
+            this.metadataWidget.setItem(this.parentModel);
+            this.metadataWidget.accessLevel = this.parentModel.getAccessLevel();
+            this.metadataWidget.setElement(this.$('.g-folder-metadata')).render();
+        }
+
         if (this.upload) {
             this.uploadDialog();
         } else if (this.folderAccess) {


### PR DESCRIPTION
Since the HierarchyWidget already takes care of instantiating the
MetadataWidget, this commit removes the one explicitly associated
with the collection.

![image](https://user-images.githubusercontent.com/219043/59480665-835c9280-8e2f-11e9-9748-d28870663a26.png)
