### PR TITLE
Add the ability to filter jobs by handler.

### DIFF
--- a/plugins/jobs/girder_jobs/job_rest.py
+++ b/plugins/jobs/girder_jobs/job_rest.py
@@ -37,9 +37,10 @@ class Job(Resource):
                     destName='parentJob', paramType='query', required=False)
         .jsonParam('types', 'Filter for type', requireArray=True, required=False)
         .jsonParam('statuses', 'Filter for status', requireArray=True, required=False)
+        .jsonParam('handlers', 'Filter for handler', requireArray=True, required=False)
         .pagingParams(defaultSort='created', defaultSortDir=SortDir.DESCENDING)
     )
-    def listJobs(self, userId, parentJob, types, statuses, limit, offset, sort):
+    def listJobs(self, userId, parentJob, types, statuses, handlers, limit, offset, sort):
         currentUser = self.getCurrentUser()
         if not userId:
             user = currentUser
@@ -54,7 +55,8 @@ class Job(Resource):
 
         return list(self._model.list(
             user=user, offset=offset, limit=limit, types=types,
-            statuses=statuses, sort=sort, currentUser=currentUser, parentJob=parent))
+            statuses=statuses, handlers=handlers,
+            sort=sort, currentUser=currentUser, parentJob=parent))
 
     @filtermodel(model=JobModel)
     @access.token(scope=constants.REST_CREATE_JOB_TOKEN_SCOPE, required=True)
@@ -92,13 +94,15 @@ class Job(Resource):
         Description('List all jobs.')
         .jsonParam('types', 'Filter for type', requireArray=True, required=False)
         .jsonParam('statuses', 'Filter for status', requireArray=True, required=False)
+        .jsonParam('handlers', 'Filter for handler', requireArray=True, required=False)
         .pagingParams(defaultSort='created', defaultSortDir=SortDir.DESCENDING)
     )
-    def listAllJobs(self, types, statuses, limit, offset, sort):
+    def listAllJobs(self, types, statuses, handlers, limit, offset, sort):
         currentUser = self.getCurrentUser()
         return list(self._model.list(
             user='all', offset=offset, limit=limit, types=types,
-            statuses=statuses, sort=sort, currentUser=currentUser))
+            statuses=statuses, handlers=handlers,
+            sort=sort, currentUser=currentUser))
 
     @access.public
     @filtermodel(JobModel)

--- a/plugins/jobs/girder_jobs/models/job.py
+++ b/plugins/jobs/girder_jobs/models/job.py
@@ -49,7 +49,7 @@ class Job(AccessControlledModel):
         if childJob['parentId']:
             raise ValidationException('Cannot overwrite the Parent Id')
 
-    def list(self, user=None, types=None, statuses=None,
+    def list(self, user=None, types=None, statuses=None, handlers=None,
              limit=0, offset=0, sort=None, currentUser=None, parentJob=None):
         """
         List a page of jobs for a given user.
@@ -60,6 +60,8 @@ class Job(AccessControlledModel):
         :type types: array of type string, or None.
         :param statuses: job status filter.
         :type statuses: array of status integer, or None.
+        :param handlers: job handler filter.
+        :type handlers: array of type string or None, or None.
         :param limit: The page limit.
         :param limit: The page limit.
         :param offset: The page offset.
@@ -69,11 +71,13 @@ class Job(AccessControlledModel):
         """
         return self.findWithPermissions(
             offset=offset, limit=limit, sort=sort, user=currentUser,
-            types=types, statuses=statuses, jobUser=user, parentJob=parentJob)
+            types=types, statuses=statuses, handlers=handlers,
+            jobUser=user, parentJob=parentJob)
 
     def findWithPermissions(self, query=None, offset=0, limit=0, timeout=None, fields=None,
                             sort=None, user=None, level=AccessType.READ,
-                            types=None, statuses=None, jobUser=None, parentJob=None, **kwargs):
+                            types=None, statuses=None, handlers=None,
+                            jobUser=None, parentJob=None, **kwargs):
         """
         Search the list of jobs.
         :param query: The search query (see general MongoDB docs for "find()")
@@ -99,6 +103,8 @@ class Job(AccessControlledModel):
         :type types: array of type string, or None.
         :param statuses: job status filter.
         :type statuses: array of status integer, or None.
+        :param handlers: job handler filter.
+        :type handlers: array of type string or None, or None.
         :param jobUser: The user who owns the job.
         :type jobUser: dict, 'all', 'none', or None.
         :param parentJob: Parent Job.
@@ -120,6 +126,8 @@ class Job(AccessControlledModel):
                 query['type'] = {'$in': types}
             if statuses is not None:
                 query['status'] = {'$in': statuses}
+            if handlers is not None:
+                query['handler'] = {'$in': handlers}
             if parentJob:
                 query['parentId'] = parentJob['_id']
         return super().findWithPermissions(

--- a/plugins/jobs/plugin_tests/jobs_test.py
+++ b/plugins/jobs/plugin_tests/jobs_test.py
@@ -190,7 +190,8 @@ class JobsTestCase(base.TestCase):
         # get with filter
         resp = self.request('/job/all', user=self.users[0], params={
             'types': json.dumps(['t']),
-            'statuses': json.dumps([0])
+            'statuses': json.dumps([0]),
+            'handlers': json.dumps([None])
         })
         self.assertStatusOk(resp)
         self.assertEqual(len(resp.json), 5)


### PR DESCRIPTION
Some users run jobs remotely and locally (e.g., with the appropriate plugins, running something via girder_worker and running an assetstore import that is exposed as a job so that it is cancelable).  It is useful to tell if any remote jobs are unfinished, as that can be used to determine whether the remote worker should be started or stopped.

We could do this in a plugin, but it would require either monkeypatching these endpoints or creating new endpoints.