### PR TITLE
Clean up errors reported when validating swagger.

### DIFF
--- a/girder/api/docs.py
+++ b/girder/api/docs.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import collections
 import functools
+
 from girder import logprint
 
 models = collections.defaultdict(dict)
@@ -30,7 +31,7 @@ def _toRoutePath(resource, route):
     return path
 
 
-def _toOperation(info, resource, handler):
+def _toOperation(info, resource, handler, path=None, method=None):
     """
     Augment route info, returning a Swagger-compatible operation description.
     """
@@ -42,6 +43,11 @@ def _toOperation(info, resource, handler):
     # all operations described in the API.
     if 'operationId' not in operation:
         operation['operationId'] = str(resource) + '_' + handler.__name__
+        if method and method.lower() != 'get':
+            operation['operationId'] += '_' + method.lower()
+        if path:
+            operation['operationId'] += '_' + path.split('/', 2)[-1].replace(
+                '/', '_').replace('{', '').replace('}', '')
     return operation
 
 
@@ -65,7 +71,7 @@ def addRouteDocs(resource, route, method, info, handler):
     """
     path = _toRoutePath(resource, route)
 
-    operation = _toOperation(info, resource, handler)
+    operation = _toOperation(info, resource, handler, path, method)
 
     # Add the operation to the given route
     if method not in routes[resource][path]:

--- a/girder/web_client/test/spec/swaggerSpec.js
+++ b/girder/web_client/test/spec/swaggerSpec.js
@@ -16,19 +16,19 @@ describe('Test the swagger pages', function () {
             $('li#resource_system.resource .heading h2 a').trigger('click');
         });
         waitsFor(function () {
-            return $('#system_system_getVersion:visible').length > 0;
+            return $('#system_system_getVersion_version:visible').length > 0;
         }, 'end points to be visible');
         runs(function () {
-            $('#system_system_getVersion h3 a').trigger('click');
+            $('#system_system_getVersion_version h3 a').trigger('click');
         });
         waitsFor(function () {
-            return $('#system_system_getVersion .sandbox_header input.submit:visible').length > 0;
+            return $('#system_system_getVersion_version .sandbox_header input.submit:visible').length > 0;
         }, 'version try out button to be visible');
         runs(function () {
-            $('#system_system_getVersion .sandbox_header input.submit').trigger('click');
+            $('#system_system_getVersion_version_content .sandbox_header input.submit').trigger('click');
         });
         waitsFor(function () {
-            return $('#system_system_getVersion .response_body.json').text().indexOf('release') >= 0;
+            return $('#system_system_getVersion_version_content .response_body.json').text().indexOf('release') >= 0;
         }, 'version information was returned');
     });
 });

--- a/tests/cases/api_describe_test.py
+++ b/tests/cases/api_describe_test.py
@@ -223,7 +223,8 @@ class ApiDescribeTestCase(base.TestCase):
         resp = self.request(path='/describe')
         self.assertStatusOk(resp)
         self.assertTrue('definitions' in resp.json)
-        self.assertHasKeys(('Body', 'Global'), resp.json['definitions'])
+        self.assertIn('Body', resp.json['definitions'])
+        self.assertIn('Global', resp.json['definitions'])
         self.assertEqual(resp.json['definitions']['Body'], testModel)
         self.assertEqual(resp.json['definitions']['Global'], globalModel)
 

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -796,7 +796,7 @@ class PythonClientTestCase(base.TestCase):
 
         def checkDescription(description):
             self.assertEqual(description['basePath'], '/api/v1')
-            self.assertEqual(description['definitions'], {})
+            self.assertNotEqual(description['definitions'], {})
             self.assertEqual(description['info']['title'], 'Girder REST API')
             self.assertEqual(description['info']['version'], girder.constants.VERSION['release'])
             self.assertGreater(len(description['paths']), 0)


### PR DESCRIPTION
This seems to be a necessary antecedent to updating swagger-ui, which is needed to resolve some warnings.