### PR TITLE
Package updates to support newer node

### DIFF
--- a/girder/cli/build.py
+++ b/girder/cli/build.py
@@ -77,7 +77,7 @@ def main(dev, mode, watch, watch_plugin, npm, reinstall):
             shutil.rmtree(path, ignore_errors=True)
 
         # Run npm install
-        installCommand = [npm, 'install']
+        installCommand = [npm, 'install', '--install-links']
         if mode == ServerMode.PRODUCTION:
             installCommand.append('--production')
         check_call(installCommand, cwd=staging)

--- a/girder/web_client/grunt_tasks/webpack.plugins.js
+++ b/girder/web_client/grunt_tasks/webpack.plugins.js
@@ -15,7 +15,7 @@ class DllBootstrapPlugin {
             compilation.mainTemplate.plugin('startup', (source, chunk) => {
                 const bootstrapEntry = this.options[chunk.name];
                 if (bootstrapEntry) {
-                    const module = chunk.modules.find((m) => m.rawRequest === bootstrapEntry);
+                    const module = chunk.mapModules((m) => m).find((m) => m.rawRequest === bootstrapEntry);
                     source = `__webpack_require__(${module.id});\n${source}`;
                 }
                 return source;

--- a/girder/web_client/package.json.template
+++ b/girder/web_client/package.json.template
@@ -14,7 +14,7 @@
         "colors": "1.1.2",
         "copy-webpack-plugin": "^4.5.2",
         "css-loader": "^0.26.1",
-        "extract-text-webpack-plugin": "^2.1.2",
+        "extract-text-webpack-plugin": "^3.0.2",
         "file-loader": "^0.11.2",
         "grunt": "~1.5.0",
         "grunt-contrib-copy": "^1.0.0",
@@ -33,7 +33,7 @@
         "stylus-loader": "^3.0.1",
         "toposort": "^1.0.3",
         "uglifyjs-webpack-plugin": "^1.1.6",
-        "webpack": "^2.7.0",
+        "webpack": "^3.12.0",
         "whatwg-fetch": "^2.0.4"
     },
     "devDependencies": {

--- a/plugins/thumbnails/plugin_tests/thumbnailsSpec.js
+++ b/plugins/thumbnails/plugin_tests/thumbnailsSpec.js
@@ -1,4 +1,4 @@
-girderTest.importPlugin('thumbnails');
+girderTest.importPlugin('jobs', 'thumbnails');
 girderTest.startApp();
 
 describe('Test the thumbnail creation UI.', function () {


### PR DESCRIPTION
master builds and tests on node 14 / npm 6.  With these changes, we can on npm 8 and run on node 16, but doesn't yet pass tests  under node 16.

To install on npm >= 7, it is necessary to add `--install-links` to the `npm install` command.  Otherwise, plugins' node modules aren't installed; with it, they are installed alongside the girder node modules (whereas with npm < 7, they are installed next to each plugin).

Upgrading to webpack 3 doesn't change much, but does show off that we failed to properly ask for plugins during one of the client tests.

Currently, node 16 reports build success, but then fails to run because `webpack.DllReferencePlugin` seems to not locate packages on start.