### PR TITLE
Fix passing integer values to diskcache options

### DIFF
--- a/girder/cli/mount.py
+++ b/girder/cli/mount.py
@@ -96,6 +96,8 @@ class ServerFuse(fuse.Operations):
         for key in list((cacheopts or {}).keys()):
             if key.startswith('diskcache'):
                 value = cacheopts.pop(key)
+                if value.strip().isdigit():
+                    value = int(value)
                 key = key[len('diskcache'):].lstrip('_')
                 use = True if use is None else use
                 if key:


### PR DESCRIPTION
If you pass `-odiskcache_size_limit=1000000000` to `girder mount`, this was setting the size limit to a string value of `1000000000`, not the integer value.  I thought this had been tested a long time ago, but currently it makes diskcache fail when checking its eviction policy which then allows the cache to grow without bounds.