### PR TITLE
Fix oauth bug

### DIFF
--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -182,7 +182,7 @@ def getCurrentUser(returnToken=False):
     if event.defaultPrevented and len(event.responses) > 0:
         return event.responses[0]
 
-    token = getCurrentToken()
+    token = getCurrentToken(True)
 
     def retVal(user, token):
         setCurrentUser(user)

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -182,7 +182,7 @@ def getCurrentUser(returnToken=False):
     if event.defaultPrevented and len(event.responses) > 0:
         return event.responses[0]
 
-    token = getCurrentToken(True)
+    token = getCurrentToken()
 
     def retVal(user, token):
         setCurrentUser(user)

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -74,6 +74,7 @@ class User(Resource):
         Description('Retrieve the currently logged-in user information.')
         .responseClass('User')
     )
+    @access.user(cookie=True)
     def getMe(self):
         return self.getCurrentUser()
 


### PR DESCRIPTION
Add decorator to the getMe function which is used with OAuth to sign in. Cookie authentication is needed, but the correct attribute is not being set without this fix.