### PR TITLE
Support cookie lifetime less than a full day

### DIFF
--- a/girder/settings.py
+++ b/girder/settings.py
@@ -175,12 +175,12 @@ class SettingValidator:
     @setting_utilities.validator(SettingKey.COOKIE_LIFETIME)
     def _validateCookieLifetime(doc):
         try:
-            doc['value'] = int(doc['value'])
+            doc['value'] = float(doc['value'])
             if doc['value'] > 0:
                 return
         except ValueError:
             pass  # We want to raise the ValidationException
-        raise ValidationException('Cookie lifetime must be an integer > 0.', 'value')
+        raise ValidationException('Cookie lifetime must be a number > 0.0.', 'value')
 
     @staticmethod
     @setting_utilities.validator(SettingKey.CORS_ALLOW_HEADERS)

--- a/girder/web_client/test/spec/adminSpec.js
+++ b/girder/web_client/test/spec/adminSpec.js
@@ -89,7 +89,7 @@ describe('Test the settings page', function () {
             $('.g-submit-settings').trigger('click');
         });
         waitsFor(function () {
-            return $('#g-settings-error-message').text() === 'Cookie lifetime must be an integer > 0.';
+            return $('#g-settings-error-message').text() === 'Cookie lifetime must be a number > 0.0.';
         }, 'error message to be shown');
         runs(function () {
             $('#g-core-cookie-lifetime').val('180');


### PR DESCRIPTION
By allowing COOKIE_LIFETIME to be a floating point value, provides more granularity on session timeout.