### PR TITLE
Upgrade to Bootstrap 3.4.1

### DIFF
--- a/girder/web_client/src/package.json
+++ b/girder/web_client/src/package.json
@@ -14,7 +14,7 @@
     "dependencies": {
         "as-jqplot": "~1.0.8",
         "backbone": "~1.4.0",
-        "bootstrap": "3.4.0",
+        "bootstrap": "~3.4.1",
         "bootstrap-switch": "~3.3.4",
         "eonasdan-bootstrap-datetimepicker": "~4.17",
         "@girder/fontello": "*",

--- a/girder/web_client/src/views/widgets/AccessWidget.js
+++ b/girder/web_client/src/views/widgets/AccessWidget.js
@@ -181,7 +181,6 @@ var AccessWidget = View.extend({
             if (!$(el).data('bs.popover')) {
                 $(el).popover({
                     trigger: 'manual',
-                    html: true,
                     placement: 'left',
                     viewport: {
                         selector: 'body',
@@ -189,7 +188,9 @@ var AccessWidget = View.extend({
                     },
                     content: function () {
                         return $(this).parent().find('.g-flags-popover-container').html();
-                    }
+                    },
+                    html: true,
+                    sanitize: false
                 }).click(function () {
                     $(this).popover('toggle');
                 });
@@ -202,7 +203,6 @@ var AccessWidget = View.extend({
             if (!$(el).data('bs.popover')) {
                 $(el).popover({
                     trigger: 'manual',
-                    html: true,
                     placement: 'right',
                     viewport: {
                         selector: 'body',
@@ -210,7 +210,9 @@ var AccessWidget = View.extend({
                     },
                     content: function () {
                         return $(this).parent().find('.g-public-flags-popover-container').html();
-                    }
+                    },
+                    html: true,
+                    sanitize: false
                 }).click(function () {
                     $(this).popover('toggle');
                 });

--- a/girder/web_client/src/views/widgets/SearchFieldWidget.js
+++ b/girder/web_client/src/views/widgets/SearchFieldWidget.js
@@ -164,7 +164,6 @@ var SearchFieldWidget = View.extend({
 
         this.$('.g-search-options-button').popover({
             trigger: 'manual',
-            html: true,
             viewport: {
                 selector: 'body',
                 padding: 10
@@ -174,14 +173,15 @@ var SearchFieldWidget = View.extend({
                     mode: this.currentMode,
                     modeHelp: SearchFieldWidget.getModeHelp(this.currentMode)
                 });
-            }
+            },
+            html: true,
+            sanitize: false
         }).click(function () {
             $(this).popover('toggle');
         });
 
         this.$('.g-search-mode-choose').popover({
             trigger: 'manual',
-            html: true,
             viewport: {
                 selector: 'body',
                 padding: 10
@@ -192,7 +192,9 @@ var SearchFieldWidget = View.extend({
                     currentMode: this.currentMode,
                     getModeDescription: SearchFieldWidget.getModeDescription
                 });
-            }
+            },
+            html: true,
+            sanitize: false
         }).click(function () {
             $(this).popover('toggle');
         });


### PR DESCRIPTION
This release includes new XSS protections, which must be disabled, since HTML escaping is done by Pug.

See: https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/