### PR TITLE
Implement the seekable function for the FileHandle class

### DIFF
--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -108,6 +108,9 @@ class FileHandle:
     def close(self):
         pass
 
+    def seekable(self):
+        return True
+
 
 class AbstractAssetstoreAdapter:
     """

--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -794,6 +794,7 @@ girder
                 close
                 read
                 seek
+                seekable
                 tell
         acl_mixin
             AccessControlMixin


### PR DESCRIPTION
This method is required for the Python's IOBase implementation and
implementing it fixes a problem with the Python 3.8 implementation
of ZipFile.