### PR TITLE
Recommend Ubuntu>=18.04 (Bionic)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,8 @@ jobs:
             - girder_env
 
   py2_integrationTests:
-    machine: true
+    machine:
+      image: ubuntu-1604:201903-01
     working_directory: /home/circleci/project  # as $CIRCLE_WORKING_DIRECTORY
 
     steps:
@@ -252,9 +253,10 @@ jobs:
           name: Install MongoDB
           command: |
             sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
-            echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
+            echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
             sudo apt-get update
             sudo apt-get install -y mongodb-org-server
+            sudo systemctl start mongod
       - run:
           # Boto doesn't work as a library if there is a /etc/boto.cfg file
           # from a different version of Python, so remove the file.
@@ -349,7 +351,8 @@ jobs:
           command: codecov --disable search pycov gcov --root girder --file girder/build/test/coverage/py_coverage.xml
 
   py3_integrationTests:
-    machine: true
+    machine:
+      image: ubuntu-1604:201903-01
     working_directory: /home/circleci/project  # as $CIRCLE_WORKING_DIRECTORY
 
     steps:
@@ -378,9 +381,10 @@ jobs:
           name: Install MongoDB
           command: |
             sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
-            echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
+            echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
             sudo apt-get update
             sudo apt-get install -y mongodb-org-server
+            sudo systemctl start mongod
       - run:
           # The "d3" npm package (required by some Girder plugins) has an optional dependency of
           # "canvas", which requires "node-gyp" to build. node-gyp strictly requires Python 2

--- a/devops/ansible-role-girder/README.md
+++ b/devops/ansible-role-girder/README.md
@@ -6,7 +6,7 @@ An Ansible role to install [Girder](https://github.com/girder/girder).
 
 ## Requirements
 
-Ubuntu 16.04+.
+Ubuntu 18.04+.
 
 Using Python 3 as
 [the target host Python interpreter](https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html)

--- a/devops/ansible-role-girder/meta/main.yml
+++ b/devops/ansible-role-girder/meta/main.yml
@@ -11,7 +11,6 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - bionic
-        - xenial
 
   galaxy_tags:
     - girder

--- a/docs/installation-quickstart.rst
+++ b/docs/installation-quickstart.rst
@@ -88,7 +88,7 @@ MongoDB
 
       .. code-block:: bash
 
-         sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
+         sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E162F504A20CDF15827F718D4B7C549A058F8B6B
          echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.2.list
          sudo apt-get update
          sudo apt-get install -y mongodb-org-server mongodb-org-shell

--- a/docs/installation-quickstart.rst
+++ b/docs/installation-quickstart.rst
@@ -7,27 +7,13 @@ Basic System Prerequisites
 --------------------------
 
 .. tabs::
-   .. group-tab:: Ubuntu 16.04
+   .. group-tab:: Ubuntu 18.04
 
       To install basic system prerequisites, run the command:
 
       .. code-block:: bash
 
          sudo apt-get install -y python-pip python-virtualenv
-
-      To install system prerequisites for Girder's ``ldap`` plugin, run the command:
-
-      .. code-block:: bash
-
-         sudo apt-get install -y libldap2-dev libsasl2-dev
-
-   .. group-tab:: Ubuntu 14.04
-
-      To install basic system prerequisites, run the command:
-
-      .. code-block:: bash
-
-         sudo apt-get install -y python-pip python-virtualenv python-dev
 
       To install system prerequisites for Girder's ``ldap`` plugin, run the command:
 
@@ -96,14 +82,14 @@ MongoDB
 -------
 
 .. tabs::
-   .. group-tab:: Ubuntu 16.04
+   .. group-tab:: Ubuntu 18.04
 
       To install, run the commands:
 
       .. code-block:: bash
 
          sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
-         echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.2.list
+         echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.2.list
          sudo apt-get update
          sudo apt-get install -y mongodb-org-server mongodb-org-shell
 
@@ -115,19 +101,6 @@ MongoDB
          sudo systemctl start mongod
          sudo systemctl enable mongod
 
-   .. group-tab:: Ubuntu 14.04
-
-      To install, run the commands:
-
-      .. code-block:: bash
-
-         sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
-         echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/4.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.0.list
-         sudo apt-get update
-         sudo apt-get install -y mongodb-org-server mongodb-org-shell
-
-      MongoDB server will register itself as an Upstart service (called ``mongod``), and will automatically start
-      immediately and on every reboot.
 
    .. group-tab:: RHEL (CentOS) 7
 
@@ -178,16 +151,7 @@ Node.js v12.0 is the `active LTS release <https://github.com/nodejs/Release#rele
 can also be used instead.
 
 .. tabs::
-   .. group-tab:: Ubuntu 16.04
-
-      To install, run the commands:
-
-      .. code-block:: bash
-
-         curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
-         sudo apt-get install -y nodejs
-
-   .. group-tab:: Ubuntu 14.04
+   .. group-tab:: Ubuntu 18.04
 
       To install, run the commands:
 


### PR DESCRIPTION
Ubuntu 14.04 has passed its End of Standard Support period: https://wiki.ubuntu.com/Releases

Ubuntu 16.04 ships with Python 3.5.x, and eventual Python 3 support in Girder will likely require Python=>3.6. For now, Ubuntu 16.04 will still function, but its use should be discouraged for new installations.