### PR TITLE
Add an assetstore method to get file size

### DIFF
--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -450,8 +450,15 @@ class File(acl_mixin.AccessControlMixin, Model):
         :param file: The file.
         :type file: dict
         """
-        # TODO: check underlying assetstore for size?
-        return file.get('size', 0), 0
+        fixes = 0
+        if file.get('assetstoreId'):
+            size = self.getAssetstoreAdapter(file).getFileSize(file)
+            if size != file.get('size', 0):
+                file['size'] = size
+                self.update({'_id': file['_id']}, {'$set': {'size': size}})
+                fixes += 1
+
+        return file.get('size', 0), fixes
 
     def open(self, file):
         """

--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -202,6 +202,16 @@ class AbstractAssetstoreAdapter:
         """
         return upload['received']
 
+    def getFileSize(self, file):
+        """
+        Get the file size (computing it, if necessary). Default behavior simply
+        returns `file.get('size', 0)`. This method exists because some
+        assetstores do not compute the file size immediately, but only when
+        it is actually needed. The assetstore may also need to update the file
+        size after some changes.
+        """
+        return file.get('size', 0)
+
     def deleteFile(self, file):
         """
         This is called when a File is deleted to allow the adapter to remove

--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -781,6 +781,7 @@ girder
                 finalizeUpload
                 findInvalidFiles
                 getChunkSize
+                getFileSize
                 getLocalFilePath
                 importData
                 initUpload


### PR DESCRIPTION
This adds a `getFileSize()` method on the assetstore, which allows assetstores to update a file size, if needed. If the file size changes, the `File` model will update it.

We plan to use this with a DICOMweb assetstore adapter so that we do not need to compute the file size right away, but only when it is needed.