### PR TITLE
Include timezone info in datetime objects

### DIFF
--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -240,6 +240,13 @@ accessible to JavaScript, which is a security best practice. If you were relying
 Note that cookies will still be sent and will still work for read-only endpoints that have
 set the ``cookie=True`` property on their ``@access`` decorator.
 
+Timezone aware datetime objects
++++++++++++++++++++++++++++++++
+
+Due to deprecated behavior in Python 3.12, Girder now uses timezone-aware datetime objects.
+If your code relied on the old behavior of naive datetimes, you may need to update it to
+handle timezone-aware datetimes.
+
 2.x |ra| 3.x
 ------------
 

--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -195,7 +195,7 @@ def getCurrentUser(returnToken=False):
             return user
 
     if (token is None
-            or token['expires'] < datetime.datetime.utcnow()
+            or token['expires'] < datetime.datetime.now(datetime.timezone.utc)
             or 'userId' not in token):
         return retVal(None, token)
     else:

--- a/girder/api/v1/notification.py
+++ b/girder/api/v1/notification.py
@@ -1,7 +1,7 @@
 import cherrypy
 import json
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 from ..describe import Description, autoDescribeRoute
 from ..rest import Resource, disableAuditLog, setResponseHeader
@@ -70,7 +70,7 @@ class Notification(Resource):
         setResponseHeader('Cache-Control', 'no-cache')
         since = params.get('since')
         if since is not None:
-            since = datetime.utcfromtimestamp(since)
+            since = datetime.fromtimestamp(since, timezone.utc)
 
         def streamGen():
             lastUpdate = since

--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -25,7 +25,7 @@ from girder.utility.progress import ProgressContext
 from ..describe import Description, autoDescribeRoute
 from ..rest import Resource
 
-ModuleStartTime = datetime.datetime.utcnow()
+ModuleStartTime = datetime.datetime.now(datetime.timezone.utc)
 LOG_BUF_SIZE = 65536
 logger = logging.getLogger(__name__)
 

--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -327,7 +327,7 @@ class User(Resource):
     def checkTemporaryPassword(self, user, token):
         token = Token().load(
             token, user=user, level=AccessType.ADMIN, objectId=False, exc=True)
-        delta = (token['expires'] - datetime.datetime.utcnow()).total_seconds()
+        delta = (token['expires'] - datetime.datetime.now(datetime.timezone.utc)).total_seconds()
         hasScope = Token().hasScope(token, TokenScope.TEMPORARY_USER_AUTH)
 
         if token.get('userId') != user['_id'] or delta <= 0 or not hasScope:
@@ -425,7 +425,7 @@ class User(Resource):
     def verifyEmail(self, user, token):
         token = Token().load(
             token, user=user, level=AccessType.ADMIN, objectId=False, exc=True)
-        delta = (token['expires'] - datetime.datetime.utcnow()).total_seconds()
+        delta = (token['expires'] - datetime.datetime.now(datetime.timezone.utc)).total_seconds()
         hasScope = Token().hasScope(token, TokenScope.EMAIL_VERIFICATION)
 
         if token.get('userId') != user['_id'] or delta <= 0 or not hasScope:

