### PR TITLE
Include flat directory in fuse paths

### DIFF
--- a/girder/cli/mount.py
+++ b/girder/cli/mount.py
@@ -170,6 +170,9 @@ class ServerFuse(fuse.Operations):
         # '/user', and 'collection' before calling this method.
         if '/' not in path.rstrip('/')[1:]:
             raise fuse.FuseOSError(errno.ENOENT)
+        flat = path.startswith('/flat')
+        if flat:
+            path = path[5:]
         try:
             # We can't filter the resource, since that removes files'
             # assetstore information and users' size information.
@@ -182,7 +185,23 @@ class ServerFuse(fuse.Operations):
         except Exception:
             logger.exception('ServerFuse server internal error')
             raise fuse.FuseOSError(errno.EROFS)
+        if flat and resource['model'] == 'item':
+            file = self._flatItemFile(resource['document'])
+            if file is not None:
+                file['name'] = resource['document']['name']
+                resource = {
+                    'model': 'file',
+                    'document': file,
+                }
         return resource   # {model, document}
+
+    def _flatItemFile(self, item):
+        return next(File().collection.aggregate([
+            {'$match': {'itemId': item['_id']}},
+            {'$addFields': {'matchName': {'$eq': ['$name', item['name']]}}},
+            {'$sort': {'matchName': -1, '_id': 1}},
+            {'$limit': 1},
+        ]), None)
 
     def _stat(self, doc, model):
         """
@@ -292,7 +311,8 @@ class ServerFuse(fuse.Operations):
         :returns: 0 if access is allowed.  An exception is raised if it is
             not.
         """
-        if path.rstrip('/') in ('', '/user', '/collection'):
+        if path.rstrip('/') in (
+                '', '/user', '/collection', '/flat', '/flat/user', '/flat/collection'):
             return super().access(path, mode)
         # mode is either F_OK or a bitfield of R_OK, W_OK, X_OK
         return 0
@@ -322,7 +342,8 @@ class ServerFuse(fuse.Operations):
             specified.
         :returns: an attribute dictionary.
         """
-        if path.rstrip('/') in ('', '/user', '/collection'):
+        if path.rstrip('/') in (
+                '', '/user', '/collection', '/flat', '/flat/user', '/flat/collection'):
             attr = self._defaultStat.copy()
             attr['st_mode'] = 0o500 | stat.S_IFDIR
             attr['st_size'] = 0
@@ -421,9 +442,16 @@ class ServerFuse(fuse.Operations):
         path = path.rstrip('/')
         result = ['.', '..']
         if path == '':
-            result.extend(['collection', 'user', 'stats'])
+            result.extend(['collection', 'user', 'stats', 'flat'])
+        elif path == '/flat':
+            result.extend(['collection', 'user'])
         elif path in ('/user', '/collection'):
             model = path[1:]
+            docList = ModelImporter.model(model).find({}, sort=None)
+            for doc in docList:
+                result.append(self._name(doc, model))
+        elif path in ('/flat/user', '/flat/collection'):
+            model = path[6:]
             docList = ModelImporter.model(model).find({}, sort=None)
             for doc in docList:
                 result.append(self._name(doc, model))
@@ -666,8 +694,12 @@ def mountServer(path, database=None, fuseOptions=None, quiet=False, verbose=0,
                 continue
             options[key] = value
     opClass = ServerFuse(stat=os.stat(path), options=options)
-    Setting().set(SettingKey.GIRDER_MOUNT_INFORMATION,
-                  {'path': path, 'mounttime': time.time()})
+    Setting().set(SettingKey.GIRDER_MOUNT_INFORMATION, {
+        'path': path,
+        'mounttime': time.time(),
+        'hasStats': True,
+        'hasFlat': True,
+    })
     FUSELogError(opClass, path, **options)
 
 

--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -483,19 +483,34 @@ class File(acl_mixin.AccessControlMixin, Model):
         """
         return self.getAssetstoreAdapter(file).open(file)
 
-    def getGirderMountFilePath(self, file, validate=True):
+    def getGirderMountFilePath(self, file, validate=True, preferFlat=False):
         """
-        If possible, get the path of the file on a local girder mount.
+        If possible, get the path of the file on a local girder mount.  Flat
+        paths exclude the item component, which, for some types of access of
+        relative paths can be preferred.
 
         :param file: The file document.
         :param validate: if True, check if the path exists and raise an
             exception if it does not.
+        :param preferFlat: if True and the mount supports it, return the flat
+            path that doesn't include item information.
         :returns: a girder mount path to the file or None if no such path is
             available.
         """
         mount = Setting().get(SettingKey.GIRDER_MOUNT_INFORMATION)
         if mount:
-            path = mount['path'].rstrip('/') + path_util.getResourcePath('file', file, force=True)
+            resPath = path_util.getResourcePath('file', file, force=True)
+            path = os.path.join(mount['path'], resPath.lstrip('/'))
+            if preferFlat and mount.get('hasFlat'):
+                flatpath = os.path.join(mount['path'], 'flat', os.path.dirname(resPath).lstrip('/'))
+                # An item can have multiple files, while flatten returns the
+                # "first" file, which might not be the file that was requested.
+                # Perform a simple size check to verify it is the file
+                # requested.  This happens even if validation is False.
+                if (
+                        os.path.exists(path) and os.path.exists(flatpath)
+                        and os.path.getsize(path) == os.path.getsize(flatpath)):
+                    return flatpath
             if not validate or os.path.exists(path):
                 return path
         if validate:

--- a/tests/cases/mount_test.py
+++ b/tests/cases/mount_test.py
@@ -90,7 +90,8 @@ class ServerFuseTestCase(base.TestCase):
         """
         mountpath = self.mountPath
         # Check that the mount lists users and collections
-        self.assertEqual(sorted(os.listdir(mountpath)), sorted(['user', 'collection', 'stats']))
+        self.assertEqual(sorted(os.listdir(mountpath)), sorted([
+            'user', 'collection', 'stats', 'flat']))
         # Check that all known paths exist and that arbitrary other paths don't
         for testpath, contents in self.knownPaths.items():
             localpath = os.path.join(mountpath, testpath)


### PR DESCRIPTION
Prior to this, the 'girder mount' command exposes some girder resources as
`<mount_path>/<user_or_collection>/<folder>/[<folder>/...]<item>/<file>`. This allows libraries that require actual files to read remote assets as if they are local files.  However, since girder includes items in the hierarchy, libraries that read files relative to one another often cannot find the adjacent files.

This PR exposes an alternative set of paths without removing the original behavior.  Specifically, files also are exposed as `<mount_path>/flat/<user_or_collection>/<folder>/[<folder>/...]/<file>`. Since items can have multiple files, this only exposes one file per item.  If the item has multiple files, it picks the earliest id.  This could be overridden by a plugin if there was some reason to have a different ordering.  Similarly, if there are no files in an item, the item remains represented as an empty directory.

There is a convenience method to get the local mount path; this has an option to prefer the flat path.  It does a nominal check that the file requested is the same file as is exposed in the flat path, but this is a cheap check based on file size since the information is not otherwise available and a true check would be expensive.

The motivation for this change is to allow reading multi-file image formats via large_image that are imported from S3 and use an opaque library like bioformats for reading the image.