### PR TITLE
Invalidate the settings cache for a key before saving it.

### DIFF
--- a/girder/models/setting.py
+++ b/girder/models/setting.py
@@ -118,6 +118,10 @@ class Setting(Model):
         else:
             setting['value'] = value
 
+        # Invlidate the cache so that events that listen for a change in the
+        # setting will be get the right value from a get.  We don't set it here
+        # as it could fail to validate and save.
+        self._get.invalidate(self, key)
         setting = self.save(setting)
 
         self._get.set(setting, self, key)

--- a/girder/models/setting.py
+++ b/girder/models/setting.py
@@ -118,7 +118,7 @@ class Setting(Model):
         else:
             setting['value'] = value
 
-        # Invlidate the cache so that events that listen for a change in the
+        # Invalidate the cache so that events that listen for a change in the
         # setting will be get the right value from a get.  We don't set it here
         # as it could fail to validate and save.
         self._get.invalidate(self, key)


### PR DESCRIPTION
In the current behavior, if the setting cache is enabled and a setting is changed, then an event listener bound to `model.setting.save.after` that gets the setting will obtain the old value, not the new value.  The event has the new value in it, but fetching from the setting gets the old one.

This change invalidates the cache before the save.  We can't set it before save, since that would bypass validation.

There is still the potential for a race condition where if two different threads are setting a key nearly simultaneously, then the wrong one could end up in the cache (that is, not the same one that ends up in the database).  This change is still a strict improvement of the current behavior.

Fixes #3201.