### PR TITLE
Remove python-dateutil requirement.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -33,6 +33,7 @@ moto[server]>=1.3.7
 pytest>=3.6
 pytest-cov>=2.6
 pytest-xdist
-python-dateutil
+# python-dateutil is pinned because of github.com/boto/botocore/issues/1872
+python-dateutil<=2.8.0
 tox
 virtualenv

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,8 @@ installReqs = [
     'PyYAML',
     'psutil',
     'pyOpenSSL',
-    'python-dateutil',
+    # python-dateutil is pinned because of github.com/boto/botocore/issues/1872
+    'python-dateutil<=2.8.0',
     'pytz',
     'requests',
     "shutilwhich ; python_version < '3'",


### PR DESCRIPTION
python-dateutil is required by botocore.  By also requiring it directly, we can end up with an incompatible version.

See https://github.com/boto/botocore/issues/1872.

We should probably release once this is merged, as the current version won't install properly without overriding either the python-dateutil or botocore version.