### PR TITLE
Replace use of "mock" with "unittest.mock"

### DIFF
--- a/plugins/ldap/plugin_tests/ldap_test.py
+++ b/plugins/ldap/plugin_tests/ldap_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
+import unittest.mock
+
 import ldap
-import mock
 
 from girder.exceptions import ValidationException
 from girder.models.setting import Setting
@@ -67,7 +68,7 @@ class LdapTestCase(base.TestCase):
             'uri': 'foo.bar.org:389'
         }])
 
-        with mock.patch('ldap.initialize', return_value=MockLdap()) as ldapInit:
+        with unittest.mock.patch('ldap.initialize', return_value=MockLdap()) as ldapInit:
             resp = self.request('/user/authentication', basicAuth='hello:world')
             self.assertEqual(len(ldapInit.mock_calls), 1)
             self.assertStatusOk(resp)
@@ -84,11 +85,11 @@ class LdapTestCase(base.TestCase):
             self.assertStatusOk(resp)
             self.assertEqual(resp.json['user']['_id'], user['_id'])
 
-        with mock.patch('ldap.initialize', return_value=MockLdap(bindFail=True)):
+        with unittest.mock.patch('ldap.initialize', return_value=MockLdap(bindFail=True)):
             resp = self.request('/user/authentication', basicAuth='hello:world')
             self.assertStatus(resp, 401)
 
-        with mock.patch('ldap.initialize', return_value=MockLdap(searchFail=True)):
+        with unittest.mock.patch('ldap.initialize', return_value=MockLdap(searchFail=True)):
             resp = self.request('/user/authentication', basicAuth='hello:world')
             self.assertStatus(resp, 401)
 
@@ -96,7 +97,7 @@ class LdapTestCase(base.TestCase):
         normalUser = User().createUser(
             login='normal', firstName='Normal', lastName='User', email='normal@girder.test',
             password='normaluser')
-        with mock.patch('ldap.initialize', return_value=MockLdap(searchFail=True)):
+        with unittest.mock.patch('ldap.initialize', return_value=MockLdap(searchFail=True)):
             resp = self.request('/user/authentication', basicAuth='normal:normaluser')
             self.assertStatusOk(resp)
             self.assertEqual(str(normalUser['_id']), resp.json['user']['_id'])
@@ -107,7 +108,7 @@ class LdapTestCase(base.TestCase):
             'mail': [b'fizz@buzz.com'],
             'distinguishedName': [b'shouldbeignored']
         }
-        with mock.patch('ldap.initialize', return_value=MockLdap(record=record)):
+        with unittest.mock.patch('ldap.initialize', return_value=MockLdap(record=record)):
             resp = self.request('/user/authentication', basicAuth='fizzbuzz:foo')
             self.assertStatusOk(resp)
             self.assertEqual(resp.json['user']['login'], 'fizz')
@@ -120,7 +121,7 @@ class LdapTestCase(base.TestCase):
             'mail': [b'fizz@buzz2.com'],
             'distinguishedName': [b'shouldbeignored']
         }
-        with mock.patch('ldap.initialize', return_value=MockLdap(record=record)):
+        with unittest.mock.patch('ldap.initialize', return_value=MockLdap(record=record)):
             resp = self.request('/user/authentication', basicAuth='fizzbuzz:foo')
             self.assertStatusOk(resp)
             self.assertEqual(resp.json['user']['login'], 'fizzbuzz')
@@ -138,13 +139,13 @@ class LdapTestCase(base.TestCase):
             'uri': 'ldap://foo.bar.org:389'
         }
 
-        with mock.patch('ldap.initialize', return_value=MockLdap(bindFail=True)):
+        with unittest.mock.patch('ldap.initialize', return_value=MockLdap(bindFail=True)):
             resp = self.request('/system/ldap_server/status', user=admin, params=params)
             self.assertStatusOk(resp)
             self.assertFalse(resp.json['connected'])
             self.assertEqual(resp.json['error'], 'LDAP connection error: failed to connect')
 
-        with mock.patch('ldap.initialize', return_value=MockLdap(bindFail=False)):
+        with unittest.mock.patch('ldap.initialize', return_value=MockLdap(bindFail=False)):
             resp = self.request('/system/ldap_server/status', user=admin, params=params)
             self.assertStatusOk(resp)
             self.assertTrue(resp.json['connected'])

--- a/pytest_girder/pytest_girder/fixtures.py
+++ b/pytest_girder/pytest_girder/fixtures.py
@@ -1,9 +1,9 @@
 import hashlib
