### PR TITLE
Disable one flaky test.

### DIFF
--- a/tests/cases/upload_test.py
+++ b/tests/cases/upload_test.py
@@ -376,7 +376,8 @@ class UploadTestCase(base.TestCase):
         self.assetstore = assetstore
         self._testUpload()
 
-    def testGridFSReplicaSetAssetstoreUpload(self):
+    # disable an intermittently failing test - 2022-02-23
+    def XtestGridFSReplicaSetAssetstoreUpload(self):
         verbose = 0
         if 'REPLICASET' in os.environ.get('EXTRADEBUG', '').split():
             verbose = 2


### PR DESCRIPTION
We do a number of tests on mongo replica sets.  One of these has been flaky lately, reporting unexpected time outs.  It is likely some mongo setting has changed and the tests timing would need to be updated to check how it handles unreliable nodes in a replica set.  Since this is mostly abstracted with newer versions of mongo, disable the test as it is an unlikely point of failure.