### PR TITLE
Add Item Tags plugin

### DIFF
--- a/plugins/.gitignore
+++ b/plugins/.gitignore
@@ -11,6 +11,7 @@
 !hashsum_download/
 !homepage/
 !item_licenses/
+!item_tags/
 !jobs/
 !ldap/
 !oauth/

--- a/plugins/item_tags/.editorconfig
+++ b/plugins/item_tags/.editorconfig
@@ -1,0 +1,27 @@
+root = true
+
+[*]
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.py]
+indent_size = 4
+max_line_length = 100
+
+[*.js]
+indent_size = 4
+
+[*.json]
+indent_size = 4
+
+[*.pug]
+indent_size = 2
+
+[*.styl]
+indent_size = 2
+
+[*.yml]
+indent_size = 2

--- a/plugins/item_tags/.gitignore
+++ b/plugins/item_tags/.gitignore
@@ -1,0 +1,50 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# pyenv
+.python-version
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/

--- a/plugins/item_tags/LICENSE
+++ b/plugins/item_tags/LICENSE
@@ -1,0 +1,15 @@
+Apache Software License 2.0
+
+Copyright (c) 2020, Daniel Chiquito
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/plugins/item_tags/MANIFEST.in
+++ b/plugins/item_tags/MANIFEST.in
@@ -1,0 +1,8 @@
+include LICENSE
+include README.rst
+include setup.py
+
+graft girder_item_tags
+graft docs
+prune test
+global-exclude *.py[co] *.cmake __pycache__ node_modules

--- a/plugins/item_tags/README.rst
+++ b/plugins/item_tags/README.rst
@@ -1,0 +1,25 @@
+=========
+Item Tags
+=========
+
+Searchable keyword tags for items.
+
+Features
+--------
+
+- Tag any item with any number of keyword tags.
+- Search for items with a given set of tags using a new custom search mode.
+- Configure a list of allowed tags in the plugin settings.
+
+Item tags are stored in the item metadata.
+Although they can be modified there, it is recommended to only use the included Tag widget.
+
+The search mode `Item tag search` must be select for tags to be searched.
+Searches are case insensitive and will only apply to tags, not to titles or descriptions.
+An item must be tagged with every word in a search query to be included in the search results;
+The search `"foo bar"` will only match items that are tagged with both `foo` and `bar`.
+
+Only tags in the allowed tag list can be apllied to items.
+Modifying or deleting items from the allowed tag list will not modify or delete those tags from items that already have them.
+If an item is tagged with `foo` and the `foo` tag is edited to be `bar`, the item will still be tagged with `foo`.
+However, it will not be possible to save any changes to the item's tags until the tag `foo` is removed from the item.

--- a/plugins/item_tags/girder_item_tags/__init__.py
+++ b/plugins/item_tags/girder_item_tags/__init__.py
@@ -1,0 +1,69 @@
+import re
+from girder import plugin
+from girder.api import access
+from girder.api.describe import Description, autoDescribeRoute
+from girder.exceptions import ValidationException
+from girder.models.item import Item
+from girder.models.setting import Setting
+from girder.utility import search, setting_utilities
+
+ITEM_TAG_LIST = 'item_tags.tag_list'
+
+
+class GirderPlugin(plugin.GirderPlugin):
+    DISPLAY_NAME = 'Item Tags'
+    CLIENT_SOURCE_PATH = 'web_client'
+
+    def load(self, info):
+        info['apiRoot'].resource.route('GET', ('tags',), getItemTags)
+        Item().ensureIndex(([('meta.girder_item_tags', 1)], {
+            'collation': {
+                'locale': 'en_US',
+                'strength': 1
+            }
+        }))
+        # Pytest reloads the plugin for every test.
+        # addSearchMode will break if called twice, so check if it's already been loaded.
+        if search.getSearchModeHandler('item_tags') is None:
+            search.addSearchMode('item_tags', search_handler)
+
+
+@setting_utilities.default(ITEM_TAG_LIST)
+def _default_item_tag_list():
+    return []
+
+
+@setting_utilities.validator(ITEM_TAG_LIST)
+def _validate_item_tag_list(tags):
+    if type(tags['value']) != list:
+        raise ValidationException('The setting is not a list', 'value')
+    for index, tag in enumerate(tags['value']):
+        if type(tag) != str:
+            raise ValidationException(f'Tag {index} is not a string', 'value')
+
+
+def search_handler(query, types, user=None, level=None, limit=0, offset=0):
+    # Break the query into a list of keywords separated by whitespace
+    query = re.compile(r'\W+').split(query.strip())
+    # Find all items that are tagged with every string in the query
+    cursor = Item()\
+        .find({'meta.girder_item_tags': {'$all': query}})\
+        .collation({'locale': 'en_US', 'strength': 1})
+    # Filter the result
+    result = {
+        'item': [
+            Item().filter(doc, user)
+            for doc in Item().filterResultsByPermission(cursor, user, level, limit, offset)
+        ]
+    }
+
+    return result
+
+
+@access.public()
+@autoDescribeRoute(
+    Description('Get the list of valid item tags.')
+    .errorResponse()
+)
+def getItemTags():
+    return Setting().get(ITEM_TAG_LIST)

