### PR TITLE
Refactor parent model usage in AccessControlMixin. Fixes #3535

### DIFF
--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -805,6 +805,7 @@ girder
                 hasAccess
                 hasAccessFlags
                 load
+                parentModel
                 permissionClauses
                 prefixSearch
                 requireAccess


### PR DESCRIPTION
Define internal property `parentModel` to handle all `ModelImporter.model()` calls. Handle the case of `resourceColl` being a tuple properly.