### PR TITLE
Fix an issue with LDAP.

### DIFF
--- a/plugins/ldap/girder_ldap/__init__.py
+++ b/plugins/ldap/girder_ldap/__init__.py
@@ -99,7 +99,10 @@ def _ldapAuth(event):
             results = conn.search_s(server['baseDn'], ldap.SCOPE_SUBTREE, searchStr, lattr)
             if results:
                 entry, attrs = results[0]
-                dn = attrs['distinguishedName'][0].decode('utf8')
+                try:
+                    dn = attrs['distinguishedName'][0].decode('utf8')
+                except KeyError:
+                    dn = entry
                 try:
                     conn.bind_s(dn, password, ldap.AUTH_SIMPLE)
                 except ldap.LDAPError:


### PR DESCRIPTION
Responses from an LDAP server via python-ldap don't include disinguishedName.  Rather, the entry that is returned should be used.

Fixes #3412

This was tested locally with the rroemhild/test-openldap docker image acting as an LDAP server.