### PR TITLE
Add query filter to LDAP plugin

### DIFF
--- a/plugins/ldap/girder_ldap/__init__.py
+++ b/plugins/ldap/girder_ldap/__init__.py
@@ -91,6 +91,9 @@ def _ldapAuth(event):
             conn.bind_s(server['bindName'], server['password'], ldap.AUTH_SIMPLE)
 
             searchStr = '%s=%s' % (server['searchField'], login)
+            if server['queryFilter']:
+                searchStr = '(&(%s)(%s))' % (searchStr, server['queryFilter'])
+
             # Add the searchStr to the attributes, keep local scope.
             lattr = _LDAP_ATTRS + (server['searchField'],)
             results = conn.search_s(server['baseDn'], ldap.SCOPE_SUBTREE, searchStr, lattr)

--- a/plugins/ldap/girder_ldap/__init__.py
+++ b/plugins/ldap/girder_ldap/__init__.py
@@ -91,7 +91,7 @@ def _ldapAuth(event):
             conn.bind_s(server['bindName'], server['password'], ldap.AUTH_SIMPLE)
 
             searchStr = '%s=%s' % (server['searchField'], login)
-            if server['queryFilter']:
+            if server.get('queryFilter'):
                 searchStr = '(&(%s)(%s))' % (searchStr, server['queryFilter'])
 
             # Add the searchStr to the attributes, keep local scope.

--- a/plugins/ldap/girder_ldap/settings.py
+++ b/plugins/ldap/girder_ldap/settings.py
@@ -45,3 +45,4 @@ def _validateServers(doc):
             server['uri'] = 'ldap://' + server['uri']
         server['password'] = server.get('password', '')
         server['searchField'] = server.get('searchField', 'uid')
+        server['queryFilter'] = server.get('queryFilter', '')

--- a/plugins/ldap/girder_ldap/web_client/templates/editServerMixin.pug
+++ b/plugins/ldap/girder_ldap/web_client/templates/editServerMixin.pug
@@ -34,6 +34,10 @@ mixin ldapServerEditPanel(server, index)
           input.input-sm.form-control(id=`g-ldap-server-${index}-searchField`,
               name="searchField", value=server.searchField, placeholder="Search field (default: uid)")
         .form-group
+          label.control-label(for=`g-ldap-server-${index}-queryFilter`) Query Filter (optional)
+          input.input-sm.form-control(id=`g-ldap-server-${index}-queryFilter`,
+              name="queryFilter", value=server.queryFilter, placeholder="Query Filter")
+        .form-group
           button.g-ldap-test.btn.btn-sm.btn-default(index=index, type="button") Test connection
           .g-ldap-test-result.hide(id=`g-ldap-server-${index}-conn-ok`, status="success")
             i.icon-ok

--- a/plugins/ldap/girder_ldap/web_client/views/ConfigView.js
+++ b/plugins/ldap/girder_ldap/web_client/views/ConfigView.js
@@ -12,7 +12,7 @@ import newServerTemplate from '../templates/newServerTemplate.pug';
 import '../stylesheets/configView.styl';
 import '@girder/core/utilities/jquery/girderEnable';
 
