### PR TITLE
girder_client: Test for response success with `result.ok`

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -454,7 +454,7 @@ class GirderClient:
             **kwargs)
 
         # If success, return the json object. Otherwise throw an exception.
-        if result.status_code in (200, 201):
+        if result.ok:
             if jsonResp:
                 return result.json()
             else:


### PR DESCRIPTION
Currently, `girder_client` only regards responses with a status code of 200 or 201 to be successes, ignoring [the various other 2xx "Success" codes](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#2xx_Success).  This PR makes the code test for errors by checking `result.ok`, which only regards 4xx and 5xx statuses as errors.