### PR TITLE
Pin tslib

### DIFF
--- a/girder/web_client/package.json.template
+++ b/girder/web_client/package.json.template
@@ -32,6 +32,7 @@
         "stylus": "^0.54.5",
         "stylus-loader": "^3.0.1",
         "toposort": "^1.0.3",
+        "tslib": "2.5.0",
         "uglifyjs-webpack-plugin": "^1.1.6",
         "webpack": "^3.12.0",
         "whatwg-fetch": "^2.0.4"


### PR DESCRIPTION
The change in tslib 2.5.2 breaks our ability to run in node < 16.

tslib is a nested dependency of remarkable, and not used directly by girder.  Pinning it causes npm 6 to use the pinned version in preference to the broken version.

I think this requires us to make a release, as otherwise, builds are broken.