### PR TITLE
Include web client fonts via npm package

### DIFF
--- a/clients/web/src/main.js
+++ b/clients/web/src/main.js
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import _ from 'underscore';
 import Backbone from 'backbone';
 import moment from 'moment';
+import 'typeface-open-sans';
 import * as girder from 'girder';
 
 window.girder = girder;

--- a/clients/web/src/package.json
+++ b/clients/web/src/package.json
@@ -1,34 +1,35 @@
 {
-    "name": "girder",
-    "version": "2.5.0",
-    "description": "Extensible data management platform",
-    "homepage": "https://girder.readthedocs.org",
-    "bugs": {
-        "url": "https://github.com/girder/girder/issues"
-    },
-    "license": "Apache-2.0",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/girder/girder.git"
-    },
-    "dependencies": {
-        "as-jqplot": "~1.0.8",
-        "backbone": "~1.3.3",
-        "bootstrap": "~3.3.7",
-        "bootstrap-switch": "3.3.4",
-        "eonasdan-bootstrap-datetimepicker": "~4.17",
-        "jquery": "~3.2.1",
-        "jsoneditor": "~5.9.3",
-        "moment": "~2.20.1",
-        "qrcode": "~1.2.0",
-        "remarkable": "~1.7.1",
-        "sprintf-js": "~1.1.1",
-        "swagger-ui": "~2.2.10",
-        "underscore": "~1.8.3",
-        "url-otpauth": "~2.0.0"
-    },
-    "main": "./index.js",
-    "scripts": {
-        "prepublishOnly": "node _prepublish.js"
-    }
+  "name": "girder",
+  "version": "2.5.0",
+  "description": "Extensible data management platform",
+  "homepage": "https://girder.readthedocs.org",
+  "bugs": {
+    "url": "https://github.com/girder/girder/issues"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/girder/girder.git"
+  },
+  "dependencies": {
+    "as-jqplot": "~1.0.8",
+    "backbone": "~1.3.3",
+    "bootstrap": "~3.3.7",
+    "bootstrap-switch": "3.3.4",
+    "eonasdan-bootstrap-datetimepicker": "~4.17",
+    "jquery": "~3.2.1",
+    "jsoneditor": "~5.9.3",
+    "moment": "~2.20.1",
+    "qrcode": "~1.2.0",
+    "remarkable": "~1.7.1",
+    "sprintf-js": "~1.1.1",
+    "swagger-ui": "~2.2.10",
+    "typeface-open-sans": "0.0.54",
+    "underscore": "~1.8.3",
+    "url-otpauth": "~2.0.0"
+  },
+  "main": "./index.js",
+  "scripts": {
+    "prepublishOnly": "node _prepublish.js"
+  }
 }

--- a/girder/api/api_docs.mako
+++ b/girder/api/api_docs.mako
@@ -3,7 +3,6 @@
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>${brandName | h} - REST API Documentation</title>
-    <link rel="stylesheet" href="${staticRoot}/built/googlefonts.css">
     <link rel="stylesheet" href="${staticRoot}/built/fontello/css/fontello.css">
     <link rel="stylesheet" href="${staticRoot}/built/swagger/css/reset.css">
     <link rel="stylesheet" href="${staticRoot}/built/swagger/css/screen.css">

--- a/girder/utility/webroot.mako
+++ b/girder/utility/webroot.mako
@@ -3,7 +3,6 @@
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>${brandName | h}</title>
-    <link rel="stylesheet" href="${staticRoot}/built/googlefonts.css">
     <link rel="stylesheet" href="${staticRoot}/built/fontello/css/fontello.css">
     <link rel="stylesheet" href="${staticRoot}/built/fontello/css/animation.css">
     <link rel="stylesheet" href="${staticRoot}/built/girder_lib.min.css">

--- a/grunt_tasks/build.js
+++ b/grunt_tasks/build.js
@@ -21,7 +21,6 @@ const _ = require('underscore');
 const extendify = require('extendify');
 const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
-const GoogleFontsPlugin = require('google-fonts-webpack-plugin');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 
 const isTrue = (str) => !!str && !['false', 'off', '0'].includes(str.toString().toLowerCase());
@@ -154,13 +153,6 @@ module.exports = function (grunt) {
                     new ExtractTextPlugin({
                         filename: '[name].min.css',
                         allChunks: true
-                    }),
-                    new GoogleFontsPlugin({
-                        filename: 'googlefonts.css',
-                        fonts: [{
-                            family: 'Open Sans',
-                            variants: ['regular', '700', 'italic', '700italic']
-                        }]
                     })
                 ]
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4352,33 +4352,6 @@
             "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
             "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
         },
-        "google-fonts-webpack-plugin": {
-            "version": "0.4.4",
-            "resolved": "https://registry.npmjs.org/google-fonts-webpack-plugin/-/google-fonts-webpack-plugin-0.4.4.tgz",
-            "integrity": "sha512-+e2D9/DVBG9EDydRovzoqMZ658SsTBGbC0c65GyZqkwNvdj8vRSYQKXqbz7/yt7QaXsCPT1MpH45r3ivWOitcw==",
-            "requires": {
-                "lodash": "^4.17.4",
-                "node-fetch": "^1.6.3",
-                "webpack-sources": "^0.2.0",
-                "yauzl": "^2.8.0"
-            },
-            "dependencies": {
-                "source-list-map": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-1.1.2.tgz",
-                    "integrity": "sha1-mIkBnRAkzOVc3AaUmDN+9hhqEaE="
-                },
-                "webpack-sources": {
-                    "version": "0.2.3",
-                    "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.2.3.tgz",
-                    "integrity": "sha1-F8Yr+vE8cH+dAsR54Nzd6DgGl/s=",
-                    "requires": {
-                        "source-list-map": "^1.1.1",
-                        "source-map": "~0.5.3"
-                    }
-                }
-            }
-        },
         "graceful-fs": {
             "version": "4.1.15",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
         "extract-text-webpack-plugin": "^2.1.2",
         "file-loader": "^0.11.2",
         "girder": "file:./clients/web/src",
-        "google-fonts-webpack-plugin": "^0.4.0",
         "grunt": "^1.0.1",
         "grunt-cli": "^1.2.0",
         "grunt-contrib-copy": "^1.0.0",


### PR DESCRIPTION
Backport pull request #2908 to the 2.x-maintenance branch to remove the
use of google-fonts-webpack-helper. Resolve issue #3088.
