### PR TITLE
Revert replacing extendify.

### DIFF
--- a/girder/web_client/grunt_tasks/build.js
+++ b/girder/web_client/grunt_tasks/build.js
@@ -2,7 +2,7 @@ const path = require('path');
 const process = require('process');
 
 const _ = require('underscore');
-const extendify = require('extendify-updated');
+const extendify = require('extendify');
 const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');

--- a/girder/web_client/package.json.template
+++ b/girder/web_client/package.json.template
@@ -14,7 +14,7 @@
         "colors": "1.1.2",
         "copy-webpack-plugin": "^4.5.2",
         "css-loader": "^0.26.1",
-        "extendify-updated": "^1.0.0",
+        "extendify": "^1.0.0",
         "extract-text-webpack-plugin": "^2.1.2",
         "file-loader": "^0.11.2",
         "grunt": "^1.0.1",


### PR DESCRIPTION
This reduced some warnings, but it pulls in too recent a very of lodash to work fully correctly.  Reverting until a better solution is implemented.