### PR TITLE
Accept limit=0 for listResources for python client

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -538,7 +538,7 @@ class GirderClient:
         """
         params = dict(params or {})
         params['offset'] = offset or 0
-        params['limit'] = limit or DEFAULT_PAGE_LIMIT
+        params['limit'] = limit if limit is not None else DEFAULT_PAGE_LIMIT
 
         while True:
             records = self.get(path, params)


### PR DESCRIPTION
limit=0 is a valid argument when listing resources on the REST-api, which,
if given, will list all items. The python client does not accept 0 as a valid
limit due to its "falsyness", and will override it with the default page
size.

This commit fixes the python-client so that limit=0 can be sent to
functions that internally call listResource.