### PR TITLE
Remove foot-shooting capability in pytest

### DIFF
--- a/pytest_girder/pytest_girder/fixtures.py
+++ b/pytest_girder/pytest_girder/fixtures.py
@@ -135,6 +135,7 @@ def boundServer(db, request):
         with serverContext(plugins, bindPort=True) as server:
             yield server
 
+
 @pytest.fixture
 def smtp(db, server):
     """
@@ -208,5 +209,4 @@ def fsAssetstore(db, request):
         shutil.rmtree(path)
 
 
-__all__ = ('admin', 'db', 'fsAssetstore', 'server', 'boundServer', 'user', 'smtp',
-           '_disableRealDatabaseConnectivity')
+__all__ = ('admin', 'db', 'fsAssetstore', 'server', 'boundServer', 'user', 'smtp')

--- a/pytest_girder/pytest_girder/fixtures.py
+++ b/pytest_girder/pytest_girder/fixtures.py
@@ -1,4 +1,5 @@
 import hashlib
+import mock
 import mongomock
 import os
 import pytest
@@ -13,6 +14,18 @@ def _uid(node):
     Generate a unique name from a pytest request node object.
     """
     return '_'.join((node.module.__name__, node.cls.__name__ if node.cls else '', node.name))
+
+
+@pytest.fixture(scope='session', autouse=True)
+def _disableRealDatabaseConnectivity():
+    from girder.utility.config import getConfig
+
+    class MockDict(dict):
+        def get(self, *args, **kwargs):
+            raise Exception('You must use the "db" fixture in tests that connect to the database.')
+
+    with mock.patch.dict(getConfig(), {'database': MockDict()}):
+        yield
 
 
 @pytest.fixture
@@ -66,6 +79,11 @@ def db(request):
 
     connection.close()
 
+    # Clear connection cache and model singletons
+    _dbClients.clear()
+    for model in model_base._modelSingletons:
+        model.__class__._instance = None
+
     if mockDb:
         mongodb_proxy.EXECUTABLE_MONGO_METHODS = executable_methods
         pymongo.MongoClient = realMongoClient
@@ -116,7 +134,6 @@ def boundServer(db, request):
         plugins = _getPluginsFromMarker(request, registry)
         with serverContext(plugins, bindPort=True) as server:
             yield server
-
 
 @pytest.fixture
 def smtp(db, server):
@@ -191,4 +208,5 @@ def fsAssetstore(db, request):
         shutil.rmtree(path)
 
 
-__all__ = ('admin', 'db', 'fsAssetstore', 'server', 'boundServer', 'user', 'smtp')
+__all__ = ('admin', 'db', 'fsAssetstore', 'server', 'boundServer', 'user', 'smtp',
+           '_disableRealDatabaseConnectivity')

--- a/pytest_girder/pytest_girder/plugin.py
+++ b/pytest_girder/pytest_girder/plugin.py
@@ -1,5 +1,6 @@
 import os
 from .fixtures import *  # noqa
+from .fixtures import _disableRealDatabaseConnectivity  # noqa
 
 
 def _makeCoverageDirs(config):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -446,3 +446,14 @@ class TestFindWithPermissions(object):
         _model.save({'name': 'second second', 'parentId': d3['_id'], 'field1': 'value1'})
         _model.save({'name': 'fourth names', 'parentId': d4['_id'], 'field1': 'value1'})
         self.generalTest(_model, admin, user)
+
+
+def testDatabaseConnectivityRequiresDbFixtureInTesting():
+    """
+    This test exists to verify that attempting to use Girder's model layer without using the
+    `db` fixture will raise a reasonable exception rather than accidentally polluting users'
+    actual databases.
+    """
+    with pytest.raises(Exception) as e:
+        User().find()
+    assert str(e.value) == 'You must use the "db" fixture in tests that connect to the database.'

--- a/test/test_route_table.py
+++ b/test/test_route_table.py
@@ -34,7 +34,7 @@ class HasWebroot(GirderPlugin):
         'other': 'route_without_a_leading_slash'
     }, r'Routes must begin with a forward slash\.$')
 ])
-def testRouteTableValidationFailure(value, err):
+def testRouteTableValidationFailure(value, err, db):
     with pytest.raises(ValidationException, match=err):
         Setting().validate({
             'key': SettingKey.ROUTE_TABLE,
@@ -47,7 +47,7 @@ def testRouteTableValidationFailure(value, err):
         GIRDER_ROUTE_ID: '/',
     }
 ])
-def testRouteTableValidationSuccess(value):
+def testRouteTableValidationSuccess(value, db):
     Setting().validate({
         'key': SettingKey.ROUTE_TABLE,
         'value': value


### PR DESCRIPTION
This forces any pytest case that uses `pytest_girder` and attempts
to connect to Girder's database to use the `db` fixture. Prior to this change, failure to add the `db` fixture to a test that talked to the database could lead to a test that inadvertently modifies a developer's actual Girder database, which is obviously undesirable.

@brianhelba PTAL, this is a fairly straightforward (if hackish) solution to the problem you brought up earlier. This problem wasn't introduced by #3139, but it seems we just discovered it. The test case I added here verifies the behavior we want with respect to requiring the fixture, which should future-proof this solution against changes inside `getDbConnection`.