-import mock
 import mongomock
 import os
 import pytest
 import shutil
+import unittest.mock
 
 from .plugin_registry import PluginRegistry
 from .utils import MockSmtpReceiver, serverContext
@@ -24,7 +24,7 @@ def _disableRealDatabaseConnectivity():
         def get(self, *args, **kwargs):
             raise Exception('You must use the "db" fixture in tests that connect to the database.')
 
-    with mock.patch.dict(getConfig(), {'database': MockDict()}):
+    with unittest.mock.patch.dict(getConfig(), {'database': MockDict()}):
         yield
 
 

--- a/pytest_girder/pytest_girder/plugin_registry.py
+++ b/pytest_girder/pytest_girder/plugin_registry.py
@@ -3,8 +3,7 @@ from contextlib import contextmanager
 import io
 from pkg_resources import iter_entry_points
 from tempfile import gettempdir
-
-import mock
+import unittest.mock
 
 
 class _MockDistribution:
@@ -34,7 +33,7 @@ class _MockEntryPoint:
         self.description = description
         self.url = url
         self.dist = _MockDistribution(package, version, description, url, location)
-        self.load = mock.Mock(return_value=pluginClass)
+        self.load = unittest.mock.Mock(return_value=pluginClass)
         self.pluginClass = pluginClass
 
 
@@ -71,7 +70,7 @@ class PluginRegistry:
         from girder import plugin
 
         try:
