### PR TITLE
Remove eslint-plugin-underscore.

### DIFF
--- a/girder/web_client/eslint-config/README.md
+++ b/girder/web_client/eslint-config/README.md
@@ -7,7 +7,7 @@ Backbone-based web clients and plugins.
 Typically, users of this package should depend on
 `@girder/eslint-config` and its peerDependencies via:
 ```bash
-npm install --save-dev @girder/eslint-config eslint@^5 eslint-config-semistandard@^13 eslint-config-standard@^12 eslint-plugin-backbone eslint-plugin-import eslint-plugin-node eslint-plugin-promise eslint-plugin-standard eslint-plugin-underscore
+npm install --save-dev @girder/eslint-config eslint@^5 eslint-config-semistandard@^13 eslint-config-standard@^12 eslint-plugin-backbone eslint-plugin-import eslint-plugin-node eslint-plugin-promise eslint-plugin-standard
 ```
 then add `"extends": "@girder"`
 [to their project's local ESLint config](https://eslint.org/docs/developer-guide/shareable-configs#using-a-shareable-config).

--- a/girder/web_client/eslint-config/index.js
+++ b/girder/web_client/eslint-config/index.js
@@ -65,7 +65,9 @@ module.exports = {
         'promise/no-native': 'error',
         'promise/no-nesting': 'error',
         'promise/no-return-in-finally': 'error',
-        'promise/no-return-wrap': 'error',
+        'promise/no-return-wrap': 'error'
+        /*
+         * See comments below about removing underscore linting.
         'underscore/collection-return': 'error',
         'underscore/identity-shorthand': ['error', 'always'],
         'underscore/jquery-each': ['error', 'never'],
@@ -88,14 +90,19 @@ module.exports = {
         'underscore/prefer-underscore-typecheck': 'error',
         'underscore/prefer-where': 'error',
         'underscore/preferred-alias': 'error',
-        'underscore/prop-shorthand': ['error', 'always']
+        'underscore/prop-shorthand': ['error', 'always']a
+        */
     },
     env: {
         browser: true
     },
     plugins: [
-        'backbone',
-        'underscore'
+        'backbone'
+        // we had included the underscore plugin, but it is woefully out of
+        // date and has security warnings on its dependencies.  Until we update
+        // to a better or newer version, disable it so that we don't pull in
+        // critically insecure packages.
+        // 'underscore'
     ],
     settings: {
         backbone: {

--- a/girder/web_client/eslint-config/package.json
+++ b/girder/web_client/eslint-config/package.json
@@ -14,8 +14,7 @@
     "eslint-config-semistandard": ">=15.0.0",
     "eslint-plugin-backbone": ">=2.1.1",
     "eslint-plugin-import": ">=2.19.1",
-    "eslint-plugin-promise": ">=4.2.1",
-    "eslint-plugin-underscore": ">=0.0.10"
+    "eslint-plugin-promise": ">=4.2.1"
   },
   "keywords": [
     "eslint",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2107,23 +2107,6 @@
             "integrity": "sha512-ZL7+QRixjTR6/528YNGyDotyffm5OQst/sGxKDwGb9Uqs4In5Egi4+jbobhqJoyoCM6/7v/1A5fhQ7ScMtDjaQ==",
             "dev": true
         },
-        "eslint-plugin-underscore": {
-            "version": "0.0.10",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-underscore/-/eslint-plugin-underscore-0.0.10.tgz",
-            "integrity": "sha1-CBm45gOVhD7x5s6j5JZoR40XfJc=",
-            "dev": true,
-            "requires": {
-                "lodash": "^3.10.1"
-            },
-            "dependencies": {
-                "lodash": {
-                    "version": "3.10.1",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                    "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-                    "dev": true
-                }
-            }
-        },
         "eslint-scope": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^4.2.1",
         "eslint-plugin-standard": "^4.0.1",
-        "eslint-plugin-underscore": "0.0.10",
         "nyc": "^15.1.0",
         "phantomjs-prebuilt": "^2.1.16",
         "pug-lint": "^2.6.0",


### PR DESCRIPTION
This removes some lint checks.  The module eslint-plugin-underscore hasn't been updated since 2016 and relies on a version of lodash that is considered to have a critical security issue.  This stops using it; it really should be replaced with a better module, but a superficial search doesn't turn up a newer module.