--- a/plugins/item_tags/girder_item_tags/web_client/main.js
+++ b/plugins/item_tags/girder_item_tags/web_client/main.js
@@ -1,0 +1,11 @@
+import './routes';
+import SearchFieldWidget from '@girder/core/views/widgets/SearchFieldWidget';
+import './views/MetadataWidget';
+
+SearchFieldWidget.addMode(
+    'item_tags',
+    ['item'],
+    'Item tag search',
+    `You are searching by item tag. Only items manually tagged with all of the search keywords
+        will be returned.`
+);

--- a/plugins/item_tags/girder_item_tags/web_client/package.json
+++ b/plugins/item_tags/girder_item_tags/web_client/package.json
@@ -1,0 +1,154 @@
+{
+    "name": "@girder/item_tags",
+    "version": "0.1.0",
+    "private": true,
+    "description": "Searchable keyword tags for items.",
+    "homepage": "https://github.com/girder/girder",
+    "license": "Apache-2.0",
+    "peerDependencies": {
+        "@girder/core": "*"
+    },
+    "girderPlugin": {
+        "name": "item_tags",
+        "main": "./main.js"
+    },
+    "scripts": {
+        "lint": "eslint . && pug-lint . && stylint"
+    },
+    "devDependencies": {
+        "@girder/eslint-config": "*",
+        "@girder/pug-lint-config": "*",
+        "eslint": "^5",
+        "eslint-config-semistandard": "^13",
+        "eslint-config-standard": "^12",
+        "eslint-plugin-backbone": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-node": "*",
+        "eslint-plugin-promise": "*",
+        "eslint-plugin-standard": "*",
+        "eslint-plugin-underscore": "*",
+        "pug-lint": "^2",
+        "stylint": "^2"
+    },
+    "eslintConfig": {
+        "extends": "@girder",
+        "root": true
+    },
+    "pugLintConfig": {
+        "extends": "@girder/pug-lint-config"
+    },
+    "stylintrc": {
+        "blocks": false,
+        "brackets": {
+            "expect": "never",
+            "error": true
+        },
+        "colons": {
+            "expect": "never",
+            "error": true
+        },
+        "colors": false,
+        "commaSpace": {
+            "expect": "always",
+            "error": true
+        },
+        "commentSpace": {
+            "expect": "always",
+            "error": true
+        },
+        "cssLiteral": {
+            "expect": "never",
+            "error": true
+        },
+        "depthLimit": false,
+        "duplicates": {
+            "expect": true,
+            "error": true
+        },
+        "efficient": {
+            "expect": "always",
+            "error": true
+        },
+        "exclude": [
+            "node_modules/**"
+        ],
+        "extendPref": "@extend",
+        "globalDupe": false,
+        "groupOutputByFile": {
+            "expect": true,
+            "error": true
+        },
+        "indentPref": {
+            "expect": 2,
+            "error": true
+        },
+        "leadingZero": {
+            "expect": "always",
+            "error": true
+        },
+        "maxErrors": false,
+        "maxWarnings": false,
+        "mixed": false,
+        "mixins": [],
+        "namingConvention": false,
+        "namingConventionStrict": false,
+        "none": {
+            "expect": "always",
+            "error": true
+        },
+        "noImportant": false,
+        "parenSpace": {
+            "expect": "never",
+            "error": true
+        },
+        "placeholders": false,
+        "prefixVarsWithDollar": {
+            "expect": "always",
+            "error": true
+        },
+        "quotePref": {
+            "expect": "double",
+            "error": true
+        },
+        "reporterOptions": {
+            "columns": [
+                "lineData",
+                "severity",
+                "description",
+                "rule"
+            ],
+            "columnSplitter": "  ",
+            "showHeaders": false,
+            "truncate": true
+        },
+        "semicolons": {
+            "expect": "never",
+            "error": true
+        },
+        "sortOrder": false,
+        "stackedProperties": {
+            "expect": "never",
+            "error": true
+        },
+        "trailingWhitespace": {
+            "expect": "never",
+            "error": true
+        },
+        "universal": {
+            "expect": "never",
+            "error": true
+        },
+        "valid": {
+            "expect": true,
+            "error": true
+        },
+        "zeroUnits": {
+            "expect": "never",
+            "error": true
+        },
+        "zIndexNormalize": {
+            "expect": 5,
+            "error": true
+        }
+    }
+}

