### PR TITLE
Restrict grunt version.

### DIFF
--- a/girder/web_client/fontello/package.json
+++ b/girder/web_client/fontello/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "fontello-cli": "^0.6.2",
-    "grunt": "^1.0.3",
+    "grunt": "~1.5.0",
     "grunt-contrib-clean": "^2.0.0",
     "grunt-shell": "^4.0.0"
   },

--- a/girder/web_client/package.json.template
+++ b/girder/web_client/package.json.template
@@ -16,7 +16,7 @@
         "css-loader": "^0.26.1",
         "extract-text-webpack-plugin": "^2.1.2",
         "file-loader": "^0.11.2",
-        "grunt": "^1.0.1",
+        "grunt": "~1.5.0",
         "grunt-contrib-copy": "^1.0.0",
         "grunt-contrib-pug": "^1.0.0",
         "grunt-contrib-stylus": "^1.2.0",


### PR DESCRIPTION
We need to do some work to work with grunt 1.6.

I expect the initial docker tests to fail until we publish a new version.