### PR TITLE
Remove flake8-docstrings pinning

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,8 +19,7 @@ deps =
     flake8
     flake8-blind-except
     flake8-bugbear
-    flake8-docstrings>=1.3
-    pydocstyle<4
+    flake8-docstrings
     flake8-quotes
     pep8-naming
 commands = flake8 {posargs}


### PR DESCRIPTION
Upstream has been fixed: https://gitlab.com/pycqa/flake8-docstrings/issues/36
