### PR TITLE
Copy items before iterating

### DIFF
--- a/girder/events.py
+++ b/girder/events.py
@@ -282,6 +282,8 @@ def trigger(eventName, info=None, pre=None, asynchronous=False, daemon=False):
     :type daemon: bool
     """
     e = Event(eventName, info, asynchronous=asynchronous)
+    # We take a copy of the items here using list(...) in case the dict is
+    # modified while we are iterating
     for name, handler in list(six.viewitems(_mapping.get(eventName, {}))):
         if daemon and not asynchronous:
             girder.logprint.warning(

--- a/girder/events.py
+++ b/girder/events.py
@@ -282,7 +282,7 @@ def trigger(eventName, info=None, pre=None, asynchronous=False, daemon=False):
     :type daemon: bool
     """
     e = Event(eventName, info, asynchronous=asynchronous)
-    for name, handler in six.viewitems(_mapping.get(eventName, {})):
+    for name, handler in list(six.viewitems(_mapping.get(eventName, {}))):
         if daemon and not asynchronous:
             girder.logprint.warning(
                 'WARNING: Handler "%s" for event "%s" was triggered on the daemon, but is '


### PR DESCRIPTION
Copy items before iterating to prevent 'OrderedDict mutated during iteration' errors. Basically we can have a handler being added while an event is fired.