### PR TITLE
Remove support for MongoDB sharding

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,7 +254,7 @@ jobs:
             sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
             echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
             sudo apt-get update
-            sudo apt-get install -y mongodb-org-server mongodb-org-mongos
+            sudo apt-get install -y mongodb-org-server
       - run:
           # Boto doesn't work as a library if there is a /etc/boto.cfg file
           # from a different version of Python, so remove the file.
@@ -380,7 +380,7 @@ jobs:
             sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
             echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
             sudo apt-get update
-            sudo apt-get install -y mongodb-org-server mongodb-org-mongos
+            sudo apt-get install -y mongodb-org-server
       - run:
           # The "d3" npm package (required by some Girder plugins) has an optional dependency of
           # "canvas", which requires "node-gyp" to build. node-gyp strictly requires Python 2

--- a/girder/api/v1/assetstore.py
+++ b/girder/api/v1/assetstore.py
@@ -63,8 +63,6 @@ class Assetstore(Resource):
         .param('db', 'Database name (for GridFS type)', required=False)
         .param('mongohost', 'Mongo host URI (for GridFS type)', required=False)
         .param('replicaset', 'Replica set name (for GridFS type)', required=False)
-        .param('shard', 'Shard the collection (for GridFS type).  Set to '
-               '"auto" to set up sharding.', required=False)
         .param('bucket', 'The S3 bucket to store data in (for S3 type).', required=False)
         .param('prefix', 'Optional path prefix within the bucket under which '
                'files will be stored (for S3 type).', required=False, default='')
@@ -88,7 +86,7 @@ class Assetstore(Resource):
         .errorResponse()
         .errorResponse('You are not an administrator.', 403)
     )
-    def createAssetstore(self, name, type, root, perms, db, mongohost, replicaset, shard, bucket,
+    def createAssetstore(self, name, type, root, perms, db, mongohost, replicaset, bucket,
                          prefix, accessKeyId, secret, service, readOnly, region, inferCredentials,
                          serverSideEncryption):
         if type == AssetstoreType.FILESYSTEM:
@@ -98,7 +96,7 @@ class Assetstore(Resource):
         elif type == AssetstoreType.GRIDFS:
             self.requireParams({'db': db})
             return self._model.createGridFsAssetstore(
-                name=name, db=db, mongohost=mongohost, replicaset=replicaset, shard=shard)
+                name=name, db=db, mongohost=mongohost, replicaset=replicaset)
         elif type == AssetstoreType.S3:
             self.requireParams({'bucket': bucket})
             return self._model.createS3Assetstore(
@@ -159,8 +157,6 @@ class Assetstore(Resource):
         .param('db', 'Database name (for GridFS type)', required=False)
         .param('mongohost', 'Mongo host URI (for GridFS type)', required=False)
         .param('replicaset', 'Replica set name (for GridFS type)', required=False)
-        .param('shard', 'Shard the collection (for GridFS type).  Set to '
-               '"auto" to set up sharding.', required=False)
         .param('bucket', 'The S3 bucket to store data in (for S3 type).', required=False)
         .param('prefix', 'Optional path prefix within the bucket under which '
                'files will be stored (for S3 type).', required=False, default='')
@@ -185,7 +181,7 @@ class Assetstore(Resource):
         .errorResponse()
         .errorResponse('You are not an administrator.', 403)
     )
