### PR TITLE
Require a minimum of Python 3.8

### DIFF
--- a/clients/python/girder_client/__init__.py
+++ b/clients/python/girder_client/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from pkg_resources import DistributionNotFound, get_distribution
 
 try:
@@ -542,8 +541,7 @@ class GirderClient:
 
         while True:
             records = self.get(path, params)
-            for record in records:
-                yield record
+            yield from records
 
             n = len(records)
             if limit or n < params['limit']:
@@ -1386,7 +1384,7 @@ class GirderClient:
         :param dest: The local download destination.
         """
         try:
-            with open(os.path.join(dest, '.girder_metadata'), 'r') as fh:
+            with open(os.path.join(dest, '.girder_metadata')) as fh:
                 self.localMetadata = json.loads(fh.read())
         except OSError:
             print('Local metadata does not exists. Falling back to download.')

--- a/clients/python/girder_client/cli.py
+++ b/clients/python/girder_client/cli.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import click
 from http.client import HTTPConnection
 import logging

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from setuptools import setup, find_packages
@@ -33,8 +32,7 @@ setup(
     name='girder-client',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
     setup_requires=[
-        'setuptools-scm<7 ; python_version < "3.7"',
-        'setuptools-scm ; python_version >= "3.7"',
+        'setuptools-scm',
     ],
     description='Python client for interacting with Girder servers',
     long_description=readme,
@@ -43,12 +41,13 @@ setup(
     url='http://girder.readthedocs.org/en/latest/python-client.html',
     license='Apache 2.0',
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3'
     ],
+    python_requires='>=3.8',
     packages=find_packages(exclude=('tests.*', 'tests')),
     install_requires=install_reqs,
     zip_safe=False,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pkg_resources
 
 import sphinx_rtd_theme
@@ -29,8 +28,8 @@ _girder_imports |= {
 # Set Sphinx variables
 master_doc = 'index'
 
-project = u'Girder'
-copyright = u'2014-2018, Kitware, Inc.'
+project = 'Girder'
+copyright = '2014-2018, Kitware, Inc.'
 release = _girder_version
 version = '.'.join(release.split('.')[:2])
 
@@ -39,7 +38,7 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_favicon = 'favicon.ico'
 
 latex_documents = [
-    ('index', 'Girder.tex', u'Girder Documentation', u'Kitware, Inc.', 'manual'),
+    ('index', 'Girder.tex', 'Girder Documentation', 'Kitware, Inc.', 'manual'),
 ]
 
 # Setup Sphinx extensions (and associated variables)

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -17,7 +17,7 @@ Installation of Girder's server has the following system dependencies:
     `OpenSSL <https://packages.ubuntu.com/bionic/openssl>`_) at a very low level, so other
     operating system distributions and versions may not be compatible.
 
-* `Python <https://www.python.org>`_ v3.6
+* `Python <https://www.python.org>`_ v3.8
 
   * This is necessary to run most of the server software.
 
@@ -110,11 +110,11 @@ Web Client Build
 ----------------
 Building Girder's web client has the following system dependencies:
 
-* `Node.js <https://nodejs.org/>`_ v10 to v14
+* `Node.js <https://nodejs.org/>`_ v14
 
   * This is necessary to execute many aspects of the web client build system.
 
-* `npm <https://www.npmjs.com/>`_ v5.2 to v6
+* `npm <https://www.npmjs.com/>`_ v6
 
   * This is necessary to install web client packages.
 

--- a/girder/__init__.py
+++ b/girder/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from pkg_resources import DistributionNotFound, get_distribution
 
 try:

--- a/girder/api/access.py
+++ b/girder/api/access.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from functools import wraps
 
 from girder.api import rest

--- a/girder/api/api_main.py
+++ b/girder/api/api_main.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import cherrypy
 
 from . import describe

--- a/girder/api/describe.py
+++ b/girder/api/describe.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import bson.json_util
 import dateutil.parser
 from functools import wraps

--- a/girder/api/docs.py
+++ b/girder/api/docs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import collections
 import functools
 

--- a/girder/api/filter_logging.py
+++ b/girder/api/filter_logging.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import cherrypy
 import logging
 import re

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import html
 import cherrypy
 import collections
@@ -751,7 +750,7 @@ def _setCommonCORSHeaders():
         allowedList = {o.strip() for o in allowed.split(',')}
         allowedListWithoutWildcard = allowedList - {'*'}
 
-        if any((fnmatch.fnmatch(origin, pattern) for pattern in allowedListWithoutWildcard)):
+        if any(fnmatch.fnmatch(origin, pattern) for pattern in allowedListWithoutWildcard):
             setResponseHeader('Access-Control-Allow-Origin', origin)
         elif '*' in allowedList:
             setResponseHeader('Access-Control-Allow-Origin', '*')

--- a/girder/api/sftp.py
+++ b/girder/api/sftp.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from functools import wraps
 import paramiko
 import socketserver
@@ -78,7 +77,7 @@ class _FileHandle(paramiko.SFTPHandle):
 
     def read(self, offset, length):
         if length > MAX_BUF_LEN:
-            raise IOError(
+            raise OSError(
                 'Requested chunk length (%d) is larger than the maximum allowed.' % length)
 
         if offset != self._handle.tell() and offset < self.file['size']:

--- a/girder/api/v1/api_key.py
+++ b/girder/api/v1/api_key.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from ..describe import Description, autoDescribeRoute
 from ..rest import Resource, filtermodel
 from girder.api import access

--- a/girder/api/v1/assetstore.py
+++ b/girder/api/v1/assetstore.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from ..describe import Description, autoDescribeRoute
 from ..rest import Resource
 from girder import events

--- a/girder/api/v1/collection.py
+++ b/girder/api/v1/collection.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from ..describe import Description, autoDescribeRoute
 from ..rest import Resource, filtermodel, setResponseHeader, setContentDisposition
 from girder.api import access
@@ -120,8 +119,7 @@ class Collection(Resource):
             zip = ziputil.ZipGenerator(collection['name'])
             for (path, file) in self._model.fileList(
                     collection, user=self.getCurrentUser(), subpath=False, mimeFilter=mimeFilter):
-                for data in zip.addFile(file, path):
-                    yield data
+                yield from zip.addFile(file, path)
             yield zip.footer()
         return stream
 

--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import cherrypy
 import errno
 
@@ -233,7 +232,7 @@ class File(Resource):
                     upload['received'], offset))
         try:
             return Upload().handleChunk(upload, chunk, filter=True, user=user)
-        except IOError as exc:
+        except OSError as exc:
             if exc.errno == errno.EACCES:
                 raise Exception('Failed to store upload.')
             raise

--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from ..describe import Description, autoDescribeRoute
 from ..rest import Resource, filtermodel, setResponseHeader, setContentDisposition
 from girder.api import access
@@ -167,8 +166,7 @@ class Folder(Resource):
             zip = ziputil.ZipGenerator(folder['name'])
             for (path, file) in self._model.fileList(
                     folder, user=user, subpath=False, mimeFilter=mimeFilter):
-                for data in zip.addFile(file, path):
-                    yield data
+                yield from zip.addFile(file, path)
             yield zip.footer()
         return stream
 

--- a/girder/api/v1/group.py
+++ b/girder/api/v1/group.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from ..describe import Description, autoDescribeRoute
 from ..rest import Resource, filtermodel
 from girder.api import access

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from ..describe import Description, autoDescribeRoute
 from ..rest import Resource, filtermodel, setResponseHeader, setContentDisposition
 from girder.utility import ziputil
@@ -242,8 +241,7 @@ class Item(Resource):
         def stream():
             zip = ziputil.ZipGenerator(item['name'])
             for (path, file) in self._model.fileList(item, subpath=False):
-                for data in zip.addFile(file, path):
-                    yield data
+                yield from zip.addFile(file, path)
             yield zip.footer()
         return stream
 

--- a/girder/api/v1/notification.py
+++ b/girder/api/v1/notification.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import cherrypy
 import json
 import time

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from ..describe import Description, autoDescribeRoute
 from ..rest import Resource as BaseResource, setResponseHeader, setContentDisposition
 from girder.constants import AccessType, TokenScope
@@ -178,8 +177,7 @@ class Resource(BaseResource):
                     doc = model.load(id=id, user=user, level=AccessType.READ)
                     for (path, file) in model.fileList(
                             doc=doc, user=user, includeMetadata=includeMetadata, subpath=True):
-                        for data in zip.addFile(file, path):
-                            yield data
+                        yield from zip.addFile(file, path)
             yield zip.footer()
         return stream
 

--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import cherrypy
 import datetime
 import errno

--- a/girder/api/v1/token.py
+++ b/girder/api/v1/token.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from ..rest import Resource
 from ..describe import Description, autoDescribeRoute
 from girder.api import access

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import base64
 import cherrypy
 import datetime

--- a/girder/cli/build.py
+++ b/girder/cli/build.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 import os
 from pkg_resources import resource_filename
@@ -113,7 +112,7 @@ def _collectPluginDependencies():
 
 
 def _generatePackageJSON(staging, source, plugins):
-    with open(source, 'r') as f:
+    with open(source) as f:
         sourceJSON = json.load(f)
     deps = sourceJSON['dependencies']
     deps['@girder/core'] = 'file:%s' % os.path.join(os.path.dirname(source), 'src')

--- a/girder/cli/mount.py
+++ b/girder/cli/mount.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import cherrypy
 import click
 import errno
@@ -50,8 +49,8 @@ class ServerFuse(fuse.Operations):
             stat = os.stat(os.path.expanduser('~'))
         # we always set st_mode, st_size, st_ino, st_nlink, so we don't need
         # to track those.
-        self._defaultStat = dict((key, getattr(stat, key)) for key in (
-            'st_atime', 'st_ctime', 'st_gid', 'st_mtime', 'st_uid', 'st_blksize'))
+        self._defaultStat = {key: getattr(stat, key) for key in (
+            'st_atime', 'st_ctime', 'st_gid', 'st_mtime', 'st_uid', 'st_blksize')}
         self.nextFH = 1
         self.openFiles = {}
         self.openFilesLock = threading.Lock()
@@ -269,9 +268,9 @@ class ServerFuse(fuse.Operations):
         :returns: a list of names.  This always includes . and ..
         """
         path = path.rstrip('/')