--- a/girder/models/api_key.py
+++ b/girder/models/api_key.py
@@ -92,7 +92,7 @@ class ApiKey(AccessControlledModel):
         :returns: The API key document that was created.
         """
         apiKey = {
-            'created': datetime.datetime.utcnow(),
+            'created': datetime.datetime.now(datetime.timezone.utc),
             'lastUse': None,
             'tokenDuration': days,
             'name': name,
@@ -131,7 +131,7 @@ class ApiKey(AccessControlledModel):
         user = User().load(apiKey['userId'], force=True)
 
         # Mark last used stamp
-        apiKey['lastUse'] = datetime.datetime.utcnow()
+        apiKey['lastUse'] = datetime.datetime.now(datetime.timezone.utc)
         apiKey = self.save(apiKey)
         token = Token().createToken(user=user, days=days, scope=apiKey['scope'], apiKey=apiKey)
         return (user, token)

--- a/girder/models/assetstore.py
+++ b/girder/models/assetstore.py
@@ -113,7 +113,7 @@ class Assetstore(Model):
     def createFilesystemAssetstore(self, name, root, perms=None):
         return self.save({
             'type': AssetstoreType.FILESYSTEM,
-            'created': datetime.datetime.utcnow(),
+            'created': datetime.datetime.now(datetime.timezone.utc),
             'name': name,
             'root': root,
             'perms': perms
@@ -124,7 +124,7 @@ class Assetstore(Model):
                            serverSideEncryption=False):
         return self.save({
             'type': AssetstoreType.S3,
-            'created': datetime.datetime.utcnow(),
+            'created': datetime.datetime.now(datetime.timezone.utc),
             'name': name,
             'accessKeyId': accessKeyId,
             'secret': secret,

--- a/girder/models/collection.py
+++ b/girder/models/collection.py
@@ -107,7 +107,7 @@ class Collection(AccessControlledModel):
             if existing:
                 return existing
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
 
         collection = {
             'name': name,
@@ -134,7 +134,7 @@ class Collection(AccessControlledModel):
         :type collection: dict
         :returns: The collection document that was edited.
         """
-        collection['updated'] = datetime.datetime.utcnow()
+        collection['updated'] = datetime.datetime.now(datetime.timezone.utc)
 
         # Validate and save the collection
         return self.save(collection)
@@ -202,7 +202,7 @@ class Collection(AccessControlledModel):
 
         self.validateKeys(collection['meta'])
 
-        collection['updated'] = datetime.datetime.utcnow()
+        collection['updated'] = datetime.datetime.now(datetime.timezone.utc)
 
         # Validate and save the collection
         return self.save(collection)
@@ -228,7 +228,7 @@ class Collection(AccessControlledModel):
         for field in fields:
             collection['meta'].pop(field, None)
 
-        collection['updated'] = datetime.datetime.utcnow()
+        collection['updated'] = datetime.datetime.now(datetime.timezone.utc)
 
         return self.save(collection)
 

