### PR TITLE
Make Python 3.6 the minimum Py3 version and improve CI Dockerfiles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -486,15 +486,6 @@ jobs:
       - checkout:
           path: girder
       - run:
-          name: Create virtual environment (if necessary)
-          command: if [ ! -d girder_env ]; then virtualenv girder_env; fi
-      - run:
-          name: Activate virtual environment
-          command: echo ". $CIRCLE_WORKING_DIRECTORY/girder_env/bin/activate" >> $BASH_ENV
-      - run:
-          name: Install tox
-          command: pip install --upgrade pip tox
-      - run:
           name: Test public symbols
           command: tox -e public_names
           working_directory: girder
@@ -509,35 +500,17 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          name: Create virtual environment (if necessary)
-          command: if [ ! -d girder_env ]; then virtualenv girder_env; fi
-      - run:
-          name: Activate virtual environment
-          command: echo ". $CIRCLE_WORKING_DIRECTORY/girder_env/bin/activate" >> $BASH_ENV
-      - run:
-          name: Install tox
-          command: pip install --upgrade pip tox
-      - run:
           name: Run Ansible tests
           command: tox -e ansible
           working_directory: girder
 
   release:
     docker:
-      - image: circleci/python:2.7
+      - image: girder/girder_test:latest-py3
     working_directory: /home/circleci/project
     steps:
       - checkout:
           path: girder
-      - run:
-          name: Create virtual environment (if necessary)
-          command: if [ ! -d girder_env ]; then virtualenv girder_env; fi
-      - run:
-          name: Activate virtual environment
-          command: echo ". $CIRCLE_WORKING_DIRECTORY/girder_env/bin/activate" >> $BASH_ENV
-      - run:
-          name: Install tox
-          command: pip install --upgrade pip tox
       - run:
           name: Publish python packages
           command: tox -e release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
           name: Generate python environment checksum file
           command: ./girder/.circleci/generatePyEnvChecksum.sh > girder/py-env-checksum
       - restore_cache:
-          key: venv-py3.5-{{ arch }}-{{ checksum "girder/py-env-checksum" }}
+          key: venv-py3.6-{{ arch }}-{{ checksum "girder/py-env-checksum" }}
       - run:
           name: Create virtual environment (if necessary)
           command: if [ ! -d girder_env ]; then python3 -m venv girder_env; fi
@@ -107,7 +107,7 @@ jobs:
             pyclean girder_env
       - save_cache:
           paths: girder_env
-          key: venv-py3.5-{{ arch }}-{{ checksum "girder/py-env-checksum" }}
+          key: venv-py3.6-{{ arch }}-{{ checksum "girder/py-env-checksum" }}
       - persist_to_workspace:
           root: /home/circleci/project
           paths:
@@ -137,12 +137,12 @@ jobs:
           command: ctest --extra-verbose --script "$CIRCLE_WORKING_DIRECTORY/girder/.circleci/ci_test.cmake" --exclude-regex '^server_pytest_core$'
           environment:
             TEST_GROUP: python
-            PYTHON_VERSION: 3.5
+            PYTHON_VERSION: 3.6
             PYTHON_EXECUTABLE: /home/circleci/project/girder_env/bin/python
           working_directory: girder_build
       - run:
           name: Run tox
-          command: tox -e lint,circleci-py35,docs
+          command: tox -e lint,circleci-py36,docs
           working_directory: girder
       - store_test_results:
           path: girder/build/test/results
@@ -193,7 +193,7 @@ jobs:
           command: ctest --extra-verbose --script "$CIRCLE_WORKING_DIRECTORY/girder/.circleci/ci_test.cmake"
           environment:
             TEST_GROUP: browser
-            PYTHON_VERSION: 3.5
+            PYTHON_VERSION: 3.6
             PYTHON_EXECUTABLE: /home/circleci/project/girder_env/bin/python
             JASMINE_TIMEOUT: 15000
           working_directory: girder_build
@@ -389,10 +389,10 @@ jobs:
           name: Allow Boto to work with Python 3
           command: sudo rm --force /etc/boto.cfg
       - run:
-          name: Set up Python 3.5
+          name: Set up Python 3.6
           command: |
-             pyenv install 3.5.4 || true
-             pyenv global 3.5.4
+             pyenv install 3.6.3 || true
+             pyenv global 3.6.3
       - run:
           name: Create and activate virtual environment
           command: |
@@ -420,7 +420,7 @@ jobs:
             girder build --dev | cat
       - run:
           name: CMake