-    def updateAssetstore(self, assetstore, name, root, perms, db, mongohost, replicaset, shard,
+    def updateAssetstore(self, assetstore, name, root, perms, db, mongohost, replicaset,
                          bucket, prefix, accessKeyId, secret, service, readOnly, region, current,
                          inferCredentials, serverSideEncryption, params):
         assetstore['name'] = name
@@ -203,8 +199,6 @@ class Assetstore(Resource):
                 assetstore['mongohost'] = mongohost
             if replicaset is not None:
                 assetstore['replicaset'] = replicaset
-            if shard is not None:
-                assetstore['shard'] = shard
         elif assetstore['type'] == AssetstoreType.S3:
             self.requireParams({
                 'bucket': bucket
@@ -224,7 +218,7 @@ class Assetstore(Resource):
                 'assetstore': assetstore,
                 'params': dict(
                     name=name, current=current, readOnly=readOnly, root=root, perms=perms,
-                    db=db, mongohost=mongohost, replicaset=replicaset, shard=shard, bucket=bucket,
+                    db=db, mongohost=mongohost, replicaset=replicaset, bucket=bucket,
                     prefix=prefix, accessKeyId=accessKeyId, secret=secret, service=service,
                     region=region, **params
                 )

--- a/girder/models/assetstore.py
+++ b/girder/models/assetstore.py
@@ -121,15 +121,14 @@ class Assetstore(Model):
         })
 
     def createGridFsAssetstore(self, name, db, mongohost=None,
-                               replicaset=None, shard=None):
+                               replicaset=None):
         return self.save({
             'type': AssetstoreType.GRIDFS,
             'created': datetime.datetime.utcnow(),
             'name': name,
             'db': db,
             'mongohost': mongohost,
-            'replicaset': replicaset,
-            'shard': shard
+            'replicaset': replicaset
         })
 
     def createS3Assetstore(self, name, bucket, accessKeyId, secret, prefix='',

--- a/girder/utility/system.py
+++ b/girder/utility/system.py
@@ -55,15 +55,10 @@ def _computeSlowStatus(process, status, db):
             # exception
             pass
     status['mongoDbStats'] = db.command('dbStats')
-    try:
-        # I don't know if this will work with a sharded database, so guard
-        # it and don't throw an exception
-        status['mongoDbPath'] = getDbConnection().admin.command(
-            'getCmdLineOpts')['parsed']['storage']['dbPath']
-        status['mongoDbDiskUsage'] = _objectToDict(
-            psutil.disk_usage(status['mongoDbPath']))
-    except Exception:
-        pass
+    status['mongoDbPath'] = getDbConnection().admin.command(
+        'getCmdLineOpts')['parsed']['storage']['dbPath']
+    status['mongoDbDiskUsage'] = _objectToDict(
+        psutil.disk_usage(status['mongoDbPath']))
 
     status['processDirectChildrenCount'] = len(process.children())
     status['processAllChildrenCount'] = len(process.children(True))

--- a/girder/web_client/src/templates/widgets/editAssetstoreWidget.pug
+++ b/girder/web_client/src/templates/widgets/editAssetstoreWidget.pug
@@ -29,10 +29,6 @@
             .form-group
               label.control-label(for="g-edit-gridfs-replicaset") Replica Set
               input#g-edit-gridfs-replicaset.input-sm.form-control(type="text", placeholder="Replica set name (blank if not using a replica set)")
-            .checkbox
-              label(title="If the Mongo Host supports sharding, this requests that the database support sharding and shards the GridFS collection using an appropriate index.")
-                input#g-edit-gridfs-shard-auto(type="checkbox")
-                | Shard collection
           if assetstore.get('type') === types.S3
             .form-group
               label.control-label(for="g-edit-s3-bucket") S3 bucket name

--- a/girder/web_client/src/templates/widgets/newAssetstore.pug
+++ b/girder/web_client/src/templates/widgets/newAssetstore.pug
@@ -60,10 +60,6 @@
             label.control-label(for="g-new-gridfs-replicaset") Replica Set
             input#g-new-gridfs-replicaset.input-sm.form-control(
                 type="text", placeholder="Replica set name (blank if not using a replica set)")
-          .checkbox
-            label(title="If the Mongo Host supports sharding, this requests that the database support sharding and shards the GridFS collection using an appropriate index.")
-              input#g-new-gridfs-shard-auto(type="checkbox")
-              | Shard collection
           p#g-new-gridfs-error.g-validation-failed-message
           input.g-new-assetstore-submit.btn.btn-sm.btn-primary(type="submit", value="Create")
 

