### PR TITLE
Browser widget test fix

### DIFF
--- a/girder/web_client/test/spec/browserSpec.js
+++ b/girder/web_client/test/spec/browserSpec.js
@@ -1082,6 +1082,9 @@ describe('browser hierarchy paginated selection', function () {
                 _item.save();
             }
         });
+        waitsFor(function () {
+            return itemlist.length === 100;
+        }, 'item creation');
     });
 
     it('test browserwidget defaultSelectedResource [item with paginated views]', function () {
@@ -1107,7 +1110,8 @@ describe('browser hierarchy paginated selection', function () {
 
         waitsFor(function () {
             return $('.g-hierarchy-widget').length > 0 &&
-                               $('.g-item-list-link').length > 0;
+                               $('.g-item-list-link').length > 0 &&
+                               $('.g-hierarachy-paginated-bar').length > 0;
         }, 'the hierarchy widget to display');
 
         runs(function () {


### PR DESCRIPTION
My fault, looks like I forgot to wait for the 100 items to be created before attempting to display them.  This should fix that issue and prevent it from failing in the future.  Obviously the async nature of it made it hard to reproduce unless the hardware couldn't keep up.  A brief search through the tests showed that most subsequent tests of the pagination system use the initial items so there shouldn't be another place where it is needed.