### PR TITLE
:whale: Fix girder docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,19 +29,6 @@ RUN python3 setup.py bdist_wheel \
  && cd dist && python3 -m pip install girder && cd .. \
  && rm -rf build dist
 
-# Build and install all plugins found in `plugins` directory
-RUN cd plugins \
- && for plugin in `ls -d *`;\
-    do \
-    echo Building ${plugin} \
-    && cd ${plugin} \
-    && python3 setup.py bdist_wheel \
-    && cd dist && python3 -m pip install girder-`echo ${plugin} | tr _ -` && cd .. \
-    && rm -rf build dist \
-    && cd ..;\
-    done \
- && cd ..
-
 RUN girder build
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,50 @@
 FROM node:12-buster
 LABEL maintainer="Kitware, Inc. <kitware@kitware.com>"
 
-EXPOSE 8080
-
-RUN mkdir /girder
-
 RUN apt-get update && apt-get install -qy \
     gcc \
     libpython3-dev \
     git \
     libldap2-dev \
-    libsasl2-dev && \
-  apt-get clean && rm -rf /var/lib/apt/lists/*
-
-RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
-
-WORKDIR /girder
-COPY . /girder/
+    libsasl2-dev \
+    python3-pip \
+&& apt-get clean && rm -rf /var/lib/apt/lists/* \
+&& python3 -m pip install --upgrade \
+    pip \
+    setuptools \
+    setuptools_scm \
+    wheel
 
 # See http://click.pocoo.org/5/python3/#python-3-surrogate-handling for more detail on
 # why this is necessary.
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
-# TODO: Do we want to create editable installs of plugins as well?  We
-# will need a plugin only requirements file for this.
-RUN pip install --upgrade --upgrade-strategy eager --editable .
+RUN mkdir /girder
+WORKDIR /girder
+COPY . /girder/
+
+# Build girder wheel file, and install it
+RUN python3 setup.py bdist_wheel \
+ && cd dist && python3 -m pip install girder && cd .. \
+ && rm -rf build dist
+
+# Build and install all plugins found in `plugins` directory
+RUN cd plugins \
+ && for plugin in `ls -d *`;\
+    do \
+    echo Building ${plugin} \
+    && cd ${plugin} \
+    && python3 setup.py bdist_wheel \
+    && cd dist && python3 -m pip install girder-`echo ${plugin} | tr _ -` && cd .. \
+    && rm -rf build dist \
+    && cd ..;\
+    done \
+ && cd ..
+
+# RUN python3 -m pip install --upgrade --upgrade-strategy eager --editable .
 RUN girder build
+
+EXPOSE 8080
 
 ENTRYPOINT ["girder", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,6 @@ RUN cd plugins \
     done \
  && cd ..
 
-# RUN python3 -m pip install --upgrade --upgrade-strategy eager --editable .
 RUN girder build
 
 EXPOSE 8080


### PR DESCRIPTION
This update fixes issue https://github.com/girder/girder/issues/3305, where docker build failed

The build error we had is presented below

The Dockerfile also installs all plugins.

I am open to suggestion to improve the Dockerfile. I think the docker build should also be included in the CI.


```
Step 12/13 : RUN girder build
 ---> Running in f7793f217cd8
Traceback (most recent call last):
  File "/usr/bin/girder", line 33, in <module>
    sys.exit(load_entry_point('girder', 'console_scripts', 'girder')())
  File "/usr/bin/girder", line 22, in importlib_load_entry_point
    for entry_point in distribution(dist_name).entry_points
  File "/usr/local/lib/python3.7/dist-packages/importlib_metadata/__init__.py", line 947, in distribution
    return Distribution.from_name(distribution_name)
  File "/usr/local/lib/python3.7/dist-packages/importlib_metadata/__init__.py", line 538, in from_name
    raise PackageNotFoundError(name)
importlib_metadata.PackageNotFoundError: No package metadata was found for girder
The command '/bin/sh -c girder build' returned a non-zero code: 1
```

It would be nice to fix this and make a docker build in the CI!