### PR TITLE
Restore and fix the link to deployment docs

### DIFF
--- a/docs/deployment-alternatives.rst
+++ b/docs/deployment-alternatives.rst
@@ -80,7 +80,7 @@ And under the containing ``server`` block, make sure to add the following rule:
 
 Ansible
 -------
-The Ansible deployment provides a complete installation workflow which depends primarily on the
+:doc:`deployment` provides a complete installation workflow which depends primarily on the
 Ansible roles:
 
 * `girder.girder <https://galaxy.ansible.com/girder/girder>`_


### PR DESCRIPTION
This follows #3331, but uses the correct link to the `deployment.rst` page.