### PR TITLE
Upgrade pip in the ansible virtualenv.

### DIFF
--- a/devops/ansible-role-girder/tasks/main.yml
+++ b/devops/ansible-role-girder/tasks/main.yml
@@ -23,6 +23,14 @@
 - import_tasks: nodejs.yml
   when: girder_web|bool
 
+- name: Upgrade pip in the virtualenv
+  pip:
+    name: pip
+    extra_args: "--update"
+    virtualenv: "{{ girder_virtualenv }}"
+    # Implicitly create a Python 3 virtualenv if it doesn't exist
+    virtualenv_command: "/usr/bin/python3 -m venv"
+
 - name: Install Girder
   pip:
     name: "{{ girder_package_path|default('girder') }}"


### PR DESCRIPTION
The CI on this will fail due to some doc issues and that it uses the ansible module BEFORE these changes.

Upgrading pip is necessary, as some dependency pulls in cryptography which now requires a rust executable which is only bundled starting with pip 21.0.1.