### PR TITLE
Fail on the first failing linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "stylint": "^1.5.9"
     },
     "scripts": {
-        "lint": "eslint --cache .  ; pug-lint . ; stylint",
+        "lint": "eslint --cache . && pug-lint . && stylint",
         "docs": "esdoc"
     },
     "esdoc": {
@@ -96,7 +96,7 @@
     "pugLintConfig": {
         "extends": "girder",
         "excludeFiles": [
-          "**/node_modules/"
+            "**/node_modules/"
         ]
     },
     "stylintrc": {


### PR DESCRIPTION
Otherwise, if any but the last linter fails, `npm run lint` will still return success.