### PR TITLE
Remove obsolete Flake8 packages from requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,15 +25,11 @@
 # External dependencies
 configparser==3.5.0
 coverage
-flake8
-flake8-blind-except
-flake8-docstrings>=1.3
 girder-worker
 httmock
 mock
 mongomock
 moto[server]>=1.3.7
-pydocstyle<4
 pytest>=3.6
 pytest-cov<2.6
 pytest-xdist


### PR DESCRIPTION
Flake8 packages are always installed via Tox.