### PR TITLE
Use the brand name in account approved email subjects

### DIFF
--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -469,8 +469,9 @@ class User(AccessControlledModel):
             'user': user,
             'url': url
         })
+        brandName = Setting().get(SettingKey.BRAND_NAME)
         mail_utils.sendMailToAdmins(
-            'Girder: Account pending approval',
+            f'{brandName}: Account pending approval',
             text)
 
     def _sendApprovedEmail(self, user):


### PR DESCRIPTION
The email subject always read Girder; it should use the configured brand name.