### PR TITLE
Require MongoDB>=3.6 and recommend MongoDB==4.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       # This image uses the oldest version of many dependencies
       - image: girder/girder_test:latest-py2
       # Use the oldest supported MongoDB
-      - image: circleci/mongo:3.4-ram
+      - image: circleci/mongo:3.6-ram
         # The "ephemeralForTest" storage engine https://docs.mongodb.com/v3.2/release-notes/3.2/#ephemeralfortest-storage-engine
         # is likely a free (and poorly documented) analogue to the enterprise-only "inMemory"
         # storage engine. We can pass alternate options to "mongod" by overwriting the default "CMD"
@@ -118,7 +118,7 @@ jobs:
     docker:
       - image: girder/girder_test:latest-py3
       # Use the latest MongoDB
-      - image: circleci/mongo:3.6-ram
+      - image: circleci/mongo:4.2-ram
         command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
 
     working_directory: /home/circleci/project  # as $CIRCLE_WORKING_DIRECTORY
@@ -157,7 +157,7 @@ jobs:
   py3_webBuild_webTest:
     docker:
       - image: girder/girder_test:latest-py3
-      - image: circleci/mongo:3.6-ram
+      - image: circleci/mongo:4.2-ram
         command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
 
     working_directory: /home/circleci/project  # as $CIRCLE_WORKING_DIRECTORY
@@ -319,7 +319,7 @@ jobs:
   py2_coverage:
     docker:
       - image: girder/girder_test:latest-py2
-      - image: circleci/mongo:3.4-ram
+      - image: circleci/mongo:3.6-ram
         command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
     working_directory: /home/circleci/project  # as $CIRCLE_WORKING_DIRECTORY
     steps:
@@ -446,7 +446,7 @@ jobs:
   py3_coverage:
     docker:
       - image: girder/girder_test:latest-py3
-      - image: circleci/mongo:3.6-ram
+      - image: circleci/mongo:4.2-ram
         command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
     working_directory: /home/circleci/project  # as $CIRCLE_WORKING_DIRECTORY
     steps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 ---
 mongodb:
-  image: mongo:3.4
+  image: mongo:4.2
   ports:
     - "27017"
   volumes:

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -86,7 +86,7 @@ Server Runtime
 --------------
 Running Girder's server has the following additional system dependencies:
 
-* `MongoDB <https://www.mongodb.org/>`_ v3.4+
+* `MongoDB <https://www.mongodb.org/>`_ v3.6+
 
   * This is necessary for Girder's primary application database.
 

--- a/docs/installation-quickstart.rst
+++ b/docs/installation-quickstart.rst
@@ -103,7 +103,7 @@ MongoDB
       .. code-block:: bash
 
          sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
-         echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
+         echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.2.list
          sudo apt-get update
          sudo apt-get install -y mongodb-org-server mongodb-org-shell
 
@@ -122,7 +122,7 @@ MongoDB
       .. code-block:: bash
 
          sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
-         echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
+         echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/4.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.0.list
          sudo apt-get update
          sudo apt-get install -y mongodb-org-server mongodb-org-shell
 
@@ -131,16 +131,16 @@ MongoDB
 
    .. group-tab:: RHEL (CentOS) 7
 
-      To install, create a file at ``/etc/yum.repos.d/mongodb-org-3.6.repo``, with:
+      To install, create a file at ``/etc/yum.repos.d/mongodb-org-4.2.repo``, with:
 
       .. code-block:: cfg
 
-         [mongodb-org-3.6]
+         [mongodb-org-4.2]
          name=MongoDB Repository
-         baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.6/x86_64/
+         baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/4.2/x86_64/
          gpgcheck=1
          enabled=1
-         gpgkey=https://www.mongodb.org/static/pgp/server-3.6.asc
+         gpgkey=https://www.mongodb.org/static/pgp/server-4.2.asc
 
       then run the command:
 

--- a/girder/utility/acl_mixin.py
+++ b/girder/utility/acl_mixin.py
@@ -282,11 +282,7 @@ class AccessControlMixin(object):
             #  Note, this also handles models which use attachedToType and
             # attachedToId, since ModelImporter.model(None) will not be an access
             # controlled model.
-            #  This is also the fall-back for Mongo < 3.4, as those versions do
-            # not support the aggregation steps that are used.
-            if (not isinstance(ModelImporter.model(self.resourceColl), AccessControlledModel)
-                    or not getattr(self, '_dbserver_version', None)
-                    or getattr(self, '_dbserver_version', None) < (3, 4)):
+            if not isinstance(ModelImporter.model(self.resourceColl), AccessControlledModel):
                 return self._findWithPermissionsFallback(
                     query, offset, limit, timeout, fields, sort, user, level,
                     **kwargs)


### PR DESCRIPTION
Earlier versions of MongoDB have passed their end of life: https://www.mongodb.com/support-policy

MongoDB 3.6 is also the earliest version to support all of the aggregation operators needed by `findWithPermissions`.