--- a/plugins/item_tags/girder_item_tags/web_client/routes.js
+++ b/plugins/item_tags/girder_item_tags/web_client/routes.js
@@ -1,0 +1,12 @@
+/* eslint-disable import/first */
+
+import router from '@girder/core/router';
+import events from '@girder/core/events';
+import { exposePluginConfig } from '@girder/core/utilities/PluginUtils';
+
+exposePluginConfig('item_tags', 'plugins/item_tags/config');
+
+import ConfigView from './views/ConfigView';
+router.route('plugins/item_tags/config', 'itemTagsConfig', function () {
+    events.trigger('g:navigateTo', ConfigView);
+});

--- a/plugins/item_tags/girder_item_tags/web_client/stylesheets/itemTagsWidget.styl
+++ b/plugins/item_tags/girder_item_tags/web_client/stylesheets/itemTagsWidget.styl
@@ -1,0 +1,54 @@
+.g-widget-item-tags-header
+  margin-top 10px
+  background-color #f0f0f0
+  padding 5px 6px
+  color #555
+  font-size 16px
+  font-weight bold
+
+  i
+    font-style normal
+
+button.g-widget-item-tags-add-button
+  float right
+  margin-right 10px
+  padding 2px 3px
+  margin-top 4px
+
+.g-widget-item-tags-container
+  margin 3px
+  margin-top 5px
+  border-bottom 1px solid #f0f0f0
+  min-height 25px
+  font-size 14px
+  color #777
+
+.g-widget-item-tags-container
+
+  .g-widget-item-tags-row
+    width 100%
+    display flex
+
+    .g-widget-item-tags-tag
+      font-size 16px
+      font-weight 700
+      flex-grow 1
+
+    .g-widget-item-tags-tag-input
+      height 24px
+      margin-left 5px
+      margin-right 5px
+      display inline-block
+      vertical-align middle
+      width auto
+      flex-grow 1
+
+    .g-widget-item-tags-edit-button, .g-widget-item-tags-cancel-button, .g-widget-item-tags-save-button, .g-widget-item-tags-delete-button
+      margin-right 4px
+      margin-top 1px
+      height 24px
+      font-size 12px
+      padding 2px
+
+.g-widget-item-tags-autocomplete-option.selected
+  background-color #ccc

--- a/plugins/item_tags/girder_item_tags/web_client/stylesheets/itemTagsWidget.styl
+++ b/plugins/item_tags/girder_item_tags/web_client/stylesheets/itemTagsWidget.styl
@@ -23,8 +23,6 @@ button.g-widget-item-tags-add-button
   font-size 14px
   color #777
 
-.g-widget-item-tags-container
-
   .g-widget-item-tags-row
     width 100%
     display flex

--- a/plugins/item_tags/girder_item_tags/web_client/templates/configView.pug
+++ b/plugins/item_tags/girder_item_tags/web_client/templates/configView.pug
@@ -1,0 +1,5 @@
+.g-config-breadcrumb-container
+p.g-item-tags-description
+  | Configure the list of allowed item tags.
+  | Modifying or removing tags from this list will not modify any items that have been tagged with those tags.
+.g-item-tags

--- a/plugins/item_tags/girder_item_tags/web_client/templates/itemTagAutocompleteMenu.pug
+++ b/plugins/item_tags/girder_item_tags/web_client/templates/itemTagAutocompleteMenu.pug
@@ -1,0 +1,13 @@
+each opt, index in autocompleteOptions
+  li(role="presentation")
+    if index !== highlightIndex
+      a.g-widget-item-tags-autocomplete-option(role="menuitem", data-tag=opt)
+        | #{opt}
+    else
+      a.g-widget-item-tags-autocomplete-option.selected(role="menuitem", data-tag=opt)
+        | #{opt}
+if autocompleteOptions.length === 0
+  li.g-widget-item-tags-autocomplete-no-options.disabled
+    a(tabindex="-1")
+      i.icon-block
+        | No results found

