### PR TITLE
google_analytics: remove deprecated navigator.doNotTrack check

### DIFF
--- a/plugins/google_analytics/girder_google_analytics/web_client/main.js
+++ b/plugins/google_analytics/girder_google_analytics/web_client/main.js
@@ -30,10 +30,7 @@ function initGoogleAnalytics() {
 }
 
 events.on('g:appload.after', function () {
-    var dnt = navigator.doNotTrack || window.doNotTrack;
-    if (dnt !== '1' && dnt !== 'yes') {
-        initGoogleAnalytics();
-    }
+    initGoogleAnalytics();
 });
 
 events.on('g:google_analytics.save', function () {


### PR DESCRIPTION
This `navigator.doNotTrack` reference is a deprecated method for checking user tracking consent. Unsure if this needs to be replaced/what it should be replaced with, feedback is definitely welcome.