### PR TITLE
Simplify and harden Ansible testing and usage

### DIFF
--- a/devops/ansible-role-girder/molecule/default/prepare.yml
+++ b/devops/ansible-role-girder/molecule/default/prepare.yml
@@ -5,6 +5,9 @@
     # gpg is needed to add other APT repositories
     - name: Install gnupg2
       apt:
+        update_cache: true
         name: gnupg2
         state: present
         force_apt_get: true
+      become: true
+      become_user: root

--- a/devops/vagrant/vagrant-playbook.yml
+++ b/devops/vagrant/vagrant-playbook.yml
@@ -28,16 +28,9 @@
         path: "{{ ansible_user_dir }}/.bashrc"
         state: present
 
-    - name: Update package cache
-      apt:
-        update_cache: true
-        force_apt_get: true
-      changed_when: false
-      become: true
-      become_user: root
-
     - name: Install Girder plugin prerequisites
       apt:
+        update_cache: true
         name:
           # Needed for 'ldap'
           - libldap2-dev

--- a/tox.ini
+++ b/tox.ini
@@ -55,9 +55,7 @@ passenv =
     DOCKER_*
 deps =
     ansible
-    # Pin ansible-lint: https://github.com/ansible-community/molecule/issues/2646
-    ansible-lint==4.2.0
-    molecule[docker,lint]>=3.0.3
+    molecule[docker,lint]
     testinfra
 commands =
     molecule {posargs: test --all}


### PR DESCRIPTION
* Clean up Ansible Molecule installation
* Harden Molecule prepare steps
* Run update_cache as part of a normal apt step in Vagrant playbook