### PR TITLE
Pin moto to allow CI to pass.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,7 +29,7 @@ coverage
 girder-worker
 httmock
 mongomock
-moto[server]>=1.3.7
+moto[server]>=1.3.7,<2
 pytest>=3.6
 pytest-cov>=2.6
 python-dateutil


### PR DESCRIPTION
moto >= 2 doesn't work with some of our tests.  Since it is only used for testing, pin to the older version.