-        result = [u'.', u'..']
+        result = ['.', '..']
         if path == '':
-            result.extend([u'collection', u'user'])
+            result.extend(['collection', 'user'])
         elif path in ('/user', '/collection'):
             model = path[1:]
             docList = ModelImporter.model(model).find({}, sort=None)

--- a/girder/cli/serve.py
+++ b/girder/cli/serve.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import cherrypy
 import click
 

--- a/girder/cli/sftpd.py
+++ b/girder/cli/sftpd.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import click
 import os
 import paramiko

--- a/girder/cli/shell.py
+++ b/girder/cli/shell.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import click
 import girder
 import sys

--- a/girder/constants.py
+++ b/girder/constants.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Constants should be defined here.
 """

--- a/girder/events.py
+++ b/girder/events.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This module contains the Girder events framework. It maintains a global mapping
 of events to listeners, and contains utilities for callers to handle or trigger

--- a/girder/models/__init__.py
+++ b/girder/models/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pymongo
 import urllib.parse
 

--- a/girder/models/api_key.py
+++ b/girder/models/api_key.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 
 from .model_base import AccessControlledModel

--- a/girder/models/assetstore.py
+++ b/girder/models/assetstore.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 
 from .model_base import Model

--- a/girder/models/collection.py
+++ b/girder/models/collection.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 import os
 
@@ -271,10 +270,9 @@ class Collection(AccessControlledModel):
             fields=['name'] + (['meta'] if includeMetadata else [])
         ))
         for folder in childFolders:
-            for (filepath, file) in folderModel.fileList(
-                    folder, user, path, includeMetadata, subpath=True,
-                    mimeFilter=mimeFilter, data=data):
-                yield (filepath, file)
+            yield from folderModel.fileList(
+                folder, user, path, includeMetadata, subpath=True,
+                mimeFilter=mimeFilter, data=data)
 
     def subtreeCount(self, doc, includeItems=True, user=None, level=None):
         """

--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import cherrypy
 import datetime
 import os
@@ -111,8 +110,7 @@ class File(acl_mixin.AccessControlMixin, Model):
                     extraParameters=extraParameters)
 
                 def downloadGenerator():