-            with mock.patch.object(
+            with unittest.mock.patch.object(
                     plugin, 'iter_entry_points', side_effect=self._iter_entry_points) as mock_:
                 yield mock_
         finally:

--- a/pytest_girder/setup.py
+++ b/pytest_girder/setup.py
@@ -32,7 +32,6 @@ setup(
     packages=find_packages(),
     install_requires=[
         'girder>=3',
-        'mock',
         'mongomock',
         'pytest>=3.6',
         'pytest-cov',

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,7 +28,6 @@ configparser==3.5.0
 coverage
 girder-worker
 httmock
-mock
 mongomock
 moto[server]>=1.3.7
 pytest>=3.6

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+import unittest.mock
 import pytest
 
 from girder import _setupCache
@@ -46,7 +46,7 @@ def testSettingsCache(db, enabledCache):
     setting.set(SettingKey.BRAND_NAME, 'bar')
 
     # verify retrieving gives us the new value
-    with mock.patch.object(setting, 'findOne') as findOneMock:
+    with unittest.mock.patch.object(setting, 'findOne') as findOneMock:
         assert setting.get(SettingKey.BRAND_NAME) == 'bar'
 
         # findOne shouldn't be called since the cache is returning the setting
@@ -56,7 +56,7 @@ def testSettingsCache(db, enabledCache):
     setting.unset(SettingKey.BRAND_NAME)
 
     # verify the database needs to be accessed to retrieve the setting now
-    with mock.patch.object(setting, 'findOne') as findOneMock:
+    with unittest.mock.patch.object(setting, 'findOne') as findOneMock:
         setting.get(SettingKey.BRAND_NAME)
 
         findOneMock.assert_called_once()

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-import mock
 import pytest
 import time
+import unittest.mock
 
 from girder import events
 
@@ -79,7 +79,7 @@ def testSynchronousEvents(eventsHelper):
         events.trigger(failname)
 
 
-@mock.patch.object(events, 'daemon', new=events.AsyncEventsThread())
+@unittest.mock.patch.object(events, 'daemon', new=events.AsyncEventsThread())
 def testAsyncEvents(eventsHelper):
     name, failname = '_test.event', '_test.failure'
     handlerName = '_test.handler'
@@ -122,7 +122,7 @@ def testAsyncEvents(eventsHelper):
         events.daemon.stop()
 
 
-@mock.patch.object(events, 'daemon', new=events.ForegroundEventsDaemon())
+@unittest.mock.patch.object(events, 'daemon', new=events.ForegroundEventsDaemon())
 def testForegroundDaemon(eventsHelper):
     assert isinstance(events.daemon, events.ForegroundEventsDaemon)
 

--- a/test/test_plugin_registry.py
+++ b/test/test_plugin_registry.py
@@ -1,6 +1,6 @@
 import tempfile
+import unittest.mock
 
-import mock
 import pytest
 from pytest_girder.plugin_registry import PluginRegistry
 
@@ -11,7 +11,7 @@ from girder.plugin import GirderPlugin
 
 @pytest.fixture
 def logprint():
-    with mock.patch.object(plugin, 'logprint') as logprintMock:
+    with unittest.mock.patch.object(plugin, 'logprint') as logprintMock:
         yield logprintMock
 
 
@@ -36,7 +36,7 @@ class InvalidPlugin(GirderPlugin):
 class TestLoadMixin:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._testLoadMock = mock.Mock()
+        self._testLoadMock = unittest.mock.Mock()
 
 
 class NoDeps(TestLoadMixin, GirderPlugin):
@@ -125,7 +125,7 @@ def testPluginWithNPMPackage(registry):
         packageJson.write(b'{"name": "@girder/test_plugin"}')
         packageJson.flush()
         pluginDef = plugin.getPlugin('client_plugin')
-        with mock.patch.object(plugin, 'resource_filename', return_value=packageJson.name):
+        with unittest.mock.patch.object(plugin, 'resource_filename', return_value=packageJson.name):
             assert '@girder/test_plugin' in pluginDef.npmPackages()
 
 
@@ -216,8 +216,8 @@ def testLoadPluginsWithDeps(registry, logprint):
 
     # Since plugin1 is the dependant, it must be loaded first
     logprint.success.assert_has_calls([
-        mock.call('Loaded plugin "plugin1"'),
-        mock.call('Loaded plugin "plugin2"')
+        unittest.mock.call('Loaded plugin "plugin1"'),
+        unittest.mock.call('Loaded plugin "plugin2"')
     ], any_order=False)
 
 

--- a/test/test_rest_exception_handling.py
+++ b/test/test_rest_exception_handling.py
@@ -1,7 +1,8 @@
 import cherrypy
 import contextlib
-import mock
 import pytest
+import unittest.mock
+
 from girder import config
 from girder.api import access
 from pytest_girder.assertions import assertStatus
@@ -30,7 +31,7 @@ def exceptionServer(server):
 @pytest.fixture
 def uuidMock():
     val = '1234'
-    with mock.patch('uuid.uuid4', return_value=val):
+    with unittest.mock.patch('uuid.uuid4', return_value=val):
         yield val
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-import mock
+import unittest.mock
+
 from girder import constants, logger
 
 # Mock the logging methods so that we don't actually write logs to disk,
 # and so tests can potentially inspect calls to logging methods.
 print(constants.TerminalColor.warning('Mocking Girder log methods.'))
 for handler in logger.handlers:
-    handler.emit = mock.MagicMock()
+    handler.emit = unittest.mock.MagicMock()

--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -4,10 +4,10 @@ import httmock
 import inspect
 import io
 import json
-import mock
 import moto
 import os
 import time
+import unittest.mock
 import zipfile
 
 from .. import base, mock_s3
@@ -752,7 +752,7 @@ class AssetstoreTestCase(base.TestCase):
         self.assertTrue(client.get_object(Bucket='bucketname', Key='foo/bar/test') is not None)
 
         # Deleting an imported file should not delete it from S3
-        with mock.patch('girder.events.daemon.trigger') as daemon:
+        with unittest.mock.patch('girder.events.daemon.trigger') as daemon:
             resp = self.request('/item/%s' % str(item['_id']), method='DELETE', user=self.admin)
             self.assertStatusOk(resp)
             self.assertEqual(len(daemon.mock_calls), 0)

--- a/tests/cases/model_singleton_test.py
+++ b/tests/cases/model_singleton_test.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-import mock
 import unittest
+import unittest.mock
 
 from girder.models.item import Item
 
 
 class ModelSingletonTest(unittest.TestCase):
-    @mock.patch.object(Item, '__init__', return_value=None)
+    @unittest.mock.patch.object(Item, '__init__', return_value=None)
     def testModelSingletonBehavior(self, initMock):
         self.assertEqual(len(initMock.mock_calls), 0)
         Item()
@@ -17,7 +17,7 @@ class ModelSingletonTest(unittest.TestCase):
         class Subclass(Item):
             pass
 
-        with mock.patch.object(Subclass, '__init__', return_value=None) as patch:
+        with unittest.mock.patch.object(Subclass, '__init__', return_value=None) as patch:
             self.assertEqual(len(patch.mock_calls), 0)
             Subclass()
             Subclass()

--- a/tests/cases/mount_test.py
+++ b/tests/cases/mount_test.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 import datetime
 import fuse
-import mock
 import os
 import stat
 import tempfile
 import threading
 import time
+import unittest.mock
 
 from girder.cli import mount
 from girder.exceptions import ValidationException
@@ -123,7 +123,7 @@ class ServerFuseTestCase(base.TestCase):
         """
         blockFile = os.path.join(self.extraMountPath, 'block')
         open(blockFile, 'wb').close()
-        with mock.patch('girder.plugin.logprint.error') as logprint:
+        with unittest.mock.patch('girder.plugin.logprint.error') as logprint:
             self._mountServer(path=self.extraMountPath, shouldSucceed=False)
             logprint.assert_called_once()
         os.unlink(blockFile)
@@ -132,7 +132,7 @@ class ServerFuseTestCase(base.TestCase):
         """
         Test that when asking for an RW mount, a warning is issued.
         """
-        with mock.patch('girder.plugin.logprint.warning') as logprint:
+        with unittest.mock.patch('girder.plugin.logprint.warning') as logprint:
             self._mountServer(path=self.extraMountPath, options='foreground,rw=true')
             logprint.assert_called_once()
             logprint.assert_called_with('Ignoring the rw=True option')

--- a/tests/cases/py_client/cli_test.py
+++ b/tests/cases/py_client/cli_test.py
@@ -4,13 +4,13 @@ import girder_client.cli
 from http.client import HTTPConnection
 import io
 import logging
-import mock
 import os
 import requests
 import shutil
 import sys
 import urllib.parse
 import httmock
+import unittest.mock
 
 from girder import config
 from girder.models.api_key import ApiKey
@@ -59,8 +59,8 @@ def invokeCli(argv, username='', password='', useApiUrl=False):
     argsList += list(argv)
 
     exitVal = 0
-    with mock.patch.object(sys, 'argv', argsList),\
-            mock.patch('sys.exit', side_effect=SysExitException) as exit,\
+    with unittest.mock.patch.object(sys, 'argv', argsList),\
+            unittest.mock.patch('sys.exit', side_effect=SysExitException) as exit,\
             captureOutput() as output:
         try:
             girder_client.cli.main()
@@ -455,8 +455,8 @@ class PythonCliTestCase(base.TestCase):
             adapter = session.adapters[gc.urlBase]
             self.assertEqual(adapter.max_retries.total, 5)
 
-        with mock.patch('girder_client.cli.GirderClient.sendRestRequest',
-                        side_effect=checkRetryHandler) as m:
+        with unittest.mock.patch('girder_client.cli.GirderClient.sendRestRequest',
+                                 side_effect=checkRetryHandler) as m:
             gc.sendRestRequest('')
 
         self.assertTrue(m.called)

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -3,12 +3,12 @@ import girder
 import girder_client
 import io
 import json
-import mock
 import os
 import requests
 import shutil
 import hashlib
 import httmock
+import unittest.mock
 
 from girder import config, events
 from girder.models.file import File
@@ -148,8 +148,8 @@ class PythonClientTestCase(base.TestCase):
         self.assertTrue(flag)
 
         # Interactive login (successfully)
-        with mock.patch('builtins.input', return_value=self.user['login']),\
-                mock.patch('getpass.getpass', return_value='password'):
+        with unittest.mock.patch('builtins.input', return_value=self.user['login']),\
+                unittest.mock.patch('getpass.getpass', return_value='password'):
             self.client.authenticate(interactive=True)
 
         # /user/me should now return our user info
@@ -382,7 +382,7 @@ class PythonClientTestCase(base.TestCase):
                 hits.append(1)
             return original_post(*args, **kwargs)
 
-        with mock.patch.object(self.client, 'post', new=mock_post):
+        with unittest.mock.patch.object(self.client, 'post', new=mock_post):
             with open(path) as fh:
                 self.client.uploadFile(
                     self.publicFolder['_id'], fh, name='test1', size=size, parentType='folder')

--- a/tests/cases/system_test.py
+++ b/tests/cases/system_test.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import json
-import mock
 import os
 import time
+import unittest.mock
 
 from .. import base
 from girder.api import access
@@ -347,10 +347,10 @@ class SystemTestCase(base.TestCase):
         _attachFileLogHandlers()
         for handler in logger.handlers:
             if handler._girderLogHandler == 'info':
-                handler.emit = mock.MagicMock()
+                handler.emit = unittest.mock.MagicMock()
                 infoEmit = handler.emit
             elif handler._girderLogHandler == 'error':
-                handler.emit = mock.MagicMock()
+                handler.emit = unittest.mock.MagicMock()
                 errorEmit = handler.emit
         # We should be an info level
         resp = self.request(path='/system/log/level', user=self.users[0])


### PR DESCRIPTION
The "mock" package is just a backport of "unittest.mock" for Python 2.