### PR TITLE
Revert "Pin python-dateutil requirement."

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -33,7 +33,6 @@ moto[server]>=1.3.7
 pytest>=3.6
 pytest-cov>=2.6
 pytest-xdist
-# python-dateutil is pinned because of github.com/boto/botocore/issues/1872
-python-dateutil<=2.8.0
+python-dateutil
 tox
 virtualenv

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,7 @@ installReqs = [
     'PyYAML',
     'psutil',
     'pyOpenSSL',
-    # python-dateutil is pinned because of github.com/boto/botocore/issues/1872
-    'python-dateutil<=2.8.0',
+    'python-dateutil',
     'pytz',
     'requests',
     "shutilwhich ; python_version < '3'",


### PR DESCRIPTION
This reverts commit c4957d3aae090b20c6c05c5a4f23581e2b5fa996.

The upstream bug was fixed: https://github.com/boto/botocore/pull/1910