--- a/girder/models/file.py
+++ b/girder/models/file.py
@@ -230,7 +230,7 @@ class File(acl_mixin.AccessControlMixin, Model):
             file = existing
         else:
             file = {
-                'created': datetime.datetime.utcnow(),
+                'created': datetime.datetime.now(datetime.timezone.utc),
                 'itemId': item['_id'],
                 'assetstoreId': None,
                 'name': name
@@ -324,7 +324,7 @@ class File(acl_mixin.AccessControlMixin, Model):
                 return existing
 
         file = {
-            'created': datetime.datetime.utcnow(),
+            'created': datetime.datetime.now(datetime.timezone.utc),
             'creatorId': creator['_id'],
             'assetstoreId': assetstore['_id'],
             'name': name,
@@ -368,7 +368,7 @@ class File(acl_mixin.AccessControlMixin, Model):
         or MIME type. This causes the updated stamp to change, and also alerts
         the underlying assetstore adapter that file information has changed.
         """
-        file['updated'] = datetime.datetime.utcnow()
+        file['updated'] = datetime.datetime.now(datetime.timezone.utc)
         file = self.save(file)
 
         if file.get('assetstoreId'):
@@ -404,7 +404,7 @@ class File(acl_mixin.AccessControlMixin, Model):
         file = srcFile.copy()
         # Immediately delete the original id so that we get a new one.
         del file['_id']
-        file['copied'] = datetime.datetime.utcnow()
+        file['copied'] = datetime.datetime.now(datetime.timezone.utc)
         file['copierId'] = creator['_id']
         if item:
             file['itemId'] = item['_id']

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -195,7 +195,7 @@ class Folder(AccessControlledModel):
             for key in toDelete:
                 del folder['meta'][key]
 
-        folder['updated'] = datetime.datetime.utcnow()
+        folder['updated'] = datetime.datetime.now(datetime.timezone.utc)
 
         self.validateKeys(folder['meta'])
 
@@ -223,7 +223,7 @@ class Folder(AccessControlledModel):
         for field in fields:
             folder['meta'].pop(field, None)
 
-        folder['updated'] = datetime.datetime.utcnow()
+        folder['updated'] = datetime.datetime.now(datetime.timezone.utc)
 
         return self.save(folder)
 
@@ -497,7 +497,7 @@ class Folder(AccessControlledModel):
             parent['baseParentId'] = parent['_id']
             parent['baseParentType'] = parentType
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
 
         if creator is None:
             creatorId = None
@@ -543,7 +543,7 @@ class Folder(AccessControlledModel):
         :type folder: dict
         :returns: The folder document that was edited.
         """
-        folder['updated'] = datetime.datetime.utcnow()
+        folder['updated'] = datetime.datetime.now(datetime.timezone.utc)
 
         # Validate and save the folder
         return self.save(folder)

--- a/girder/models/group.py
+++ b/girder/models/group.py
@@ -266,7 +266,7 @@ class Group(AccessControlledModel):
         """
         assert isinstance(public, bool)
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
 
         group = {
             'name': name,
@@ -303,7 +303,7 @@ class Group(AccessControlledModel):
         :type group: dict
         :returns: The group document that was edited.
         """
-        group['updated'] = datetime.datetime.utcnow()
+        group['updated'] = datetime.datetime.now(datetime.timezone.utc)
 
         # Validate and save the group
         return self.save(group)

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -268,7 +268,7 @@ class Item(acl_mixin.AccessControlMixin, Model):
             if existing:
                 return existing
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
 
         if not isinstance(creator, dict) or '_id' not in creator:
             # Internal error -- this shouldn't be called without a user.
@@ -302,7 +302,7 @@ class Item(acl_mixin.AccessControlMixin, Model):
         :type item: dict
         :returns: The item document that was edited.
         """
-        item['updated'] = datetime.datetime.utcnow()
+        item['updated'] = datetime.datetime.now(datetime.timezone.utc)
 
         # Validate and save the item
         return self.save(item)
@@ -348,7 +348,7 @@ class Item(acl_mixin.AccessControlMixin, Model):
 
         self.validateKeys(item['meta'])
 
-        item['updated'] = datetime.datetime.utcnow()
+        item['updated'] = datetime.datetime.now(datetime.timezone.utc)
 
         # Validate and save the item
         return self.save(item)
@@ -374,7 +374,7 @@ class Item(acl_mixin.AccessControlMixin, Model):
         for field in fields:
             item['meta'].pop(field, None)
 
-        item['updated'] = datetime.datetime.utcnow()
+        item['updated'] = datetime.datetime.now(datetime.timezone.utc)
 
         return self.save(item)
 

--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -7,7 +7,9 @@ import pymongo
 import re
 
 from bson.objectid import ObjectId
+from bson.codec_options import CodecOptions
 from bson.errors import InvalidId
+from datetime import timezone
 from pymongo.errors import WriteError
 from girder import events, auditLogger
 from girder.constants import AccessType, CoreEventHandler, ACCESS_FLAGS, TEXT_SCORE_SORT_MAX
@@ -117,7 +119,8 @@ class Model(metaclass=_ModelSingleton):
         db_connection = getDbConnection()
         self._dbserver_version = tuple(db_connection.server_info()['versionArray'])
         self.database = db_connection.get_database()
-        self.collection = self.database[self.name]
+        self.collection = self.database[self.name].with_options(
+            codec_options=CodecOptions(tz_aware=True, tzinfo=timezone.utc))
 
         for index in self._indices:
             self._createIndex(index)

--- a/girder/models/notification.py
+++ b/girder/models/notification.py
@@ -53,7 +53,7 @@ class Notification(Model):
             instead of a user.
         :type token: dict
         """
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         currentTime = time.time()
         doc = {
             'type': type,
@@ -117,7 +117,7 @@ class Notification(Model):
             'resource': resource,
             'resourceName': resourceName
         }
-        expires = datetime.datetime.utcnow() + datetime.timedelta(hours=1)
+        expires = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1)
 
         return self.createNotification('progress', data, user, expires,
                                        token=token)
@@ -157,7 +157,7 @@ class Notification(Model):
             if field in ('total', 'current', 'state', 'message'):
                 record['data'][field] = value
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
 
         if 'expires' in kwargs:
             expires = kwargs['expires']

--- a/girder/models/token.py
+++ b/girder/models/token.py
@@ -42,7 +42,7 @@ class Token(AccessControlledModel):
         """
         from .setting import Setting
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         days = days or Setting().get(SettingKey.COOKIE_LIFETIME)
 
         if scope is None:

--- a/girder/models/upload.py
+++ b/girder/models/upload.py
@@ -105,7 +105,7 @@ class Upload(Model):
         if doc['received'] > doc['size']:
             raise ValidationException('Received too many bytes.')
 
-        doc['updated'] = datetime.datetime.utcnow()
+        doc['updated'] = datetime.datetime.now(datetime.timezone.utc)
 
         return doc
 
@@ -196,7 +196,7 @@ class Upload(Model):
 
             # Update file info
             file['creatorId'] = upload['userId']
-            file['created'] = datetime.datetime.utcnow()
+            file['created'] = datetime.datetime.now(datetime.timezone.utc)
             file['assetstoreId'] = assetstore['_id']
             file['size'] = upload['size']
             # If the file was previously imported, it is no longer.
@@ -300,7 +300,7 @@ class Upload(Model):
 
         assetstore = self.getTargetAssetstore('file', file, assetstore)
         adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
 
         if 'attachedToId' in file:
             parent = ModelImporter.model(
@@ -367,7 +367,7 @@ class Upload(Model):
 
         assetstore = self.getTargetAssetstore(parentType, parent, assetstore)
         adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
 
         if not mimeType:
             mimeType = 'application/octet-stream'
@@ -477,7 +477,7 @@ class Upload(Model):
                             query[key] = id
             if 'minimumAge' in filters:
                 query['updated'] = {
-                    '$lte': datetime.datetime.utcnow() - datetime.timedelta(
+                    '$lte': datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
                         days=float(filters['minimumAge']))
                     }
         # Perform the find; we'll do access-based filtering of the result

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -401,7 +401,7 @@ class User(AccessControlledModel):
             'email': email,
             'firstName': firstName,
             'lastName': lastName,
-            'created': datetime.datetime.utcnow(),
+            'created': datetime.datetime.now(datetime.timezone.utc),
             'emailVerified': False,
             'status': 'pending' if requireApproval else 'enabled',
             'admin': admin,

--- a/girder/utility/progress.py
+++ b/girder/utility/progress.py
@@ -57,7 +57,7 @@ class ProgressContext:
 
         Notification().updateProgress(
             self.progress, state=state, message=message,
-            expires=datetime.datetime.utcnow() + datetime.timedelta(seconds=30)
+            expires=datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=30)
         )
 
     def update(self, force=False, **kwargs):

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -433,7 +433,7 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
                    user, force_recursive=True, **kwargs):
         importPath = params.get('importPath', '').strip().lstrip('/')
         bucket = self.assetstore['bucket']
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         paginator = self.client.get_paginator('list_objects')
         pageIterator = paginator.paginate(Bucket=bucket, Prefix=importPath, Delimiter='/')
         for resp in pageIterator:

--- a/plugins/audit_logs/girder_audit_logs/__init__.py
+++ b/plugins/audit_logs/girder_audit_logs/__init__.py
@@ -43,7 +43,7 @@ class _AuditLogDatabaseHandler(logging.Handler):
             'details': record.details,
             'ip': cherrypy.request.remote.ip,
             'userId': user and user['_id'],
-            'when': datetime.datetime.utcnow()
+            'when': datetime.datetime.now(datetime.timezone.utc)
         }, triggerEvents=False)
 
 

--- a/plugins/audit_logs/girder_audit_logs/cleanup.py
+++ b/plugins/audit_logs/girder_audit_logs/cleanup.py
@@ -14,7 +14,11 @@ from girder_audit_logs import Record
 @click.option('--types', help='Which record types to remove as a comma separated list. If not '
               'provided, removes all record types.')
 def cleanup(days, types):
-    filter = {'when': {'$lt': datetime.datetime.utcnow() - datetime.timedelta(days=days)}}
+    filter = {
+        'when': {
+            '$lt': datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=days)
+        }
+    }
 
     if types:
         filter['type'] = {'$in': types.split(',')}

--- a/plugins/jobs/girder_jobs/models/job.py
+++ b/plugins/jobs/girder_jobs/models/job.py
@@ -213,7 +213,7 @@ class Job(AccessControlledModel):
         :param otherFields: Any additional fields to set on the job.
         :type otherFields: dict
         """
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
 
         if when is None:
             when = now
@@ -262,7 +262,8 @@ class Job(AccessControlledModel):
 
             Notification().createNotification(
                 type='job_created', data=job, user=user,
-                expires=datetime.datetime.utcnow() + datetime.timedelta(seconds=30))
+                expires=datetime.datetime.now(datetime.timezone.utc)
+                + datetime.timedelta(seconds=30))
 
             job['kwargs'] = deserialized_kwargs
 
