### PR TITLE
Cache the parsed JSON body on cherrypy.request

### DIFF
--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -282,6 +282,10 @@ def getBodyJson(allowConstants=False):
     parsed value, or raises a :class:`girder.api.rest.RestException` for
     invalid JSON.
 
+    It's important to note that this function caches the parsed JSON body; subsequent
+    calls to this within the same request lifecycle will always return the same object as
+    the first call, regardless of the arguments passed in to this function.
+
     :param allowConstants: Whether the keywords Infinity, -Infinity, and NaN
         should be allowed. These keywords are valid JavaScript and will parse
         to the correct float values, but are not valid in strict JSON.

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -287,17 +287,20 @@ def getBodyJson(allowConstants=False):
         to the correct float values, but are not valid in strict JSON.
     :type allowConstants: bool
     """
-    if allowConstants:
-        _parseConstants = None
-    else:
-        def _parseConstants(val):
-            raise RestException('Error: "%s" is not valid JSON.' % val)
+    if not hasattr(cherrypy.request, 'girderBodyJson'):
+        if allowConstants:
+            _parseConstants = None
+        else:
+            def _parseConstants(val):
+                raise RestException('Error: "%s" is not valid JSON.' % val)
 
-    text = cherrypy.request.body.read().decode('utf8')
-    try:
-        return json.loads(text, parse_constant=_parseConstants)
-    except ValueError:
-        raise RestException('Invalid JSON passed in request body.')
+        text = cherrypy.request.body.read().decode('utf8')
+        try:
+            cherrypy.request.girderBodyJson = json.loads(text, parse_constant=_parseConstants)
+        except ValueError:
+            raise RestException('Invalid JSON passed in request body.')
+
+    return cherrypy.request.girderBodyJson
 
 
 def getParamJson(name, params, default=None):


### PR DESCRIPTION
This will make multiple calls to `getBodyJson` work, where before they would throw an error due to the request stream already being consumed.
