### PR TITLE
Change how items are found in virtual folders

### DIFF
--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -407,7 +407,7 @@ Server changes
 * Several core models supported an older, nonstandard kwarg format in their ``filter`` method.
   This is no longer supported; the argument representing the document to filter is now always
   called ``doc`` rather than using the model name for the kwarg. If you were using positional args
-  or using the ``filterModel`` decorator, this change will not affect your code.
+  or using the ``filtermodel`` decorator, this change will not affect your code.
 * Multiple configurable plugin loading paths are no longer supported. Use
   ``girder-install plugin <your_plugin_path>`` to install plugins that are not already in the
   plugins directory. Pass ``-s`` to that command to symlink instead of copying the directory.

--- a/plugins/virtual_folders/girder_virtual_folders/__init__.py
+++ b/plugins/virtual_folders/girder_virtual_folders/__init__.py
@@ -99,10 +99,14 @@ def _virtualChildItems(self, event):
         sort = json.loads(folder['virtualItemsSort'])
 
     item = Item()
-    # These items may reside in folders that the user cannot read, so we must filter
-    items = item.filterResultsByPermission(
-        item.find(q, sort=sort), user, level=AccessType.READ, limit=limit, offset=offset)
-    event.preventDefault().addResponse([item.filter(i, user) for i in items])
+    # These items may reside in folders that the user cannot read, so we must
+    # find with permissions
+    items = item.findWithPermissions(
+        q, sort=sort, user=user, level=AccessType.READ, limit=limit, offset=offset)
+    # We don't perform this filter on the standard item/find endpoint, so don't
+    # do it here.  Otherwise, we could return
+    # [item.filter(i, user) for i in items]
+    event.preventDefault().addResponse(items)
 
 
 class VirtualFoldersPlugin(GirderPlugin):


### PR DESCRIPTION
This uses `findWithPermissions` instead of filtering, as it is more efficient.  Also, to match how items are returned from the regular find endpoint, don't filter documents.  This has the virtue that the found item count is returned in the Girder-Total-Count header.