--- a/girder/web_client/src/views/widgets/EditAssetstoreWidget.js
+++ b/girder/web_client/src/views/widgets/EditAssetstoreWidget.js
@@ -105,15 +105,13 @@ fieldsMap[AssetstoreType.GRIDFS] = {
         return {
             db: this.$('#g-edit-gridfs-db').val(),
             mongohost: this.$('#g-edit-gridfs-mongohost').val(),
-            replicaset: this.$('#g-edit-gridfs-replicaset').val(),
-            shard: this.$('#g-edit-gridfs-shard-auto').is(':checked') ? 'auto' : false
+            replicaset: this.$('#g-edit-gridfs-replicaset').val()
         };
     },
     set: function () {
         this.$('#g-edit-gridfs-db').val(this.model.get('db'));
         this.$('#g-edit-gridfs-mongohost').val(this.model.get('mongohost'));
         this.$('#g-edit-gridfs-replicaset').val(this.model.get('replicaset'));
-        this.$('#g-edit-gridfs-shard-auto').attr('checked', this.model.get('shard') === 'auto');
     }
 };
 

--- a/girder/web_client/src/views/widgets/NewAssetstoreWidget.js
+++ b/girder/web_client/src/views/widgets/NewAssetstoreWidget.js
@@ -29,8 +29,7 @@ var NewAssetstoreWidget = View.extend({
                 name: this.$('#g-new-gridfs-name').val(),
                 db: this.$('#g-new-gridfs-db').val(),
                 mongohost: this.$('#g-new-gridfs-mongohost').val(),
-                replicaset: this.$('#g-new-gridfs-replicaset').val(),
-                shard: this.$('#g-new-gridfs-shard-auto').is(':checked') ? 'auto' : false
+                replicaset: this.$('#g-new-gridfs-replicaset').val()
             });
         },
 

