### PR TITLE
Add sort kwarg to Model.findOne. Fixes #3323

### DIFF
--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -309,7 +309,7 @@ class Model(metaclass=_ModelSingleton):
 
         return cursor
 
-    def findOne(self, query=None, fields=None, **kwargs):
+    def findOne(self, query=None, fields=None, sort=None, **kwargs):
         """
         Search the collection by a set of parameters. Passes any kwargs
         through to the underlying pymongo.collection.find_one function.
@@ -328,7 +328,7 @@ class Model(metaclass=_ModelSingleton):
         """
         query = query or {}
         kwargs = {k: kwargs[k] for k in kwargs if k in _allowedFindArgs}
-        return self.collection.find_one(query, projection=fields, **kwargs)
+        return self.collection.find_one(query, projection=fields, sort=sort, **kwargs)
 
     def _textSearchFilters(self, query, filters=None, fields=None):
         """


### PR DESCRIPTION
Respect sort keyword argument in `Model.findOne`.