### PR TITLE
Remove obsolete flake8-blind-except

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ skip_install = true
 skipsdist = true
 deps =
     flake8
-    flake8-blind-except
     flake8-bugbear
     flake8-docstrings
     flake8-quotes


### PR DESCRIPTION
This is now provided by https://github.com/PyCQA/pycodestyle/commit/543f12b06592c53e2e60edc4846ee02ab9550e8b