### PR TITLE
Creation date in FileListWidget.  Creator on FileInfoWidget.

### DIFF
--- a/girder/web_client/src/stylesheets/body/itemPage.styl
+++ b/girder/web_client/src/stylesheets/body/itemPage.styl
@@ -37,19 +37,25 @@
   >li
     padding 3px 5px
     border-bottom 1px solid #f2f2f2
+    display flex
 
     .g-file-list-link
       margin-right 3px
       border-right 1px solid #e3e3e3
       padding-right 6px
+      flex-shrink 0
 
-    .g-file-size
+    .g-file-detail
       margin 0 6px
       color #888
       display inline-block
+      overflow hidden
+      white-space nowrap
+      text-overflow ellipsis
 
     .g-file-actions-container
-      float right
+      margin-left auto
+      flex-shrink 0
 
 .g-item-breadcrumb-container
   margin-bottom 10px

--- a/girder/web_client/src/templates/widgets/fileInfoDialog.pug
+++ b/girder/web_client/src/templates/widgets/fileInfoDialog.pug
@@ -13,6 +13,11 @@
           span= 'Created '
           span.g-bold-part= formatDate(file.get('created'), DATE_SECOND)
 
+        .g-file-info-line(property="creator")
+          i.icon-user
+          span= 'Creator: '
+          span.g-bold-part #{user && user.login || 'unknown'}
+
         .g-file-info-line(property="mimeType")
           i.icon-info
           span MIME type:

--- a/girder/web_client/src/templates/widgets/fileList.pug
+++ b/girder/web_client/src/templates/widgets/fileList.pug
@@ -17,7 +17,13 @@ ul.g-file-list
       a.g-show-info(file-cid=file.cid, title="Show info")
         i.icon-info
       if file.has('size')
-        .g-file-size= formatSize(file.get('size'))
+        .g-file-detail
+          i.icon-hdd
+          | #{formatSize(file.get('size'))}
+      if file.has('created')
+        .g-file-detail
+          i.icon-clock
+          | #{formatDate(file.get('created'), DATE_SECOND)}
       .g-file-actions-container(file-cid=file.cid)
         if parentItem && parentItem.get('_accessLevel') >= AccessType.WRITE
           a.g-update-info(title="Edit file info")

--- a/girder/web_client/src/views/widgets/FileInfoWidget.js
+++ b/girder/web_client/src/views/widgets/FileInfoWidget.js
@@ -11,11 +11,13 @@ import '@girder/core/utilities/jquery/girderModal';
 var FileInfoWidget = View.extend({
     initialize: function (settings) {
         this.parentItem = settings.parentItem;
+        this.user = settings.user;
     },
 
     render: function () {
         this.$el.html(FileInfoDialogTemplate({
             file: this.model,
+            user: this.user,
             formatDate: formatDate,
             DATE_SECOND: DATE_SECOND
         })).girderModal(this);

--- a/girder/web_client/src/views/widgets/FileListWidget.js
+++ b/girder/web_client/src/views/widgets/FileListWidget.js
@@ -7,7 +7,7 @@ import UploadWidget from '@girder/core/views/widgets/UploadWidget';
 import View from '@girder/core/views/View';
 import { AccessType } from '@girder/core/constants';
 import { confirm } from '@girder/core/dialog';
-import { formatSize } from '@girder/core/misc';
+import { formatSize, formatDate, DATE_SECOND } from '@girder/core/misc';
 import events from '@girder/core/events';
 
 import FileListTemplate from '@girder/core/templates/widgets/fileList.pug';
@@ -123,8 +123,10 @@ var FileListWidget = View.extend({
             files: this.collection.toArray(),
             hasMore: this.collection.hasNextPage(),
             AccessType: AccessType,
+            parentItem: this.parentItem,
             formatSize: formatSize,
-            parentItem: this.parentItem
+            formatDate: formatDate,
+            DATE_SECOND: DATE_SECOND
         }));
 
         if (this.fileEdit) {

--- a/girder/web_client/src/views/widgets/FileListWidget.js
+++ b/girder/web_client/src/views/widgets/FileListWidget.js
@@ -9,6 +9,7 @@ import { AccessType } from '@girder/core/constants';
 import { confirm } from '@girder/core/dialog';
 import { formatSize, formatDate, DATE_SECOND } from '@girder/core/misc';
 import events from '@girder/core/events';
+import { restRequest } from '@girder/core/rest';
 
 import FileListTemplate from '@girder/core/templates/widgets/fileList.pug';
 
@@ -23,12 +24,19 @@ var FileListWidget = View.extend({
 
         'click a.g-show-info': function (e) {
             var cid = $(e.currentTarget).attr('file-cid');
-            new FileInfoWidget({
-                el: $('#g-dialog-container'),
-                model: this.collection.get(cid),
-                parentItem: this.parentItem,
-                parentView: this
-            }).render();
+            var model = this.collection.get(cid);
+            var id = model.get('creatorId');
+            restRequest({
+                url: 'user/' + id
+            }).done((user) => {
+                new FileInfoWidget({
+                    el: $('#g-dialog-container'),
+                    model,
+                    user,
+                    parentItem: this.parentItem,
+                    parentView: this
+                }).render();
+            });
         },
 
         'click a.g-update-contents': function (e) {


### PR DESCRIPTION
VolView's [grider plugin](https://github.com/PaulHax/girder_volview) saves annotations as files under Items.  Adding more information to the file list helps track mutliple annotation versions.

Adds creation date to file list:
![image](https://github.com/girder/girder/assets/16823231/4ee7649e-3fe4-41ea-af97-969bc9a0bbc6)

Adds Creator field to file info modal:
![image](https://github.com/girder/girder/assets/16823231/14647c8d-0d5a-4e2d-98d2-b44fee706104)
