### PR TITLE
Better handle adjustments to paginated item lists

### DIFF
--- a/girder/web_client/src/views/widgets/HierarchyWidget.js
+++ b/girder/web_client/src/views/widgets/HierarchyWidget.js
@@ -281,14 +281,17 @@ var HierarchyWidget = View.extend({
                 this.itemCount = this.itemListView.collection.length;
                 this._childCountCheck();
                 if (this._paginated && this.hierarchyPaginated && this.itemListView.getNumPages() > 1) {
-                    this.render();
+                    if (this.parentModel.resourceName !== 'collection') {
+                        this.hierarchyPaginated.setElement(this.$('.g-hierarachy-paginated-bar')).render();
+                    }
                     this.$('.g-hierarchy-breadcrumb-bar').addClass('g-hierarchy-sticky');
                     this.$('.g-hierarachy-paginated-bar').addClass('g-hierarchy-sticky');
                     this.$('.g-hierarchy-breadcrumb-bar').css({ top: 0 });
                     this.$('.g-hierarachy-paginated-bar').css({ bottom: 0 });
+                    this.$('.g-hierarachy-paginated-bar').removeClass('hidden');
                 } else {
                     // We remove the bar if the current folder doesn't have more than one page, keep the sticky breadcrumb though
-                    this.$('.g-hierarachy-paginated-bar').remove();
+                    this.$('.g-hierarachy-paginated-bar').addClass('hidden');
                 }
             });
             // Only emitted when there is more than one page of data

--- a/girder/web_client/test/spec/browserSpec.js
+++ b/girder/web_client/test/spec/browserSpec.js
@@ -1162,11 +1162,11 @@ describe('browser hierarchy paginated selection', function () {
         });
 
         waitsFor(function () {
-            return $('.g-hierarachy-paginated-bar').length === 0;
+            return $('.g-hierarachy-paginated-bar:not(.hidden)').length === 0;
         }, 'The removal of the page selection');
 
         runs(function () {
-            expect($('.g-hierarachy-paginated-bar').length).toBe(0);
+            expect($('.g-hierarachy-paginated-bar:not(.hidden)').length).toBe(0);
             $('.g-breadcrumb-link[g-index="1"]').trigger('click');
         }, 'Make sure paginated text is removed when a folder has less than one page');
 


### PR DESCRIPTION
When a list of items is updated dynamically, this was rendering too much.  By only rendering the part that changes and using classes to hide UI, this is more responsive.