### PR TITLE
Explicitly forbid multipart upload

### DIFF
--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -212,6 +212,10 @@ class File(Resource):
         upload. The passed offset is a verification mechanism for ensuring the
         server and client agree on the number of bytes sent/received.
         """
+        if cherrypy.request.headers.get('Content-Type', '').startswith('multipart/form-data'):
+            raise RestException('Multipart encoding is no longer supported. Send the chunk in '
+                                'the request body, and other parameters in the query string.')
+
         if 'chunk' in params:
             # If we see the undocumented "chunk" query string parameter, then we abort trying to
             # read the body, use the query string value as chunk, and pass it through to


### PR DESCRIPTION
Refs #3113

I didn't add an automated test to cover this exception, since it would have involved some new infrastructure (or resurrecting old infrastructure) to send a multipart request. Rather, I tested it with Postman:

![Screen Shot 2019-08-09 at 9 20 28 AM](https://user-images.githubusercontent.com/555959/62781886-f298e080-ba86-11e9-80dd-4c6850dca43c.png)