--- a/plugins/item_tags/girder_item_tags/web_client/templates/itemTagWidget.pug
+++ b/plugins/item_tags/girder_item_tags/web_client/templates/itemTagWidget.pug
@@ -10,8 +10,8 @@ if accessLevel >= AccessType.WRITE
     button.btn.btn-sm.btn-primary.g-widget-item-tags-save-button(title="Accept")
       i.icon-ok
   else
-    div.g-widget-item-tags-tag #{tag}
+    .g-widget-item-tags-tag #{tag}
     button.btn.btn-sm.btn-default.g-widget-item-tags-edit-button(title="Edit")
       i.icon-pencil
 else
-  div.g-widget-item-tags-tag #{tag}
+  .g-widget-item-tags-tag #{tag}

--- a/plugins/item_tags/girder_item_tags/web_client/templates/itemTagWidget.pug
+++ b/plugins/item_tags/girder_item_tags/web_client/templates/itemTagWidget.pug
@@ -1,0 +1,17 @@
+if accessLevel >= AccessType.WRITE
+  if editing
+    button.btn.btn-sm.btn-danger.g-widget-item-tags-delete-button(title="Delete")
+      i.icon-trash
+    .g-widget-item-tags-autocomplete-menu.dropdown
+      ul.dropdown-menu(role="menu")
+    input.input-sm.form-control.g-widget-item-tags-tag-input(type="text", value=tag, placeholder="Tag")
+    button.btn.btn-sm.btn-warning.g-widget-item-tags-cancel-button(title="Cancel")
+      i.icon-cancel
+    button.btn.btn-sm.btn-primary.g-widget-item-tags-save-button(title="Accept")
+      i.icon-ok
+  else
+    div.g-widget-item-tags-tag #{tag}
+    button.btn.btn-sm.btn-default.g-widget-item-tags-edit-button(title="Edit")
+      i.icon-pencil
+else
+  div.g-widget-item-tags-tag #{tag}

--- a/plugins/item_tags/girder_item_tags/web_client/templates/itemTagsWidget.pug
+++ b/plugins/item_tags/girder_item_tags/web_client/templates/itemTagsWidget.pug
@@ -1,0 +1,8 @@
+.g-item-tags
+  if (accessLevel >= AccessType.WRITE)
+    .btn-group.pull-right
+      button.g-widget-item-tags-add-button.btn.btn-sm.btn-primary.btn-default(title="Add Tag")
+        i.icon-plus
+  .g-widget-item-tags-header
+    i.icon-tags Tags
+  .g-widget-item-tags-container

--- a/plugins/item_tags/girder_item_tags/web_client/views/ConfigView.js
+++ b/plugins/item_tags/girder_item_tags/web_client/views/ConfigView.js
@@ -1,0 +1,48 @@
+import { AccessType } from '@girder/core/constants';
+import PluginConfigBreadcrumbWidget from '@girder/core/views/widgets/PluginConfigBreadcrumbWidget';
+import View from '@girder/core/views/View';
+import { restRequest } from '@girder/core/rest';
+
+import ConfigViewTemplate from '../templates/configView.pug';
+
+import ItemTagsWidget from './ItemTagsWidget';
+
+var ConfigView = View.extend({
+
+    render: function () {
+        this.$el.html(ConfigViewTemplate({
+            licenses: JSON.stringify(this.licenses, null, 4)
+        }));
+        restRequest({ url: 'system/setting', data: { key: 'item_tags.tag_list' }, method: 'GET' })
+            .then((resp) => {
+                this.itemTagsWidget = new ItemTagsWidget({
+                    el: this.$el.find('.g-item-tags'),
+                    tags: resp,
+                    allowedTags: null,
+                    accessLevel: AccessType.ADMIN,
+                    parentView: this,
+                    saveTags: this.saveTags.bind(this),
+                    AccessType: AccessType
+                });
+                return true;
+            });
+
+        this.breadcrumb = new PluginConfigBreadcrumbWidget({
+            pluginName: 'Item Tags',
+            el: this.$('.g-config-breadcrumb-container'),
+            parentView: this
+        }).render();
+
+        return this;
+    },
+
+    saveTags: function (tags) {
+        tags = tags.sort();
+        restRequest({ url: 'system/setting', data: { key: 'item_tags.tag_list', value: JSON.stringify(tags) }, method: 'PUT' })
+            .then(() => {
+                return this.render();
+            });
+    }
+});
+
+export default ConfigView;

