### PR TITLE
Relax package pinning.

### DIFF
--- a/girder/web_client/package.json.template
+++ b/girder/web_client/package.json.template
@@ -16,7 +16,7 @@
         "css-loader": "^0.26.1",
         "extract-text-webpack-plugin": "^3.0.2",
         "file-loader": "^0.11.2",
-        "grunt": "~1.5.0",
+        "grunt": "^1.5.0",
         "grunt-contrib-copy": "^1.0.0",
         "grunt-contrib-pug": "^1.0.0",
         "grunt-contrib-stylus": "^1.2.0",

--- a/girder/web_client/src/package.json
+++ b/girder/web_client/src/package.json
@@ -12,23 +12,23 @@
         "url": "https://github.com/girder/girder.git"
     },
     "dependencies": {
-        "as-jqplot": "~1.0.8",
-        "backbone": "~1.4.0",
-        "bootstrap": "~3.4.1",
+        "as-jqplot": "^1.0.8",
+        "backbone": "^1.4.0",
+        "bootstrap": "^3.4.1",
         "bootstrap-switch": "~3.3.4",
-        "eonasdan-bootstrap-datetimepicker": "~4.17",
+        "eonasdan-bootstrap-datetimepicker": "^4.17",
         "@girder/fontello": "*",
-        "jquery": "~3.5.1",
+        "jquery": "^3.7.0",
         "jsoneditor": "~5.9.3",
-        "moment": "~2.24.0",
-        "moment-timezone": "~0.5.27",
+        "moment": "^2.24.0",
+        "moment-timezone": "^0.5.27",
         "qrcode": "~1.4.4",
-        "remarkable": "~2.0.0",
-        "sprintf-js": "~1.1.2",
-        "swagger-ui": "~2.2.10",
+        "remarkable": "^2.0.0",
+        "sprintf-js": "^1.1.2",
+        "swagger-ui": "^2.2.10",
         "typeface-open-sans": "^0.0.75",
-        "underscore": "~1.13.6",
-        "url-otpauth": "~2.0.0"
+        "underscore": "^1.13.6",
+        "url-otpauth": "^2.0.0"
     },
     "main": "./index.js"
 }

--- a/plugins/dicom_viewer/girder_dicom_viewer/web_client/package.json
+++ b/plugins/dicom_viewer/girder_dicom_viewer/web_client/package.json
@@ -15,9 +15,9 @@
         "@girder/core": "*"
     },
     "dependencies": {
-        "daikon": "^1.2.15",
-        "shader-loader": "1.3.0",
-        "vtk.js": "5.10.3"
+        "daikon": "^1.2.44",
+        "shader-loader": "^1.3.0",
+        "vtk.js": "^5.10.3"
     },
     "girderPlugin": {
         "name": "dicom_viewer",


### PR DESCRIPTION
This allows moving to newer packages where appropriate, reducing a few of the security warnings.