-                    for data in fileDownload():
-                        yield data
+                    yield from fileDownload()
                     if endByte is None or endByte >= file['size']:
                         events.trigger('model.file.download.complete', info={
                             'file': file,

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import copy
 import datetime
 import json
@@ -699,10 +698,9 @@ class Folder(AccessControlledModel):
         for sub in childFolders:
             if sub['name'] == metadataFile:
                 metadataFile = None
-            for (filepath, file) in self.fileList(
-                    sub, user, path, includeMetadata, subpath=True,
-                    mimeFilter=mimeFilter, data=data):
-                yield (filepath, file)
+            yield from self.fileList(
+                sub, user, path, includeMetadata, subpath=True,
+                mimeFilter=mimeFilter, data=data)
 
         # Eagerly evaluate this list, as the MongoDB cursor can time out on long requests
         childItems = list(self.childItems(
@@ -711,9 +709,8 @@ class Folder(AccessControlledModel):
         for item in childItems:
             if item['name'] == metadataFile:
                 metadataFile = None
-            for (filepath, file) in itemModel.fileList(
-                    item, user, path, includeMetadata, mimeFilter=mimeFilter, data=data):
-                yield (filepath, file)
+            yield from itemModel.fileList(
+                item, user, path, includeMetadata, mimeFilter=mimeFilter, data=data)
 
         if includeMetadata and metadataFile and doc.get('meta', {}):
             def stream():

--- a/girder/models/group.py
+++ b/girder/models/group.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 
 from .model_base import AccessControlledModel

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import copy
 import datetime
 import json

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import copy
 import functools
 import itertools

--- a/girder/models/notification.py
+++ b/girder/models/notification.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 import time
 

--- a/girder/models/setting.py
+++ b/girder/models/setting.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 import os
 

--- a/girder/models/token.py
+++ b/girder/models/token.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 
 from girder.constants import AccessType, TokenScope

--- a/girder/models/upload.py
+++ b/girder/models/upload.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 import io
 from bson.objectid import ObjectId

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 import os
 import re
@@ -558,9 +557,8 @@ class User(AccessControlledModel):
             fields=['name'] + (['meta'] if includeMetadata else [])
         ))
         for folder in childFolders:
-            for (filepath, file) in folderModel.fileList(
-                    folder, user, path, includeMetadata, subpath=True, data=data):
-                yield (filepath, file)
+            yield from folderModel.fileList(
+                folder, user, path, includeMetadata, subpath=True, data=data)
 
     def subtreeCount(self, doc, includeItems=True, user=None, level=None):
         """

--- a/girder/plugin.py
+++ b/girder/plugin.py
@@ -115,7 +115,7 @@ class GirderPlugin(metaclass=_PluginMeta):
         if not os.path.isfile(packageJsonFile):
             raise Exception('Invalid web client path provided: %s' % packageJsonFile)
 
-        with open(packageJsonFile, 'r') as f:
+        with open(packageJsonFile) as f:
             packageJson = json.load(f)
             packageName = packageJson['name']
 

--- a/girder/settings.py
+++ b/girder/settings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from collections import OrderedDict
 
 import cherrypy

--- a/girder/utility/__init__.py
+++ b/girder/utility/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import cherrypy
 import datetime
 import dateutil.parser

--- a/girder/utility/acl_mixin.py
+++ b/girder/utility/acl_mixin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import collections
 import itertools
 from collections import abc

--- a/girder/utility/assetstore_utilities.py
+++ b/girder/utility/assetstore_utilities.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from ..constants import AssetstoreType
 from ..exceptions import NoAssetstoreAdapter
 from .filesystem_assetstore_adapter import FilesystemAssetstoreAdapter

--- a/girder/utility/config.py
+++ b/girder/utility/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import cherrypy
 import os
 

--- a/girder/utility/filesystem_assetstore_adapter.py
+++ b/girder/utility/filesystem_assetstore_adapter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import filelock
 from hashlib import sha512
 import io

--- a/girder/utility/gridfs_assetstore_adapter.py
+++ b/girder/utility/gridfs_assetstore_adapter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import bson
 from hashlib import sha512
 import io

--- a/girder/utility/mail_utils.py
+++ b/girder/utility/mail_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import re
 import smtplib

--- a/girder/utility/model_importer.py
+++ b/girder/utility/model_importer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 _modelClasses = {}
 _coreModelsRegistered = False
 

--- a/girder/utility/path.py
+++ b/girder/utility/path.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """This module contains utility methods for parsing girder path strings."""
 
 import re

--- a/girder/utility/progress.py
+++ b/girder/utility/progress.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import cherrypy
 import datetime
 import time

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 import json
 import re

--- a/girder/utility/search.py
+++ b/girder/utility/search.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from functools import partial
 
 from girder.exceptions import GirderException

--- a/girder/utility/server.py
+++ b/girder/utility/server.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import cherrypy
 import mako
 import mimetypes

--- a/girder/utility/setting_utilities.py
+++ b/girder/utility/setting_utilities.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 _validators = {}
 _defaultFunctions = {}
 

--- a/girder/utility/system.py
+++ b/girder/utility/system.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import cherrypy
 import os
 import psutil

--- a/girder/utility/webroot.py
+++ b/girder/utility/webroot.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 import os
 import re

--- a/girder/utility/ziputil.py
+++ b/girder/utility/ziputil.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This module is essentially a subset of the python zipfile module that has been
 modified to allow it to read arbitrary streams (using generators) as input,

--- a/plugins/audit_logs/girder_audit_logs/report.py
+++ b/plugins/audit_logs/girder_audit_logs/report.py
@@ -24,7 +24,7 @@ from girder_audit_logs import Record
 
 def index_folder(folderId):
     if Folder().load(folderId, force=True) is None:
-        raise ValueError('folderId={} was not a valid folder'.format(folderId))
+        raise ValueError(f'folderId={folderId} was not a valid folder')
     items = Item().find({'folderId': ObjectId(folderId)})
     subfolders = Folder().find({'parentId': ObjectId(folderId)})
 

--- a/plugins/audit_logs/setup.py
+++ b/plugins/audit_logs/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from setuptools import find_packages, setup
@@ -23,8 +22,7 @@ setup(
     name='girder-audit-logs',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
     setup_requires=[
-        'setuptools-scm<7 ; python_version < "3.7"',
-        'setuptools-scm ; python_version >= "3.7"',
+        'setuptools-scm',
     ],
     description='Keeps detailed logs of every REST request and low-level file download event.',
     author='Kitware, Inc.',
@@ -37,10 +35,8 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
     ],
+    python_requires='>=3.8',
     packages=find_packages(),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/authorized_upload/girder_authorized_upload/__init__.py
+++ b/plugins/authorized_upload/girder_authorized_upload/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from bson.objectid import ObjectId

--- a/plugins/authorized_upload/girder_authorized_upload/constants.py
+++ b/plugins/authorized_upload/girder_authorized_upload/constants.py
@@ -1,2 +1,1 @@
-# -*- coding: utf-8 -*-
 TOKEN_SCOPE_AUTHORIZED_UPLOAD = 'authorized_upload'

--- a/plugins/authorized_upload/girder_authorized_upload/rest.py
+++ b/plugins/authorized_upload/girder_authorized_upload/rest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from girder.api import access
 from girder.api.describe import describeRoute, Description
 from girder.api.rest import loadmodel, Resource

--- a/plugins/authorized_upload/plugin_tests/upload_test.py
+++ b/plugins/authorized_upload/plugin_tests/upload_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from girder.models.folder import Folder
 from girder.models.setting import Setting
 from girder.models.token import Token

--- a/plugins/authorized_upload/setup.py
+++ b/plugins/authorized_upload/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from setuptools import find_packages, setup
@@ -24,8 +23,7 @@ setup(
     name='girder-authorized-upload',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
     setup_requires=[
-        'setuptools-scm<7 ; python_version < "3.7"',
-        'setuptools-scm ; python_version >= "3.7"',
+        'setuptools-scm',
         'setuptools-git',
     ],
     description='Allows registered users to authorize file uploads on their behalf '
@@ -41,11 +39,9 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
+    python_requires='>=3.8',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/autojoin/setup.py
+++ b/plugins/autojoin/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from setuptools import find_packages, setup
@@ -24,8 +23,7 @@ setup(
     name='girder-autojoin',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
     setup_requires=[
-        'setuptools-scm<7 ; python_version < "3.7"',
-        'setuptools-scm ; python_version >= "3.7"',
+        'setuptools-scm',
         'setuptools-git',
     ],
     description='Automatically assign new users to groups based on their email domain',
@@ -40,11 +38,9 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
+    python_requires='>=3.8',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/dicom_viewer/girder_dicom_viewer/__init__.py
+++ b/plugins/dicom_viewer/girder_dicom_viewer/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 import json
 
@@ -114,20 +113,20 @@ def _removeUniqueMetadata(dicomMeta, additionalMeta):
     this means not have any dict or list as properties
     """
     return dict(
-        set(
+        {
             (
                 k,
                 tuple(v) if isinstance(v, list) else v
             )
             for k, v in dicomMeta.items()
-        )
-        & set(
+        }
+        & {
             (
                 k,
                 tuple(v) if isinstance(v, list) else v
             )
             for k, v in additionalMeta.items()
-        )
+        }
     )
 
 
@@ -183,7 +182,7 @@ def _coerceMetadata(dataset):
     for tag in dataset.keys():
         try:
             dataElement = dataset[tag]
-        except IOError:
+        except OSError:
             continue
         if dataElement.tag.element == 0:
             # Skip Group Length tags, which are always element 0x0000

--- a/plugins/dicom_viewer/girder_dicom_viewer/event_helper.py
+++ b/plugins/dicom_viewer/girder_dicom_viewer/event_helper.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import threading
 
 from girder import events

--- a/plugins/dicom_viewer/plugin_tests/dicom_viewer_test.py
+++ b/plugins/dicom_viewer/plugin_tests/dicom_viewer_test.py
@@ -117,7 +117,7 @@ class DicomViewerTest(base.TestCase):
         for i in range(0, 4):
             self.assertTrue('_id' in dicomItem['dicom']['files'][i])
             self.assertTrue('name' in dicomItem['dicom']['files'][i])
-            self.assertEqual(dicomItem['dicom']['files'][i]['name'], 'dicomFile{}.dcm'.format(i))
+            self.assertEqual(dicomItem['dicom']['files'][i]['name'], f'dicomFile{i}.dcm')
             self.assertTrue('SeriesNumber' in dicomItem['dicom']['files'][i]['dicom'])
             self.assertTrue('InstanceNumber' in dicomItem['dicom']['files'][i]['dicom'])
             self.assertTrue('SliceLocation' in dicomItem['dicom']['files'][i]['dicom'])
@@ -176,7 +176,7 @@ class DicomViewerTest(base.TestCase):
                 dcmFile = Upload().uploadFromFile(
                     obj=fp,
                     size=os.path.getsize(file),
-                    name='dicomFile{}.dcm'.format(i),
+                    name=f'dicomFile{i}.dcm',
                     parentType='item',
                     parent=item,
                     mimeType='application/dicom',

--- a/plugins/dicom_viewer/setup.py
+++ b/plugins/dicom_viewer/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from setuptools import find_packages, setup
@@ -24,8 +23,7 @@ setup(
     name='girder-dicom-viewer',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
     setup_requires=[
-        'setuptools-scm<7 ; python_version < "3.7"',
-        'setuptools-scm ; python_version >= "3.7"',
+        'setuptools-scm',
         'setuptools-git',
     ],
     description='View DICOM images in the browser',
@@ -40,17 +38,14 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
+    python_requires='>=3.8',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=[
         'girder>=3',
-        'pydicom>=2.0.0,<2.1.0;python_version<"3.7"',
-        'pydicom>=2.0.0;python_version>="3.7"',
+        'pydicom>=2',
     ],
     entry_points={
         'girder.plugin': [

--- a/plugins/download_statistics/girder_download_statistics/__init__.py
+++ b/plugins/download_statistics/girder_download_statistics/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from girder import events
 from girder.constants import AccessType
 from girder.models.file import File

--- a/plugins/download_statistics/plugin_tests/download_statistics_test.py
+++ b/plugins/download_statistics/plugin_tests/download_statistics_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import json
 

--- a/plugins/download_statistics/setup.py
+++ b/plugins/download_statistics/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from setuptools import find_packages, setup
@@ -24,8 +23,7 @@ setup(
     name='girder-download-statistics',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
     setup_requires=[
-        'setuptools-scm<7 ; python_version < "3.7"',
-        'setuptools-scm ; python_version >= "3.7"',
+        'setuptools-scm',
         'setuptools-git',
     ],
     description='Record file download statistics',
@@ -39,11 +37,9 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
+    python_requires='>=3.8',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/google_analytics/girder_google_analytics/__init__.py
+++ b/plugins/google_analytics/girder_google_analytics/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from girder.plugin import GirderPlugin
 
 from . import rest

--- a/plugins/google_analytics/girder_google_analytics/rest.py
+++ b/plugins/google_analytics/girder_google_analytics/rest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from girder.api import access
 from girder.api.describe import Description, describeRoute
 from girder.api.rest import Resource

--- a/plugins/google_analytics/plugin_tests/google_analytics_test.py
+++ b/plugins/google_analytics/plugin_tests/google_analytics_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from tests import base
 from girder.models.setting import Setting
 

--- a/plugins/google_analytics/setup.py
+++ b/plugins/google_analytics/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from setuptools import find_packages, setup
@@ -24,8 +23,7 @@ setup(
     name='girder-google-analytics',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
     setup_requires=[
-        'setuptools-scm<7 ; python_version < "3.7"',
-        'setuptools-scm ; python_version >= "3.7"',
+        'setuptools-scm',
         'setuptools-git',
     ],
     description='Allow the tracking of page views via Google Analytics.',
@@ -40,11 +38,9 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
+    python_requires='>=3.8',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/gravatar/girder_gravatar/__init__.py
+++ b/plugins/gravatar/girder_gravatar/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import cherrypy
 import hashlib
 

--- a/plugins/gravatar/plugin_tests/gravatar_test.py
+++ b/plugins/gravatar/plugin_tests/gravatar_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import hashlib
 
 from tests import base

--- a/plugins/gravatar/setup.py
+++ b/plugins/gravatar/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from setuptools import find_packages, setup
@@ -24,8 +23,7 @@ setup(
     name='girder-gravatar',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
     setup_requires=[
-        'setuptools-scm<7 ; python_version < "3.7"',
-        'setuptools-scm ; python_version >= "3.7"',
+        'setuptools-scm',
         'setuptools-git',
     ],
     description='Adds Gravatar URLs for users.',
@@ -40,11 +38,9 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
+    python_requires='>=3.8',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/hashsum_download/girder_hashsum_download/__init__.py
+++ b/plugins/hashsum_download/girder_hashsum_download/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import hashlib
 
 import girder

--- a/plugins/hashsum_download/plugin_tests/hashsum_download_test.py
+++ b/plugins/hashsum_download/plugin_tests/hashsum_download_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import hashlib
 import io
 import time
@@ -56,8 +55,8 @@ class HashsumDownloadTest(base.TestCase):
             else:
                 self.privateFolder = folder
 
-        self.userData = u'\u266a Il dolce suono mi ' \
-                        u'colp\u00ec di sua voce! \u266a'.encode('utf8')
+        self.userData = '\u266a Il dolce suono mi ' \
+                        'colp\u00ec di sua voce! \u266a'.encode()
         self.privateFile = Upload().uploadFromFile(
             obj=io.BytesIO(self.userData),
             size=len(self.userData),
@@ -87,7 +86,7 @@ class HashsumDownloadTest(base.TestCase):
         )
 
         self.privateOnlyData =\
-            u'\u2641 \u2600 \u2601 \u2614 \u2665'.encode('utf8')
+            '\u2641 \u2600 \u2601 \u2614 \u2665'.encode()
         self.privateOnlyFile = Upload().uploadFromFile(
             obj=io.BytesIO(self.privateOnlyData),
             size=len(self.privateOnlyData),

--- a/plugins/hashsum_download/setup.py
+++ b/plugins/hashsum_download/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from setuptools import find_packages, setup
@@ -24,8 +23,7 @@ setup(
     name='girder-hashsum-download',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
     setup_requires=[
-        'setuptools-scm<7 ; python_version < "3.7"',
-        'setuptools-scm ; python_version >= "3.7"',
+        'setuptools-scm',
         'setuptools-git',
     ],
     description='Allows download of a file by its hashsum.',
@@ -40,11 +38,9 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
+    python_requires='>=3.8',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/homepage/girder_homepage/__init__.py
+++ b/plugins/homepage/girder_homepage/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from girder.plugin import GirderPlugin
 
 from . import rest

--- a/plugins/homepage/girder_homepage/constants.py
+++ b/plugins/homepage/girder_homepage/constants.py
@@ -1,2 +1,1 @@
-# -*- coding: utf-8 -*-
 COLLECTION_NAME = 'Homepage Assets'

--- a/plugins/homepage/girder_homepage/rest.py
+++ b/plugins/homepage/girder_homepage/rest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
 from girder.api.rest import Resource

--- a/plugins/homepage/plugin_tests/homepage_test.py
+++ b/plugins/homepage/plugin_tests/homepage_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from girder.models.setting import Setting
 from tests import base
 

--- a/plugins/homepage/setup.py
+++ b/plugins/homepage/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from setuptools import find_packages, setup
@@ -24,8 +23,7 @@ setup(
     name='girder-homepage',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
     setup_requires=[
-        'setuptools-scm<7 ; python_version < "3.7"',
-        'setuptools-scm ; python_version >= "3.7"',
+        'setuptools-scm',
         'setuptools-git',
     ],
     description='Customize the homepage using Markdown.',
@@ -40,11 +38,9 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
+    python_requires='>=3.8',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/item_licenses/girder_item_licenses/__init__.py
+++ b/plugins/item_licenses/girder_item_licenses/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from girder import events
 from girder.constants import AccessType
 from girder.exceptions import ValidationException

--- a/plugins/item_licenses/girder_item_licenses/rest.py
+++ b/plugins/item_licenses/girder_item_licenses/rest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
 from girder.api.rest import boundHandler

--- a/plugins/item_licenses/plugin_tests/item_licenses_test.py
+++ b/plugins/item_licenses/plugin_tests/item_licenses_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from girder.exceptions import ValidationException
 from girder.models.folder import Folder
 from girder.models.setting import Setting

--- a/plugins/item_licenses/setup.py
+++ b/plugins/item_licenses/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from setuptools import find_packages, setup
@@ -24,8 +23,7 @@ setup(
     name='girder-item-licenses',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
     setup_requires=[
-        'setuptools-scm<7 ; python_version < "3.7"',
-        'setuptools-scm ; python_version >= "3.7"',
+        'setuptools-scm',
         'setuptools-git',
     ],
     description='Add a license field to items.',
@@ -39,11 +37,9 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
+    python_requires='>=3.8',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/jobs/girder_jobs/__init__.py
+++ b/plugins/jobs/girder_jobs/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import importlib
 
 from girder import events

--- a/plugins/jobs/girder_jobs/constants.py
+++ b/plugins/jobs/girder_jobs/constants.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from girder import events
 from girder.models.notification import ProgressState
 

--- a/plugins/jobs/girder_jobs/job_rest.py
+++ b/plugins/jobs/girder_jobs/job_rest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
 from girder.api.rest import Resource, filtermodel

--- a/plugins/jobs/girder_jobs/models/job.py
+++ b/plugins/jobs/girder_jobs/models/job.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 from bson import json_util
 
@@ -592,5 +591,4 @@ class Job(AccessControlledModel):
         query = {'parentId': job['_id']}
         cursor = self.find(query)
         user = User().load(job['userId'], force=True)
-        for r in self.filterResultsByPermission(cursor=cursor, user=user, level=AccessType.READ):
-            yield r
+        yield from self.filterResultsByPermission(cursor=cursor, user=user, level=AccessType.READ)

--- a/plugins/jobs/plugin_tests/jobs_test.py
+++ b/plugins/jobs/plugin_tests/jobs_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 import time
 from bson import json_util

--- a/plugins/jobs/plugin_tests/local_job_impl.py
+++ b/plugins/jobs/plugin_tests/local_job_impl.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from girder_jobs.models.job import Job
 
 

--- a/plugins/jobs/setup.py
+++ b/plugins/jobs/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from setuptools import find_packages, setup
@@ -24,8 +23,7 @@ setup(
     name='girder-jobs',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
     setup_requires=[
-        'setuptools-scm<7 ; python_version < "3.7"',
-        'setuptools-scm ; python_version >= "3.7"',
+        'setuptools-scm',
         'setuptools-git',
     ],
     description='A general purpose plugin for managing offline jobs.',
@@ -40,11 +38,9 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
+    python_requires='>=3.8',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/ldap/girder_ldap/__init__.py
+++ b/plugins/ldap/girder_ldap/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import ldap
 
 from girder import events

--- a/plugins/ldap/plugin_tests/ldap_test.py
+++ b/plugins/ldap/plugin_tests/ldap_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import unittest.mock
 
 import ldap

--- a/plugins/ldap/setup.py
+++ b/plugins/ldap/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from setuptools import find_packages, setup
@@ -24,8 +23,7 @@ setup(
     name='girder-ldap',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
     setup_requires=[
-        'setuptools-scm<7 ; python_version < "3.7"',
-        'setuptools-scm ; python_version >= "3.7"',
+        'setuptools-scm',
         'setuptools-git',
     ],
     description='Authenticate user credentials against LDAP or Active Directory servers.',
@@ -39,11 +37,9 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
+    python_requires='>=3.8',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3', 'pyldap'],

--- a/plugins/oauth/girder_oauth/__init__.py
+++ b/plugins/oauth/girder_oauth/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from girder import events
 from girder.constants import SortDir
 from girder.exceptions import ValidationException

--- a/plugins/oauth/girder_oauth/providers/__init__.py
+++ b/plugins/oauth/girder_oauth/providers/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import collections
 
 from .google import Google

--- a/plugins/oauth/girder_oauth/providers/base.py
+++ b/plugins/oauth/girder_oauth/providers/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 import re
 import requests

--- a/plugins/oauth/girder_oauth/providers/bitbucket.py
+++ b/plugins/oauth/girder_oauth/providers/bitbucket.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import urllib.parse
 
 from girder.api.rest import getApiUrl

--- a/plugins/oauth/girder_oauth/providers/box.py
+++ b/plugins/oauth/girder_oauth/providers/box.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import urllib.parse
 
 from girder.api.rest import getApiUrl

--- a/plugins/oauth/girder_oauth/providers/github.py
+++ b/plugins/oauth/girder_oauth/providers/github.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import urllib.parse
 
 from girder.api.rest import getApiUrl

--- a/plugins/oauth/girder_oauth/providers/globus.py
+++ b/plugins/oauth/girder_oauth/providers/globus.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import urllib.parse
 
 from girder.api.rest import getApiUrl

--- a/plugins/oauth/girder_oauth/providers/google.py
+++ b/plugins/oauth/girder_oauth/providers/google.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import urllib.parse
 
 import jwt

--- a/plugins/oauth/girder_oauth/providers/linkedin.py
+++ b/plugins/oauth/girder_oauth/providers/linkedin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import urllib.parse
 
 from girder.api.rest import getApiUrl

--- a/plugins/oauth/girder_oauth/providers/microsoft.py
+++ b/plugins/oauth/girder_oauth/providers/microsoft.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import warnings
 
 from msal import ConfidentialClientApplication

--- a/plugins/oauth/girder_oauth/rest.py
+++ b/plugins/oauth/girder_oauth/rest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import cherrypy
 import datetime
 

--- a/plugins/oauth/plugin_tests/oauth_test.py
+++ b/plugins/oauth/plugin_tests/oauth_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 import json
 import re

--- a/plugins/oauth/setup.py
+++ b/plugins/oauth/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from setuptools import find_packages, setup
@@ -24,8 +23,7 @@ setup(
     name='girder-oauth',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
     setup_requires=[
-        'setuptools-scm<7 ; python_version < "3.7"',
-        'setuptools-scm ; python_version >= "3.7"',
+        'setuptools-scm',
         'setuptools-git',
     ],
     description='Allow users to login via supported OAuth2 providers.',
@@ -40,11 +38,9 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
+    python_requires='>=3.8',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=[

--- a/plugins/readme/girder_readme/__init__.py
+++ b/plugins/readme/girder_readme/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from girder.plugin import GirderPlugin
 from .rest import _getFolderReadme
 

--- a/plugins/readme/girder_readme/rest.py
+++ b/plugins/readme/girder_readme/rest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import re
 import cherrypy
 from girder.api import access

--- a/plugins/readme/setup.py
+++ b/plugins/readme/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from setuptools import find_packages, setup
@@ -24,8 +23,7 @@ setup(
     name='girder-readme',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
     setup_requires=[
-        'setuptools-scm<7 ; python_version < "3.7"',
-        'setuptools-scm ; python_version >= "3.7"',
+        'setuptools-scm',
         'setuptools-git',
     ],
     description='Render READMEs from the folder view',
@@ -39,11 +37,9 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
+    python_requires='>=3.8',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/sentry/girder_sentry/__init__.py
+++ b/plugins/sentry/girder_sentry/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import sentry_sdk
 from girder.plugin import GirderPlugin
 from girder.models.setting import Setting

--- a/plugins/sentry/girder_sentry/rest.py
+++ b/plugins/sentry/girder_sentry/rest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from girder.api import access
 from girder.api.describe import Description, describeRoute
 from girder.api.rest import Resource

--- a/plugins/sentry/setup.py
+++ b/plugins/sentry/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from setuptools import find_packages, setup
@@ -24,8 +23,7 @@ setup(
     name='girder-sentry',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
     setup_requires=[
-        'setuptools-scm<7 ; python_version < "3.7"',
-        'setuptools-scm ; python_version >= "3.7"',
+        'setuptools-scm',
         'setuptools-git',
     ],
     description='Allow the automatic tracking of issues using Sentry.',
@@ -39,11 +37,9 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
+    python_requires='>=3.8',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=[

--- a/plugins/terms/girder_terms/__init__.py
+++ b/plugins/terms/girder_terms/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 import hashlib
 

--- a/plugins/terms/plugin_tests/terms_test.py
+++ b/plugins/terms/plugin_tests/terms_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from girder.models.setting import Setting
 from girder.models.user import User
 from girder.settings import SettingKey
@@ -69,7 +68,7 @@ class TermsTest(base.TestCase):
             'name': 'Terms Collection',
             'description': 'Some other description.',
             'public': True,
-            'terms': u'# Sample Terms of Use\n\n**\u00af\\\\\\_(\u30c4)\\_/\u00af**'.encode('utf-8')
+            'terms': '# Sample Terms of Use\n\n**\u00af\\\\\\_(\u30c4)\\_/\u00af**'.encode()
         })
         self.assertStatusOk(resp)
         self.assertDictContainsSubset({
@@ -78,7 +77,7 @@ class TermsTest(base.TestCase):
             'public': True,
             'size': 0,
             '_modelType': 'collection',
-            'terms': u'# Sample Terms of Use\n\n**\u00af\\\\\\_(\u30c4)\\_/\u00af**'
+            'terms': '# Sample Terms of Use\n\n**\u00af\\\\\\_(\u30c4)\\_/\u00af**'
         }, resp.json)
         termsCollectionId = resp.json['_id']
 
@@ -92,7 +91,7 @@ class TermsTest(base.TestCase):
             'public': True,
             'size': 0,
             '_modelType': 'collection',
-            'terms': u'# Sample Terms of Use\n\n**\u00af\\\\\\_(\u30c4)\\_/\u00af**'
+            'terms': '# Sample Terms of Use\n\n**\u00af\\\\\\_(\u30c4)\\_/\u00af**'
         }, resp.json)
 
         # Ensure that the user has not yet accepted any terms

--- a/plugins/terms/setup.py
+++ b/plugins/terms/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from setuptools import find_packages, setup
@@ -24,8 +23,7 @@ setup(
     name='girder-terms',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
     setup_requires=[
-        'setuptools-scm<7 ; python_version < "3.7"',
-        'setuptools-scm ; python_version >= "3.7"',
+        'setuptools-scm',
         'setuptools-git',
     ],
     description='Allows Girder collections to require users to accept terms of '
@@ -41,11 +39,9 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
+    python_requires='>=3.8',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/thumbnails/girder_thumbnails/__init__.py
+++ b/plugins/thumbnails/girder_thumbnails/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 from girder import events
 from girder.constants import AccessType

--- a/plugins/thumbnails/girder_thumbnails/rest.py
+++ b/plugins/thumbnails/girder_thumbnails/rest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
 from girder.api.rest import filtermodel, Resource

--- a/plugins/thumbnails/girder_thumbnails/worker.py
+++ b/plugins/thumbnails/girder_thumbnails/worker.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from bson.objectid import ObjectId
 import functools
 import io

--- a/plugins/thumbnails/plugin_tests/thumbnail_test.py
+++ b/plugins/thumbnails/plugin_tests/thumbnail_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import io
 import json
 import os

--- a/plugins/thumbnails/setup.py
+++ b/plugins/thumbnails/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from setuptools import find_packages, setup
@@ -24,8 +23,7 @@ setup(
     name='girder-thumbnails',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
     setup_requires=[
-        'setuptools-scm<7 ; python_version < "3.7"',
-        'setuptools-scm ; python_version >= "3.7"',
+        'setuptools-scm',
         'setuptools-git',
     ],
     description='Generate thumbnails from files.',
@@ -39,19 +37,16 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
+    python_requires='>=3.8',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=[
         'girder>=3',
         'girder-jobs>=3',
         'Pillow',
-        'pydicom>=2.0.0,<2.1.0;python_version<"3.7"',
-        'pydicom>=2.0.0;python_version>="3.7"',
+        'pydicom>=2',
         'numpy'
     ],
     entry_points={

--- a/plugins/user_quota/girder_user_quota/__init__.py
+++ b/plugins/user_quota/girder_user_quota/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from girder import events
 from girder.plugin import GirderPlugin
 

--- a/plugins/user_quota/girder_user_quota/quota.py
+++ b/plugins/user_quota/girder_user_quota/quota.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from bson.objectid import ObjectId, InvalidId
 from girder import logger
 from girder.api import access

--- a/plugins/user_quota/plugin_tests/user_quota_test.py
+++ b/plugins/user_quota/plugin_tests/user_quota_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 import json
 import os

--- a/plugins/user_quota/setup.py
+++ b/plugins/user_quota/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from setuptools import find_packages, setup
@@ -24,8 +23,7 @@ setup(
     name='girder-user-quota',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
     setup_requires=[
-        'setuptools-scm<7 ; python_version < "3.7"',
-        'setuptools-scm ; python_version >= "3.7"',
+        'setuptools-scm',
         'setuptools-git',
     ],
     description='Limits total file size stored for individual users and '
@@ -40,11 +38,9 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
+    python_requires='>=3.8',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/virtual_folders/setup.py
+++ b/plugins/virtual_folders/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from setuptools import find_packages, setup
@@ -24,8 +23,7 @@ setup(
     name='girder-virtual-folders',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
     setup_requires=[
-        'setuptools-scm<7 ; python_version < "3.7"',
-        'setuptools-scm ; python_version >= "3.7"',
+        'setuptools-scm',
         'setuptools-git',
     ],
     description='Allows folders to list child items using arbitrary database queries',
@@ -39,11 +37,9 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
     ],
     include_package_data=True,
+    python_requires='>=3.8',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/pytest_girder/pytest_girder/plugin_registry.py
+++ b/pytest_girder/pytest_girder/plugin_registry.py
@@ -65,10 +65,8 @@ class PluginRegistry:
 
     def _iter_entry_points(self, *args, **kwargs):
         if self._include_installed_plugins:
-            for ep in iter_entry_points(*args, **kwargs):
-                yield ep
-        for ep in self._plugins:
-            yield ep
+            yield from iter_entry_points(*args, **kwargs)
+        yield from self._plugins
 
     @contextmanager
     def __call__(self):

--- a/pytest_girder/setup.py
+++ b/pytest_girder/setup.py
@@ -22,8 +22,7 @@ setup(
     name='pytest-girder',
     use_scm_version={'root': '..', 'local_scheme': prerelease_local_scheme},
     setup_requires=[
-        'setuptools-scm<7 ; python_version < "3.7"',
-        'setuptools-scm ; python_version >= "3.7"',
+        'setuptools-scm',
     ],
     description='A set of pytest fixtures for testing Girder applications.',
     author='Kitware, Inc.',
@@ -32,6 +31,7 @@ setup(
     classifiers=[
         'Framework :: Pytest'
     ],
+    python_requires='>=3.8',
     packages=find_packages(),
     install_requires=[
         'girder>=3',

--- a/scripts/midas/migrate.py
+++ b/scripts/midas/migrate.py
@@ -269,7 +269,7 @@ def handle_item(item, parent, depth, bc):
             # "The item must have at least one revision to have metadata"
             metadata = None
         if metadata:
-            metadata = dict((x['qualifier'], x['value']) for x in metadata)
+            metadata = {x['qualifier']: x['value'] for x in metadata}
             breadcrumb('Metadata', bc, '[%d keys]' % len(metadata))
             if not DRY_RUN:
                 gc.addMetadataToItem(newItem['_id'], metadata)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from setuptools import find_packages, setup
@@ -30,7 +29,6 @@ installReqs = [
     'click-plugins',
     'dogpile.cache',
     'filelock',
-    'importlib-metadata<5 ; python_version < "3.8"',
     'jsonschema',
     'Mako',
     'passlib [bcrypt,totp]',
@@ -56,8 +54,7 @@ setup(
     name='girder',
     use_scm_version={'local_scheme': prerelease_local_scheme},
     setup_requires=[
-        'setuptools-scm<7 ; python_version < "3.7"',
-        'setuptools-scm ; python_version >= "3.7"',
+        'setuptools-scm',
     ],
     description='Web-based data management platform',
     long_description=readme,
@@ -72,15 +69,12 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
     ],
+    python_requires='>=3.8',
     packages=find_packages(
         exclude=('girder.test', 'tests.*', 'tests', '*.plugin_tests.*', '*.plugin_tests')
     ),
     include_package_data=True,
-    python_requires='>=3.6',
     install_requires=installReqs,
     extras_require=extrasReqs,
     zip_safe=False,

--- a/test/test_access.py
+++ b/test/test_access.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 
 from girder.api.rest import loadmodel, Resource

--- a/test/test_api_docs.py
+++ b/test/test_api_docs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 import pytest

--- a/test/test_api_key.py
+++ b/test/test_api_key.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 import json
 import pytest

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import unittest.mock
 import pytest
 

--- a/test/test_custom_root.py
+++ b/test/test_custom_root.py
@@ -61,7 +61,7 @@ class Other(Resource):
     @describeRoute(None)
     def rawReturningText(self, params):
         setResponseHeader('Content-Type', 'text/plain')
-        return u'this is not encoded \U0001F44D'
+        return 'this is not encoded \U0001F44D'
 
     @access.public
     @describeRoute(None)

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 import time
 import unittest.mock

--- a/test/test_folder.py
+++ b/test/test_folder.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 from bson.objectid import ObjectId
 

--- a/test/test_hash_state.py
+++ b/test/test_hash_state.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from girder.utility import _hash_state
 import hashlib
 import pytest

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 import pytest
@@ -71,7 +70,7 @@ def testPluginTemplates(server):
 
 
 def testUnicodeEmail(smtp):
-    text = u'Contains unic\xf8de \u0420\u043e\u0441\u0441\u0438\u044f'
+    text = 'Contains unic\xf8de \u0420\u043e\u0441\u0441\u0438\u044f'
     mail_utils.sendMail(text, text, ['fake@fake.com'])
     assert smtp.waitForMail()
     message = smtp.getMail(parse=True)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 
 from girder.models.model_base import AccessControlledModel, Model, AccessType

--- a/test/test_notification.py
+++ b/test/test_notification.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 import pytest
 from pytest_girder.assertions import assertStatus, assertStatusOk

--- a/test/test_position_endpoint.py
+++ b/test/test_position_endpoint.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 
 from girder.models.item import Item

--- a/test/test_rest_utils.py
+++ b/test/test_rest_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 import json
 import pytest
@@ -125,9 +124,9 @@ def testSetContentDispositionFails(name, disp, msg):
     ('filename', 'form-data; name="chunk"', 'form-data; name="chunk"; filename="filename"'),
     ('file "name"', None, 'attachment; filename="file \\"name\\""'),
     ('file\\name', None, 'attachment; filename="file\\\\name"'),
-    (u'\u043e\u0431\u0440\u0430\u0437\u0435\u0446', None,
+    ('\u043e\u0431\u0440\u0430\u0437\u0435\u0446', None,
      'attachment; filename=""; filename*=UTF-8\'\'%D0%BE%D0%B1%D1%80%D0%B0%D0%B7%D0%B5%D1%86'),
-    (u'\U0001f603', None, 'attachment; filename=""; filename*=UTF-8\'\'%F0%9F%98%83')
+    ('\U0001f603', None, 'attachment; filename=""; filename*=UTF-8\'\'%F0%9F%98%83')
 ])
 def testSetContentDisposition(name, disp, expected):
     if disp is None:

--- a/test/test_route_table.py
+++ b/test/test_route_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 from pytest_girder.assertions import assertStatusOk
 from pytest_girder.utils import getResponseBody

--- a/test/test_size.py
+++ b/test/test_size.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import collections
 import pytest
 

--- a/test/test_user_otp.py
+++ b/test/test_user_otp.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 
 from girder.exceptions import AccessException

--- a/test/test_webroot.py
+++ b/test/test_webroot.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import cherrypy
 
 from girder.models.setting import Setting

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import unittest.mock
 
 from girder import constants, logger

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import base64
 import cherrypy
 import io

--- a/tests/cases/api_describe_test.py
+++ b/tests/cases/api_describe_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 import json
 from .. import base

--- a/tests/cases/assetstore_test.py
+++ b/tests/cases/assetstore_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import botocore
 import httmock
 import inspect

--- a/tests/cases/collection_test.py
+++ b/tests/cases/collection_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 
 from .. import base

--- a/tests/cases/external_data_core_test.py
+++ b/tests/cases/external_data_core_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import unittest
 import hashlib
 import os
@@ -17,7 +16,7 @@ class ExternalDataCoreTest(unittest.TestCase):
         )
 
         hash = hashlib.md5()
-        with open(filepath, 'r') as f:
+        with open(filepath) as f:
             hash.update(f.read().encode('utf-8'))
             self.assertEqual(
                 hash.hexdigest(),

--- a/tests/cases/external_data_plugin_test.py
+++ b/tests/cases/external_data_plugin_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from .external_data_core_test import ExternalDataCoreTest
 import os
 import hashlib
@@ -19,7 +18,7 @@ class ExternalDataPluginTest(ExternalDataCoreTest):
         )
 
         hash = hashlib.md5()
-        with open(filepath, 'r') as f:
+        with open(filepath) as f:
             hash.update(f.read().encode('utf-8'))
             self.assertEqual(
                 hash.hexdigest(),

--- a/tests/cases/file_test.py
+++ b/tests/cases/file_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import boto3
 import httmock
 import io
@@ -424,7 +423,7 @@ class FileTestCase(base.TestCase):
                     for (path, file) in Folder().fileList(
                         testFolder, user=self.user,
                         subpath=True, data=False)]
-        self.assertEqual(fileList, [(u'Test/random.bin', u'random.bin')])
+        self.assertEqual(fileList, [('Test/random.bin', 'random.bin')])
 
         # Download the folder
         resp = self.request(
@@ -795,9 +794,9 @@ class FileTestCase(base.TestCase):
 
         # Test unicode filenames for content disposition.  The test name has
         # quotes, a Linear-B codepoint, Cyrllic, Arabic, Chinese, and an emoji.
-        filename = u'Unicode "sample" \U00010088 ' + \
-                   u'\u043e\u0431\u0440\u0430\u0437\u0435\u0446 ' + \
-                   u'\u0639\u064a\u0646\u0629 \u6a23\u54c1 \U0001f603'
+        filename = 'Unicode "sample" \U00010088 ' + \
+                   '\u043e\u0431\u0440\u0430\u0437\u0435\u0446 ' + \
+                   '\u0639\u064a\u0646\u0629 \u6a23\u54c1 \U0001f603'
         file = self._testUploadFile(filename)
         file = File().load(file['_id'], force=True)
         testval = 'filename="Unicode \\"sample\\"     "; filename*=UTF-8\'\'' \

--- a/tests/cases/filter_logging_test.py
+++ b/tests/cases/filter_logging_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import cherrypy
 import logging
 import os

--- a/tests/cases/folder_test.py
+++ b/tests/cases/folder_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 import json
 
@@ -37,7 +36,7 @@ class FolderTestCase(base.TestCase):
             'lastName': 'Last',
             'password': 'goodpassword'
         })
-        self.admin, self.user = [User().createUser(**user) for user in users]
+        self.admin, self.user = (User().createUser(**user) for user in users)
 
     def testLegacyFolders(self):
         folder = Folder().createFolder(

--- a/tests/cases/group_test.py
+++ b/tests/cases/group_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from .. import base
 from girder.constants import AccessType
 from girder.models.folder import Folder

--- a/tests/cases/item_test.py
+++ b/tests/cases/item_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import io
 import itertools

--- a/tests/cases/model_singleton_test.py
+++ b/tests/cases/model_singleton_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import unittest
 import unittest.mock
 

--- a/tests/cases/mount_command_test.py
+++ b/tests/cases/mount_command_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import subprocess
 import tempfile

--- a/tests/cases/mount_test.py
+++ b/tests/cases/mount_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 import os
 import stat
@@ -66,9 +65,9 @@ class ServerFuseTestCase(base.TestCase):
             'user/user/Private/Item 4/File 4': 'File 4',
             'user/user/Private/Folder/Item 5/File 5': 'File 5',
             'collection/Test Collection/Private/Collection Item/Collection File': 'File 1A',
-            u'collection/Test Collection/Private/Collection Item/'
-            u'\u0444\u0430\u0439\u043b \u043a\u043e\u043b\u043b\u0435\u043a'
-            u'\u0446\u0438\u0438': 'File 1A',
+            'collection/Test Collection/Private/Collection Item/'
+            '\u0444\u0430\u0439\u043b \u043a\u043e\u043b\u043b\u0435\u043a'
+            '\u0446\u0438\u0438': 'File 1A',
         }
         self.adminFileName = 'user/admin/Private/Item 1/File 1A'
         self.publicFileName = 'user/user/Public/Item 3/File 3'

--- a/tests/cases/notification_test.py
+++ b/tests/cases/notification_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import time
 
 from .. import base

--- a/tests/cases/py_client/cli_test.py
+++ b/tests/cases/py_client/cli_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import contextlib
 import girder_client.cli
 from http.client import HTTPConnection

--- a/tests/cases/py_client/lib_test.py
+++ b/tests/cases/py_client/lib_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import girder
 import girder_client
 import io

--- a/tests/cases/resource_test.py
+++ b/tests/cases/resource_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 import io
 import json
@@ -709,7 +708,7 @@ class ResourceTestCase(base.TestCase):
             pass
         # Test that we don't crash on Unicode file names
         for _ in zip.addFile(
-                genEmptyFile(100), u'\u0421\u0443\u043f\u0435\u0440-\u0440'
+                genEmptyFile(100), '\u0421\u0443\u043f\u0435\u0440-\u0440'
                 '\u0443\u0441\u0441\u043a\u0438, \u0627\u0633\u0645 \u0627'
                 '\u0644\u0645\u0644\u0641 \u0628\u0627\u0644\u0644\u063a'
                 '\u0629 \u0627\u0644\u0639\u0631\u0628\u064a\u0629'):

--- a/tests/cases/rest_decorator_test.py
+++ b/tests/cases/rest_decorator_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 import os
 import requests
@@ -29,7 +28,7 @@ class TestEndpointDecoratorException(base.TestCase):
 
     @endpoint
     def pointlessEndpointUnicode(self, path, params):
-        raise Exception(u'\u0400 cannot be converted to ascii.')
+        raise Exception('\u0400 cannot be converted to ascii.')
 
     @endpoint
     def pointlessEndpointBytes(self, path, params):
@@ -91,4 +90,4 @@ class TestEndpointDecoratorException(base.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.headers['Content-Type'], 'text/plain;charset=utf-8')
         self.assertEqual(resp.content, b'this is not encoded \xf0\x9f\x91\x8d')
-        self.assertEqual(resp.text, u'this is not encoded \U0001F44D')
+        self.assertEqual(resp.text, 'this is not encoded \U0001F44D')

--- a/tests/cases/routes_test.py
+++ b/tests/cases/routes_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import requests
 

--- a/tests/cases/search_test.py
+++ b/tests/cases/search_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 
 from .. import base

--- a/tests/cases/setting_test.py
+++ b/tests/cases/setting_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from .. import base
 from girder.exceptions import ValidationException
 from girder.models.setting import Setting

--- a/tests/cases/setup_database_test.py
+++ b/tests/cases/setup_database_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from .. import base
 from girder.models.collection import Collection
 from girder.models.file import File

--- a/tests/cases/sftp_test.py
+++ b/tests/cases/sftp_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import paramiko
 import io
 import socket
@@ -75,7 +74,7 @@ class SftpTestCase(base.TestCase):
             'password': 'passwd'
         })
 
-        admin, user = [User().createUser(**user) for user in users]
+        admin, user = (User().createUser(**user) for user in users)
 
         collections = ({
             'name': 'public collection',

--- a/tests/cases/stream_test.py
+++ b/tests/cases/stream_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import requests
 import time

--- a/tests/cases/system_test.py
+++ b/tests/cases/system_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 import os
 import time

--- a/tests/cases/upload_test.py
+++ b/tests/cases/upload_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import boto3
 import io
 import json

--- a/tests/cases/user_test.py
+++ b/tests/cases/user_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import cherrypy
 import collections
 import datetime
@@ -622,7 +621,7 @@ class UserTestCase(base.TestCase):
             'parentId': user1['_id'],
             'parentCollection': 'user'})
         self.assertSetEqual(
-            set(folder['name'] for folder in user1Folders),
+            {folder['name'] for folder in user1Folders},
             {'Public', 'Private'}
         )
 
@@ -643,7 +642,7 @@ class UserTestCase(base.TestCase):
             'parentId': user2['_id'],
             'parentCollection': 'user'})
         self.assertSetEqual(
-            set(folder['name'] for folder in user2Folders),
+            {folder['name'] for folder in user2Folders},
             set()
         )
 

--- a/tests/mock_s3.py
+++ b/tests/mock_s3.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import argparse
 import boto3
 import errno
@@ -56,7 +55,7 @@ def startMockS3Server():
         try:
             test_socket.bind(('0.0.0.0', port))
             selectedPort = port
-        except socket.error as err:
+        except OSError as err:
             # Allow address in use errors to fail quietly
             if err.errno != errno.EADDRINUSE:
                 raise

--- a/tests/mongo_replicaset.py
+++ b/tests/mongo_replicaset.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import argparse
 import atexit
 import os

--- a/tests/setup_database.py
+++ b/tests/setup_database.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import mimetypes
 import os
 import tempfile

--- a/tests/web_client_test.py
+++ b/tests/web_client_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import subprocess
 import sys


### PR DESCRIPTION
pyupgrade was used to automatically migrate files.

All plugins now also mark their minimum python versions.