### PR TITLE
Better cache flushing in tests

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -117,6 +117,11 @@ def dropTestDatabase(dropModels=True):
         for model in _modelSingletons:
             model.reconnect()
 
+    # Invalidate cache regions which persist across tests -- if we dropped
+    # the database, we want to flush the cache, too.
+    cache.invalidate()
+    requestCache.invalidate()
+
 
 def dropGridFSDatabase(dbName):
     """


### PR DESCRIPTION
When testing in a local environment where caching was turned on, some tests failed because they used the local girder.cfg file and the settings cache was persisted across database flushes.  This avoids that problem.

It would be better for tests to never use the local girder.cfg file.