### PR TITLE
Shift where imports are done for the mock smtp tests

### DIFF
--- a/pytest_girder/pytest_girder/utils.py
+++ b/pytest_girder/pytest_girder/utils.py
@@ -29,6 +29,10 @@ class MockSmtpReceiver:
         the current process so as to reduce potential conflicts with parallel
         tests that are started nearly simultaneously.
         """
+        # These imports are not at module level because the smtpd package was
+        # removed from Python 3.12.  By having them within the class, tests
+        # that do not require the smtp mocks can still use the pytest girder
+        # fixtures.
         import smtpd
 
         class MockSmtpServer(smtpd.SMTPServer):
@@ -53,6 +57,7 @@ class MockSmtpReceiver:
         self.thread.start()
 
     def loop(self):
+        # See comment in start about import scoping
         import asyncore
 
         """

--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -1330,11 +1330,11 @@ pytest_girder
                 isMailQueueEmpty
                 loop
                 start
+                    MockSmtpServer
+                        mailQueue
+                        process_message
                 stop
                 waitForMail
-            MockSmtpServer
-                mailQueue
-                process_message
             buildHeaders
             getResponseBody
             request

--- a/tests/mock_smtp.py
+++ b/tests/mock_smtp.py
@@ -1,2 +1,2 @@
 # These symbols are preserved for backward compatibility
-from pytest_girder.utils import MockSmtpReceiver, MockSmtpServer  # noqa
+from pytest_girder.utils import MockSmtpReceiver  # noqa


### PR DESCRIPTION
Python 3.12 no longer has smtpd or asyncore.  To enable these tests in Python 3.12, they will have to be refactored.  This change allows clients to use pytest_girder with Python 3.12 (unless they use the smtp mocks).