### PR TITLE
Ignore N818 linting failures

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -162,6 +162,8 @@ ignore =
     N815,
     # N816 - mixedCase variable in global scope
     N816,
+    # N818 - error suffix in exception name
+    N818,
     # W503 - Line break occurred before a binary operator
     W503,
 


### PR DESCRIPTION
It is not feasible to rename existing exceptions to comply with this new rule.