### PR TITLE
Allow additional content in ansible service script

### DIFF
--- a/devops/ansible-role-girder/README.md
+++ b/devops/ansible-role-girder/README.md
@@ -14,16 +14,17 @@ Setting `ansible_python_interpreter: auto` will enable this behavior.
 
 ## Role Variables
 
-| parameter                 | required | default                                      | comments                                                                                  |
-| ------------------------- | -------- | -------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `girder_bind_public`      | no       | `false`                                      | Whether to bind to all network interfaces.                                                |
-| `girder_daemonize`        | no       | `true`                                       | Whether to install the systemd service.                                                   |
-| `girder_database_uri`     | no       | `mongodb://localhost:27017/girder`           | The Connection String URI for MongoDB.                                                    |
-| `girder_development_mode` | no       | `false`                                      | Whether to enable Girder's development mode and disable HTTP reverse proxy configuration. |
-| `girder_version`          | no       | `latest`                                     | The version of Girder to install, as either ``latest``, ``release``, or a PyPI version.   |
-| `girder_virtualenv`       | no       | `{{ ansible_user_dir }}/.virtualenvs/girder` | Path to a Python virtual environment to install Girder in.                                |
-| `girder_web`              | no       | `true`                                       | Whether to build the Girder web client.                                                   |
-| `girder_package_path`     | no       |                                              | If set, a filesystem path on the target to install the Girder package from.               |
+| parameter                        | required | default                                      | comments                                                                                  |
+| -------------------------------- | -------- | -------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `girder_bind_public`             | no       | `false`                                      | Whether to bind to all network interfaces.                                                |
+| `girder_daemonize`               | no       | `true`                                       | Whether to install the systemd service.                                                   |
+| `girder_database_uri`            | no       | `mongodb://localhost:27017/girder`           | The Connection String URI for MongoDB.                                                    |
+| `girder_development_mode`        | no       | `false`                                      | Whether to enable Girder's development mode and disable HTTP reverse proxy configuration. |
+| `girder_version`                 | no       | `latest`                                     | The version of Girder to install, as either ``latest``, ``release``, or a PyPI version.   |
+| `girder_virtualenv`              | no       | `{{ ansible_user_dir }}/.virtualenvs/girder` | Path to a Python virtual environment to install Girder in.                                |
+| `girder_web`                     | no       | `true`                                       | Whether to build the Girder web client.                                                   |
+| `girder_package_path`            | no       |                                              | If set, a filesystem path on the target to install the Girder package from.               |
+| `girder_service_script_content`  | no       |                                              | Additional content to place inside the systemd script "Service" section.                  |
 
 ### Notes on `girder_virtualenv`
 

--- a/devops/ansible-role-girder/defaults/main.yml
+++ b/devops/ansible-role-girder/defaults/main.yml
@@ -6,3 +6,4 @@ girder_development_mode: false
 girder_version: "latest"
 girder_virtualenv: "{{ ansible_user_dir }}/.virtualenvs/girder"
 girder_web: true
+girder_service_script_content: ""

--- a/devops/ansible-role-girder/templates/daemon/girder.service.j2
+++ b/devops/ansible-role-girder/templates/daemon/girder.service.j2
@@ -9,6 +9,7 @@ Restart=always
 ExecStart={{ girder_virtualenv }}/bin/girder serve
 Environment=LC_ALL=C.UTF-8
 Environment=LANG=C.UTF-8
+{{ girder_service_script_content }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This is one of only three small changes required to these roles to make it broadly applicable to a "specialized-workflow" style girder deployment that involves a custom front-end app and girder-worker for data processing.

This particular change is useful for scenarios where environment variables are used to control runtime behavior of the Girder server-side application.

This can of course be achieved with `lineinfile` or just overriding the whole file with one's own template, and at first that was my approach. However that is problematic because it removes ansible idempotency purity. The girder.girder template task for the service script always shows as dirty, and then the subsequent overwrite does as well, even though the end state is unchanged. That state of affairs will unnecessarily trigger handlers.