### PR TITLE
Frontend: Add support for unicode in passwords

### DIFF
--- a/girder/web_client/grunt_tasks/test.js
+++ b/girder/web_client/grunt_tasks/test.js
@@ -38,6 +38,7 @@ module.exports = function (grunt) {
                     [resolveBuiltPath('testing.min.js')]: [
                         require.resolve('babel-polyfill/dist/polyfill.js'),
                         require.resolve('whatwg-fetch/fetch.js'),
+                        require.resolve('text-encoding/lib/encoding.js'),
                         resolveTestPath('lib/jasmine-1.3.1/jasmine.js'),
                         resolveTestPath('lib/jasmine-1.3.1/ConsoleReporter.js'),
                         resolveBuiltPath('testUtils.es5.js')

--- a/girder/web_client/package.json.template
+++ b/girder/web_client/package.json.template
@@ -31,6 +31,7 @@
         "style-loader": "^0.13.2",
         "stylus": "^0.54.5",
         "stylus-loader": "^3.0.1",
+        "text-encoding": "^0.7.0",
         "toposort": "^1.0.3",
         "tslib": "2.5.0",
         "uglifyjs-webpack-plugin": "^1.1.6",

--- a/girder/web_client/src/auth.js
+++ b/girder/web_client/src/auth.js
@@ -69,6 +69,15 @@ function fetchCurrentUser() {
 }
 
 /**
+ * Encode password using TextEncoder to support unicode
+ */
+function basicAuthEncode(username, password) {
+  const encoder = new TextEncoder()
+  const data = encoder.encode(username + ':' + password)
+  return 'Basic ' + btoa(String.fromCharCode(...data))
+}
+
+/**
  * Log in to the server. If successful, sets the value of currentUser
  * and currentToken and triggers the "g:login" and "g:login.success".
  * On failure, triggers the "g:login.error" event.
@@ -81,7 +90,7 @@ function fetchCurrentUser() {
  * @param otpToken An optional one-time password to include with the login.
  */
 function login(username, password, cors = corsAuth, otpToken = null) {
-    var auth = 'Basic ' + window.btoa(username + ':' + password);
+    var auth = basicAuthEncode(username, password);
 
     const headers = {
         Authorization: auth

--- a/girder/web_client/src/auth.js
+++ b/girder/web_client/src/auth.js
@@ -72,9 +72,9 @@ function fetchCurrentUser() {
  * Encode password using TextEncoder to support unicode
  */
 function basicAuthEncode(username, password) {
-  const encoder = new TextEncoder()
-  const data = encoder.encode(username + ':' + password)
-  return 'Basic ' + btoa(String.fromCharCode(...data))
+    const encoder = new TextEncoder();
+    const data = encoder.encode(username + ':' + password);
+    return 'Basic ' + btoa(String.fromCharCode(...data));
 }
 
 /**


### PR DESCRIPTION
The backend already decodes the auth string with utf8, but the frontend uses btoa, which encodes with latin1. This fixes the mismatch between back- and frontend and allows any unicode chars in the pw.