### PR TITLE
Fix rendering 0 user quotas in the dashboard

### DIFF
--- a/plugins/user_quota/girder_user_quota/web_client/templates/configView.pug
+++ b/plugins/user_quota/girder_user_quota/web_client/templates/configView.pug
@@ -13,7 +13,7 @@ form#g-user-quota-form(role="form")
         | quota is explicitly set.
       input.input-sm.g-sizeValue.form-control(
           id=`g-user-quota-${resource.model}-size-value`,
-          type="text", value=resource.sizeValue || '',
+          type="text", value=resource.sizeValue,
           placeholder="Maximum allowed size of all files, or blank for no limit")
       select.form-control.input-sm.g-sizeUnits(
           id=`g-user-quota-${resource.model}-size-units`)

--- a/plugins/user_quota/girder_user_quota/web_client/utilities/Conversions.js
+++ b/plugins/user_quota/girder_user_quota/web_client/utilities/Conversions.js
@@ -11,7 +11,7 @@ function sizeToValueAndUnits(sizeValue) {
                 1024 === sizeValue; sizeUnits += 1) {
             sizeValue /= 1024;
         }
-    } else {
+    } else if (sizeValue !== 0) {
         sizeValue = '';
     }
     return { sizeUnits: sizeUnits, sizeValue: sizeValue };


### PR DESCRIPTION
Fix the dashboard rendering and saving user quotas of 0. I neglected to
check that the UI worked correctly when I changed the user-quota plugin
to allow user quotas to be set to 0.