### PR TITLE
Only use 'updated' metadata field for sync test

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -1320,7 +1320,7 @@ class GirderClient:
             for item in items:
                 _id = item['_id']
                 self.incomingMetadata[_id] = item
-                if sync and _id in self.localMetadata and item == self.localMetadata[_id]:
+                if sync and _id in self.localMetadata and item['updated'] == self.localMetadata[_id]['updated']:
                     continue
                 self.downloadItem(item['_id'], dest, name=item['name'])
 


### PR DESCRIPTION
The use of all metadata for sync test in downloadFolderRecursive() causes to always fail, as the 'downloadStatistics' field will change everytime. The 'updated' field alone is relevant for this test and allows for a correct skipping of unchanged files.

See [this issue]( https://github.com/girder/girder/issues/3394#issue-1179269942) for more details.