--- a/plugins/item_tags/girder_item_tags/web_client/views/ItemTagsWidget.js
+++ b/plugins/item_tags/girder_item_tags/web_client/views/ItemTagsWidget.js
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import _ from 'underscore';
 
 import { AccessType } from '@girder/core/constants';

--- a/plugins/item_tags/girder_item_tags/web_client/views/ItemTagsWidget.js
+++ b/plugins/item_tags/girder_item_tags/web_client/views/ItemTagsWidget.js
@@ -1,0 +1,202 @@
+import _ from 'underscore';
+
+import { AccessType } from '@girder/core/constants';
+import events from '@girder/core/events';
+import View from '@girder/core/views/View';
+
+import ItemTagsWidgetTemplate from '../templates/itemTagsWidget.pug';
+import ItemTagWidgetTemplate from '../templates/itemTagWidget.pug';
+import ItemTagAutocompleteMenuTemplate from '../templates/itemTagAutocompleteMenu.pug';
+
+import 'bootstrap/js/dropdown';
+
+import '../stylesheets/itemTagsWidget.styl';
+
+/**
+ * A widget for rendering a single item tag.
+ */
+const ItemTagWidget = View.extend({
+    className: 'g-widget-item-tags-row',
+    events: {
+        'click .g-widget-item-tags-edit-button': 'editTag',
+        'click .g-widget-item-tags-cancel-button': 'cancelTag',
+        'click .g-widget-item-tags-save-button': 'saveTag',
+        'click .g-widget-item-tags-delete-button': 'deleteTag',
+        'keyup .g-widget-item-tags-tag-input': function (event) {
+            if (event.key === 'Enter') {
+                if (this.highlightIndex >= 0) {
+                    // an autocomplete option is highlighted, select it instead of saving
+                    const tag = this.$el.find('.g-widget-item-tags-autocomplete-option.selected').attr('data-tag');
+                    this.$el.find('.g-widget-item-tags-tag-input').val(tag);
+                    this.highlightIndex = -1;
+                    this.updateAutocomplete();
+                } else {
+                    this.saveTag();
+                }
+            } else {
+                if (event.key === 'ArrowUp') {
+                    this.highlightIndex--;
+                } else if (event.key === 'ArrowDown') {
+                    this.highlightIndex++;
+                } else {
+                    // any non arrow key events will remove the autocomplete option highlight
+                    this.highlightIndex = -1;
+                }
+                this.updateAutocomplete();
+            }
+        },
+        'focusin .g-widget-item-tags-tag-input': 'showAutocomplete',
+        'focusout .g-widget-item-tags-tag-input': 'hideAutocomplete',
+        'mousedown .g-widget-item-tags-autocomplete-option': 'selectAutocompleteOption'
+    },
+    initialize: function (settings) {
+        this.tag = settings.tag;
+        this.index = settings.index;
+        this.accessLevel = settings.accessLevel;
+        this.parentView = settings.parentView;
+        this.onItemSaved = settings.onItemSaved;
+        this.onItemDeleted = settings.onItemDeleted;
+        this.editing = settings.editing || false;
+        this.highlightIndex = -1; // -1 means no autocomplete option selected
+    },
+    render: function () {
+        this.$el.html(ItemTagWidgetTemplate({
+            tag: this.tag,
+            editing: this.editing,
+            accessLevel: this.accessLevel,
+            AccessType: AccessType
+        }));
+        if (this.editing) {
+            this.updateAutocomplete();
+        }
+        return this;
+    },
+    editTag: function () {
+        this.editing = true;
+        this.render();
+        this.$el.find('.g-widget-item-tags-tag-input').focus();
+    },
+    cancelTag: function () {
+        this.editing = false;
+        this.render();
+    },
+    saveTag: function () {
+        this.onItemSaved(this.index, this.$el.find('.g-widget-item-tags-tag-input').val());
+    },
+    deleteTag: function () {
+        this.onItemDeleted(this.index, this.tag);
+    },
+    /** Updates the autocomplete options, including highlighting */
+    updateAutocomplete: function () {
+        const input = this.$el.find('.g-widget-item-tags-tag-input');
+        if (input === '') {
+            return;
+        }
+        if (this.parentView.allowedTags !== null) {
+            const autocompleteOptions = this.parentView.allowedTags.filter(function (tag) {
+                return tag.startsWith(input.val());
+            }).slice(0, 10);
+            if (this.highlightIndex < -1) {
+            // user must have wrapped around, change the highlight to the end of the array
+                this.highlightIndex = autocompleteOptions.length - 1;
+            }
+            if (this.highlightIndex >= autocompleteOptions.length) {
+            // user must have gone off the end of the list, change highlight back to -1 (no option selected)
+                this.highlightIndex = -1;
+            }
+            this.$el.find('.g-widget-item-tags-autocomplete-menu .dropdown-menu').html(ItemTagAutocompleteMenuTemplate({
+                autocompleteOptions: autocompleteOptions,
+                highlightIndex: this.highlightIndex
+            }));
+            this.showAutocomplete();
+        }
+    },
+    /** Show the autocomplete dropdown if autocomplete is possible */
+    showAutocomplete: function () {
+        if (this.parentView.allowedTags !== null) {
+            this.$el.find('.dropdown').addClass('open');
+        }
+    },
+    /** Hide the autocomplete dropdown */
+    hideAutocomplete: function () {
+        this.$el.find('.dropdown').removeClass('open');
+    },
+    /** Handles click events on the autocomplete dropdown options */
+    selectAutocompleteOption: function (event) {
+        this.$el.find('.g-widget-item-tags-tag-input').val(event.target.getAttribute('data-tag'));
+        this.updateAutocomplete();
+    }
+});
+
+/**
+ * A widget for displaying a list of item tags.
+ */
+const ItemTagsWidget = View.extend({
+    events: {
+        'click .g-widget-item-tags-add-button': 'addItemTag'
+    },
+    initialize: function (settings) {
+        this.tags = settings.tags;
+        this.accessLevel = settings.accessLevel;
+        this.saveTags = settings.saveTags;
+        this.allowedTags = settings.allowedTags;
+        this.render();
+    },
+    render: function () {
+        this.$el.html(ItemTagsWidgetTemplate({
+            accessLevel: this.accessLevel,
+            AccessType: AccessType
+        }));
+        _.each(this.tags, function (tag, index) {
+            this.$el.find('.g-widget-item-tags-container').append(new ItemTagWidget({
+                tag: tag,
+                index: index,
+                accessLevel: this.accessLevel,
+                parentView: this,
+                onItemSaved: this.itemSaved.bind(this),
+                onItemDeleted: this.itemDeleted.bind(this),
+                editing: tag === '' // new tags start empty, they should be initially editable
+            }).render().$el);
+        }, this);
+        return this;
+    },
+    addItemTag: function () {
+        if (!this.tags.includes('')) {
+            this.tags.push('');
+            this.render();
+        }
+        $('.g-widget-item-tags-tag-input').last().focus();
+    },
+    /** Passed to ItemTagWidget and called when a tag being edited is saved */
+    itemSaved: function (index, tag) {
+        this.tags[index] = tag;
+        if (this.validateTags()) {
+            this.saveTags(this.tags);
+        }
+    },
+    /** Passed to ItemTagWidget and called when a tag being edited is deleted */
+    itemDeleted: function (index, tag) {
+        this.tags.splice(index, 1);
+        this.saveTags();
+    },
+    /** Validates that the current list of tags is a subset of allowedTags */
+    validateTags: function () {
+        if (this.allowedTags === null) {
+            return true;
+        }
+
+        var failedValidation = false;
+        for (const tag of this.tags) {
+            if (!this.allowedTags.includes(tag)) {
+                events.trigger('g:alert', {
+                    text: `Tag "${tag}" is not defined`,
+                    type: 'danger'
+                });
+                failedValidation = true;
+            }
+        }
+        return !failedValidation;
+    }
+});
+
+export default ItemTagsWidget;

