### PR TITLE
Use path relative to plugin for setuptools-scm

### DIFF
--- a/plugins/audit_logs/setup.py
+++ b/plugins/audit_logs/setup.py
@@ -19,9 +19,10 @@ def prerelease_local_scheme(version):
         return get_local_node_and_date(version)
 
 
+root = os.path.dirname(__file__) + '/../..'
 setup(
     name='girder-audit-logs',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': root, 'local_scheme': prerelease_local_scheme},
     setup_requires=['setuptools-scm'],
     description='Keeps detailed logs of every REST request and low-level file download event.',
     author='Kitware, Inc.',

--- a/plugins/authorized_upload/setup.py
+++ b/plugins/authorized_upload/setup.py
@@ -19,10 +19,10 @@ def prerelease_local_scheme(version):
         return get_local_node_and_date(version)
 
 
-# perform the install
+root = os.path.dirname(__file__) + '/../..'
 setup(
     name='girder-authorized-upload',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': root, 'local_scheme': prerelease_local_scheme},
     setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Allows registered users to authorize file uploads on their behalf '
     'via a secure one-use URL.',

--- a/plugins/autojoin/setup.py
+++ b/plugins/autojoin/setup.py
@@ -19,10 +19,10 @@ def prerelease_local_scheme(version):
         return get_local_node_and_date(version)
 
 
-# perform the install
+root = os.path.dirname(__file__) + '/../..'
 setup(
     name='girder-autojoin',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': root, 'local_scheme': prerelease_local_scheme},
     setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Automatically assign new users to groups based on their email domain',
     author='Kitware, Inc.',

--- a/plugins/dicom_viewer/setup.py
+++ b/plugins/dicom_viewer/setup.py
@@ -19,10 +19,10 @@ def prerelease_local_scheme(version):
         return get_local_node_and_date(version)
 
 
-# perform the install
+root = os.path.dirname(__file__) + '/../..'
 setup(
     name='girder-dicom-viewer',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': root, 'local_scheme': prerelease_local_scheme},
     setup_requires=['setuptools-scm', 'setuptools-git'],
     description='View DICOM images in the browser',
     author='Kitware, Inc.',

--- a/plugins/download_statistics/setup.py
+++ b/plugins/download_statistics/setup.py
@@ -19,10 +19,10 @@ def prerelease_local_scheme(version):
         return get_local_node_and_date(version)
 
 
-# perform the install
+root = os.path.dirname(__file__) + '/../..'
 setup(
     name='girder-download-statistics',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': root, 'local_scheme': prerelease_local_scheme},
     setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Record file download statistics',
     author='Kitware, Inc.',

--- a/plugins/google_analytics/setup.py
+++ b/plugins/google_analytics/setup.py
@@ -19,10 +19,10 @@ def prerelease_local_scheme(version):
         return get_local_node_and_date(version)
 
 
-# perform the install
+root = os.path.dirname(__file__) + '/../..'
 setup(
     name='girder-google-analytics',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': root, 'local_scheme': prerelease_local_scheme},
     setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Allow the tracking of page views via Google Analytics.',
     author='Kitware, Inc.',

--- a/plugins/gravatar/setup.py
+++ b/plugins/gravatar/setup.py
@@ -19,10 +19,10 @@ def prerelease_local_scheme(version):
         return get_local_node_and_date(version)
 
 
-# perform the install
+root = os.path.dirname(__file__) + '/../..'
 setup(
     name='girder-gravatar',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': root, 'local_scheme': prerelease_local_scheme},
     setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Adds Gravatar URLs for users.',
     author='Kitware, Inc.',

--- a/plugins/hashsum_download/setup.py
+++ b/plugins/hashsum_download/setup.py
@@ -19,10 +19,10 @@ def prerelease_local_scheme(version):
         return get_local_node_and_date(version)
 
 
-# perform the install
+root = os.path.dirname(__file__) + '/../..'
 setup(
     name='girder-hashsum-download',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': root, 'local_scheme': prerelease_local_scheme},
     setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Allows download of a file by its hashsum.',
     author='Kitware, Inc.',

--- a/plugins/homepage/setup.py
+++ b/plugins/homepage/setup.py
@@ -19,10 +19,10 @@ def prerelease_local_scheme(version):
         return get_local_node_and_date(version)
 
 
-# perform the install
+root = os.path.dirname(__file__) + '/../..'
 setup(
     name='girder-homepage',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': root, 'local_scheme': prerelease_local_scheme},
     setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Customize the homepage using Markdown.',
     author='Kitware, Inc.',

--- a/plugins/item_licenses/setup.py
+++ b/plugins/item_licenses/setup.py
@@ -19,10 +19,10 @@ def prerelease_local_scheme(version):
         return get_local_node_and_date(version)
 
 
-# perform the install
+root = os.path.dirname(__file__) + '/../..'
 setup(
     name='girder-item-licenses',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': root, 'local_scheme': prerelease_local_scheme},
     setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Add a license field to items.',
     author='Kitware, Inc.',

--- a/plugins/jobs/setup.py
+++ b/plugins/jobs/setup.py
@@ -19,10 +19,10 @@ def prerelease_local_scheme(version):
         return get_local_node_and_date(version)
 
 
-# perform the install
+root = os.path.dirname(__file__) + '/../..'
 setup(
     name='girder-jobs',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': root, 'local_scheme': prerelease_local_scheme},
     setup_requires=['setuptools-scm', 'setuptools-git'],
     description='A general purpose plugin for managing offline jobs.',
     author='Kitware, Inc.',

--- a/plugins/ldap/setup.py
+++ b/plugins/ldap/setup.py
@@ -19,10 +19,10 @@ def prerelease_local_scheme(version):
         return get_local_node_and_date(version)
 
 
-# perform the install
+root = os.path.dirname(__file__) + '/../..'
 setup(
     name='girder-ldap',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': root, 'local_scheme': prerelease_local_scheme},
     setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Authenticate user credentials against LDAP or Active Directory servers.',
     author='Kitware, Inc.',

--- a/plugins/oauth/setup.py
+++ b/plugins/oauth/setup.py
@@ -19,10 +19,10 @@ def prerelease_local_scheme(version):
         return get_local_node_and_date(version)
 
 
-# perform the install
+root = os.path.dirname(__file__) + '/../..'
 setup(
     name='girder-oauth',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': root, 'local_scheme': prerelease_local_scheme},
     setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Allow users to login via supported OAuth2 providers.',
     author='Kitware, Inc.',

--- a/plugins/sentry/setup.py
+++ b/plugins/sentry/setup.py
@@ -19,10 +19,10 @@ def prerelease_local_scheme(version):
         return get_local_node_and_date(version)
 
 
-# perform the install
+root = os.path.dirname(__file__) + '/../..'
 setup(
     name='girder-sentry',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': root, 'local_scheme': prerelease_local_scheme},
     setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Allow the automatic tracking of issues using Sentry.',
     maintainer='Kitware, Inc.',

--- a/plugins/terms/setup.py
+++ b/plugins/terms/setup.py
@@ -19,10 +19,10 @@ def prerelease_local_scheme(version):
         return get_local_node_and_date(version)
 
 
-# perform the install
+root = os.path.dirname(__file__) + '/../..'
 setup(
     name='girder-terms',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': root, 'local_scheme': prerelease_local_scheme},
     setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Allows Girder collections to require users to accept terms of '
     'use before browsing.',

--- a/plugins/thumbnails/setup.py
+++ b/plugins/thumbnails/setup.py
@@ -19,10 +19,10 @@ def prerelease_local_scheme(version):
         return get_local_node_and_date(version)
 
 
-# perform the install
+root = os.path.dirname(__file__) + '/../..'
 setup(
     name='girder-thumbnails',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': root, 'local_scheme': prerelease_local_scheme},
     setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Generate thumbnails from files.',
     author='Kitware, Inc.',

--- a/plugins/user_quota/setup.py
+++ b/plugins/user_quota/setup.py
@@ -19,10 +19,10 @@ def prerelease_local_scheme(version):
         return get_local_node_and_date(version)
 
 
-# perform the install
+root = os.path.dirname(__file__) + '/../..'
 setup(
     name='girder-user-quota',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': root, 'local_scheme': prerelease_local_scheme},
     setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Limits total file size stored for individual users and '
     'collections and can direct all files to a specific assetstore',

--- a/plugins/virtual_folders/setup.py
+++ b/plugins/virtual_folders/setup.py
@@ -19,10 +19,10 @@ def prerelease_local_scheme(version):
         return get_local_node_and_date(version)
 
 
-# perform the install
+root = os.path.dirname(__file__) + '/../..'
 setup(
     name='girder-virtual-folders',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': root, 'local_scheme': prerelease_local_scheme},
     setup_requires=['setuptools-scm', 'setuptools-git'],
     description='Allows folders to list child items using arbitrary database queries',
     author='Kitware, Inc.',


### PR DESCRIPTION
Prior to this change, setuptools-scm was looking for the repository root relative to the working dir, not the plugin dir. This was causing downstream failures when trying to install these plugins from a Girder git repository rather than pypi.