### PR TITLE
Ensure that login policy is enforced for OAuth users. Fixes #3228

### DIFF
--- a/plugins/oauth/girder_oauth/rest.py
+++ b/plugins/oauth/girder_oauth/rest.py
@@ -9,6 +9,7 @@ from girder.api.describe import Description, autoDescribeRoute
 from girder.api.rest import Resource
 from girder.api import access
 from girder.models.setting import Setting
+from girder.models.user import User
 from girder.models.token import Token
 
 from . import providers
@@ -124,6 +125,7 @@ class OAuth(Resource):
             raise cherrypy.HTTPRedirect(redirect)
 
         user = providerObj.getUser(token)
+        User().verifyLogin(user)
 
         event = events.trigger('oauth.auth_callback.after', {
             'provider': provider,

--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -707,6 +707,7 @@ girder
                 subtreeCount
                 updateSize
                 validate
+                verifyLogin
                 verifyOtp
     plugin
         GirderPlugin


### PR DESCRIPTION
This PR ensures that during the OAuth flow we check whether user `canLogin` before returning `girderToken`. I marked it as WIP because I haven't been able to set up testing env locally for girder 3.x  yet and I'm sure it will break all the things. I will add tests as soon as I get it going. Nevertheless it's ready for review/comments.