### PR TITLE
Do not catch redundant exception types in Python 3

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -1401,7 +1401,7 @@ class GirderClient(object):
         try:
             with open(os.path.join(dest, '.girder_metadata'), 'r') as fh:
                 self.localMetadata = json.loads(fh.read())
-        except (IOError, OSError):
+        except (OSError if six.PY3 else (IOError, OSError)):
             print('Local metadata does not exists. Falling back to download.')
 
     def inheritAccessControlRecursive(self, ancestorFolderId, access=None, public=None):


### PR DESCRIPTION
As of Python 3.3, IOError is an alias of OSError.