### PR TITLE
Escape resource paths with slashes.

### DIFF
--- a/girder/cli/mount.py
+++ b/girder/cli/mount.py
@@ -152,6 +152,7 @@ class ServerFuse(fuse.Operations):
         name = path_util.getResourceName(model, doc)
         if isinstance(name, bytes):
             name = name.decode('utf8')
+        name = path_util.encode(name)
         return name
 
     def _list(self, doc, model):

--- a/girder/utility/path.py
+++ b/girder/utility/path.py
@@ -21,7 +21,7 @@ def encode(token):
     :return: The encoded string
     :rtype: str
     """
-    return token.replace('\\', '\\\\').replace('/', '\\/')
+    return token.replace('\\', '\\\\').replace('/', '\\-')
 
 
 def decode(token):
@@ -31,7 +31,7 @@ def decode(token):
     :return: The decoded string
     :rtype: str
     """
-    return token.replace(r'\/', '/').replace('\\\\', '\\')
+    return token.replace('\\-', '/').replace('\\\\', '\\')
 
 
 def split(path):

--- a/test/test_path_utilities.py
+++ b/test/test_path_utilities.py
@@ -1,14 +1,15 @@
 import pytest
+
 from girder.utility import path
 
 
 @pytest.mark.parametrize('raw,encoded', [
     ('abcd', 'abcd'),
-    ('/', '\\/'),
+    ('/', '\\-'),
     ('\\', '\\\\'),
-    ('/\\', '\\/\\\\'),
-    ('\\//\\', '\\\\\\/\\/\\\\'),
-    ('a\\\\b//c\\d', 'a\\\\\\\\b\\/\\/c\\\\d')
+    ('/\\', '\\-\\\\'),
+    ('\\//\\', '\\\\\\-\\-\\\\'),
+    ('a\\\\b//c\\d', 'a\\\\\\\\b\\-\\-c\\\\d')
 ])
 def testCodec(raw, encoded):
     assert path.encode(raw) == encoded
@@ -20,15 +21,15 @@ def testCodec(raw, encoded):
     ('/abcd', ['', 'abcd']),
     ('/ab/cd/ef/gh', ['', 'ab', 'cd', 'ef', 'gh']),
     ('/ab/cd//', ['', 'ab', 'cd', '', '']),
-    ('ab\\/cd', ['ab/cd']),
-    ('ab\\/c/d', ['ab/c', 'd']),
-    ('ab\\//cd', ['ab/', 'cd']),
-    ('ab/\\/cd', ['ab', '/cd']),
+    ('ab\\-cd', ['ab/cd']),
+    ('ab\\-c/d', ['ab/c', 'd']),
+    ('ab\\-/cd', ['ab/', 'cd']),
+    ('ab/\\-cd', ['ab', '/cd']),
     ('ab\\\\/cd', ['ab\\', 'cd']),
     ('ab\\\\/\\\\cd', ['ab\\', '\\cd']),
-    ('ab\\\\\\/\\\\cd', ['ab\\/\\cd']),
+    ('ab\\\\\\-\\\\cd', ['ab\\/\\cd']),
     ('/\\\\abcd\\\\/', ['', '\\abcd\\', '']),
-    ('/\\\\\\\\/\\//\\\\', ['', '\\\\', '/', '\\'])
+    ('/\\\\\\\\/\\-/\\\\', ['', '\\\\', '/', '\\'])
 ])
 def testSplitAndJoin(pth, tokens):
     assert path.split(pth) == tokens

--- a/tests/cases/resource_test.py
+++ b/tests/cases/resource_test.py
@@ -403,7 +403,7 @@ class ResourceTestCase(base.TestCase):
         privateFolder = self.collectionPrivateFolder['name']
         paths = ('/user/goodlogin/Public/Item 1',
                  '/user/goodlogin/Public/Item 2',
-                 '/user/goodlogin/Public/Folder 1/It\\\\em\\/3',
+                 '/user/goodlogin/Public/Folder 1/It\\\\em\\-3',
                  '/collection/Test Collection/%s/Item 4' % privateFolder,
                  '/collection/Test Collection/%s/Item 5' % privateFolder)
 
@@ -461,7 +461,7 @@ class ResourceTestCase(base.TestCase):
                             method='GET', user=self.user,
                             params={'type': 'item'})
         self.assertStatusOk(resp)
-        self.assertEqual(resp.json, '/user/goodlogin/Public/Folder 1/It\\\\em\\/3')
+        self.assertEqual(resp.json, '/user/goodlogin/Public/Folder 1/It\\\\em\\-3')
 
         # Get a file's path
         resp = self.request(path='/resource/' + str(self.file1['_id']) + '/path',


### PR DESCRIPTION
We use resource paths for file paths with the mount command.  This wasn't working for paths with / or \ in them, because / is never allowed in a posix path except as a separator and \ wasn't being encoded in the mount directory lists.