### PR TITLE
pymongo 4.9 requires explicit import of command_cursor.

### DIFF
--- a/girder/api/rest.py
+++ b/girder/api/rest.py
@@ -7,6 +7,7 @@ import inspect
 import json
 import posixpath
 import pymongo
+import pymongo.command_cursor
 import sys
 import traceback
 import types

--- a/girder/models/__init__.py
+++ b/girder/models/__init__.py
@@ -18,11 +18,13 @@ if not hasattr(pymongo.cursor.Cursor, 'count'):
             stacklevel=2,
         )
         params = {}
-        if with_limit_and_skip and self._Cursor__limit:
-            params['limit'] = self._Cursor__limit
-        if with_limit_and_skip and self._Cursor__skip:
-            params['skip'] = self._Cursor__skip
-        return self._Cursor__collection.count_documents(self._Cursor__spec, **params)
+        if with_limit_and_skip and getattr(self, '_limit', getattr(self, '_Cursor__limit', None)):
+            params['limit'] = getattr(self, '_limit', getattr(self, '_Cursor__limit', None))
+        if with_limit_and_skip and getattr(self, '_skip', getattr(self, '_Cursor__skip', None)):
+            params['skip'] = getattr(self, '_skip', getattr(self, '_Cursor__skip', None))
+        return getattr(self, '_collection', getattr(
+            self, '_Cursor__collection', None)).count_documents(
+                getattr(self, '_spec', getattr(self, '_Cursor__spec', None)), **params)
 
     pymongo.cursor.Cursor.count = _cursorCount
 


### PR DESCRIPTION
Also, the internals of pymongo cursor have changed.

This is backwards compatible with all of pymongo 4.x (and probably 3.x)