### PR TITLE
Unpin CherryPy.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ installReqs = [
     'botocore',
     # CherryPy version is restricted due to a bug in versions >=11.1
     # https://github.com/cherrypy/cherrypy/issues/1662
-    'CherryPy<11.1',
+    'CherryPy',
     'click',
     'click-plugins',
     'dogpile.cache',


### PR DESCRIPTION
As of cheroot 8.2.0 we can use CherryPy master again.  Current CherryPy (18.4.0) requires an appropriate version.  Older versions specify a minimum cheroot version; for instance, this commit with Python 2.7 uses CherryPy 17.x which only requires cheroot > 6.(something).

This resolves #2475.

Upgrading CherryPy is necessary to support Python 3.8.