@@ -361,7 +362,7 @@ class Job(AccessControlledModel):
         if event.defaultPrevented:
             return job
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         user = None
         otherFields = otherFields or {}
         if job['userId']:

--- a/plugins/oauth/girder_oauth/rest.py
+++ b/plugins/oauth/girder_oauth/rest.py
@@ -45,7 +45,7 @@ class OAuth(Resource):
 
         Token().remove(token)
 
-        if token['expires'] < datetime.datetime.utcnow():
+        if token['expires'] < datetime.datetime.now(datetime.timezone.utc):
             raise RestException('Expired CSRF token (state="%s").' % state,
                                 code=403)
 

--- a/plugins/oauth/plugin_tests/oauth_test.py
+++ b/plugins/oauth/plugin_tests/oauth_test.py
@@ -220,7 +220,7 @@ class OauthTest(base.TestCase):
             token = Token().load(csrfTokenParts[0], force=True, objectId=False)
             self.assertLess(
                 token['expires'],
-                datetime.datetime.utcnow() + datetime.timedelta(days=0.30))
+                datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=0.30))
             self.assertEqual(csrfTokenParts[2], 'http://localhost/#foo/bar')
             return providerResp
 

--- a/plugins/user_quota/plugin_tests/user_quota_test.py
+++ b/plugins/user_quota/plugin_tests/user_quota_test.py
@@ -369,7 +369,7 @@ class QuotaTestCase(base.TestCase):
                 'name': 'Broken Store',
                 'type': AssetstoreType.FILESYSTEM,
                 'root': '/dev/null',
