### PR TITLE
Fix an issue removing uninstalled assetstore types.

### DIFF
--- a/girder/models/assetstore.py
+++ b/girder/models/assetstore.py
@@ -62,10 +62,10 @@ class Assetstore(Model):
         if files is not None:
             raise ValidationException('You may not delete an assetstore that contains files.')
         # delete partial uploads before we delete the store.
-        adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
         try:
+            adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
             adapter.untrackedUploads([], delete=True)
-        except ValidationException:
+        except (NoAssetstoreAdapter, ValidationException):
             # this assetstore is currently unreachable, so skip this step
             pass
         # now remove the assetstore

--- a/girder/models/upload.py
+++ b/girder/models/upload.py
@@ -6,7 +6,7 @@ from bson.objectid import ObjectId
 from girder import events, logger
 from girder.api import rest
 from .model_base import Model
-from girder.exceptions import GirderException, ValidationException
+from girder.exceptions import GirderException, ValidationException, NoAssetstoreAdapter
 from girder.settings import SettingKey
 from girder.utility import RequestBodyStream
 from girder.utility.progress import noProgress
@@ -512,7 +512,10 @@ class Upload(Model):
         for assetstore in Assetstore().list():
             if assetstoreId and assetstoreId != assetstore['_id']:
                 continue
-            adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
+            try:
+                adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
+            except NoAssetstoreAdapter:
+                continue
             try:
                 results.extend(adapter.untrackedUploads(
                     knownUploads, delete=(action == 'delete')))


### PR DESCRIPTION
You could not delete an assetstore that is a type that is no longer present in the system, specifically because it attempted to delete untracked uploads.  If it couldn't reach the assestore (for instance, an S3 instance whose credentials were no longer valid), you could delete the assetstore because this step was deemed non-essential.  However, if you install a plugin to add an assetstore type, add an assetstore, and the uninstall the plugin, you could not then remove the assetstore.

This guards that condition, so you do not need to reinstall the plugin just to remove the assetstore.  Since the untracked uploads weren't essential for removing an assetstore, this doesn't result in any difference in functional behavior.

A similar guard was added to the enumeration of untracked uploads which is accessible from the system/uploads endpoints.