### PR TITLE
Jquery testing

### DIFF
--- a/girder/web_client/src/package.json
+++ b/girder/web_client/src/package.json
@@ -18,7 +18,7 @@
         "bootstrap-switch": "~3.3.4",
         "eonasdan-bootstrap-datetimepicker": "~4.17",
         "@girder/fontello": "*",
-        "jquery": "~3.2.1",
+        "jquery": "~3.5.1",
         "jsoneditor": "~5.9.3",
         "moment": "~2.24.0",
         "moment-timezone": "~0.5.27",

--- a/plugins/jobs/plugin_tests/jobsSpec.js
+++ b/plugins/jobs/plugin_tests/jobsSpec.js
@@ -430,18 +430,20 @@ describe('Unit test the job list widget.', function () {
         runs(function () {
             // button is disabled when no job is checked
             expect(widget.$('.g-job-check-menu-button').is(':disabled')).toBe(true);
+            /* Within this test checkbox DOM elements are clicked directly instead of .trigger because of
+             * an issue with Jquery trigger handler and the way the joblist is rendered */
 
-            widget.$('input:checkbox:not(:checked).g-job-checkbox').trigger('click');
-            widget.$('input:checkbox:not(:checked).g-job-checkbox').trigger('click');
-            widget.$('input:checkbox:not(:checked).g-job-checkbox').trigger('click');
+            widget.$('input:checkbox:not(:checked).g-job-checkbox')[0].click();
+            widget.$('input:checkbox:not(:checked).g-job-checkbox')[0].click();
+            widget.$('input:checkbox:not(:checked).g-job-checkbox')[0].click();
 
             expect(widget.$('.g-job-check-menu-button').is(':disabled')).toBe(false);
             expect(widget.$('.g-job-checkbox-all').is(':checked')).toBe(true);
-            widget.$('.g-job-checkbox-all').trigger('click');
+            widget.$('.g-job-checkbox-all')[0].click();
 
             expect(widget.$('input:checkbox:not(:checked).g-job-checkbox').length).toBe(3);
 
-            widget.$('.g-job-checkbox-all').trigger('click');
+            widget.$('.g-job-checkbox-all')[0].click();
             expect(widget.$('input:checkbox:not(:checked).g-job-checkbox').length).toBe(0);
 
             widget.$('.g-jobs-list-cancel').trigger('click');


### PR DESCRIPTION
**TLDR**: Jquery bug in how `.trigger` operates causes an issue on the checkboxes that have their change event is bound to re-render (destroy/recreate) of the element.  Changed the test to utilize DOM native click instead of jQuery click.  Further in depth explanation below.


Changes the JobsList test to fix an issue with Jquery and the way the JobsList renders.
The JobsList has a connection between all of the checkboxes in the list and the parent check/uncheck all button and actions.  Whenever a button is checked it will toggle the state of parent checkbox.  To do this it re-renders the entire list each time a checkbox is clicked and calculates if none, any, or all boxes are checked.
![GirderJobsList](https://user-images.githubusercontent.com/61746913/86467498-7abd4f80-bd03-11ea-85ab-c0f8e450afc9.gif)

An update to jQuery caused the `.trigger` and `.click` methods to attempt to access an non-existent data member.
Specific Change that caused the issue: [Code Link](https://github.com/jquery/jquery/commit/24d71ac70406f522fc1b09bf7c4025251ec3aee6?diff=unified#diff-031bb62d959e7e4949d1847c82507f33L579-R583) in PR [4354](https://github.com/jquery/jquery/pull/4354)

There is a current in process PR to fix the issue which may work it's way through:  [Fixing in Process PR #4725](https://github.com/jquery/jquery/pull/4725)
After the fix we could revert the change to the test to utilize `.trigger` again.

Other option is a future refactor of how the checkboxes function in the JobList.

