### PR TITLE
Pin pymongo version.

### DIFF
--- a/girder/utility/acl_mixin.py
+++ b/girder/utility/acl_mixin.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-from bson.py3compat import abc
 import collections
 import itertools
+from collections import abc
 
 from ..models.model_base import Model, AccessControlledModel, _permissionClauses
 from ..exceptions import AccessException

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ installReqs = [
     'jsonschema',
     'Mako',
     'passlib [bcrypt,totp]',
-    'pymongo>=3.6',
+    'pymongo>=3.6,<4',
     'PyYAML',
     'psutil',
     'pyOpenSSL',


### PR DESCRIPTION
Pin pymongo to version < 4 until we can verify Girder works with pymongo 4.

Remove a reference to bson.py3compat.  Since we require Python 3, "abc" can just be imported from collections.