### PR TITLE
Update file size for range requests if it is None

### DIFF
--- a/girder/api/v1/file.py
+++ b/girder/api/v1/file.py
@@ -264,8 +264,12 @@ class File(Resource):
         Defers to the underlying assetstore adapter to stream a file out.
         Requires read permission on the folder that contains the file's item.
         """
-        rangeHeader = cherrypy.lib.httputil.get_ranges(
-            cherrypy.request.headers.get('Range'), file.get('size', 0))
+        rangeRequest = cherrypy.request.headers.get('Range')
+        if rangeRequest and file.get('size') is None:
+            # Ensure the file size is updated
+            self._model.updateSize(file)
+
+        rangeHeader = cherrypy.lib.httputil.get_ranges(rangeRequest, file.get('size', 0))
 
         # The HTTP Range header takes precedence over query params
         if rangeHeader and len(rangeHeader):


### PR DESCRIPTION
We are using `None` for the file size to indicate that it hasn't been computed yet.

If a range request is performed, the file size is required. So if the file size is `None`, call `updateSize()` on the file before proceeding.

A similar update is being done for fuse mounting in #3494.

The assetstore adapter is able to update the file size since #3495.