### PR TITLE
Update to handle newer pytest-cov.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,9 @@ jobs:
           name: Run tox
           command: tox -e lint,circleci-py36,docs
           working_directory: girder
+      - run:
+          name: make coverage file distinct
+          command: cp girder/build/test/coverage/python_temp/.coverage girder/build/test/coverage/python_temp/.coverage.py3Coverage
       - store_test_results:
           path: girder/build/test/results
       - persist_to_workspace:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -31,7 +31,7 @@ mock
 mongomock
 moto[server]>=1.3.7
 pytest>=3.6
-pytest-cov<2.6
+pytest-cov>=2.6
 pytest-xdist
 python-dateutil
 tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,10 +12,14 @@ include =
     .tox/*/lib/*/site-packages/girder_*/*
 parallel = True
 [coverage:paths]
+# As of pytest-cov 2.6, all but the first source line is relative to the first
+# source line.  The first line is relative to the local path.  Prior to 2.6,
+# all lines were relative to the local path.
+
 # Include sources from installed package in Tox's {envsitepackagesdir}
 girder =
     girder/
-    .tox/*/lib/*/site-packages/girder/
+    ../.tox/*/lib/*/site-packages/girder/
 # TODO: There should be entries for each plugin to merge results from pytest and
 #       cmake tests.  Do we want to list each individually?
 [coverage:html]


### PR DESCRIPTION
Pytest-cov 2.6 changed how multiple source paths were processed.  Before, all paths were relative to the base path.  Now, the first path is relative to the base and subsequent paths are relative to the first path.