### PR TITLE
Check if length attribute is none instead of accessing length_known.

### DIFF
--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -55,7 +55,7 @@ class GirderCli(GirderClient):
 
             def formatPos(_self):
                 pos = formatSize(_self.pos)
-                if _self.length_known:
+                if _self.length is not None:
                     pos += '/%s' % formatSize(_self.length)
                 return pos
 


### PR DESCRIPTION
This resolves Issue #3357 where the `length_known` attribute has been removed from `click` progress bars as of click version 8.0. Looking at older versions, `length_known` was defined as `length is not None`, I think this should work.

This is my first PR to this project, so apologies if I've not followed proper procedures. Thanks!
@girder/developers