-                'created': datetime.datetime.utcnow()
+                'created': datetime.datetime.now(datetime.timezone.utc)
             }, validate=False)
 
             # Now get the assetstores and save their ids for later

--- a/test/test_notification.py
+++ b/test/test_notification.py
@@ -3,7 +3,7 @@ import pytest
 from pytest_girder.assertions import assertStatus, assertStatusOk
 from girder.models.notification import Notification
 
-OLD_TIME = datetime.datetime.utcnow() - datetime.timedelta(days=3)
+OLD_TIME = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=3)
 SINCE = OLD_TIME + datetime.timedelta(days=1)
 
 

--- a/tests/cases/folder_test.py
+++ b/tests/cases/folder_test.py
@@ -478,7 +478,7 @@ class FolderTestCase(base.TestCase):
             self.assertEqual(notifs[0]['data']['message'], 'Done')
             self.assertEqual(notifs[0]['data']['total'], 3)
             self.assertEqual(notifs[0]['data']['current'], 3)
-            self.assertTrue(notifs[0]['expires'] < datetime.datetime.utcnow()
+            self.assertTrue(notifs[0]['expires'] < datetime.datetime.now(datetime.timezone.utc)
                             + datetime.timedelta(minutes=1))
 
             # Make sure our event handler was called with expected args

--- a/tests/cases/mount_test.py
+++ b/tests/cases/mount_test.py
@@ -299,7 +299,9 @@ class ServerFuseTestCase(base.TestCase):
         self.assertEqual(attr['st_ctime'], attr['st_mtime'])
         self.assertEqual(attr['st_mode'], 0o400 | stat.S_IFREG)
         self.assertGreater(attr['st_size'], len(self.knownPaths[self.publicFileName]))
-        resource['document']['updated'] = datetime.datetime.utcfromtimestamp(time.time() + 1)
+        resource['document']['updated'] = datetime.datetime.fromtimestamp(
+            time.time() + 1, datetime.timezone.utc
+        )
         File().save(resource['document'])
         oldmtime = attr['st_mtime']
         resource = op._get_path(self.publicFileName)

--- a/tests/cases/resource_test.py
+++ b/tests/cases/resource_test.py
@@ -117,7 +117,7 @@ class ResourceTestCase(base.TestCase):
             + [self.items[4]['name'], 'girder-item-metadata.json']))
         self.expectedZip[path] = meta
 
