### PR TITLE
Prefer Cursor.count_documents() to Cursor.count()

### DIFF
--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -438,7 +438,9 @@ class filtermodel:  # noqa: class name
             user = getCurrentUser()
 
             if isinstance(val, _MONGO_CURSOR_TYPES):
-                if callable(getattr(val, 'count', None)):
+                if callable(getattr(val, 'count_documents', None)):
+                    cherrypy.response.headers['Girder-Total-Count'] = val.count_documents()
+                elif callable(getattr(val, 'count', None)):
                     cherrypy.response.headers['Girder-Total-Count'] = val.count()
                 return [model.filter(m, user, self.addFields) for m in val]
             elif isinstance(val, (list, tuple, types.GeneratorType)):
@@ -613,7 +615,9 @@ def _mongoCursorToList(val):
     # This needs to be before the callable check, as mongo cursors can
     # be callable.
     if isinstance(val, _MONGO_CURSOR_TYPES):
-        if callable(getattr(val, 'count', None)):
+        if callable(getattr(val, 'count_documents', None)):
+            cherrypy.response.headers['Girder-Total-Count'] = val.count_documents()
+        elif callable(getattr(val, 'count', None)):
             cherrypy.response.headers['Girder-Total-Count'] = val.count()
         val = list(val)
     return val


### PR DESCRIPTION
Version 3.7 of pymongo deprecated `Cursor.count()` in favor of the newly-added `Cursor.count_documents()`, and so running girder with newer versions of pymongo currently produces a DeprecationWarning.  This PR eliminates the warning by checking for `count_documents` first, falling back to `count` only to support instances still using pymongo 3.6.