--- a/plugins/item_tags/girder_item_tags/web_client/views/MetadataWidget.js
+++ b/plugins/item_tags/girder_item_tags/web_client/views/MetadataWidget.js
@@ -1,0 +1,67 @@
+import $ from 'jquery';
+
+import { AccessType } from '@girder/core/constants';
+import events from '@girder/core/events';
+import { restRequest } from '@girder/core/rest';
+import { wrap } from '@girder/core/utilities/PluginUtils';
+import MetadataWidget from '@girder/core/views/widgets/MetadataWidget';
+
+import ItemTagsWidgetTemplate from '../templates/itemTagsWidget.pug';
+import ItemTagsWidget from './ItemTagsWidget';
+
+/** The key in the item metadata that item tags are saved under */
+const METADATA_KEY = 'girder_item_tags';
+
+/**
+ * Saves the
+ * Passed to ItemTagsWidget and called when a tag being edited is saved.
+ */
+const saveTags = function (tags) {
+    tags = tags.filter(function (tag) {
+        // filter out empty string tags
+        return tag !== '';
+    }).filter(function (item, pos, self) {
+        // filter out duplicate tags
+        return self.indexOf(item) === pos;
+    }).sort(); // sort
+    const successCallback = function () {
+        this.itemTagsWidget.tags = tags;
+        this.item.trigger('g:changed');
+    };
+    const errorCallback = function () {
+        events.trigger('g:alert', {
+            text: 'Failed to save tags',
+            type: 'danger'
+        });
+    };
+    this.item.editMetadata(METADATA_KEY, METADATA_KEY, tags, successCallback.bind(this), errorCallback.bind(this));
+};
+
+// Add the Item Tags widget before the Metadata widget
+wrap(MetadataWidget, 'render', function (render) {
+    render.call(this);
+    // Only attach if it hasn't been attached yet
+    // Only attach to items, not folders or collections
+    if ($('.g-item-tags').length === 0 && this.item.attributes._modelType === 'item') {
+        this.$el.before(ItemTagsWidgetTemplate({
+            accessLevel: this.accessLevel,
+            AccessType: AccessType
+        }));
+        restRequest({ url: 'resource/tags', method: 'GET' })
+            .then((resp) => {
+                this.itemTagsWidget = new ItemTagsWidget({
+                    el: this.el.previousSibling,
+                    tags: this.item.attributes.meta[METADATA_KEY] || [],
+                    allowedTags: resp,
+                    accessLevel: this.accessLevel,
+                    parentView: this,
+                    saveTags: saveTags.bind(this),
+                    AccessType: AccessType
+                });
+                this.item.on('g:changed', function () {
+                    this.itemTagsWidget.render();
+                }, this);
+                return true;
+            });
+    }
+});

