### PR TITLE
Make Girder natively respond to SIGTERM and SIGHUP

### DIFF
--- a/girder/cli/serve.py
+++ b/girder/cli/serve.py
@@ -34,5 +34,6 @@ def main(dev, mode, database, host, port):
     _attachFileLogHandlers()
     server.setup(mode)
 
+    cherrypy.engine.signal_handler.subscribe()
     cherrypy.engine.start()
     cherrypy.engine.block()


### PR DESCRIPTION
See: http://docs.cherrypy.org/en/3.3.0/refman/process/plugins/signalhandler.html

After this change, Girder will now natively exit when sent `SIGTERM` and `SIGHUP`. This most immediately impacts Girder's behavior in a container, where it is PID 1 (as PID 1 does not default to being killed when receiving an unhandled `SIGTERM`).

This was tested by using `docker kill -s SIGTERM` on a locally built slim container.

Fixes #3247.