### PR TITLE
Use a supported systemd Docker image for Ansible testing

### DIFF
--- a/devops/ansible-role-girder/molecule/ansible-module/molecule.yml
+++ b/devops/ansible-role-girder/molecule/ansible-module/molecule.yml
@@ -10,16 +10,15 @@ driver:
   name: docker
 platforms:
   - name: ubuntu18
-    image: solita/ubuntu-systemd:18.04
+    image: jrei/systemd-ubuntu:18.04
     privileged: false
     override_command: false
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     tmpfs:
+      - /tmp
       - /run
       - /run/lock
-    security_opts:
-      - seccomp=unconfined
     networks:
       - name: molecule
     groups:

--- a/devops/ansible-role-girder/molecule/default/molecule.yml
+++ b/devops/ansible-role-girder/molecule/default/molecule.yml
@@ -11,16 +11,15 @@ driver:
   name: docker
 platforms:
   - name: ubuntu18
-    image: solita/ubuntu-systemd:18.04
+    image: jrei/systemd-ubuntu:18.04
     privileged: false
     override_command: false
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     tmpfs:
+      - /tmp
       - /run
       - /run/lock
-    security_opts:
-      - seccomp=unconfined
     networks:
       - name: molecule
     groups:


### PR DESCRIPTION
This is the version used to test `girder.nginx` and `girder.mongodb` too.