### PR TITLE
Update Tox configuration and documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
           working_directory: girder_build
       - run:
           name: Run tox
-          command: tox -e lint,circleci-py36,docs
+          command: tox -e lint,pytest_circleci,docs
           working_directory: girder
       - run:
           name: Make coverage file distinct

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,17 @@
 [tox]
-envlist = lint,py36,docs,public_names
-skip_missing_interpreters = true
+envlist = lint,pytest
 
-[testenv]
-deps = -rrequirements-dev.txt
+[testenv:pytest]
 # In the install command, we include the "girder" package as `.`.  This is because
 # tox runs the install command *before* installing girder, but girder is a dependency
 # of many of the packages in requirements-dev.txt (pytest-girder and all of the plugins).
 # Without this, pip attempts to install girder from pypi during the dependency
 # installation.
-install_command = pip install --upgrade --upgrade-strategy eager {opts} . {packages}
-commands = pytest {posargs}
+install_command = python -m pip install {opts} . {packages}
+deps =
+    -rrequirements-dev.txt
+commands =
+    pytest {posargs}
 
 [testenv:lint]
 skip_install = true
@@ -22,20 +23,21 @@ deps =
     flake8-docstrings
     flake8-quotes
     pep8-naming
-commands = flake8 {posargs}
+commands =
+    flake8 {posargs}
 
 [testenv:docs]
-# Building docs has a direct dependency on Sphinx. Documentation dependencies are listed in a
-# separate file to allow readthedocs.org to read and install them.
-deps = -rdocs/requirements-docs.txt
 # readthedocs.org runs "python setup.py install" (which installs no dependencies). With the
 # limitations of Tox (not being able to use a different install_command for deps installation and
 # package installation) and the desire to install cleanly via pip (instead of directly with
 # setuptools), skip_install and an explicit "pip install" run command seems to be the best
 # configuration possible.
 skip_install = true
-# In combination with skip_install, usedevelop just prevents Tox from creating an sdist.
-usedevelop = true
+skipsdist = true
+# Building docs has a direct dependency on Sphinx. Documentation dependencies are listed in a
+# separate file to allow readthedocs.org to read and install them.
+deps =
+    -rdocs/requirements-docs.txt
 commands =
     pip install --no-deps --editable . --editable clients/python
     sphinx-build \
@@ -49,52 +51,59 @@ commands =
 skip_install = true
 skipsdist = true
 changedir = devops/ansible-role-girder
-passenv = DOCKER_*
+passenv =
+    DOCKER_*
 deps =
-  ansible
-  # Pin ansible-lint: https://github.com/ansible-community/molecule/issues/2646
-  ansible-lint==4.2.0
-  molecule[docker,lint]>=3.0.3
-  testinfra
+    ansible
+    # Pin ansible-lint: https://github.com/ansible-community/molecule/issues/2646
+    ansible-lint==4.2.0
+    molecule[docker,lint]>=3.0.3
+    testinfra
 commands =
-  molecule {posargs: test --all}
+    molecule {posargs: test --all}
 
 [testenv:publish]
 skip_install = true
 skipsdist = true
 passenv =
-  CIRCLE_BRANCH
-  TWINE_USERNAME
-  TWINE_PASSWORD
+    CIRCLE_BRANCH
+    TWINE_USERNAME
+    TWINE_PASSWORD
 deps =
-  setuptools-git
-  setuptools-scm
-  twine
+    setuptools-git
+    setuptools-scm
+    twine
 commands =
-  {toxinidir}/.circleci/publish_pypi.sh
+    {toxinidir}/.circleci/publish_pypi.sh
 
 [testenv:release_ansible]
 skip_install = true
 skipsdist = true
 passenv =
-  ANSIBLE_GALAXY_API_KEY
+    ANSIBLE_GALAXY_API_KEY
 deps =
-  ansible
+    ansible
 commands =
-  {toxinidir}/.circleci/create_ansible_subtree.sh
-  ansible-galaxy import --api-key {env:ANSIBLE_GALAXY_API_KEY} girder ansible-role-girder
+    {toxinidir}/.circleci/create_ansible_subtree.sh
+    ansible-galaxy import --api-key {env:ANSIBLE_GALAXY_API_KEY} girder ansible-role-girder
 
 [testenv:public_names]
-commands = {toxinidir}/scripts/test_names.sh
+commands =
+    {toxinidir}/scripts/test_names.sh
 
-[testenv:circleci-py36]
-basepython = python3.6
-commands = pytest \
-           --tb=long \
-           --junit-xml="build/test/results/pytest-3.6.xml" \
-           --cov-append \
-           --keep-db \
-            {posargs}
+[testenv:pytest_circleci]
+install_command = {[testenv:pytest]install_command}
+deps =
+    {[testenv:pytest]deps}
+commands =
+    pytest \
+        --tb=long \
+        --junit-xml="build/test/results/pytest-3.6.xml" \
+        --cov \
+        --cov-append \
+        --cov-report="" \
+        --keep-db \
+        {posargs}
 
 [flake8]
 max-line-length = 100
@@ -137,7 +146,7 @@ ignore =
     W503,
 
 [pytest]
-addopts = --verbose --strict --showlocals --cov-report="" --cov
+addopts = --verbose --strict --showlocals
 cache_dir = build/test/pytest_cache
 junit_family = xunit2
 testpaths = test


### PR DESCRIPTION
* Update the Tox file:
  * Only run lint and pytest tests by default
  * Allow Pytest to be run from any Python version (not just 3.6)
  * Prevent superfluous dependencies from being installed in the "public_names" environment, making it faster to start
  * Explicitly name the "pytest" environment
  * Format indentation and section ordering more consistently
  * Don't track coverage by default, since no report is actually generated
* Update the docs on server testing
  * This removes obsolete content and attempts to present the most important information for new developers.