### PR TITLE
Fix a test failure caused by upstream flake8-docstring bugs

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -33,6 +33,7 @@ httmock
 mock
 mongomock
 moto[server]>=1.3.7
+pydocstyle<4
 pytest>=3.6
 pytest-cov<2.6
 pytest-xdist

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ deps =
     flake8-blind-except
     flake8-bugbear
     flake8-docstrings>=1.3
+    pydocstyle<4
     flake8-quotes
     pep8-naming
 commands = flake8 {posargs}


### PR DESCRIPTION
The issue is tracked at: https://gitlab.com/pycqa/flake8-docstrings/issues/36