-const FIELDS = ['uri', 'bindName', 'baseDn', 'password', 'searchField'];
+const FIELDS = ['uri', 'bindName', 'baseDn', 'password', 'searchField', 'queryFilter'];
 
 var ConfigView = View.extend({
     events: {

--- a/plugins/ldap/plugin_tests/ldap_test.py
+++ b/plugins/ldap/plugin_tests/ldap_test.py
@@ -152,7 +152,7 @@ class LdapTestCase(base.TestCase):
             self.assertNotIn('error', resp.json)
 
     def testLdapQueryFilter(self):
-        
+
         class RecordSearchMockLdap(MockLdap):
             def __init__(self):
                 MockLdap.__init__(self)
@@ -166,18 +166,19 @@ class LdapTestCase(base.TestCase):
         with unittest.mock.patch('ldap.initialize', return_value=mockLdap):
 
             # Test whether existing queryFilter is ANDed with searchField
+            queryFilter = 'memberOf=cn=MyGroup,ou=Groups,dc=foo,dc=bar,dc=org'
             Setting().set(PluginSettings.SERVERS, [{
                 'baseDn': 'ou=Users,dc=foo,dc=bar,dc=org',
                 'bindName': 'cn=foo,ou=Users,dc=foo,dc=bar,dc=org',
                 'password': 'foo',
                 'searchField': 'uid',
-                'queryFilter': 'memberOf=cn=MyGroup,ou=Groups,dc=foo,dc=bar,dc=org',
+                'queryFilter': queryFilter,
                 'uri': 'foo.bar.org:389'
             }])
 
             resp = self.request('/user/authentication', basicAuth='hello:world')
             self.assertStatusOk(resp)
-            self.assertEqual(mockLdap.lastSearchStr, "(&(uid=hello)(memberOf=cn=MyGroup,ou=Groups,dc=foo,dc=bar,dc=org))")
+            self.assertEqual(mockLdap.lastSearchStr, '(&(uid=hello)(%s))' % queryFilter)
 
             # Verify backwards compatibility when queryFilter is not set
             Setting().set(PluginSettings.SERVERS, [{
@@ -190,4 +191,4 @@ class LdapTestCase(base.TestCase):
 
             resp = self.request('/user/authentication', basicAuth='hello:world')
             self.assertStatusOk(resp)
-            self.assertEqual(mockLdap.lastSearchStr, "uid=hello")
+            self.assertEqual(mockLdap.lastSearchStr, 'uid=hello')

--- a/plugins/ldap/plugin_tests/ldap_test.py
+++ b/plugins/ldap/plugin_tests/ldap_test.py
@@ -150,3 +150,44 @@ class LdapTestCase(base.TestCase):
             self.assertStatusOk(resp)
             self.assertTrue(resp.json['connected'])
             self.assertNotIn('error', resp.json)
+
+    def testLdapQueryFilter(self):
+        
+        class RecordSearchMockLdap(MockLdap):
+            def __init__(self):
+                MockLdap.__init__(self)
+                self.lastSearchStr = None
+            def search_s(self, baseDn, scope, searchStr, lattr):
+                self.lastSearchStr = searchStr
+                return MockLdap.search_s(self, baseDn, scope, searchStr, lattr)
+
+        mockLdap = RecordSearchMockLdap()
+
+        with unittest.mock.patch('ldap.initialize', return_value=mockLdap):
+
+            # Test whether existing queryFilter is ANDed with searchField
+            Setting().set(PluginSettings.SERVERS, [{
+                'baseDn': 'ou=Users,dc=foo,dc=bar,dc=org',
+                'bindName': 'cn=foo,ou=Users,dc=foo,dc=bar,dc=org',
+                'password': 'foo',
+                'searchField': 'sAMAccountName',
+                'queryFilter': 'memberOf=cn=MyGroup,ou=Users,dc=foo,dc=bar,dc=org',
+                'uri': 'foo.bar.org:389'
+            }])
+
+            resp = self.request('/user/authentication', basicAuth='hello:world')
+            self.assertStatusOk(resp)
+            self.assertEqual(mockLdap.lastSearchStr, "(&(sAMAccountName=hello)(memberOf=cn=MyGroup,ou=Users,dc=foo,dc=bar,dc=org))")
+
+            # Verify backwards compatibility when queryFilter is not set
+            Setting().set(PluginSettings.SERVERS, [{
+                'baseDn': 'ou=Users,dc=foo,dc=bar,dc=org',
+                'bindName': 'cn=foo,ou=Users,dc=foo,dc=bar,dc=org',
+                'password': 'foo',
+                'searchField': 'sAMAccountName',
+                'uri': 'foo.bar.org:389'
+            }])
+
+            resp = self.request('/user/authentication', basicAuth='hello:world')
+            self.assertStatusOk(resp)
+            self.assertEqual(mockLdap.lastSearchStr, "sAMAccountName=hello")

--- a/plugins/ldap/plugin_tests/ldap_test.py
+++ b/plugins/ldap/plugin_tests/ldap_test.py
@@ -157,6 +157,7 @@ class LdapTestCase(base.TestCase):
             def __init__(self):
                 MockLdap.__init__(self)
                 self.lastSearchStr = None
+
             def search_s(self, baseDn, scope, searchStr, lattr):
                 self.lastSearchStr = searchStr
                 return MockLdap.search_s(self, baseDn, scope, searchStr, lattr)

--- a/plugins/ldap/plugin_tests/ldap_test.py
+++ b/plugins/ldap/plugin_tests/ldap_test.py
@@ -177,7 +177,7 @@ class LdapTestCase(base.TestCase):
 
             resp = self.request('/user/authentication', basicAuth='hello:world')
             self.assertStatusOk(resp)
-            self.assertEqual(mockLdap.lastSearchStr, "(&(uid=hello)(memberOf=cn=MyGroup,ou=Users,dc=foo,dc=bar,dc=org))")
+            self.assertEqual(mockLdap.lastSearchStr, "(&(uid=hello)(memberOf=cn=MyGroup,ou=Groups,dc=foo,dc=bar,dc=org))")
 
             # Verify backwards compatibility when queryFilter is not set
             Setting().set(PluginSettings.SERVERS, [{

--- a/plugins/ldap/plugin_tests/ldap_test.py
+++ b/plugins/ldap/plugin_tests/ldap_test.py
@@ -170,24 +170,24 @@ class LdapTestCase(base.TestCase):
                 'baseDn': 'ou=Users,dc=foo,dc=bar,dc=org',
                 'bindName': 'cn=foo,ou=Users,dc=foo,dc=bar,dc=org',
                 'password': 'foo',
-                'searchField': 'sAMAccountName',
-                'queryFilter': 'memberOf=cn=MyGroup,ou=Users,dc=foo,dc=bar,dc=org',
+                'searchField': 'uid',
+                'queryFilter': 'memberOf=cn=MyGroup,ou=Groups,dc=foo,dc=bar,dc=org',
                 'uri': 'foo.bar.org:389'
             }])
 
             resp = self.request('/user/authentication', basicAuth='hello:world')
             self.assertStatusOk(resp)
-            self.assertEqual(mockLdap.lastSearchStr, "(&(sAMAccountName=hello)(memberOf=cn=MyGroup,ou=Users,dc=foo,dc=bar,dc=org))")
+            self.assertEqual(mockLdap.lastSearchStr, "(&(uid=hello)(memberOf=cn=MyGroup,ou=Users,dc=foo,dc=bar,dc=org))")
 
             # Verify backwards compatibility when queryFilter is not set
             Setting().set(PluginSettings.SERVERS, [{
                 'baseDn': 'ou=Users,dc=foo,dc=bar,dc=org',
                 'bindName': 'cn=foo,ou=Users,dc=foo,dc=bar,dc=org',
                 'password': 'foo',
-                'searchField': 'sAMAccountName',
+                'searchField': 'uid',
                 'uri': 'foo.bar.org:389'
             }])
 
             resp = self.request('/user/authentication', basicAuth='hello:world')
             self.assertStatusOk(resp)
-            self.assertEqual(mockLdap.lastSearchStr, "sAMAccountName=hello")
+            self.assertEqual(mockLdap.lastSearchStr, "uid=hello")


### PR DESCRIPTION
An optional query filter is helpful if, for example, only users of a specific LDAP group should be able to authenticate. This way, the administrator can specify additional criteria for the user search without the need to put them into a special root, e.g., an own OU that is configured for the Base DN.
Whenever the field 'queryFilter' is set to a non-empty string, the search string is ANDed: `(&(<searchField>=<login>)(<queryFilter>))`. If the queryFilter is not set, the search string is `<searchField>=<login>` as it was before in order to stay backwards compatible.