-          command: cmake ../girder -DPYTHON_VERSION=3.5 -DPYTHON_EXECUTABLE=/home/circleci/.virtualenvs/girder/bin/python
+          command: cmake ../girder -DPYTHON_VERSION=3.6 -DPYTHON_EXECUTABLE=/home/circleci/.virtualenvs/girder/bin/python
           working_directory: girder_build
       - run:
           name: make
@@ -457,7 +457,7 @@ jobs:
           command: ctest --extra-verbose --script "$CIRCLE_WORKING_DIRECTORY/girder/.circleci/ci_test.cmake"
           environment:
             TEST_GROUP: coverage
-            PYTHON_VERSION: 3.5
+            PYTHON_VERSION: 3.6
             PYTHON_EXECUTABLE: /home/circleci/project/girder_env/bin/python
             JASMINE_TIMEOUT: 15000
             BUILD_JAVASCRIPT_TESTS: "ON"
@@ -559,7 +559,7 @@ jobs:
           name: Generate python environment checksum file
           command: ./girder/.circleci/generatePyEnvChecksum.sh > girder/py-env-checksum
       - restore_cache:
-          key: venv-py3.5-{{ arch }}-{{ checksum "girder/py-env-checksum" }}
+          key: venv-py3.6-{{ arch }}-{{ checksum "girder/py-env-checksum" }}
       - run:
           name: Activate virtual environment
           command: echo ". $CIRCLE_WORKING_DIRECTORY/girder_env/bin/activate" >> $BASH_ENV

--- a/.circleci/girder_test_py2/Dockerfile
+++ b/.circleci/girder_test_py2/Dockerfile
@@ -20,7 +20,6 @@ RUN apt-get update \
 # Install Girder development prereqs
 RUN apt-get update \
   && apt-get install --assume-yes \
-# CMake < 3.1 does not install properly from binaries, so fetch 3.0 from packages
     cmake
 
 USER circleci

--- a/.circleci/girder_test_py2/Dockerfile
+++ b/.circleci/girder_test_py2/Dockerfile
@@ -1,5 +1,5 @@
 FROM circleci/python:2.7
-MAINTAINER Kitware, Inc. <kitware@kitware.com>
+LABEL maintainer="Kitware, Inc. <kitware@kitware.com>"
 
 # Don't use "sudo"
 USER root

--- a/.circleci/girder_test_py2/Dockerfile
+++ b/.circleci/girder_test_py2/Dockerfile
@@ -20,6 +20,10 @@ RUN apt-get update \
 # Install Girder development prereqs
 RUN apt-get update \
   && apt-get install --assume-yes \
-    cmake
+    cmake \
+  && pip install --no-cache --upgrade \
+    pip \
+    setuptools \
+    tox
 
 USER circleci

--- a/.circleci/girder_test_py2/Dockerfile
+++ b/.circleci/girder_test_py2/Dockerfile
@@ -6,17 +6,21 @@ USER root
 
 # Install Node.js 8
 RUN curl --silent --location https://deb.nodesource.com/setup_8.x | bash - \
-  && apt-get install --assume-yes nodejs \
-  && npm install --global npm
+  && apt-get install --assume-yes \
+    nodejs \
+  && npm install --global \
+    npm
 
 # Install Girder system prereqs (including those for all plugins)
-RUN apt-get update && apt-get install --assume-yes \
+RUN apt-get update \
+  && apt-get install --assume-yes \
     libldap2-dev \
     libsasl2-dev
 
 # Install Girder development prereqs
+RUN apt-get update \
+  && apt-get install --assume-yes \
 # CMake < 3.1 does not install properly from binaries, so fetch 3.0 from packages
-RUN apt-get update && apt-get install --assume-yes \
     cmake
 
 USER circleci

--- a/.circleci/girder_test_py2/Dockerfile
+++ b/.circleci/girder_test_py2/Dockerfile
@@ -7,7 +7,7 @@ USER root
 # Install Node.js 8
 RUN curl --silent --location https://deb.nodesource.com/setup_8.x | bash - \
   && apt-get install --assume-yes \
-    nodejs \
+    'nodejs=8.*' \
   && npm install --global \
     npm
 

--- a/.circleci/girder_test_py3/Dockerfile
+++ b/.circleci/girder_test_py3/Dockerfile
@@ -10,7 +10,8 @@ RUN curl --silent --location https://deb.nodesource.com/setup_10.x | bash - \
   && npm install --global npm
 
 # Install Girder system prereqs (including those for all plugins)
