### PR TITLE
Pass progressCurrent to job.update event

### DIFF
--- a/plugins/jobs/girder_jobs/models/job.py
+++ b/plugins/jobs/girder_jobs/models/job.py
@@ -356,6 +356,7 @@ class Job(AccessControlledModel):
                 'overwrite': overwrite,
                 'status': status,
                 'progressTotal': progressTotal,
+                'progressCurrent': progressCurrent,
                 'progressMessage': progressMessage,
                 'otherFields': otherFields
             }


### PR DESCRIPTION
During my quest to switch back to vanilla Girder I found this minor issue. Is there any reason not to include `progressCurrent` in `jobs.job.update` event?