### PR TITLE
Fix for  _passArg in the describe API

### DIFF
--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -629,6 +629,8 @@ class autoDescribeRoute(describeRoute):  # noqa: class name
             params = {k: v for k, v in six.viewitems(kwargs) if k != 'params'}
             params.update(kwargs.get('params', {}))
 
+            kwargs['params'] = kwargs.get('params', {})
+
             for descParam in self.description.params:
                 # We need either a type or a schema ( for message body )
                 if 'type' not in descParam and 'schema' not in descParam:


### PR DESCRIPTION
The `_passArg` function may add arguments with a given name into the  `params` kwargs but it did notcheck the existence of `params` a priori. This PR fix this behavior.
