### PR TITLE
Allow passage of arbitrary parameters for assetstore/{id}/import route

### DIFF
--- a/girder/api/v1/assetstore.py
+++ b/girder/api/v1/assetstore.py
@@ -132,10 +132,13 @@ class Assetstore(Resource):
         .errorResponse('You are not an administrator.', 403)
     )
     def importData(self, assetstore, importPath, destinationId, destinationType, progress,
-                   leafFoldersAsItems, fileIncludeRegex, fileExcludeRegex):
+                   leafFoldersAsItems, fileIncludeRegex, fileExcludeRegex, **kwargs):
         user = self.getCurrentUser()
         parent = ModelImporter.model(destinationType).load(
             destinationId, user=user, level=AccessType.ADMIN, exc=True)
+
+        # Capture any additional parameters passed to route
+        extraParams = kwargs.get('params', {})
 
         with ProgressContext(progress, user=user, title='Importing data') as ctx:
             return self._model.importData(
@@ -143,6 +146,7 @@ class Assetstore(Resource):
                     'fileIncludeRegex': fileIncludeRegex,
                     'fileExcludeRegex': fileExcludeRegex,
                     'importPath': importPath,
+                    **extraParams
                 }, progress=ctx, user=user, leafFoldersAsItems=leafFoldersAsItems)
 
     @access.admin


### PR DESCRIPTION
Use girder route `param` kwarg handling to pass arbitrary assetstore `importData` parameters. This allows plugins that define custom assetstores to reuse the `/assetstore/{id}/import` route by allowing for the passage of plugin-specific parameters to an assetstore adapter.