### PR TITLE
Do not rely on JavaScript-readable cookies for OAuth login

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ commands:
           name: Generate python environment checksum file
           command: ./girder/.circleci/generatePyEnvChecksum.sh > girder/py-env-checksum
       - restore_cache:
-          key: venv-py3.8-{{ arch }}-{{ checksum "girder/py-env-checksum" }}
+          key: venv-py3.8-{{ arch }}-{{ checksum "girder/py-env-checksum" }}-2
       - run:
           name: Create virtual environment (if necessary)
           command: if [ ! -d girder_env ]; then python3 -m venv girder_env; fi
@@ -52,7 +52,7 @@ commands:
       - save_cache:
           paths:
             - girder_env
-          key: venv-py3.8-{{ arch }}-{{ checksum "girder/py-env-checksum" }}
+          key: venv-py3.8-{{ arch }}-{{ checksum "girder/py-env-checksum" }}-2
 
 jobs:
   server-lint-test:

--- a/plugins/oauth/girder_oauth/web_client/main.js
+++ b/plugins/oauth/girder_oauth/web_client/main.js
@@ -1,5 +1,21 @@
+import { setCurrentToken } from '@girder/core/auth';
+
 import './routes';
 
 // Extends and overrides API
 import './views/LoginView';
 import './views/RegisterView';
+
+// If the current URL contains a `girderToken` query parameter, set the current token to its value
+const girderToken = new URLSearchParams(window.location.search).get('girderToken');
+
+if (girderToken) {
+    // This means we have been redirected from a successful OAuth login.
+    // Save the token, and delete the query parameter from the URL.
+    window.localStorage.setItem('girderToken', girderToken);
+    setCurrentToken(girderToken);
+
+    const queryParams = new URLSearchParams(window.location.search);
+    queryParams.delete('girderToken');
+    window.location.search = queryParams.toString();
+}

--- a/plugins/oauth/plugin_tests/oauth_test.py
+++ b/plugins/oauth/plugin_tests/oauth_test.py
@@ -135,7 +135,7 @@ class OauthTest(base.TestCase):
             }
             return callbackParams
 
-        redirect = 'http://localhost/#foo/bar?token={girderToken}'
+        redirect = 'http://localhost/#foo/bar'
 
         class EventHandler:
             def __init__(self):
@@ -167,7 +167,7 @@ class OauthTest(base.TestCase):
             resp = self.request(
                 '/oauth/%s/callback' % providerInfo['id'], params=params, isJson=False)
             self.assertStatus(resp, 303)
-            self.assertTrue('girderToken' not in resp.cookie)
+            self.assertTrue('girderToken' not in resp.headers['Location'])
             self.assertEqual(event_handler.state, 'been in "before"')
 
         params = _getCallbackParams(providerInfo, redirect)
@@ -183,50 +183,8 @@ class OauthTest(base.TestCase):
             resp = self.request(
                 '/oauth/%s/callback' % providerInfo['id'], params=params, isJson=False)
             self.assertStatus(resp, 303)
-            self.assertTrue('girderToken' not in resp.cookie)
+            self.assertTrue('girderToken' not in resp.headers['Location'])
             self.assertEqual(event_handler.state, 'been in "after"')
-
-    def _testOauthTokenAsParam(self, providerInfo):
-        self.accountType = 'existing'
-
-        def _getCallbackParams(providerInfo, redirect):
-            resp = self.request('/oauth/provider', params={
-                'redirect': redirect,
-                'list': True
-            })
-            self.assertStatusOk(resp)
-            providerResp = resp.json[0]
-            resp = requests.get(providerResp['url'], allow_redirects=False)
-            self.assertEqual(resp.status_code, 302)
-            callbackLoc = urllib.parse.urlparse(resp.headers['location'])
-            self.assertEqual(
-                callbackLoc.path, r'/api/v1/oauth/%s/callback' % providerInfo['id'])
-            callbackLocQuery = urllib.parse.parse_qs(callbackLoc.query)
-            self.assertNotHasKeys(callbackLocQuery, ('error',))
-            callbackParams = {
-                key: val[0] for key, val in callbackLocQuery.items()
-            }
-            return callbackParams
-
-        redirect = 'http://localhost/#foo/bar?token={girderToken}'
-        params = _getCallbackParams(providerInfo, redirect)
-
-        resp = self.request(
-            '/oauth/%s/callback' % providerInfo['id'], params=params, isJson=False)
-        self.assertStatus(resp, 303)
-        self.assertTrue('girderToken' in resp.cookie)
-        self.assertEqual(
-            resp.headers['Location'],
-            redirect.format(girderToken=resp.cookie['girderToken'].value))
-
-        redirect = 'http://localhost/#foo/bar?token={foobar}'
-        params = _getCallbackParams(providerInfo, redirect)
-
-        resp = self.request(
-            '/oauth/%s/callback' % providerInfo['id'], params=params, isJson=False)
-        self.assertStatus(resp, 303)
-        self.assertTrue('girderToken' in resp.cookie)
-        self.assertEqual(resp.headers['Location'], redirect)
 
     def _testOauth(self, providerInfo):
         # Close registration to start off, and simulate a new user
@@ -349,10 +307,11 @@ class OauthTest(base.TestCase):
             resp = self.request(
                 '/oauth/%s/callback' % providerInfo['id'], params=params, isJson=False)
             self.assertStatus(resp, 303)
-            self.assertEqual(resp.headers['Location'], 'http://localhost/#foo/bar')
-            self.assertTrue('girderToken' in resp.cookie)
+            expr = re.compile(r'^http://localhost/\?girderToken=(\w+)#foo/bar$')
+            self.assertRegex(resp.headers['Location'], expr)
 
-            resp = self.request('/user/me', token=resp.cookie['girderToken'].value)
+            girderToken = expr.match(resp.headers['Location']).group(1)
+            resp = self.request('/user/me', token=girderToken)
             user = resp.json
             self.assertStatusOk(resp)
             self.assertEqual(
@@ -1001,7 +960,6 @@ class OauthTest(base.TestCase):
             self.mockOtherRequest
         ):
             self._testOauth(providerInfo)
-            self._testOauthTokenAsParam(providerInfo)
             self._testOauthEventHandling(providerInfo)
 
     def testLinkedinOauth(self):  # noqa


### PR DESCRIPTION
Instead, we send a query parameter on successful OAuth login completion, and the client reads and removes it from the URL.

Refs #3505 