--- a/plugins/item_tags/requirements-dev.txt
+++ b/plugins/item_tags/requirements-dev.txt
@@ -1,0 +1,3 @@
+pip>=9
+tox
+virtualenv

--- a/plugins/item_tags/setup.cfg
+++ b/plugins/item_tags/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/plugins/item_tags/setup.py
+++ b/plugins/item_tags/setup.py
@@ -1,0 +1,39 @@
+from setuptools import setup, find_packages
+
+with open('README.rst') as readme_file:
+    readme = readme_file.read()
+
+requirements = [
+    'girder>=3.0.0a1'
+]
+
+setup(
+    author='Daniel Chiquito',
+    author_email='daniel.chiquito@kitware.com',
+    classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'License :: OSI Approved :: Apache Software License',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8'
+    ],
+    description='Searchable keyword tags for items.',
+    install_requires=requirements,
+    license='Apache Software License 2.0',
+    long_description=readme,
+    long_description_content_type='text/x-rst',
+    include_package_data=True,
+    keywords='girder-plugin, item_tags',
+    name='girder-item-tags',
+    packages=find_packages(exclude=['test', 'test.*']),
+    url='https://github.com/girder/girder',
+    version='0.1.0',
+    zip_safe=False,
+    entry_points={
+        'girder.plugin': [
+            'item_tags = girder_item_tags:GirderPlugin'
+        ]
+    }
+)