-        meta = {'key2': 'value2', 'date': datetime.datetime.utcnow()}
+        meta = {'key2': 'value2', 'date': datetime.datetime.now(datetime.timezone.utc)}
         # mongo rounds to millisecond, so adjust our expectations
         meta['date'] -= datetime.timedelta(
             microseconds=meta['date'].microsecond % 1000)
@@ -238,7 +238,7 @@ class ResourceTestCase(base.TestCase):
         self.assertEqual(notifs[0]['data']['message'], 'Done')
         self.assertEqual(notifs[0]['data']['total'], 6)
         self.assertEqual(notifs[0]['data']['current'], 6)
-        self.assertTrue(notifs[0]['expires'] < datetime.datetime.utcnow()
+        self.assertTrue(notifs[0]['expires'] < datetime.datetime.now(datetime.timezone.utc)
                         + datetime.timedelta(minutes=1))
         # Test deletes using a body on the request
         resourceList = {
@@ -722,8 +722,8 @@ class ResourceTestCase(base.TestCase):
     def testResourceTimestamps(self):
         self._createFiles()
 
-        created = datetime.datetime(2000, 1, 1)
-        updated = datetime.datetime(2001, 1, 1)
+        created = datetime.datetime(2000, 1, 1, tzinfo=datetime.timezone.utc)
+        updated = datetime.datetime(2001, 1, 1, tzinfo=datetime.timezone.utc)
 
         # non-admin cannot use this endpoint
         resp = self.request(

--- a/tests/cases/user_test.py
+++ b/tests/cases/user_test.py
@@ -544,7 +544,7 @@ class UserTestCase(base.TestCase):
 
         # Artificially adjust the token to have expired.
         token = Token().load(tokenId, force=True, objectId=False)
-        token['expires'] = (datetime.datetime.utcnow()
+        token['expires'] = (datetime.datetime.now(datetime.timezone.utc)
                             - datetime.timedelta(days=1))
         Token().save(token)
         resp = self.request(path=path, method='GET', params={'token': tokenId})


### PR DESCRIPTION
Should be a noop, but it fixes a lot of warnings I get during tests with py3.12. Nice write-up about why: https://blog.miguelgrinberg.com/post/it-s-time-for-a-change-datetime-utcnow-is-now-deprecated