### PR TITLE
Take into account `None` file size when deleting

### DIFF
--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -59,7 +59,7 @@ class File(acl_mixin.AccessControlMixin, Model):
             item = Item().load(file['itemId'], force=True)
             if item is not None:
                 # files that are linkUrls might not have a size field
-                if 'size' in file:
+                if file.get('size') is not None:
                     self.propagateSizeChange(item, -file['size'], updateItemSize)
             else:
                 girder.logger.warning('Broken reference in file %s: no item %s exists' %


### PR DESCRIPTION
It is possible for the file size to be set to `None`. Only propagate item size changes if the file size is not `None`.