### PR TITLE
Fix file downloads for users logged in via OAuth plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ commands:
           name: Generate python environment checksum file
           command: ./girder/.circleci/generatePyEnvChecksum.sh > girder/py-env-checksum
       - restore_cache:
-          key: venv-py3.8-{{ arch }}-{{ checksum "girder/py-env-checksum" }}-4
+          key: venv-py3.8-{{ arch }}-{{ checksum "girder/py-env-checksum" }}-5
       - run:
           name: Create virtual environment (if necessary)
           command: if [ ! -d girder_env ]; then python3 -m venv girder_env; fi
@@ -52,7 +52,7 @@ commands:
       - save_cache:
           paths:
             - girder_env
-          key: venv-py3.8-{{ arch }}-{{ checksum "girder/py-env-checksum" }}-4
+          key: venv-py3.8-{{ arch }}-{{ checksum "girder/py-env-checksum" }}-5
 
 jobs:
   server-lint-test:

--- a/plugins/oauth/plugin_tests/oauth_test.py
+++ b/plugins/oauth/plugin_tests/oauth_test.py
@@ -309,6 +309,7 @@ class OauthTest(base.TestCase):
             self.assertStatus(resp, 303)
             expr = re.compile(r'^http://localhost/\?girderToken=(\w+)#foo/bar$')
             self.assertRegex(resp.headers['Location'], expr)
+            self.assertTrue('girderToken' in resp.cookie)
 
             girderToken = expr.match(resp.headers['Location']).group(1)
             resp = self.request('/user/me', token=girderToken)


### PR DESCRIPTION
This fixes a regression that occurred when we disabled the sending of cookies in order to support the use of HttpOnly cookies.

We still need the cookies for file downloads, so this should not have been removed.