### PR TITLE
Fix how tox installs pip packages

### DIFF
--- a/plugins/dicom_viewer/setup.py
+++ b/plugins/dicom_viewer/setup.py
@@ -43,7 +43,11 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
-    install_requires=['girder>=3', 'pydicom>=2.0.0'],
+    install_requires=[
+        'girder>=3',
+        'pydicom>=2.0.0,<2.1.0;python_version<"3.7"',
+        'pydicom>=2.0.0;python_version>="3.7"',
+    ],
     entry_points={
         'girder.plugin': [
             'dicom_viewer = girder_dicom_viewer:DicomViewerPlugin'

--- a/plugins/oauth/setup.py
+++ b/plugins/oauth/setup.py
@@ -43,7 +43,10 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
-    install_requires=['girder>=3', 'pyjwt'],
+    install_requires=[
+        'girder>=3',
+        'pyjwt<2',
+    ],
     entry_points={
         'girder.plugin': [
             'oauth = girder_oauth:OAuthPlugin'

--- a/plugins/thumbnails/setup.py
+++ b/plugins/thumbnails/setup.py
@@ -46,7 +46,8 @@ setup(
         'girder>=3',
         'girder-jobs>=3',
         'Pillow',
-        'pydicom>=2.0.0',
+        'pydicom>=2.0.0,<2.1.0;python_version<"3.7"',
+        'pydicom>=2.0.0;python_version>="3.7"',
         'numpy'
     ],
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,6 @@
 envlist = lint,pytest
 
 [testenv:pytest]
-# In the install command, we include the "girder" package as `.`.  This is because
-# tox runs the install command *before* installing girder, but girder is a dependency
-# of many of the packages in requirements-dev.txt (pytest-girder and all of the plugins).
-# Without this, pip attempts to install girder from pypi during the dependency
-# installation.
-install_command = python -m pip install {opts} . {packages}
 deps =
     -rrequirements-dev.txt
 commands =
@@ -115,7 +109,6 @@ commands =
     {toxinidir}/scripts/test_names.sh
 
 [testenv:pytest_circleci]
-install_command = {[testenv:pytest]install_command}
 deps =
     {[testenv:pytest]deps}
 commands =


### PR DESCRIPTION
We explicitly stated an install_command that specified the local directory.  This is part of how tox does installations in any case.  With the introduction of the new resolver in pip, this now fails.

This also adjusts some installation requirements for the pydicom package, as the most recent version of that package has dropped support for Python 3.6 without properly specifying so.

This also specifies the version pyjwt as the oauth plugin does not work with the most recent release.