### PR TITLE
Wrap route handler and dispatch `failed` event

### DIFF
--- a/docs/plugin-development.rst
+++ b/docs/plugin-development.rst
@@ -479,6 +479,14 @@ You may change the access level of the route in your handler, but you will
 need to do so explicitly by declaring a different decorator than the underlying
 route handler.
 
+*  **Exception during REST call**
+
+This event is fired if an exception is raised while the default handler is executing.
+Like the before REST call event, this event recieves the same kwargs as the default
+route handler. The caught exception is raised again after this event is handled.
+The identifier for this event is, e.g., ``rest.get.item/:id.failed``.
+
+
 *  **After REST call**
 
 Just like the before REST call event, but this is fired after the default

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -975,9 +975,9 @@ class Resource:
             # exception is raised.
             try:
                 val = handler(**kwargs)
-            except Exception as e:
+            except Exception:
                 events.trigger('.'.join((eventPrefix, 'failed')), kwargs)
-                raise e
+                raise
 
         # Fire the after-call event that has a chance to augment the
         # return value of the API method that was called. You can


### PR DESCRIPTION
This PR adds a `failed` rest event, in the form of `rest.method.group.failed`. This will fire if an exception is raised during the request, re-raising the exception as to not modify behavior.