### PR TITLE
Run stylint via npm only

### DIFF
--- a/.circleci/ci_test.cmake
+++ b/.circleci/ci_test.cmake
@@ -13,7 +13,6 @@ if(test_group STREQUAL python)
     -DVIRTUALENV_EXECUTABLE=$ENV{VIRTUALENV_EXECUTABLE}
     -DPYTHON_STATIC_ANALYSIS=ON
     -DBUILD_JAVASCRIPT_TESTS=OFF
-    -DJAVASCRIPT_STYLE_TESTS=OFF
   )
 
   set(_test_labels "girder_python")
@@ -23,7 +22,6 @@ elseif(test_group STREQUAL browser)
     -DPYTHON_EXECUTABLE=$ENV{PYTHON_EXECUTABLE}
     -DPYTHON_STATIC_ANALYSIS=OFF
     -DBUILD_JAVASCRIPT_TESTS=ON
-    -DJAVASCRIPT_STYLE_TESTS=ON
   )
 
   set(_test_labels "girder_browser")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,6 @@ set(PYTHON_VERSION "2.7" CACHE STRING "Python version used for testing")
 find_package(PythonInterp ${PYTHON_VERSION} REQUIRED)
 
 option(PYTHON_STATIC_ANALYSIS "Run Python static analysis tests with flake8" ON)
-option(JAVASCRIPT_STYLE_TESTS "Run Javascript style tests with eslint" ON)
 option(BUILD_JAVASCRIPT_TESTS "Build Javascript tests" ON)
 option(RUN_CORE_TESTS "Whether to run the core tests" ON)
 set(TEST_PLUGINS "" CACHE STRING "List of plugins to test. Leave empty to test all plugins")

--- a/package.json
+++ b/package.json
@@ -94,7 +94,10 @@
         "temp-directory": "build/test/coverage/web_temp"
     },
     "pugLintConfig": {
-        "extends": "girder"
+        "extends": "girder",
+        "excludeFiles": [
+          "**/node_modules/"
+        ]
     },
     "stylintrc": {
         "blocks": false,
@@ -129,7 +132,7 @@
             "error": true
         },
         "exclude": [
-            "node_modules/**/*"
+            "**/node_modules/**"
         ],
         "extendPref": "@extend",
         "globalDupe": false,

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "stylint": "^1.5.9"
     },
     "scripts": {
-        "lint": "eslint --cache .  ; pug-lint . ; stylint girder/web_client/src/stylesheets",
+        "lint": "eslint --cache .  ; pug-lint . ; stylint",
         "docs": "esdoc"
     },
     "esdoc": {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -108,17 +108,15 @@ macro(add_standard_plugin_tests)
   # Add a set of basic tests for a plugin.
   # This will add:
   #   * Server static analysis, if a server component exists.
-  #   * Client static analysis (for both Javascript and Pug), if a web_client component exists.
   #   * Server plugin_tests and associated static analysis, if they exist.
-  #   * Client plugin_tests and associated static analysis, if they exist as "*Spec.js" files.
+  #   * Client plugin_tests, if they exist as "*Spec.js" files.
   #
   # Optional parameters:
   #   * NO_SERVER: Never add server static analysis.
-  #   * NO_CLIENT: Never add client static analysis.
   #   * NO_SERVER_TESTS: Never add server plugin_tests and associated static analysis.
   #   * NO_CLIENT_TESTS: Never add client plugin_tests and associated static analysis.
 
-  set(_options NO_SERVER NO_CLIENT NO_SERVER_TESTS NO_CLIENT_TESTS)
+  set(_options NO_SERVER NO_SERVER_TESTS NO_CLIENT_TESTS)
   set(_args "PACKAGE")
   set(_multival_args "")
   cmake_parse_arguments(_fn "${_options}" "${_args}" "${_multival_args}" ${ARGN})
@@ -130,10 +128,6 @@ macro(add_standard_plugin_tests)
   # Server static analysis
   if(IS_DIRECTORY "${_packageDir}" AND (NOT _fn_NO_SERVER))
     add_python_style_test(python_static_analysis_${_pluginName} "${_packageDir}")
-  endif()
-
-  # Client static analysis
-  if(IS_DIRECTORY "${_packageDir}/web_client" AND (NOT _fn_NO_CLIENT))
   endif()
 
   # Server plugin_tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -134,9 +134,6 @@ macro(add_standard_plugin_tests)
 
   # Client static analysis
   if(IS_DIRECTORY "${_packageDir}/web_client" AND (NOT _fn_NO_CLIENT))
-    if(IS_DIRECTORY "${_packageDir}/web_client/stylesheets")
-      add_stylint_test(${_pluginName} "${_packageDir}/web_client/stylesheets")
-    endif()
   endif()
 
   # Server plugin_tests

--- a/tests/JavascriptTests.cmake
+++ b/tests/JavascriptTests.cmake
@@ -18,19 +18,6 @@ function(javascript_tests_init)
   set_property(TEST js_coverage_combine_report PROPERTY LABELS girder_coverage)
 endfunction()
 
-function(add_stylint_test name path)
-  if (NOT JAVASCRIPT_STYLE_TESTS)
-    return()
-  endif()
-
-  add_test(
-    NAME "stylint_${name}"
-    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-    COMMAND npx stylint "${path}"
-  )
-  set_property(TEST "stylint_${name}" PROPERTY LABELS girder_browser)
-endfunction()
-
 function(add_web_client_test case specFile)
   # test a web client using a spec file and the specRunner
   # :param case: the name of this test case

--- a/tests/clients/CMakeLists.txt
+++ b/tests/clients/CMakeLists.txt
@@ -1,3 +1,1 @@
-add_subdirectory(web)
-
 add_python_style_test(python_static_analysis_python_client "${PROJECT_SOURCE_DIR}/clients/python")

--- a/tests/clients/web/CMakeLists.txt
+++ b/tests/clients/web/CMakeLists.txt
@@ -1,1 +1,0 @@
-# All of our core javascript will be checked with a single test

--- a/tests/clients/web/CMakeLists.txt
+++ b/tests/clients/web/CMakeLists.txt
@@ -1,2 +1,1 @@
 # All of our core javascript will be checked with a single test
-add_stylint_test(core "${PROJECT_SOURCE_DIR}/girder/web_client/src/stylesheets")


### PR DESCRIPTION
* Run stylint via npm only
* Remove CMake harness for Javascript style testing
* Fix lint ignores for nested node_modules