-RUN apt-get update && apt-get install --assume-yes \
+RUN apt-get update \
+  && apt-get install --assume-yes \
     libldap2-dev \
     libsasl2-dev
 

--- a/.circleci/girder_test_py3/Dockerfile
+++ b/.circleci/girder_test_py3/Dockerfile
@@ -1,13 +1,8 @@
-FROM circleci/python:3.6
+FROM circleci/python:3.6-node
 LABEL maintainer="Kitware, Inc. <kitware@kitware.com>"
 
 # Don't use "sudo"
 USER root
-
-# Install Node.js 10
-RUN curl --silent --location https://deb.nodesource.com/setup_10.x | bash - \
-  && apt-get install --assume-yes nodejs \
-  && npm install --global npm
 
 # Install Girder system prereqs (including those for all plugins)
 RUN apt-get update \

--- a/.circleci/girder_test_py3/Dockerfile
+++ b/.circleci/girder_test_py3/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/python:3.5
+FROM circleci/python:3.6
 MAINTAINER Kitware, Inc. <kitware@kitware.com>
 
 # Don't use "sudo"

--- a/.circleci/girder_test_py3/Dockerfile
+++ b/.circleci/girder_test_py3/Dockerfile
@@ -16,13 +16,9 @@ RUN apt-get update \
     libsasl2-dev
 
 # Install Girder development prereqs
-# Get a very recent version of CMake
-RUN mkdir --parents "/opt/cmake" \
-  && curl --location "https://cmake.org/files/v3.12/cmake-3.12.2-Linux-x86_64.tar.gz" | \
-    gunzip --stdout | \
-    tar --extract --directory "/opt/cmake" --strip-components 1 \
-  && ln --symbolic --force "/opt/cmake/bin/cmake" "/usr/local/bin/cmake" \
-  && ln --symbolic --force "/opt/cmake/bin/ctest" "/usr/local/bin/ctest" \
+RUN apt-get update \
+  && apt-get install --assume-yes \
+    cmake \
   # Note: universal-ctags is installed for use in the public_names CI job.
   && git clone "https://github.com/universal-ctags/ctags.git" "./ctags" \
   && cd ./ctags \

--- a/.circleci/girder_test_py3/Dockerfile
+++ b/.circleci/girder_test_py3/Dockerfile
@@ -22,6 +22,10 @@ RUN apt-get update \
   && make \
   && make install \
   && cd .. \
-  && rm -rf ./ctags
+  && rm -rf ./ctags \
+  && pip3 install --no-cache --upgrade \
+    pip \
+    setuptools \
+    tox
 
 USER circleci

--- a/.circleci/girder_test_py3/Dockerfile
+++ b/.circleci/girder_test_py3/Dockerfile
@@ -1,5 +1,5 @@
 FROM circleci/python:3.6
-MAINTAINER Kitware, Inc. <kitware@kitware.com>
+LABEL maintainer="Kitware, Inc. <kitware@kitware.com>"
 
 # Don't use "sudo"
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:8-stretch
-MAINTAINER Kitware, Inc. <kitware@kitware.com>
+LABEL maintainer="Kitware, Inc. <kitware@kitware.com>"
 
 EXPOSE 8080
 

--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -1,5 +1,5 @@
 FROM node:8-stretch
-MAINTAINER Kitware, Inc. <kitware@kitware.com>
+LABEL maintainer="Kitware, Inc. <kitware@kitware.com>"
 
 EXPOSE 8080
 

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -7,7 +7,7 @@ Server Install
 --------------
 Installation of Girder's server has the following system dependencies:
 
-* `Python <https://www.python.org>`_ v2.7 or v3.5+
+* `Python <https://www.python.org>`_ v2.7 or v3.6+
 
   * This is necessary to run most of the server software.
 
@@ -15,8 +15,8 @@ Installation of Girder's server has the following system dependencies:
                Namely, the ``hdfs_assetstore`` plugin and the ``metadata_extractor`` plugin will only be available in a
                Python v2.7 environment.
 
-  .. note:: Girder performs continuous integration testing using Python v2.7 and Python v3.5. Girder *should* work on
-            newer Python v3.6+ versions as well, but that support is not verified by Girder's automated testing at this
+  .. note:: Girder performs continuous integration testing using Python v2.7 and Python v3.6. Girder *should* work on
+            newer Python v3.7+ versions as well, but that support is not verified by Girder's automated testing at this
             time, so use at your own risk.
 
 * `pip <https://pip.pypa.io/>`_ v8.1+

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -110,7 +110,7 @@ will override the defaults.
 Server Development
 ------------------
 
