### PR TITLE
Fix an issue with ubuntu, distutils, and pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get update && apt-get install -qy \
 # why this is necessary.
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
+# See https://github.com/pypa/distutils/issues/17
+ENV SETUPTOOLS_USE_DISTUTILS=stdlib
 
 RUN mkdir /girder
 WORKDIR /girder


### PR DESCRIPTION
The issue appears when doing 'pip install -e <package>', the package does not show up when doing 'pip freeze'.  This is caused by Ubuntu installing a patched version of distutils (see pypa/distutils/issues/17 and pypa/setuptools/issues/3301; see also pypa/setuptools/issues/3625 for when this will stop working).

This adds a workaround.  Better would be to create a virtualenv and install into that and be insulated from odd OS upstream choices.