### PR TITLE
Support pymongo 4

### DIFF
--- a/girder/models/__init__.py
+++ b/girder/models/__init__.py
@@ -1,10 +1,30 @@
 import pymongo
+import pymongo.cursor
 import urllib.parse
 
 from girder import logprint
 from girder.utility import config
 
 _dbClients = {}
+
+
+if not hasattr(pymongo.cursor.Cursor, 'count'):
+    import warnings
+
+    def _cursorCount(self, with_limit_and_skip=False):
+        warnings.warn(
+            'count is deprecated. Use Collection.count_documents instead.',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        params = {}
+        if with_limit_and_skip and self._Cursor__limit:
+            params['limit'] = self._Cursor__limit
+        if with_limit_and_skip and self._Cursor__skip:
+            params['skip'] = self._Cursor__skip
+        return self._Cursor__collection.count_documents(self._Cursor__spec, **params)
+
+    pymongo.cursor.Cursor.count = _cursorCount
 
 
 def getDbConfig():

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ installReqs = [
     'jsonschema',
     'Mako',
     'passlib [bcrypt,totp]',
-    'pymongo>=3.6,<4',
+    'pymongo>=4',
     'PyYAML',
     'psutil',
     'pyOpenSSL',

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,10 +45,6 @@ if(RUN_CORE_TESTS)
 
   add_web_client_test(data_filesystem "${PROJECT_SOURCE_DIR}/girder/web_client/test/spec/dataSpec.js" ASSETSTORE filesystem)
   add_web_client_test(data_gridfs "${PROJECT_SOURCE_DIR}/girder/web_client/test/spec/dataSpec.js" ASSETSTORE gridfs)
-  add_web_client_test(data_gridfsrs "${PROJECT_SOURCE_DIR}/girder/web_client/test/spec/dataSpec.js" ASSETSTORE gridfsrs RESOURCE_LOCKS replicaset REQUIRED_FILES "${MONGOD_EXECUTABLE}")
-  if (BUILD_JAVASCRIPT_TESTS)
-    set_property(TEST web_client_data_gridfsrs PROPERTY LABELS girder_integration)
-  endif()
   add_web_client_test(data_s3 "${PROJECT_SOURCE_DIR}/girder/web_client/test/spec/dataSpec.js" ASSETSTORE s3 WEBSECURITY false)
   add_web_client_test(admin "${PROJECT_SOURCE_DIR}/girder/web_client/test/spec/adminSpec.js" ASSETSTORE s3 WEBSECURITY false
     RESOURCE_LOCKS replicaset


### PR DESCRIPTION
This is done by re-adding the count method to cursors based on code in pymongo 3.  It still shows a deprecation warning, as it'd be better for future support to refactor code to use the count_documents method.

Although this could be merged as is, it is intended as, at last, a point for discussing the approach that should be taken.

There are a few points in Girder (and probably several in plugins as well) where counts are used adjacent to the query.  These places are relatively straightforward to update, and, for each, one could choose to use the count_documents or estimated_document_count as appropriate.  The sticking point is that when we return a cursor from an endpoint, we serialize the requested records and add a Girder-Total-Count header with the document count.  If we don't have a cursor count method or a workaround equivalent to it, then any endpoint that returns a cursor would instead need to also store the count in some out-of-band part of the response (adding the header itself, adding the count to a property of some class, or something similar).  This seems like it is more burdensome and more prove to failure than the cursor count method, but has the virtue of less surprise in the future.