### PR TITLE
Add environment variables to upload codecov results without a token

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -73,6 +73,9 @@ commands =
 [testenv:codecov_upload]
 skip_install = true
 skipsdist = true
+passenv =
+    CI
+    CIRCLE*
 deps =
     codecov
 commands =
@@ -80,7 +83,6 @@ commands =
         --disable search pycov gcov \
         --root girder \
         --required \
-        --token {env:CODECOV_TOKEN} \
         --file build/test/coverage/py_coverage.xml build/test/coverage/cobertura-coverage.xml
 
 [testenv:publish]


### PR DESCRIPTION
This worked in https://app.circleci.com/pipelines/github/girder/girder/1036/workflows/de720239-3ce3-4d19-a16b-dee390870e26/jobs/28677.