--- a/girder/web_client/test/spec/adminSpec.js
+++ b/girder/web_client/test/spec/adminSpec.js
@@ -535,8 +535,7 @@ describe('Test the assetstore page', function () {
         'g-new-gridfs-db': 'girder_webclient_gridfsrs',
         'g-new-gridfs-mongohost': 'mongodb://127.0.0.2:27080,127.0.0.2:27081,' +
                                   '127.0.0.2:27082/?serverSelectionTimeoutMS=250',
-        'g-new-gridfs-replicaset': 'replicaset',
-        'g-new-gridfs-shard-auto': false
+        'g-new-gridfs-replicaset': 'replicaset'
     }, null, function () {
         return $('.g-validation-failed-message:contains(' +
                  '"Could not connect to the database: ")').length === 1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,12 +4,6 @@ if("${MONGOD_EXECUTABLE}" STREQUAL "MONGOD_EXECUTABLE-NOTFOUND")
   set(MONGOD_EXECUTABLE "local mongod required")
 endif()
 
-# Test if mongos is present for tests that require it.
-find_program(MONGOS_EXECUTABLE mongod)
-if("${MONGOS_EXECUTABLE}" STREQUAL "MONGOS_EXECUTABLE-NOTFOUND")
-  set(MONGOS_EXECUTABLE "local mongos required")
-endif()
-
 python_tests_init()
 javascript_tests_init()
 
@@ -42,7 +36,7 @@ if(RUN_CORE_TESTS)
   add_python_test(system)
   set_property(TEST server_system PROPERTY LABELS girder_integration)
   # Upload test uses mongo replicaset and a lot of resources, so we run it by itself
-  add_python_test(upload RUN_SERIAL RESOURCE_LOCKS replicaset REQUIRED_FILES "${MONGOD_EXECUTABLE}" "${MONGOS_EXECUTABLE}")
+  add_python_test(upload RUN_SERIAL RESOURCE_LOCKS replicaset REQUIRED_FILES "${MONGOD_EXECUTABLE}")
   set_property(TEST server_upload PROPERTY LABELS girder_integration)
   add_python_test(user)
   add_python_test(setup_database)
@@ -55,10 +49,6 @@ if(RUN_CORE_TESTS)
   add_web_client_test(data_gridfsrs "${PROJECT_SOURCE_DIR}/girder/web_client/test/spec/dataSpec.js" ASSETSTORE gridfsrs RESOURCE_LOCKS replicaset REQUIRED_FILES "${MONGOD_EXECUTABLE}")
   if (BUILD_JAVASCRIPT_TESTS)
     set_property(TEST web_client_data_gridfsrs PROPERTY LABELS girder_integration)
-  endif()
-  add_web_client_test(data_gridfsshard "${PROJECT_SOURCE_DIR}/girder/web_client/test/spec/dataSpec.js" ASSETSTORE gridfsshard RESOURCE_LOCKS replicaset REQUIRED_FILES "${MONGOD_EXECUTABLE}" "${MONGOS_EXECUTABLE}")
-  if (BUILD_JAVASCRIPT_TESTS)
-    set_property(TEST web_client_data_gridfsshard PROPERTY LABELS girder_integration)
   endif()
   add_web_client_test(data_s3 "${PROJECT_SOURCE_DIR}/girder/web_client/test/spec/dataSpec.js" ASSETSTORE s3 WEBSECURITY false)
   add_web_client_test(admin "${PROJECT_SOURCE_DIR}/girder/web_client/test/spec/adminSpec.js" ASSETSTORE s3 WEBSECURITY false

--- a/tests/base.py
+++ b/tests/base.py
@@ -155,8 +155,7 @@ class TestCase(unittest.TestCase):
         database before each test. We then add an assetstore so the file model
         can be used without 500 errors.
         :param assetstoreType: if 'gridfs' or 's3', use that assetstore.
-            'gridfsrs' uses a GridFS assetstore with a replicaset, and
-            'gridfsshard' one with a sharding server.  For any other value, use
+            'gridfsrs' uses a GridFS assetstore with a replicaset. For any other value, use
             a filesystem assetstore.
         """
         self.assetstoreType = assetstoreType
@@ -178,14 +177,6 @@ class TestCase(unittest.TestCase):
                 name='Test', db=gridfsDbName,
                 mongohost='mongodb://127.0.0.1:27070,127.0.0.1:27071,'
                 '127.0.0.1:27072', replicaset='replicaset')
-        elif assetstoreType == 'gridfsshard':
-            gridfsDbName = 'girder_test_%s_shard_assetstore_auto' % assetstoreName
-            self.replicaSetConfig = mongo_replicaset.makeConfig(
-                port=27073, shard=True, sharddb=None)
-            mongo_replicaset.startMongoReplicaSet(self.replicaSetConfig)
-            self.assetstore = Assetstore().createGridFsAssetstore(
-                name='Test', db=gridfsDbName,
-                mongohost='mongodb://127.0.0.1:27073', shard='auto')
         elif assetstoreType == 's3':
             self.assetstore = Assetstore().createS3Assetstore(
                 name='Test', bucket='bucketname', accessKeyId='test',
@@ -208,7 +199,7 @@ class TestCase(unittest.TestCase):
         Stop any services that we started just for this test.
         """
         # If "self.setUp" is overridden, "self.assetstoreType" may not be set
-        if getattr(self, 'assetstoreType', None) in ('gridfsrs', 'gridfsshard'):
+        if getattr(self, 'assetstoreType', None) == 'gridfsrs':
             mongo_replicaset.stopMongoReplicaSet(self.replicaSetConfig)
 
         # Invalidate cache regions which persist across tests


### PR DESCRIPTION
This support adds significant code complexity and will likely never be needed for any deployment of Girder. Support for MongoDB replica sets remains intact.