### PR TITLE
Reference the API root as an absolute path in all documentation

### DIFF
--- a/docs/api-docs.rst
+++ b/docs/api-docs.rst
@@ -15,8 +15,7 @@ that uses `Swagger <https://swagger.io>`_ to document
 all available RESTful endpoints in the web API and also provide an easy way
 for users to execute those endpoints with parameters of their choosing. In
 this way, the Swagger page is just the simplest and lightest client application
-for Girder. This page is served out of the path ``/api`` under the root path of
-your Girder instance.
+for Girder. This page is served out of the path ``/api``.
 
 
 Internal Python API

--- a/docs/developer-cookbook.rst
+++ b/docs/developer-cookbook.rst
@@ -16,7 +16,7 @@ Authenticating to the web API
 Clients can make authenticated web API calls by passing a secure temporary token
 with their requests. Tokens are obtained via the login process; the standard
 login process requires the client to make an HTTP ``GET`` request to the
-``api/v1/user/authentication`` route, using HTTP Basic Auth to pass the user
+``/api/v1/user/authentication`` route, using HTTP Basic Auth to pass the user
 credentials. For example, for a user with login "john" and password "hello",
 first base-64 encode the string ``"john:hello"`` which yields ``"am9objpoZWxsbw=="``.
 Then take the base-64 encoded value and pass it via the ``Authorization`` header: ::

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -137,8 +137,8 @@ Client Development
 If you are writing a custom client application that communicates with the Girder
 REST API, you should look at the Swagger page that describes all of the available
 API endpoints. The Swagger page can be accessed by navigating a web browser to
-``api/v1`` relative to the server root. If you wish to consume the Swagger-compliant
-API specification programmatically, the JSON listing is served out of ``api/v1/describe``.
+``/api/v1``. If you wish to consume the Swagger-compliant
+API specification programmatically, the JSON listing is served out of ``/api/v1/describe``.
 
 If you are working on the main Girder web client, either in core or extending it via
 plugins, there are a few conventions that should be followed. Namely, if you write

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -184,7 +184,7 @@ E.g., upload my_datafile.txt and download the my_data.txt.sha512 file, then chec
 my_data.txt.sha512 file into your source repository.
 
 You can use the Girder API to get the hash of the file given the file id, with the endpoint
-``api/v1/file/<file id>/hashsum_file/sha512``, where the file id comes from the specific file in
+``/api/v1/file/<file id>/hashsum_file/sha512``, where the file id comes from the specific file in
 Girder.
 
 You can also use the API to download the file based on the hash returned by the previous endpoint,


### PR DESCRIPTION
Mounting the API root elsewhere is an advanced configuration for custom Girder deployments. The docs are simpler and more consistent without referencing this case.