### PR TITLE
The filter regex for s3 import weren't being used.

### DIFF
--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -453,7 +453,7 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
                     parent=parent, name=name, parentType=parentType, creator=user,
                     reuseExisting=True)
                 self.importData(parent=folder, parentType='folder', params={
-                    'importPath': obj['Prefix']
+                    **params, 'importPath': obj['Prefix']
                 }, progress=progress, user=user, **kwargs)
 
     def deleteFile(self, file):


### PR DESCRIPTION
Fix a bug where the include and exclude filter regex were not being used for subdirectories when importing from an S3 assetstore.

Resolves #3327.