### PR TITLE
Fix #3344

### DIFF
--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -327,7 +327,7 @@ class Description:
             that were passed.
         :type schema: dict
         """
-        if default:
+        if default is not None:
             default = bson.json_util.dumps(default)
 
         self.param(


### PR DESCRIPTION
Note that this changes the behavior of other falsey json serializable types, such as `0` and `""`.

The current behavior for those is also incorrect, but there may be places where the incorrect behavior is relied upon.

fixes #3344