### PR TITLE
Support Python 3.8.

### DIFF
--- a/plugins/audit_logs/setup.py
+++ b/plugins/audit_logs/setup.py
@@ -36,7 +36,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     packages=find_packages(),
     zip_safe=False,

--- a/plugins/authorized_upload/setup.py
+++ b/plugins/authorized_upload/setup.py
@@ -39,7 +39,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/autojoin/setup.py
+++ b/plugins/autojoin/setup.py
@@ -38,7 +38,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/dicom_viewer/setup.py
+++ b/plugins/dicom_viewer/setup.py
@@ -38,7 +38,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/download_statistics/setup.py
+++ b/plugins/download_statistics/setup.py
@@ -37,7 +37,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/google_analytics/setup.py
+++ b/plugins/google_analytics/setup.py
@@ -38,7 +38,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/gravatar/setup.py
+++ b/plugins/gravatar/setup.py
@@ -38,7 +38,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/hashsum_download/setup.py
+++ b/plugins/hashsum_download/setup.py
@@ -38,7 +38,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/homepage/setup.py
+++ b/plugins/homepage/setup.py
@@ -38,7 +38,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/item_licenses/setup.py
+++ b/plugins/item_licenses/setup.py
@@ -37,7 +37,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/jobs/setup.py
+++ b/plugins/jobs/setup.py
@@ -38,7 +38,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/ldap/setup.py
+++ b/plugins/ldap/setup.py
@@ -37,7 +37,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/oauth/setup.py
+++ b/plugins/oauth/setup.py
@@ -38,7 +38,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/sentry/setup.py
+++ b/plugins/sentry/setup.py
@@ -37,7 +37,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/terms/setup.py
+++ b/plugins/terms/setup.py
@@ -39,7 +39,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/thumbnails/setup.py
+++ b/plugins/thumbnails/setup.py
@@ -37,7 +37,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/user_quota/setup.py
+++ b/plugins/user_quota/setup.py
@@ -38,7 +38,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/plugins/virtual_folders/setup.py
+++ b/plugins/virtual_folders/setup.py
@@ -37,7 +37,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     packages=find_packages(
         exclude=('girder.test', 'tests.*', 'tests', '*.plugin_tests.*', '*.plugin_tests')


### PR DESCRIPTION
This fixes the hash state function to work with Python 3.7 and adds Python3.8 to the classifiers in all setup.py files.