### PR TITLE
Fix a misleading exception in virtual folders

### DIFF
--- a/plugins/virtual_folders/girder_virtual_folders/__init__.py
+++ b/plugins/virtual_folders/girder_virtual_folders/__init__.py
@@ -83,13 +83,13 @@ def _folderUpdate(self, event):
 def _virtualChildItems(self, event):
     params = event.info['params']
 
-    if 'folderId' not in params:
+    if not params.get('folderId'):
         return  # This is not a child listing request
 
     user = self.getCurrentUser()
     folder = Folder().load(params['folderId'], user=user, level=AccessType.READ)
 
-    if not folder.get('isVirtual') or 'virtualItemsQuery' not in folder:
+    if not folder or not folder.get('isVirtual') or 'virtualItemsQuery' not in folder:
         return  # Parent is not a virtual folder, proceed as normal
 
     limit, offset, sort = self.getPagingParameters(params, defaultSortField='name')


### PR DESCRIPTION
When asking for a folder that doesn't exist, this threw an exception while checking if the folder was a virtual folder.  Rather, it should just return and let the parent method handle the issue.

This specifically occurred when trying to find items in a folder that didn't exist via a rest call (item?folderId=<non existant id>).