### PR TITLE
Directly use an Ansible Galaxy API key to publish roles

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -78,13 +78,12 @@ commands =
 skip_install = true
 skipsdist = true
 passenv =
-  $ANSIBLE_GALAXY_GITHUB_TOKEN
+  ANSIBLE_GALAXY_API_KEY
 deps =
   ansible
 commands =
   {toxinidir}/.circleci/create_ansible_subtree.sh
-  ansible-galaxy login --github-token="$ANSIBLE_GALAXY_GITHUB_TOKEN"
-  ansible-galaxy import girder ansible-role-girder
+  ansible-galaxy import --api-key {env:ANSIBLE_GALAXY_API_KEY} girder ansible-role-girder
 
 [testenv:public_names]
 deps = six


### PR DESCRIPTION
This fixes a bug, but also should be slightly more secure to use, as the secret token is just for Ansible Galaxy, not GitHub.