### PR TITLE
Tox shows a warning that the base python version doesn't match.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -88,7 +88,7 @@ commands = pytest \
            {posargs}
 
 [testenv:circleci-py36]
-basepython = python3.5
+basepython = python3.6
 commands = pytest \
            --tb=long \
            --junit-xml="build/test/results/pytest-3.6.xml" \


### PR DESCRIPTION
This fixes the warning: `UserWarning: conflicting basepython version (set 35, should be 36) for env 'circleci-py36'`.