### PR TITLE
Created layering context for folder and item containers

### DIFF
--- a/girder/web_client/src/stylesheets/widgets/hierarchyWidget.styl
+++ b/girder/web_client/src/stylesheets/widgets/hierarchyWidget.styl
@@ -92,6 +92,10 @@
         right -3px
         padding 0 0.3em
 
+  .g-folder-list-container, .g-item-list-container
+    position relative
+    z-index 0
+
   .g-folder-list, .g-item-list, .g-file-list
     margin 0
     padding 0

--- a/girder/web_client/src/views/widgets/HierarchyWidget.js
+++ b/girder/web_client/src/views/widgets/HierarchyWidget.js
@@ -71,11 +71,14 @@ var HierarchyBreadcrumbView = View.extend({
 var HierarchyPaginatedView = View.extend({
     events: {
         'change #g-page-selection-input': function (event) {
-            this.disabled = true;
-            this.itemListWidget.setPage(Number(event.target.value)).done(() => {
-                this.disabled = false;
-                this.render();
-            });
+            const num = Number(event.target.value);
+            if (this.itemListWidget && num <= this.itemListWidget.getNumPages() && num > 0) {
+                this.disabled = true;
+                this.itemListWidget.setPage(num).done(() => {
+                    this.disabled = false;
+                    this.render();
+                });
+            }
             this.render();
         },
         'click li.g-page-next:not(.disabled) a#g-next-paginated': function () {


### PR DESCRIPTION
Sets the Folder and Item Lists so they have their own z-index stack so that plugins can place items in there under their own z-index.  This fixes an issue where items could go above the breadcrumb bar when it was in static mode for paginated items.


Forces numbers outside of the pagination range to revert back to the current page instead of displaying the incorrect number.  I.E. there are 2 pages and a user types 56 in the input area, before it wouldn't go to page 56 but 56 would remain in the input.  This updates it so that it reverts back to the current page number instead.