### PR TITLE
Use more robust Ansible facts for service configuration

### DIFF
--- a/devops/ansible-role-girder/templates/daemon/girder.service.j2
+++ b/devops/ansible-role-girder/templates/daemon/girder.service.j2
@@ -1,10 +1,11 @@
+# {{ ansible_managed }}
 [Unit]
 Description=Girder
 After=network.target
 
 [Service]
-User={{ ansible_facts['user_id'] }}
-Group={{ ansible_facts['user_id'] }}
+User={{ ansible_facts['real_user_id'] }}
+Group={{ ansible_facts['real_group_id'] }}
 Restart=always
 ExecStart={{ girder_virtualenv }}/bin/girder serve
 Environment=LC_ALL=C.UTF-8


### PR DESCRIPTION
This no longer assumes that the user's primary group is named the same as the user. It is also more explicitly uses the non-assumed user ID, rather than the assumed ID.