### PR TITLE
S3 Assetstore emit events, fix prefix behavior

### DIFF
--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -409,7 +409,8 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
                         yield chunk
             return stream
 
-    def importData(self, parent, parentType, params, progress, user, force_recursive=True, **kwargs):
+    def importData(self, parent, parentType, params, progress,
+                   user, force_recursive=True, **kwargs):
         importPath = params.get('importPath', '').strip().lstrip('/')
         bucket = self.assetstore['bucket']
         now = datetime.datetime.utcnow()

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -412,7 +412,7 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
     def importData(self, parent, parentType, params, progress, user, recursive=True, **kwargs):
         importPath = params.get('importPath', '').strip().lstrip('/')
         bucket = self.assetstore['bucket']
-        paginator = self.client.get_paginator('list_objects_v2')
+        paginator = self.client.get_paginator('list_objects')
         pageIterator = paginator.paginate(Bucket=bucket, Prefix=importPath, Delimiter='/')
         for resp in pageIterator:
             # Start with objects

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import json
-import os
 import re
 import urllib.parse
 import uuid

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -459,7 +459,7 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
                     events.trigger('s3_assetstore_imported', {
                         'id': folder['_id'],
                         'type': 'folder',
-                        'importPath': obj['Key'],
+                        'importPath': obj['Prefix'],
                     })
                     self.importData(parent=folder, parentType='folder', params={
                         **params, 'importPath': obj['Prefix']

--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -686,7 +686,7 @@ class AssetstoreTestCase(base.TestCase):
         # Attempt to import item directly into user; should fail
         resp = self.request(
             '/assetstore/%s/import' % assetstore['_id'], method='POST', params={
-                'importPath': '/foo/bar',
+                'importPath': '/foo/bar/',
                 'destinationType': 'user',
                 'destinationId': self.admin['_id']
             }, user=self.admin)


### PR DESCRIPTION
* Allow blocking of recursive import to target a single directory (as defined by prefix)
* Emit events on import similar to the filesystem assetstore import behavior (items and folders only, no file events)
* ~~Upgrade to `list_objects_v2` (no behavior change, pagination hides the difference)~~
* Bugfix behavior of `importPath`:
  * Example: a folder where you wanted to import all the objects starting with 'foo' by passing prefix `folder/foo` would have a delimiter added to the end and result in no imports
  * Example: a folder where you wanted to import an object exactly matching prefix would also be ignored if you pass prefix `folder/myfile.csv`.
  * If the user supplies a prefix without a trailing slash intending it to be a directory name, everything will still work, you'll just get an extra level of nesting, which I believe is correct behavior.  I expect this behavior would also teach the user how to use delimiters properly.