### PR TITLE
Record and report some statistics on the mount

### DIFF
--- a/girder/utility/abstract_assetstore_adapter.py
+++ b/girder/utility/abstract_assetstore_adapter.py
@@ -65,6 +65,8 @@ class FileHandle:
             raise GirderException('Read exceeds maximum allowed size.')
         data = io.BytesIO()
         length = 0
+        if self._stream is None:
+            self._stream = self._adapter.downloadFile(self._file, offset=self._pos, headers=False)()
         for chunk in itertools.chain(self._prev, self._stream):
             chunkLen = len(chunk)
 
@@ -103,7 +105,7 @@ class FileHandle:
 
         if self._pos != oldPos:
             self._prev = []
-            self._stream = self._adapter.downloadFile(self._file, offset=self._pos, headers=False)()
+            self._stream = None
 
     def close(self):
         pass

--- a/tests/cases/mount_test.py
+++ b/tests/cases/mount_test.py
@@ -90,7 +90,7 @@ class ServerFuseTestCase(base.TestCase):
         """
         mountpath = self.mountPath
         # Check that the mount lists users and collections
-        self.assertEqual(sorted(os.listdir(mountpath)), sorted(['user', 'collection']))
+        self.assertEqual(sorted(os.listdir(mountpath)), sorted(['user', 'collection', 'stats']))
         # Check that all known paths exist and that arbitrary other paths don't
         for testpath, contents in self.knownPaths.items():
             localpath = os.path.join(mountpath, testpath)
@@ -117,6 +117,7 @@ class ServerFuseTestCase(base.TestCase):
                 self.assertEqual(os.path.getsize(localpath), 0)
                 # An arbitrary alternate file should not exist
                 self.assertFalse(os.path.exists(localpath + '.other'))
+        self.assertTrue(len(open(os.path.join(mountpath, 'stats')).read()) > 100)
 
     def testBlockedMount(self):
         """


### PR DESCRIPTION
Cache checking if a file has a direct path in the fuse mount.

The /stats file will show statistics like
```
{
  "open": 21327,
  "read": 61565,
  "release": 20051,
  "dir": 623,
  "bytesread": 2992361472,
  "pathlookups": 19134,
  "directpathchecks": 2556,
  "openfiles": {
    "35": "/user/manthey/Public/sample/DSC_7704.JPG/DSC_7704.JPG",
  }
}
```
If diskcache is enabled, there is a section for that.  This helps determine (a) which file handles are open (/proc should reflect these somewhere, too), (b) how bytes are actually going through the mount (direct files don't count), (c) how well diskcache and buffering is working.

This has made it easier to track down a file handle bleed in a plugin.