### PR TITLE
Harden Molecule prepare steps

### DIFF
--- a/devops/ansible-role-girder/molecule/ansible-module/prepare.yml
+++ b/devops/ansible-role-girder/molecule/ansible-module/prepare.yml
@@ -5,9 +5,12 @@
     # gpg is needed to add other APT repositories
     - name: Install gnupg2
       apt:
+        update_cache: true
         name: gnupg2
         state: present
         force_apt_get: true
+      become: true
+      become_user: root
   roles:
     - role: girder.girder
       vars:


### PR DESCRIPTION
This applies [`30214c2` (#3292)](https://github.com/girder/girder/pull/3292/commits/30214c22998cf445633bd34bbaedcf803542c139) to the `ansible-module` scenario.

It fixes broken tests, following an upstream Molecule release.