### PR TITLE
Remove `reconnect` after index declaration in plugin

### DIFF
--- a/plugins/oauth/girder_oauth/__init__.py
+++ b/plugins/oauth/girder_oauth/__init__.py
@@ -46,7 +46,6 @@ class OAuthPlugin(GirderPlugin):
         User().ensureIndex((
             (('oauth.provider', SortDir.ASCENDING),
              ('oauth.id', SortDir.ASCENDING)), {}))
-        User().reconnect()
 
         events.bind('no_password_login_attempt', 'oauth', checkOauthUser)
 


### PR DESCRIPTION
This isn't necessary, and we don't want it to accidentally propagate via copy-paste.