### PR TITLE
Update based on changes to the ctags program.

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/python:3.6-node
+FROM cimg/python:3.6
 LABEL maintainer="Kitware, Inc. <kitware@kitware.com>"
 
 # Don't use "sudo"
@@ -8,7 +8,13 @@ USER root
 RUN apt-get update \
   && apt-get install --assume-yes \
     libldap2-dev \
-    libsasl2-dev
+    libsasl2-dev \
+  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+  && apt-get install -y nodejs \
+  && find / -xdev -name __pycache__ -type d -exec rm -r {} \+ \
+  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install Girder development prereqs
 RUN apt-get update \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,6 +298,49 @@ jobs:
           command: tox -e ansible
           working_directory: girder
 
+  dockers:
+    machine:
+        image: ubuntu-2004:202111-02
+    steps:
+      - checkout
+      - run:
+          name: Build the Girder docker
+          command: |
+            docker build --force-rm -t girder/girder .
+      - run:
+          name: Build the Girder test docker
+          command: |
+            cd .circleci
+            docker build --force-rm -t girder/girder_test .
+
+  publish-dockers:
+    machine:
+        image: ubuntu-2004:202111-02
+    steps:
+      - checkout
+      - run:
+          name: Build the Girder docker
+          command: |
+            docker build --force-rm -t girder/girder .
+      - run:
+          name: Build the Girder test docker
+          command: |
+            cd .circleci
+            docker build --force-rm -t girder/girder_test .
+      - run:
+          name: Publish the images to Docker Hub
+          command: |
+              echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+              docker push girder/girder:latest
+              docker tag girder/girder:latest girder/girder:latest-py3
+              docker push girder/girder:latest-py3
+              if [[ $CIRCLE_TAG =~ ^v.*$ ]]; then
+              docker tag girder/girder:latest "girder/girder:$CIRCLE_TAG"
+              docker push "girder/girder:$CIRCLE_TAG"
+              docker tag girder/girder:latest "girder/girder:${CIRCLE_TAG}-py3"
+              docker push "girder/girder:${CIRCLE_TAG}-py3"
+              fi
+
   publish:
     executor: py3
     steps:
@@ -363,6 +406,10 @@ workflows:
           filters:
             tags:
               only: /^v[0-9]+.*/
+      - dockers:
+          filters:
+            tags:
+              only: /^v[0-9]+.*/
       - publish:
           requires:
             - server-lint-test
@@ -385,3 +432,13 @@ workflows:
               only: /^v[0-9]+.*/
             branches:
               ignore: /.*/
+      - publish-dockers:
+          requires:
+            - dockers
+            - publish-release
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only:
+                - master

--- a/scripts/publicNames.py
+++ b/scripts/publicNames.py
@@ -41,7 +41,7 @@ def addFileSymbols(filePath, symbolTree):
             # Skip "as"-renamed imported modules
             '-I'
             # Skip unknown symbols (which are typically "as"-renamed imported symbols)
-            '-x',
+            '-Y',
 
         ]),
         filePath


### PR DESCRIPTION
The ctags module we use to check for public names changed the "unknown" flag in the Python parser from -x to -Y (see
https://github.com/universal-ctags/ctags/commit/933cf68d31d5a1cfd3c8ec8f775f2687323575c0).

This also starts building the docker images using circleci; they stopped being built around a year ago when docker hub changed a policy.