### PR TITLE
Rename the Ansible variable girder_package_path and default it to empty

### DIFF
--- a/devops/ansible-role-girder/README.md
+++ b/devops/ansible-role-girder/README.md
@@ -14,16 +14,16 @@ is recommended. Setting `ansible_python_interpreter: auto` will enable this beha
 
 ## Role Variables
 
-| parameter                 | required | default                                      | comments                                                                                                                           |
-| ------------------------- | -------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `girder_bind_public`      | no       | `false`                                      | Whether to bind to all network interfaces.                                                                                         |
-| `girder_daemonize`        | no       | `true`                                       | Whether to install the systemd service.                                                                                            |
-| `girder_database_uri`     | no       | `mongodb://localhost:27017/girder`           | The Connection String URI for MongoDB.                                                                                             |
-| `girder_development_mode` | no       | `false`                                      | Whether to enable Girder's development mode, disable HTTP reverse proxy configuration, and install the Python package as editable. |
-| `girder_package`          | no       | `girder`                                     | Package name to install via `pip`, can be a path.                                                                                  |
-| `girder_version`          | no       | `latest`                                     | The version of Girder to install, as either ``latest``, ``release``, or a PyPI version.                                            |
-| `girder_virtualenv`       | no       | `{{ ansible_user_dir }}/.virtualenvs/girder` | Path to a Python virtual environment to install Girder in.                                                                         |
-| `girder_web`              | no       | `true`                                       | Whether to build the Girder web client.                                                                                            |
+| parameter                 | required | default                                      | comments                                                                                  |
+| ------------------------- | -------- | -------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `girder_bind_public`      | no       | `false`                                      | Whether to bind to all network interfaces.                                                |
+| `girder_daemonize`        | no       | `true`                                       | Whether to install the systemd service.                                                   |
+| `girder_database_uri`     | no       | `mongodb://localhost:27017/girder`           | The Connection String URI for MongoDB.                                                    |
+| `girder_development_mode` | no       | `false`                                      | Whether to enable Girder's development mode and disable HTTP reverse proxy configuration. |
+| `girder_version`          | no       | `latest`                                     | The version of Girder to install, as either ``latest``, ``release``, or a PyPI version.   |
+| `girder_virtualenv`       | no       | `{{ ansible_user_dir }}/.virtualenvs/girder` | Path to a Python virtual environment to install Girder in.                                |
+| `girder_web`              | no       | `true`                                       | Whether to build the Girder web client.                                                   |
+| `girder_package_path`     | no       |                                              | If set, a filesystem path on the target to install the Girder package from.               |
 
 ### Notes on `girder_virtualenv`
 

--- a/devops/ansible-role-girder/defaults/main.yml
+++ b/devops/ansible-role-girder/defaults/main.yml
@@ -3,7 +3,6 @@ girder_bind_public: false
 girder_daemonize: true
 girder_database_uri: "mongodb://localhost:27017/girder"
 girder_development_mode: false
-girder_package: "girder"
 girder_version: "latest"
 girder_virtualenv: "{{ ansible_user_dir }}/.virtualenvs/girder"
 girder_web: true

--- a/devops/ansible-role-girder/tasks/main.yml
+++ b/devops/ansible-role-girder/tasks/main.yml
@@ -22,11 +22,11 @@
 
 - name: Install Girder
   pip:
-    name: "{{ girder_package }}"
+    name: "{{ girder_package_path|default('girder') }}"
     version: "{{ girder_version if girder_version not in ['latest', 'release'] else omit }}"
     extra_args: "{{ '--pre' if girder_version == 'latest' else omit }}"
     state: "{{ 'latest' if girder_version in ['latest', 'release'] else omit }}"
-    editable: "{{ girder_development_mode }}"
+    editable: "{{ girder_package_path is defined }}"
     virtualenv: "{{ girder_virtualenv }}"
     # Implicitly create a Python 3 virtualenv if it doesn't exist
     virtualenv_command: "/usr/bin/python3 -m venv"

--- a/devops/vagrant/vagrant-playbook.yml
+++ b/devops/vagrant/vagrant-playbook.yml
@@ -54,7 +54,7 @@
         girder_bind_public: true
         girder_daemonize: false
         girder_development_mode: true
-        girder_package: "{{ ansible_user_dir }}/girder"
+        girder_package_path: "{{ ansible_user_dir }}/girder"
         # girder_virtualenv is overridden too
 
   post_tasks:


### PR DESCRIPTION
This also causes girder_package_path to control pip's --editable flag, fixing a bug.