### PR TITLE
Change how we test if we can access s3 readonly assetstores

### DIFF
--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -417,10 +417,6 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
     def importData(self, parent, parentType, params, progress,
                    user, force_recursive=True, **kwargs):
         importPath = params.get('importPath', '').strip().lstrip('/')
-        if (self.assetstore.get('prefix', '')
-                and importPath != self.assetstore['prefix']
-                and not importPath.startswith(self.assetstore['prefix'] + '/')):
-            importPath = (self.assetstore['prefix'] + '/' + importPath).rstrip('/')
         bucket = self.assetstore['bucket']
         now = datetime.datetime.utcnow()
         paginator = self.client.get_paginator('list_objects')

--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -719,15 +719,6 @@ class AssetstoreTestCase(base.TestCase):
         self.assertStatusOk(resp)
         children = resp.json
         self.assertEqual(len(children), 1)
-        self.assertEqual(children[0]['name'], 'foo')
-
-        resp = self.request('/folder', user=self.admin, params={
-            'parentId': children[0]['_id'],
-            'parentType': 'folder'
-        })
-        self.assertStatusOk(resp)
-        children = resp.json
-        self.assertEqual(len(children), 1)
         self.assertEqual(children[0]['name'], 'bar')
 
         resp = self.request('/item', user=self.admin, params={

--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -719,6 +719,15 @@ class AssetstoreTestCase(base.TestCase):
         self.assertStatusOk(resp)
         children = resp.json
         self.assertEqual(len(children), 1)
+        self.assertEqual(children[0]['name'], 'foo')
+
+        resp = self.request('/folder', user=self.admin, params={
+            'parentId': children[0]['_id'],
+            'parentType': 'folder'
+        })
+        self.assertStatusOk(resp)
+        children = resp.json
+        self.assertEqual(len(children), 1)
         self.assertEqual(children[0]['name'], 'bar')
 
         resp = self.request('/item', user=self.admin, params={


### PR DESCRIPTION
Before, if a prefix was used and access to the root bucket was limited but access to a folder was allowed, this would always fail.

Also, ensure imports are from the prefix used in the assetstore.