### PR TITLE
Automatically convert too-large GET/PUT requests to POST in JS client

### DIFF
--- a/girder/web/src/rest.js
+++ b/girder/web/src/rest.js
@@ -121,6 +121,18 @@ const restRequest = function (opts) {
     // Overwrite defaults with passed opts, but do not mutate opts
     const args = _.extend({}, defaults, opts);
 
+    try {
+        // If the data is too large for a GET or PUT request, convert it to a POST request.
+        // Girder's REST API handles this for all requests.
+        if ((!args.method || args.method === 'GET' || args.method === 'PUT') && args.data && !args.contentType) {
+            if (JSON.stringify(args.data).length > 1536) {
+                args.headers = args.header || {};
+                args.headers['X-HTTP-Method-Override'] = args.method || 'GET';
+                args.method = 'POST';
+            }
+        }
+    } catch (err) { }
+
     if (!args.url) {
         throw new Error('restRequest requires a "url" argument');
     }


### PR DESCRIPTION
I'm upstreaming this from large_image's Girder plugin because when converting that plugin to CJS, it no longer lets us overwrite top-level module symbols. This is generally supported behavior, so my workaround is to simply upstream it and remove the need for the wrapping in large_image altogether.