### PR TITLE
Move attached files between assetstores

### DIFF
--- a/girder/models/upload.py
+++ b/girder/models/upload.py
@@ -194,7 +194,7 @@ class Upload(Model):
 
             # Update file info
             file['creatorId'] = upload['userId']
-            file['updated'] = datetime.datetime.utcnow()
+            file['created'] = datetime.datetime.utcnow()
             file['assetstoreId'] = assetstore['_id']
             file['size'] = upload['size']
             # If the file was previously imported, it is no longer.

--- a/girder/models/upload.py
+++ b/girder/models/upload.py
@@ -9,6 +9,7 @@ from .model_base import Model
 from girder.exceptions import GirderException, ValidationException, NoAssetstoreAdapter
 from girder.settings import SettingKey
 from girder.utility import RequestBodyStream
+from girder.utility.model_importer import ModelImporter
 from girder.utility.progress import noProgress
 
 
@@ -292,14 +293,14 @@ class Upload(Model):
             unspecified, the current assetstore is used.
         """
         from girder.utility import assetstore_utilities
-        from .item import Item
 
         assetstore = self.getTargetAssetstore('file', file, assetstore)
         adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
         now = datetime.datetime.utcnow()
 
         if 'attachedToId' in file:
-            parent = Item().findOne({'_id': file['attachedToId']})
+            parent = ModelImporter.model(
+                file['attachedToType']).findOne({'_id': file['attachedToId']})
             upload = self.createUpload(
                 user=None, name=file['name'], parentType=file['attachedToType'],
                 parent=parent, size=file['size'], mimeType=file['mimeType'],

--- a/girder/models/upload.py
+++ b/girder/models/upload.py
@@ -183,12 +183,9 @@ class Upload(Model):
         if 'fileId' in upload:  # Updating an existing file's contents
             file = File().load(upload['fileId'], force=True)
 
-            if upload.get('attachParent'):
-                item = Item().load(upload['parentId'], force=True)
-            else:
+            if not upload.get('attachParent'):
                 item = Item().load(file['itemId'], force=True)
-
-            File().propagateSizeChange(item, upload['size'] - file['size'])
+                File().propagateSizeChange(item, upload['size'] - file['size'])
 
             # Delete the previous file contents from the containing assetstore
             assetstore_utilities.getAssetstoreAdapter(

--- a/plugins/user_quota/girder_user_quota/quota.py
+++ b/plugins/user_quota/girder_user_quota/quota.py
@@ -256,12 +256,14 @@ class QuotaPolicy(Resource):
                 resource = ModelImporter.model(model).load(id=resource, force=True)
             except ImportError:
                 return None, None
+
+        # Attached files have no quota
+        if resource.get('attachedToId'):
+            return None, None
+
         if model == 'file':
             model = 'item'
-            if 'attachedToId' in resource:
-                resource = Item().load(id=resource['attachedToId'], force=True)
-            else:
-                resource = Item().load(id=resource['itemId'], force=True)
+            resource = Item().load(id=resource['itemId'], force=True)
         if model in ('folder', 'item'):
             if ('baseParentType' not in resource
                     or 'baseParentId' not in resource):

--- a/plugins/user_quota/girder_user_quota/quota.py
+++ b/plugins/user_quota/girder_user_quota/quota.py
@@ -258,7 +258,10 @@ class QuotaPolicy(Resource):
                 return None, None
         if model == 'file':
             model = 'item'
-            resource = Item().load(id=resource['itemId'], force=True)
+            if 'attachedToId' in resource:
+                resource = Item().load(id=resource['attachedToId'], force=True)
+            else:
+                resource = Item().load(id=resource['itemId'], force=True)
         if model in ('folder', 'item'):
             if ('baseParentType' not in resource
                     or 'baseParentId' not in resource):


### PR DESCRIPTION
Fixed edge cases where attached files wouldn't be transferred properly by `moveFileToAssetstore`.

Addresses #3467 