--- a/plugins/item_tags/tests/test_item_tag_search.py
+++ b/plugins/item_tags/tests/test_item_tag_search.py
@@ -1,0 +1,95 @@
+import pytest
+from pytest_girder.assertions import assertStatusOk
+
+from girder.models.folder import Folder
+from girder.models.item import Item
+
+
+@pytest.fixture
+def userFolder(user, fsAssetstore):
+    folders = Folder().childFolders(
+        parent=user, parentType='user', user=user
+    )
+    for folder in folders:
+        if folder['public'] is True:
+            return folder
+
+
+@pytest.fixture
+def adminFolder(admin, fsAssetstore):
+    folders = Folder().childFolders(
+        parent=admin, parentType='user', user=admin
+    )
+    for folder in folders:
+        if folder['public'] is True:
+            return folder
+
+
+def createItem(name, user, folder, tags):
+    item = Item().createItem(name, user, folder)
+    return Item().setMetadata(item, {'girder_item_tags': tags})
+
+
+@pytest.mark.plugin('item_tags')
+def test_search_case_insensitive(server, user, userFolder):
+    item = createItem('testItem', user, userFolder, ['AbC'])
+    resp = server.request(
+        path='/resource/search',
+        method='GET',
+        user=user,
+        params={
+            'q': 'aBc',
+            'mode': 'item_tags',
+            'types': '["item"]'
+        }
+    )
+    assertStatusOk(resp)
+    results = resp.json['item']
+    print(results)
+    assert len(results) == 1
+    assert results[0]['_id'] == str(item['_id'])
+
+
+@pytest.mark.plugin('item_tags')
+def test_search_multiple_results(server, user, userFolder):
+    item1 = createItem('testItem1', user, userFolder, ['abc', '123'])
+    item2 = createItem('testItem2', user, userFolder, ['xyz', 'abc'])
+    createItem('testItem3', user, userFolder, ['123', 'xyz'])
+    resp = server.request(
+        path='/resource/search',
+        method='GET',
+        user=user,
+        params={
+            'q': 'abc',
+            'mode': 'item_tags',
+            'types': '["item"]'
+        }
+    )
+    assertStatusOk(resp)
+    results = resp.json['item']
+    print(results)
+    assert len(results) == 2
+    assert results[0]['_id'] == str(item1['_id'])
+    assert results[1]['_id'] == str(item2['_id'])
+
+
+@pytest.mark.plugin('item_tags')
+def test_search_multiple_search_tags(server, user, userFolder):
+    createItem('testItem1', user, userFolder, ['abc', '123'])
+    item2 = createItem('testItem2', user, userFolder, ['xyz', 'abc'])
+    createItem('testItem3', user, userFolder, ['123', 'xyz'])
+    resp = server.request(
+        path='/resource/search',
+        method='GET',
+        user=user,
+        params={
+            'q': 'abc xyz',
+            'mode': 'item_tags',
+            'types': '["item"]'
+        }
+    )
+    assertStatusOk(resp)
+    results = resp.json['item']
+    print(results)
+    assert len(results) == 1
+    assert results[0]['_id'] == str(item2['_id'])

--- a/plugins/item_tags/tox.ini
+++ b/plugins/item_tags/tox.ini
@@ -1,0 +1,81 @@
+[tox]
+envlist =
+    lint,
+    py3
+
+[testenv]
+deps =
+    coverage
+    mock
+    pytest
+    pytest-cov
+    pytest-girder>=0.1.0a1
+    pytest-xdist
+commands =
+    pytest --cov {envsitepackagesdir}/girder_item_tags {posargs}
+
+[testenv:lint]
+skipsdist = true
+skip_install = true
+deps =
+    flake8
+    flake8-blind-except
+    flake8-bugbear
+    flake8-docstrings
+    flake8-quotes
+    pep8-naming
+commands =
+    flake8 {posargs}
+
+[testenv:release]
+passenv =
+    TWINE_USERNAME
+    TWINE_PASSWORD
+deps =
+    twine
+commands =
+    twine check {distdir}/*
+    twine upload --skip-existing {distdir}/*
+
+[flake8]
+max-line-length = 100
+show-source = True
+format = pylint
+exclude =
+    node_modules,
+    .eggs,
+    .git,
+    __pycache__,
+    .tox
+ignore =
+    # D10* - Missing docstring in *
+    D10,
+    # E123 - Closing bracket does not match indentation of opening bracket’s line
+    E123
+    # N802 - Function name should be lowercase.
+    N802,
+    # N803 - Argument name should be lowercase.
+    N803,
+    # N806 - Variable in function should be lowercase.
+    N806,
+    # N812 - Lowercase imported as non lowercase.
+    N812,
+    # N815 - mixedCase variable in class scope
+    N815,
+    # N816 - mixedCase variable in global scope
+    N816,
+    # W503 - Line break before binary operator
+    W503,
+
+[pytest]
+addopts = --verbose --strict --showlocals --cov-report="term"
+testpaths = tests
+
+[coverage:paths]
+source =
+    girder_item_tags/
+    .tox/*/lib/python*/site-packages/girder_item_tags/
+
+[coverage:run]
+branch = True
+parallel = True

--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -1080,6 +1080,23 @@ plugins
             updateItemLicense
             validateItem
             validateString
+    item_tags
+        girder_item_tags
+            GirderPlugin
+                CLIENT_SOURCE_PATH
+                DISPLAY_NAME
+                load
+            ITEM_TAG_LIST
+            getItemTags
+            search_handler
+        tests
+            test_item_tag_search
+                adminFolder
+                createItem
+                test_search_case_insensitive
+                test_search_multiple_results
+                test_search_multiple_search_tags
+                userFolder
     jobs
         girder_jobs
             JobsPlugin


### PR DESCRIPTION
A plugin for tagging items and searching for those tags.
Item tags are stored in item metadata.
Item tags can be modified from the item view.
There is also a list of allowed tags that is stored in a setting.
Allowed tags can be modified from the plugin settings.

Closes #3251 