### PR TITLE
Update build

### DIFF
--- a/plugins/dicom_viewer/girder_dicom_viewer/web_client/package.json
+++ b/plugins/dicom_viewer/girder_dicom_viewer/web_client/package.json
@@ -17,6 +17,7 @@
     "dependencies": {
         "daikon": "^1.2.44",
         "shader-loader": "^1.3.0",
+        "jpeg-lossless-decoder-js": "~2.0",
         "vtk.js": "^5.10.3"
     },
     "girderPlugin": {

--- a/pytest_girder/pytest_girder/plugin_registry.py
+++ b/pytest_girder/pytest_girder/plugin_registry.py
@@ -27,6 +27,8 @@ class _MockDistribution:
         meta.provides_extras = ()
         meta.license_file = None
         meta.license_files = None
+        meta.install_requires = []
+        meta.extras_require = {}
         pkgInfo = io.StringIO()
         meta.write_pkg_file(pkgInfo)
         return pkgInfo.getvalue()


### PR DESCRIPTION
This has two changes to get CI to pass:

- Pin a package used by the DICOM viewer plugin.  We are going to drop this plugin with the frontend build refactor; just fix it by pinning a dependency for now.
- Improve mock distribution object used in mocking plugins in tests.  The most recent version of distutils expects that install_requires and extras_require are populated.
