### PR TITLE
Export assetstoreImportViewMap from AssetstoresView.js

### DIFF
--- a/girder/web_client/src/views/body/AssetstoresView.js
+++ b/girder/web_client/src/views/body/AssetstoresView.js
@@ -231,4 +231,6 @@ var AssetstoresView = View.extend({
     }
 });
 
+
+export { assetstoreImportViewMap };
 export default AssetstoresView;

--- a/girder/web_client/src/views/body/AssetstoresView.js
+++ b/girder/web_client/src/views/body/AssetstoresView.js
@@ -231,6 +231,5 @@ var AssetstoresView = View.extend({
     }
 });
 
-
 export { assetstoreImportViewMap };
 export default AssetstoresView;


### PR DESCRIPTION
Added `assetstoreImportViewMap` to exports for AssetstoresView.js to allow external plugins to define their own assetstore views to be used in `AssetstoresView.import`.