### PR TITLE
JobDetailsWidget: ensure log validity before pushing

### DIFF
--- a/plugins/jobs/girder_jobs/web_client/views/JobDetailsWidget.js
+++ b/plugins/jobs/girder_jobs/web_client/views/JobDetailsWidget.js
@@ -37,6 +37,9 @@ var JobDetailsWidget = View.extend({
                     this.job.set({ log: [info.text] });
                     container.text(info.text);
                 } else {
+                    if (this.job.get('log') === undefined) {
+                        this.job.set({ log: [] });
+                    }
                     this.job.get('log').push(info.text);
                     container.append(_.escape(info.text));
                 }


### PR DESCRIPTION
Check a job's `log` array exists before pushing to it.

In certain edge cases `log` was undefined before the first `job_log` event, making `JobDetailsWidget` (namely the cancel job button) fail to render.