### PR TITLE
Update girder-client for adding collection metadata

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -1126,6 +1126,17 @@ class GirderClient(object):
         obj = self.put(path, json=metadata)
         return obj
 
+    def addMetadataToCollection(self, collectionId, metadata):
+        """
+        Takes a collection ID and a dictionary containing the metadata
+
+        :param collectionId: ID of the collection to set metadata on.
+        :param metadata: dictionary of metadata to set on collection.
+        """
+        path = 'collection/' + collectionId + '/metadata'
+        obj = self.put(path, json=metadata)
+        return obj
+
     def transformFilename(self, name):
         """
         Sanitize a resource name from Girder into a name that is safe to use

--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -12,6 +12,7 @@ clients
                 MAX_CHUNK_SIZE
                 addFolderUploadCallback
                 addItemUploadCallback
+                addMetadataToCollection
                 addMetadataToFolder
                 addMetadataToItem
                 authenticate

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -15,6 +15,7 @@ from girder import config, events
 from girder.models.file import File
 from girder.models.folder import Folder
 from girder.models.item import Item
+from girder.models.collection import Collection
 from girder.models.upload import Upload
 from girder.models.user import User
 from tests import base
@@ -642,6 +643,15 @@ class PythonClientTestCase(base.TestCase):
         self.client.addMetadataToFolder(self.publicFolder['_id'], meta)
         updatedFolder = Folder().load(self.publicFolder['_id'], force=True)
         self.assertEqual(updatedFolder['meta'], meta)
+
+    def testAddMetadataToCollection(self):
+        collection = self.client.createCollection('CoolCollection', description='', public=True)
+        meta = {
+            'nothing': 'to see here!'
+        }
+        self.client.addMetadataToCollection(collection['_id'], meta)
+        updatedCollection = Collection().load(collection['_id'], force=True)
+        self.assertEqual(updatedCollection['meta'], meta)
 
     def testPatch(self):
         patchUrl = 'patch'


### PR DESCRIPTION
This is a bit last minute as today's my last day, but I thought I'd just make this PR before leaving. When attempting to use girder-client, I noticed there's no function for adding metadata to a collection, despite having support for folders and items.