### PR TITLE
Fix CWD file download

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -41,11 +41,12 @@ def _safeMakedirs(path):
 
     :param path: The directory to create.
     """
-    try:
-        os.makedirs(path)
-    except OSError as exception:
-        if exception.errno != errno.EEXIST:
-            raise
+    if path != '':
+        try:
+            os.makedirs(path)
+        except OSError as exception:
+            if exception.errno != errno.EEXIST:
+                raise
 
 
 class AuthenticationError(RuntimeError):


### PR DESCRIPTION
This is a bugfix for an issue in girder-client when you download a file without specifying a prefix directory. 

A MWE example to reproduce this issue is:

```bash
girder-client --api-url https://data.kitware.com/api/v1 download --parent-type file 5dcf0d1faf2e2eed35fad5d1 scallop.jpg
```

The issue is that the system attempts to create the containing directory if it does not exist using `dirname`. However, if there is no prefix path as in this example, then the `dirname` call resolves to `''`, which causes the subsequent makedirs call to fail with the error:

```
Traceback (most recent call last):
  File "/home/joncrall/.local/conda/envs/py38/bin/girder-client", line 11, in <module>
    load_entry_point('girder-client', 'console_scripts', 'girder-client')()
  File "/home/joncrall/.local/conda/envs/py38/lib/python3.8/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/joncrall/.local/conda/envs/py38/lib/python3.8/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/joncrall/.local/conda/envs/py38/lib/python3.8/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/joncrall/.local/conda/envs/py38/lib/python3.8/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/joncrall/.local/conda/envs/py38/lib/python3.8/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/joncrall/.local/conda/envs/py38/lib/python3.8/site-packages/click/decorators.py", line 27, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/home/joncrall/code/girder/clients/python/girder_client/cli.py", line 301, in _download
    gc.downloadFile(parent_id, local_folder)
  File "/home/joncrall/code/girder/clients/python/girder_client/__init__.py", line 1225, in downloadFile
    _safeMakedirs(os.path.dirname(path))
  File "/home/joncrall/code/girder/clients/python/girder_client/__init__.py", line 45, in _safeMakedirs
    os.makedirs(path)
  File "/home/joncrall/.local/conda/envs/py38/lib/python3.8/os.py", line 221, in makedirs
    mkdir(name, mode)
FileNotFoundError: [Errno 2] No such file or directory: ''
```

In contrast if you simply prefix the destination path with `./` then the command works:

```bash
girder-client --api-url https://data.kitware.com/api/v1 download --parent-type file 5dcf0d1faf2e2eed35fad5d1 ./scallop.jpg
```

However, a user should not be required to do that. An easy fix for this issue is to check for an empty path variable before calling `makedirs`, and do nothing in that case. Adding this patch fixes the issue. 


 