### PR TITLE
Clear the stored user and token on a 401 error

### DIFF
--- a/girder/web_client/src/rest.js
+++ b/girder/web_client/src/rest.js
@@ -3,7 +3,7 @@ import _ from 'underscore';
 import Backbone from 'backbone';
 
 import events from '@girder/core/events';
-import { getCurrentToken } from '@girder/core/auth';
+import { getCurrentToken, setCurrentUser, setCurrentToken } from '@girder/core/auth';
 
 let apiRoot;
 var uploadHandlers = {};
@@ -75,6 +75,8 @@ const restRequest = function (opts) {
         error: (error, status) => {
             let info;
             if (error.status === 401) {
+                setCurrentUser(null);
+                setCurrentToken(null);
                 events.trigger('g:loginUi');
                 info = {
                     text: 'You must log in to view this resource',

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,7 +29,7 @@ coverage
 girder-worker
 httmock
 mongomock
-moto[server]
+moto[server]<4.2.12
 pytest
 pytest-cov
 python-dateutil


### PR DESCRIPTION
When the user is not logged in, the server returns a 401 on some endpoints.  This triggers showing the login dialog IF the browser 
doesn't have a current user.  If you have two web pages open and you log out in one, however, the second will get 401 errors but NOT show the login dialog because it still tracks a current user.  This leaves the UI showing errors but not a clear please-log-in-again method.

Also, pinned moto because version 4.2.12 breaks one of our tests.