-All commits to the core python code must work in both python 2.7 and 3.5.
+All commits to the core python code must work in both python 2.7 and 3.6.
 Python code in plugins should also work in both, but some plugins may depend
 on third party libraries that do not support python 3. If that is the case, those
 plugins should declare ``"python_requires<3.0`` in their **setup.py** file
@@ -222,7 +222,7 @@ environments. By default, running ``tox`` will create a virtual environment, ins
 dependencies, install Girder, and run ``pytest`` for each version of Python that Girder supports.
 
 Sometimes it might be desirable to only run ``tox`` against a single Python environment, such as
-Python 3.5. To do this run ``tox -e py35``. Note that a list of valid environments can be found by
+Python 3.6. To do this run ``tox -e py36``. Note that a list of valid environments can be found by
 running ``tox -a``.
 
 Specific arguments can be passed through to ``pytest`` by adding them after the ``tox``

--- a/plugins/audit_logs/setup.py
+++ b/plugins/audit_logs/setup.py
@@ -36,7 +36,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.6'
     ],
     packages=find_packages(),
     zip_safe=False,

--- a/plugins/authorized_upload/setup.py
+++ b/plugins/authorized_upload/setup.py
@@ -39,7 +39,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.6'
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/autojoin/setup.py
+++ b/plugins/autojoin/setup.py
@@ -38,7 +38,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.6'
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/dicom_viewer/setup.py
+++ b/plugins/dicom_viewer/setup.py
@@ -38,7 +38,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.6'
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/download_statistics/setup.py
+++ b/plugins/download_statistics/setup.py
@@ -37,7 +37,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.6'
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/google_analytics/setup.py
+++ b/plugins/google_analytics/setup.py
@@ -38,7 +38,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.6'
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/gravatar/setup.py
+++ b/plugins/gravatar/setup.py
@@ -38,7 +38,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.6'
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/hashsum_download/setup.py
+++ b/plugins/hashsum_download/setup.py
@@ -38,7 +38,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.6'
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/homepage/setup.py
+++ b/plugins/homepage/setup.py
@@ -38,7 +38,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.6'
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/item_licenses/setup.py
+++ b/plugins/item_licenses/setup.py
@@ -37,7 +37,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.6'
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/jobs/setup.py
+++ b/plugins/jobs/setup.py
@@ -38,7 +38,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.6'
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/ldap/setup.py
+++ b/plugins/ldap/setup.py
@@ -37,7 +37,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.6'
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/oauth/setup.py
+++ b/plugins/oauth/setup.py
@@ -38,7 +38,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.6'
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/sentry/setup.py
+++ b/plugins/sentry/setup.py
@@ -37,7 +37,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.6'
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/terms/setup.py
+++ b/plugins/terms/setup.py
@@ -39,7 +39,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.6'
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/thumbnails/setup.py
+++ b/plugins/thumbnails/setup.py
@@ -37,7 +37,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.6'
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/user_quota/setup.py
+++ b/plugins/user_quota/setup.py
@@ -38,7 +38,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.6'
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/virtual_folders/setup.py
+++ b/plugins/virtual_folders/setup.py
@@ -37,7 +37,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.6'
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.6'
     ],
     packages=find_packages(
         exclude=('girder.test', 'tests.*', 'tests', '*.plugin_tests.*', '*.plugin_tests')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py{27,35,36},docs,public_names
+envlist = lint,py{27,36},docs,public_names
 skip_missing_interpreters = true
 
 [testenv]
@@ -89,11 +89,11 @@ commands = pytest \
            --keep-db \
            {posargs}
 
-[testenv:circleci-py35]
+[testenv:circleci-py36]
 basepython = python3.5
 commands = pytest \
            --tb=long \
-           --junit-xml="build/test/results/pytest-3.5.xml" \
+           --junit-xml="build/test/results/pytest-3.6.xml" \
            --cov-append \
            --keep-db \
             {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,6 @@ commands =
 [testenv:release]
 skip_install = true
 skipsdist = true
-basepython = python2.7
 passenv =
   CIRCLE_BRANCH
   TWINE_USERNAME


### PR DESCRIPTION
* Make Python 3.6 the minimum Python 3 version
* Remove deprecated MAINTAINER command from Dockerfiles
* Clean up formatting in test Dockerfiles
* Use a simpler, constant version of CMake in testing
* Use a Python 3 testing Docker image with NodeJS pre-installed
* Install Tox globally in Docker testing images
* Ensure the correct NodeJS version is installed in the testing Docker