### PR TITLE
Update girder build to remove old node_modules

### DIFF
--- a/girder/cli/build.py
+++ b/girder/cli/build.py
@@ -55,7 +55,8 @@ def main(dev, mode, watch, watch_plugin, npm, reinstall):
 
     staging = _GIRDER_BUILD_ASSETS_PATH
     pluginDependencies = _collectPluginDependencies()
-    _generatePackageJSON(staging, os.path.join(_GIRDER_BUILD_ASSETS_PATH, 'package.json.template'), pluginDependencies)
+    _generatePackageJSON(staging, os.path.join(_GIRDER_BUILD_ASSETS_PATH,
+                         'package.json.template'), pluginDependencies)
 
     if not os.path.isdir(os.path.join(staging, 'node_modules')) or reinstall:
         # The autogeneration of package.json breaks how package-lock.json is
@@ -66,7 +67,8 @@ def main(dev, mode, watch, watch_plugin, npm, reinstall):
             os.unlink(npmLockFile)
 
         # Remove any lingering node_modules to ensure clean install
-        pluginDirs = [version.replace('file:', '') for version in filter(lambda ver: 'file:' in ver, pluginDependencies.values())]
+        pluginDirs = [version.replace('file:', '') for version in
+                      filter(lambda ver: 'file:' in ver, pluginDependencies.values())]
         dirs = [staging, os.path.join(staging, 'src')] + pluginDirs
         nodeModuleDirs = [os.path.join(d, 'node_modules') for d in dirs]
 

--- a/girder/cli/build.py
+++ b/girder/cli/build.py
@@ -63,6 +63,18 @@ def main(dev, mode, watch, watch_plugin, npm, reinstall):
         npmLockFile = os.path.join(staging, 'package-lock.json')
         if os.path.exists(npmLockFile):
             os.unlink(npmLockFile)
+
+        # Remove any lingering node_modules to ensure clean install
+        web_client_core = os.path.join(staging, 'src')
+        plugin_dirs = [path.replace('file:', '') for path in _collectPluginDependencies().values()]
+        node_module_dirs = [os.path.join(d, 'node_modules') for d in (staging, web_client_core, *plugin_dirs)]
+
+        for path in node_module_dirs:
+            # Include ignore_errors=True to delete readonly files
+            # and skip over nonexistant directories
+            shutil.rmtree(path, ignore_errors=True)
+
+        # Run npm install
         installCommand = [npm, 'install']
         if mode == ServerMode.PRODUCTION:
             installCommand.append('--production')

--- a/girder/cli/build.py
+++ b/girder/cli/build.py
@@ -67,7 +67,7 @@ def main(dev, mode, watch, watch_plugin, npm, reinstall):
         # Remove any lingering node_modules to ensure clean install
         web_client_core = os.path.join(staging, 'src')
         plugin_dirs = [path.replace('file:', '') for path in _collectPluginDependencies().values()]
-        node_module_dirs = [os.path.join(d, 'node_modules') for d in (staging, web_client_core, *plugin_dirs)]
+        node_module_dirs = [os.path.join(d, 'node_modules') for d in [staging, web_client_core].extend(plugin_dirs)]
 
         for path in node_module_dirs:
             # Include ignore_errors=True to delete readonly files

--- a/girder/cli/build.py
+++ b/girder/cli/build.py
@@ -67,10 +67,13 @@ def main(dev, mode, watch, watch_plugin, npm, reinstall):
             os.unlink(npmLockFile)
 
         # Remove any lingering node_modules to ensure clean install
-        pluginDirs = [version.replace('file:', '') for version in
-                      filter(lambda ver: 'file:' in ver, pluginDependencies.values())]
-        dirs = [staging, os.path.join(staging, 'src')] + pluginDirs
-        nodeModuleDirs = [os.path.join(d, 'node_modules') for d in dirs]
+        pluginDirs = [
+            version.replace('file:', '')
+            for version in pluginDependencies.values()
+            if version.startswith('file:')
+        ]
+        pluginSrcDirs = [staging, os.path.join(staging, 'src')] + pluginDirs
+        nodeModuleDirs = [os.path.join(d, 'node_modules') for d in pluginSrcDirs]
 
         for path in nodeModuleDirs:
             # Include ignore_errors=True to delete readonly files

--- a/girder/cli/build.py
+++ b/girder/cli/build.py
@@ -65,9 +65,10 @@ def main(dev, mode, watch, watch_plugin, npm, reinstall):
             os.unlink(npmLockFile)
 
         # Remove any lingering node_modules to ensure clean install
-        web_client_core = os.path.join(staging, 'src')
         plugin_dirs = [path.replace('file:', '') for path in _collectPluginDependencies().values()]
-        node_module_dirs = [os.path.join(d, 'node_modules') for d in [staging, web_client_core].extend(plugin_dirs)]
+        dirs = [staging, os.path.join(staging, 'src')]
+        dirs.extend(plugin_dirs)
+        node_module_dirs = [os.path.join(d, 'node_modules') for d in dirs]
 
         for path in node_module_dirs:
             # Include ignore_errors=True to delete readonly files

--- a/girder/cli/build.py
+++ b/girder/cli/build.py
@@ -66,7 +66,7 @@ def main(dev, mode, watch, watch_plugin, npm, reinstall):
             os.unlink(npmLockFile)
 
         # Remove any lingering node_modules to ensure clean install
-        pluginDirs = [version.replace('file:', '') for version in pluginDependencies.values()]
+        pluginDirs = [version.replace('file:', '') for version in filter(lambda ver: 'file:' in ver, pluginDependencies.values())]
         dirs = [staging, os.path.join(staging, 'src')] + pluginDirs
         nodeModuleDirs = [os.path.join(d, 'node_modules') for d in dirs]
 


### PR DESCRIPTION
This fixes a bug that can occur when re-running girder build after a dependency change, by removing `girder/web_client/node_modules`, `girder/web_client/src/node_modules`, and the `web_client/node_modules` folder of any installed plugins.