### PR TITLE
Resolve paths in the CLI before passing them to the client library

### DIFF
--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -268,7 +268,8 @@ def _CommonParameters(path_exists=False, path_writable=True,
             click.argument(
                 'local_folder',
                 type=click.Path(exists=path_exists, dir_okay=True,
-                                writable=path_writable, readable=True),
+                                writable=path_writable, readable=True,
+                                resolve_path=True),
                 default=path_default,
                 nargs=1 if not multiple_local else -1,
                 required=multiple_local


### PR DESCRIPTION
For default paths such as ".", this will expand to an absolute path and allow filesystem traversal in the client library to succeed.

See PR #3250 for a fuller description of this issue.