### PR TITLE
Style update (experimental)

### DIFF
--- a/girder/utility/webroot.mako
+++ b/girder/utility/webroot.mako
@@ -7,7 +7,232 @@
     <link rel="icon" type="image/png" href="${staticPublicPath}/built/Girder_Favicon.png">
     % for plugin in pluginCss:
     <link rel="stylesheet" href="${staticPublicPath}/built/plugins/${plugin}/plugin.min.css">
+    <link rel="stylesheet" href="${staticPublicPath}/built/extras/extra.css">
     % endfor
+    <!-- TODO: In Girder 5 install tailwind the right way -->
+    <script src="https://cdn.tailwindcss.com"></script>
+
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        primary: {
+                            DEFAULT: 'hsl(var(--primary-h), var(--primary-s), var(--primary-l))',
+                            hover: 'var(--primary-hover)',
+                            content: 'var(--primary-content)',
+                        },
+                        secondary: {
+                            DEFAULT: 'hsl(var(--secondary-h), var(--secondary-s), var(--secondary-l))',
+                            hover: 'var(--secondary-hover)',
+                            content: 'var(--secondary-content)',
+                        },
+                        accent: {
+                            DEFAULT: 'hsl(var(--accent-h), var(--accent-s), var(--accent-l))',
+                            hover: 'var(--accent-hover)',
+                            content: 'var(--accent-content)',
+                        },
+                    },
+                    zIndex: {
+                        '100': '100',
+                    },
+                },
+            },
+            plugins: [],
+            blocklist: ['collapse'], // disable because bootstrap uses it for something else
+        };
+    </script>
+
+<style type="text/tailwindcss">
+    @layer base {
+        :root {
+            /* User-defined hex values */
+            --primary: #EB1700;
+            --secondary: #EB1700;
+            --accent: #EB1700;
+        }
+
+        body {
+            @apply bg-zinc-100;
+        }
+
+        /* Typography Styles */
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
+            @apply font-bold;
+        }
+
+        h1 {
+            @apply text-4xl;
+        }
+
+        h2 {
+            @apply text-3xl;
+        }
+
+        h3 {
+            @apply text-2xl;
+        }
+
+        h4 {
+            @apply text-xl;
+        }
+
+        h5 {
+            @apply text-lg;
+        }
+
+        h6 {
+            @apply text-base;
+        }
+    }
+
+    @layer components {
+
+        /*
+        Define button styles:
+            1. Sizes
+            2. Colors
+            3. Types
+        */
+
+        .htk-btn {
+            @apply duration-200 ease-in-out inline-flex items-center justify-center px-3 py-[6px] rounded-md text-base tracking-wider transition-all gap-2 h-9;
+        }
+
+        .htk-btn i {
+            @apply leading-[0];
+        }
+
+        /* 1. Sizes */
+
+        .htk-btn.htk-btn-lg {
+            @apply px-4 text-lg h-11;
+        }
+
+        .htk-btn.htk-btn-sm {
+            @apply px-[10px] text-sm h-[30px] gap-1;
+        }
+
+        .htk-btn.htk-btn-xs {
+            @apply px-[7px] rounded text-xs h-[22px] gap-1;
+        }
+
+        /* 2. Colors */
+
+        .htk-btn.htk-btn-primary {
+            @apply bg-primary text-primary-content;
+        }
+
+        .htk-btn.htk-btn-primary:hover {
+            @apply bg-primary-hover;
+        }
+
+        .htk-btn.htk-btn-secondary {
+            @apply bg-secondary text-secondary-content;
+        }
+
+        .htk-btn.htk-btn-secondary:hover {
+            @apply bg-secondary-hover;
+        }
+
+        .htk-btn.htk-btn-accent {
+            @apply bg-accent text-accent-content;
+        }
+
+        .htk-btn.htk-btn-accent:hover {
+            @apply bg-accent-hover;
+        }
+
+        /* 3. Types
+                a. Ghost
+                b. Icon Only
+                c. Disabled
+        */
+
+        /* a. Ghost */
+
+        .htk-btn.htk-btn-ghost {
+            @apply bg-neutral-800 bg-opacity-0;
+        }
+
+        .htk-btn.htk-btn-ghost:hover {
+            @apply bg-opacity-10;
+        }
+
+        /* Primary Color */
+
+        .htk-btn.htk-btn-primary.htk-btn-ghost {
+            background-color: hsla(var(--primary-h), var(--primary-s), var(--primary-l), 0);
+            @apply text-primary;
+        }
+        .htk-btn.htk-btn-primary.htk-btn-ghost:hover {
+            background-color: hsla(var(--primary-h), var(--primary-s), var(--primary-l), 0.1);
+        }
+
+        /* Secondary Color */
+
+        .htk-btn.htk-btn-secondary.htk-btn-ghost {
+            background-color: hsla(var(--secondary-h), var(--secondary-s), var(--secondary-l), 0);
+            @apply text-secondary;
+        }
+        .htk-btn.htk-btn-secondary.htk-btn-ghost:hover {
+            background-color: hsla(var(--secondary-h), var(--secondary-s), var(--secondary-l), 0.1);
+        }
+
+        /* Accent Color */
+
+        .htk-btn.htk-btn-accent.htk-btn-ghost {
+            background-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0);
+            @apply text-accent;
+        }
+        .htk-btn.htk-btn-accent.htk-btn-ghost:hover {
+            background-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.1);
+        }
+
+        /* b. Icon Only */
+
+        .htk-btn.htk-btn-icon {
+            /* "tracking-[0]" ensures icons are always centered when using icon fonts */
+            @apply rounded-full !leading-none text-xl w-9 aspect-square tracking-[0];
+        }
+
+        /* Large */
+
+        .htk-btn.htk-btn-icon.htk-btn-lg {
+            @apply text-2xl w-11;
+        }
+
+        /* Small */
+
+        .htk-btn.htk-btn-icon.htk-btn-sm {
+            @apply text-lg w-[30px];
+        }
+
+        /* X-Small */
+
+        .htk-btn.htk-btn-icon.htk-btn-xs {
+            @apply text-sm w-[22px];
+        }
+
+        /* c. Disabled */
+        .htk-btn.htk-btn-disabled {
+            @apply bg-neutral-200 border border-neutral-300 text-neutral-400 !cursor-not-allowed;
+        }
+
+        /* Use this instead of Tailwind's hidden until we remove bootstrap */
+        /* Required for now to account for the fact that bootstrap has !important on .hidden */
+        .htk-hidden {
+            display: none;
+        }
+    }
+</style>
+
+
   </head>
   <body>
     <div id="g-global-info-apiroot" class="hide">${apiRoot}</div>
@@ -32,5 +257,78 @@
     % for plugin in pluginJs:
     <script src="${staticPublicPath}/built/plugins/${plugin}/plugin.min.js"></script>
     % endfor
+
+
+<%text>
+<script type="text/javascript">
+    function hexToHSL(hex) {
+        let r = 0, g = 0, b = 0;
+        if (hex.length === 4) {
+            r = parseInt(hex[1] + hex[1], 16);
+            g = parseInt(hex[2] + hex[2], 16);
+            b = parseInt(hex[3] + hex[3], 16);
+        } else if (hex.length === 7) {
+            r = parseInt(hex[1] + hex[2], 16);
+            g = parseInt(hex[3] + hex[4], 16);
+            b = parseInt(hex[5] + hex[6], 16);
+        }
+        r /= 255;
+        g /= 255;
+        b /= 255;
+        const max = Math.max(r, g, b), min = Math.min(r, g, b);
+        let h = 0, s = 0, l = (max + min) / 2;
+        if (max !== min) {
+            const d = max - min;
+            s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+            switch (max) {
+                case r: h = (g - b) / d + (g < b ? 6 : 0); break;
+                case g: h = (b - r) / d + 2; break;
+                case b: h = (r - g) / d + 4; break;
+            }
+            h /= 6;
+        }
+        s = s * 100;
+        l = l * 100;
+        h = Math.round(h * 360);
+        s = Math.round(s);
+        l = Math.round(l);
+        return { h, s, l };
+    }
+
+    function setColorVariables(hexVar, prefix) {
+        const hex = getComputedStyle(document.documentElement).getPropertyValue(hexVar).trim();
+        const { h, s, l } = hexToHSL(hex);
+
+        const styles = `
+            --${prefix}-h: ${h};
+            --${prefix}-s: ${s}%;
+            --${prefix}-l: ${l}%;
+            --${prefix}-hover: hsl(${h}, ${s}%, ${l + (l > 50 ? -10 : 10)}%);
+            --${prefix}-content: hsl(${h}, ${s}%, ${l > 50 ? l - 60 : l + 60}%);
+        `;
+        return styles;
+    }
+
+    function injectStyles() {
+        const primaryStyles = setColorVariables('--primary', 'primary');
+        const secondaryStyles = setColorVariables('--secondary', 'secondary');
+        const accentStyles = setColorVariables('--accent', 'accent');
+
+        let styleElement = document.getElementById('dynamic-color-styles');
+
+        if (!styleElement) {
+            styleElement = document.createElement('style');
+            styleElement.id = 'dynamic-color-styles';
+            document.head.appendChild(styleElement);
+        }
+
+        styleElement.textContent = `:root { ${primaryStyles} ${secondaryStyles} ${accentStyles} }`;
+    }
+
+    injectStyles();
+</script>
+</%text>
+
+
   </body>
 </html>

--- a/girder/web_client/grunt_tasks/build.js
+++ b/girder/web_client/grunt_tasks/build.js
@@ -183,7 +183,12 @@ module.exports = function (grunt) {
                         from: 'static/img/Girder_Favicon.png',
                         to: grunt.config.get('builtPath'),
                         toType: 'dir'
-                    }])
+                    }]),
+                    new CopyWebpackPlugin([{
+                        from: 'static/extras',
+                        to: path.join(grunt.config.get('builtPath'), 'extras'),
+                        toType: 'dir'
+                    }]),
                 ]
             }
         },

--- a/girder/web_client/package.json.template
+++ b/girder/web_client/package.json.template
@@ -28,6 +28,7 @@
         "nib": "^1.1.2",
         "pug": "^2.0.0-rc.3",
         "pug-loader": "^2.3.0",
+        "remixicon": "^4.3.0",
         "style-loader": "^0.13.2",
         "stylus": "^0.54.5",
         "stylus-loader": "^3.0.1",

--- a/girder/web_client/src/stylesheets/body/collectionPage.styl
+++ b/girder/web_client/src/stylesheets/body/collectionPage.styl
@@ -1,6 +1,2 @@
-.g-collection-header
-  border-bottom 1px solid #ddd
-  margin-bottom 15px
-
 .g-collection-folders-container
   margin-top 15px

--- a/girder/web_client/src/stylesheets/body/plugins.styl
+++ b/girder/web_client/src/stylesheets/body/plugins.styl
@@ -9,9 +9,6 @@ $warnColor = #f0ad4e
     padding 10px
     border-bottom 1px solid #e2e2e2
 
-    &:hover
-      background-color #f4f4f4
-
     .g-plugin-name
       font-weight bold
       font-size 16px

--- a/girder/web_client/src/stylesheets/layout/footer.styl
+++ b/girder/web_client/src/stylesheets/layout/footer.styl
@@ -1,7 +1,5 @@
 #g-app-footer-container
-  border-top 1px solid #eee
   text-align center
-  background-image linear-gradient(to bottom, #f6f6f6 0, #fff 5px)
 
 .g-quick-search-form
   >.form-group

--- a/girder/web_client/src/stylesheets/layout/global.styl
+++ b/girder/web_client/src/stylesheets/layout/global.styl
@@ -2,11 +2,15 @@
  * Place global styles in this file.
  */
 
+html
+  font-size initial
+
 body
   // Override the default font from Bootstrap
-  font-family "Open Sans", sans-serif !important
+  font-family "Open Sans", sans-serif
   padding 0
   word-wrap break-word
+  font-size initial
 
 i
   -webkit-font-smoothing antialiased
@@ -14,6 +18,12 @@ i
 a
   cursor pointer
   text-decoration none !important
+
+a:hover
+  color unset
+
+a:focus
+  color initial
 
 .g-clear-both
   clear both

--- a/girder/web_client/src/stylesheets/layout/globalNav.styl
+++ b/girder/web_client/src/stylesheets/layout/globalNav.styl
@@ -3,8 +3,6 @@ $emptyBorder=1px solid transparent
 $minHeight=500px
 
 .g-global-nav-main
-  box-shadow inset 0 -35px 45px -10px #fff
-  background-image linear-gradient(to left, #f4f4f4 0, #fff 7px)
   min-height $minHeight - 12px
   padding 15px 0 20px 6px
 
@@ -22,12 +20,10 @@ ul.g-global-nav
   padding-left 0
 
   >li
-    border $emptyBorder
     list-style-type none
     text-decoration none
 
   >li:hover:not(.g-active)
-    background-color #fafafa
     .g-nav-link
       position relative
       color #222
@@ -37,11 +33,6 @@ ul.g-global-nav
   >li.g-active
     pointer-events none
     cursor default
-    background-color white
-    border-top $navLinkBorder
-    border-bottom $navLinkBorder
-    border-left $navLinkBorder
-    box-shadow -1px 1px 3px rgba(0, 0, 0, 0.05)
     .g-nav-link
       color black
     i
@@ -55,19 +46,9 @@ ul.g-global-nav
 
   ul.g-global-nav
     width 100%
-    border-bottom $navLinkBorder
     >li
       display inline-block
       padding 4px 5px
-      border $emptyBorder
-    >li.g-active
-      box-shadow none
-      border-bottom $emptyBorder
-      border-left $navLinkBorder
-      border-right $navLinkBorder
-      border-top $navLinkBorder
-    >li:not(.g-active)
-      background-color #f1f1f1
 
 @media (min-width 721px)
   ul.g-global-nav
@@ -79,11 +60,8 @@ ul.g-global-nav
         top -1px
         bottom -1px
         right -1px
-        background-color #ffcc00
 
 @media (max-width 720px)
   .g-global-nav-main
     padding 0
-    box-shadow none
-    background-image none
     min-height 0

--- a/girder/web_client/src/stylesheets/layout/header.styl
+++ b/girder/web_client/src/stylesheets/layout/header.styl
@@ -2,13 +2,11 @@
 
 .g-header-wrapper
   height $headerHeight
-  vertical-align middle
   padding 0 15px
 
 .g-app-title
   display inline
   font-size 25px
-  font-weight bold
   margin-right 35px
   line-height $headerHeight
   cursor pointer

--- a/girder/web_client/src/stylesheets/layout/headerUser.styl
+++ b/girder/web_client/src/stylesheets/layout/headerUser.styl
@@ -4,11 +4,7 @@
   line-height $headerHeight
 
   a
-    color white
     display inline-block
-
-    &:hover
-      color #e0e0e0
 
   .g-user-dropdown-link
     display inline-block

--- a/girder/web_client/src/stylesheets/layout/layout.styl
+++ b/girder/web_client/src/stylesheets/layout/layout.styl
@@ -1,5 +1,4 @@
 @import "layoutVars"
-
 #g-app-header-container
   position fixed
   top 0

--- a/girder/web_client/src/stylesheets/widgets/hierarchyWidget.styl
+++ b/girder/web_client/src/stylesheets/widgets/hierarchyWidget.styl
@@ -1,26 +1,8 @@
 .g-hierarchy-widget
-  border 1px solid #eaeaea
 
   .g-hierarchy-sticky
     position sticky
     z-index 10
-
-  .g-hierarchy-actions-header
-    background linear-gradient(to bottom, #e6e6e6 0, #f7f7f7 8px)
-    padding 4px 5px 3px
-    background-color #f6f6f6
-    border-top 1px solid #ddd
-
-    .g-select-all
-      font-size 16px
-      background-color green
-
-    .btn-group
-      margin-left 10px
-
-    button
-      margin-left 10px
-      padding 4px 8px
 
   .g-folder-header-buttons
     float right
@@ -44,56 +26,6 @@
         #g-page-selection-input
           margin-left 3px
           margin-right 3px
-
-
-  .g-hierarchy-breadcrumb-bar
-    ol.breadcrumb
-      margin-bottom 0
-      background-color #eaebea
-      border-radius 0
-      padding-left 5px
-      padding-right 5px
-      text-overflow ellipsis
-      overflow hidden
-      white-space nowrap
-
-      .g-description-preview
-        margin-left 8px
-        font-size 11px
-        vertical-align middle
-        color #999
-
-        &:hover
-          text-decoration underline !important
-
-      >li.active
-        color #555
-
-    .g-child-count-container
-      display inline-block
-      margin-right 10px
-      color #888
-      font-size 16px
-      user-select none
-      cursor default
-
-      .g-subfolder-count-container
-      .g-item-count-container
-        display inline-block
-        position relative
-        margin-left 8px
-
-      .g-subfolder-count
-      .g-item-count
-        display inline-block
-        border-radius 3px
-        color black
-        background-color rgba(255, 255, 255, 0.75)
-        position absolute
-        font-size 9px
-        bottom -2px
-        right -3px
-        padding 0 0.3em
 
   .g-folder-list-container
   .g-item-list-container

--- a/girder/web_client/src/templates/body/collectionPage.pug
+++ b/girder/web_client/src/templates/body/collectionPage.pug
@@ -1,36 +1,36 @@
-.g-collection-header
+//- .g-collection-header
 
-  .btn-group.pull-right
-    button.g-collection-actions-button.btn.btn-default.dropdown-toggle(
-        data-toggle="dropdown", title="Collection actions")
-      i.icon-sitemap
-      |  Actions
-      i.icon-down-dir
-    ul.g-collection-actions-menu.dropdown-menu.pull-right(role="menu")
-      li(role="presentation")
-        a.g-download-collection(role="menuitem", href=collection.downloadUrl())
-          i.icon-download
-          | Download collection
-      if (collection.getAccessLevel() >= AccessType.WRITE)
-        li.divider(role="presentation")
-        li(role="presentation")
-          a.g-edit-collection(role="menuitem")
-            i.icon-edit
-            | Edit collection
-      if (collection.getAccessLevel() >= AccessType.ADMIN)
-        li.divider(role="presentation")
-        li(role="presentation")
-          a.g-collection-access-control(role="menuitem")
-            i.icon-lock
-            | Access control
-        li(role="presentation")
-          a.g-delete-collection(role="menuitem")
-            i.icon-trash
-            | Delete collection
+//-   .btn-group.pull-right
+//-     button.g-collection-actions-button.btn.btn-default.dropdown-toggle(
+//-         data-toggle="dropdown", title="Collection actions")
+//-       i.icon-sitemap
+//-       |  Actions
+//-       i.icon-down-dir
+//-     ul.g-collection-actions-menu.dropdown-menu.pull-right(role="menu")
+//-       li(role="presentation")
+//-         a.g-download-collection(role="menuitem", href=collection.downloadUrl())
+//-           i.icon-download
+//-           | Download collection
+//-       if (collection.getAccessLevel() >= AccessType.WRITE)
+//-         li.divider(role="presentation")
+//-         li(role="presentation")
+//-           a.g-edit-collection(role="menuitem")
+//-             i.icon-edit
+//-             | Edit collection
+//-       if (collection.getAccessLevel() >= AccessType.ADMIN)
+//-         li.divider(role="presentation")
+//-         li(role="presentation")
+//-           a.g-collection-access-control(role="menuitem")
+//-             i.icon-lock
+//-             | Access control
+//-         li(role="presentation")
+//-           a.g-delete-collection(role="menuitem")
+//-             i.icon-trash
+//-             | Delete collection
 
-  .g-collection-name.g-body-title= collection.name()
-  if collection.get('description')
-    .g-collection-description!= renderMarkdown(collection.get('description'))
-  .g-clear-right
+//-   .g-collection-name.g-body-title= collection.name()
+//-   if collection.get('description')
+//-     .g-collection-description!= renderMarkdown(collection.get('description'))
+//-   .g-clear-right
 
 .g-collection-hierarchy-container

--- a/girder/web_client/src/templates/body/frontPage.pug
+++ b/girder/web_client/src/templates/body/frontPage.pug
@@ -5,7 +5,7 @@
     .g-frontpage-title #{brandName}
     .g-frontpage-subtitle Data management platform
 
-.g-frontpage-body
+.g-frontpage-body.bg-white
   .g-frontpage-paragraph
     .g-frontpage-welcome-text-content
       b.g-frontpage-welcome-text Welcome to #{brandName}!

--- a/girder/web_client/src/templates/body/plugins.pug
+++ b/girder/web_client/src/templates/body/plugins.pug
@@ -1,5 +1,5 @@
 .g-body-title Plugins
-.g-plugin-list-container
+.g-plugin-list-container.bg-white
   each plugin in allPlugins
     - var experimental = plugin.value.version ? plugin.value.version.indexOf('0.') === 0 : true
     .g-plugin-list-item(data-name=plugin.key)

--- a/girder/web_client/src/templates/layout/layout.pug
+++ b/girder/web_client/src/templates/layout/layout.pug
@@ -1,7 +1,7 @@
 #g-app-header-container
 #g-global-nav-container
 #g-app-body-container.g-default-layout
-#g-app-footer-container
+#g-app-footer-container.text-sm
 
 #g-app-progress-container
 

--- a/girder/web_client/src/templates/layout/layoutHeader.pug
+++ b/girder/web_client/src/templates/layout/layoutHeader.pug
@@ -1,8 +1,20 @@
-.g-header-wrapper(style=`background-color: ${bannerColor}; color: ${textColor}`)
-  .g-app-title #{brandName}
+<div class="g-header-wrapper text-center h-shadow bg-white">
 
-  form.g-quick-search-form(role="form")
-    .form-group.g-quick-search-container
+  //- form.g-quick-search-form(role="form")
+  //-   .form-group.g-quick-search-container
 
-  .g-current-user-wrapper
-  .g-clear-both
+  <ul class="flex flex-wrap -mb-px h-full text-sm">
+    <li class="g-app-title text-primary"> #{brandName} </li>
+    - var tab = hash.startsWith('#collection') || hash.startsWith('#item') || hash.startsWith('#folder') ? 'explorer' : 'home';
+    - var activeClass = 'border-primary';
+    - var inactiveClass = 'border-transparent hover:border-gray-300';
+    <li class="h-full flex items-center border-b-2 #{tab == 'home' ? activeClass : inactiveClass}">
+      <a href="#" class="inline-block px-4">Home</a>
+    </li>
+    <li class="h-full flex items-center border-b-2 #{tab == 'explorer' ? activeClass : inactiveClass}">
+      <a href="/#collections" class="inline-block px-4 active" aria-current="page">Image Explorer</a>
+    </li>
+    <li class="g-current-user-wrapper ml-auto"></li>
+    <li class="g-clear-both"></li>
+  </ul>
+</div>

--- a/girder/web_client/src/templates/layout/layoutHeaderUser.pug
+++ b/girder/web_client/src/templates/layout/layoutHeaderUser.pug
@@ -1,9 +1,9 @@
-.g-user-text
+.g-user-text.h-full.flex.items-center 
   if user
     a.g-user-dropdown-link(data-toggle="dropdown", data-target="#g-user-action-menu")
       | #[i.icon-user] #{user.get('login')}
       i.icon-down-open
-    #g-user-action-menu.dropdown
+    #g-user-action-menu.dropdown.mt-8
       ul.dropdown-menu(role="menu")
         li(role="presentation")
           a.g-my-folders(href=`#user/${user.id}`)

--- a/girder/web_client/src/templates/widgets/checkedActionsMenu.pug
+++ b/girder/web_client/src/templates/widgets/checkedActionsMenu.pug
@@ -1,46 +1,48 @@
-li.g-checked-menu-header.dropdown-header(role="presentation")
+<a class="g-download-folder text-gray-700 block px-3 py-2 text-sm rounded-md">
   if folderCount
-    i.icon-folder
+    <i class="ri-folder-6-line text-base pr-2"></i>
     span.g-checked-folder-count #{folderCount}
   if itemCount
-    i.icon-doc-text-inv
+    <i class="ri-file-3-line text-base pr-2"></i>
     span.g-checked-item-count #{itemCount}
   if pickedCount
-    i.icon-plus-circled
+    <i class="ri-add-circle-line text-base pr-2"></i>
     span.g-checked-picked-count #{pickedCount}
+</a>
+
 if folderCount || itemCount
-  li
-    a.g-download-checked
-      i.icon-download
-      | Download checked resources
-  li
-    a.g-pick-checked
-      i.icon-plus-circled
-      | Pick checked resources for Move or Copy
+  <a class="g-download-checked text-gray-700 block px-3 py-2 text-sm hover:bg-zinc-100 rounded-md">
+    <i class="ri-download-line pr-2"></i>
+    | Download checked resources
+  </a>
+  <a class="g-pick-checked text-gray-700 block px-3 py-2 text-sm hover:bg-zinc-100 rounded-md">
+    <i class="ri-add-circle-line pr-2"></i>
+    | Pick checked resources for Move or Copy
+  </a>
 
 if HierarchyWidget.getPickedResources()
-  li.g-admin.divider
+  <div class="g-admin divider"></div>
   if pickedMoveAllowed
-    li
-      a.g-move-picked
-        i.icon-move
-        | Move picked resources here
+    <a class="g-move-picked text-gray-700 block px-3 py-2 text-sm hover:bg-zinc-100 rounded-md">
+      <i class="ri-folder-transfer-line pr-2"></i>
+      | Move picked resources here
+    </a>
   if pickedCopyAllowed
-    li
-      a.g-copy-picked
-        i.icon-paste
-        | Copy picked resources here
-  li
-    a.g-clear-picked
-      i.icon-minus-circled
-      | Clear picked resources
-      if pickedDesc
-        |  (#{pickedDesc})
+    <a class="g-copy-picked text-gray-700 block px-3 py-2 text-sm hover:bg-zinc-100 rounded-md">
+      <i class="ri-clipboard-line pr-2"></i>
+      | Copy picked resources here
+    </a>
+  <a class="g-clear-picked text-gray-700 block px-3 py-2 text-sm hover:bg-zinc-100 rounded-md">
+    <i class="ri-close-circle-line pr-2"></i>
+    | Clear picked resources
+    if pickedDesc
+      |  (#{pickedDesc})
+  </a>
 
 if folderCount || itemCount
   if (minFolderLevel >= AccessType.ADMIN && minItemLevel >= AccessType.WRITE)
-    li.g-admin.divider
-    li.g-admin
-      a.g-delete-checked
-        i.icon-trash
-        | Delete checked resources
+    <div class="g-admin divider"></div>
+    <a class="g-admin g-delete-checked text-gray-700 block px-3 py-2 text-sm hover:bg-zinc-100 rounded-md">
+      <i class="ri-delete-bin-line pr-2"></i>
+      | Delete checked resources
+    </a>

--- a/girder/web_client/src/templates/widgets/hierarchyBreadcrumb.pug
+++ b/girder/web_client/src/templates/widgets/hierarchyBreadcrumb.pug
@@ -1,37 +1,74 @@
-- var idx = 0
-each obj in links
-  li
-    a.g-breadcrumb-link(g-index=idx)
-      if obj.resourceName === 'user'
-        i.icon-user
-      else if obj.resourceName === 'collection'
-        i.icon-sitemap
-      = obj.name()
-  - idx += 1
+<!-- Path/Breadcrumbs -->
+<div class="flex flex-grow">
+  <div class="flex items-center p-1">
+      <div class="group relative">
+          if links.length > 0
+            <div class="absolute bg-zinc-800 bg-opacity-80 px-2 py-1 text-white left-1/2 -translate-x-1/2 bottom-full z-100 rounded-md mb-[2px] text-sm whitespace-nowrap htk-hidden group-hover:block">
+                | Go up one level
+            </div>
+            <button class="g-hierarchy-level-up htk-btn htk-btn-ghost htk-btn-secondary htk-btn-sm htk-btn-icon">
+                <i class="ri-corner-left-up-line text-base"></i>
+            </button>
+      </div>
+  </div>
 
-if current
-  li.active
-    if current.resourceName === 'user'
-      i.icon-user
-    else if current.resourceName === 'collection'
-      i.icon-sitemap
-    = current.name()
+  <ol class="flex items-center whitespace-nowrap h-full">
+    - var idx = 0
+    each obj in links
+      <li class="inline-flex items-center">
+        <a g-index="#{idx}" class="g-breadcrumb-link flex items-center text-sm px-[6px] text-zinc-600 hover:text-secondary focus:outline-none focus:text-secondary">
+          if obj.resourceName === 'user'
+            <i class="ri-user-fill text-zinc-400 mr-2"></i>
+          else if obj.resourceName === 'collection'
+            <i class="ri-database-fill text-zinc-400 mr-2"></i>
+          else if obj.resourceName === 'folder'
+            <i class="ri-folder-fill text-zinc-400 mr-2"></i>
+          = obj.name()
+        </a>
+        <i class="ri-arrow-right-s-line text-lg text-zinc-300"></i>
+      </li>
+      - idx += 1
 
-if descriptionText
-  a.g-description-preview= descriptionText
+    if current
+      <li class="inline-flex items-center">
+        <a g-index="#{idx}" class="flex items-center text-sm px-[6px] text-zinc-600 hover:text-secondary focus:outline-none focus:text-secondary">
+          if current.resourceName === 'user'
+            <i class="ri-user-fill text-zinc-400 mr-2"></i>
+          else if current.resourceName === 'collection'
+            <i class="ri-database-fill text-zinc-400 mr-2"></i>
+          else if current.resourceName === 'folder'
+            <i class="ri-folder-fill text-zinc-400 mr-2"></i>
+          = current.name()
+        </a>
+      </li>
 
-.pull-right
-  .g-child-count-container.hide
-    .g-subfolder-count-container(title='total folders')
-      i.icon-folder
-      .g-subfolder-count
+      if current.resourceName === 'folder' || current.resourceName === 'collection'
+        <li class="g-description-preview inline-flex items-center">
+            <div class="group relative">
+                <div class="absolute bg-zinc-800 bg-opacity-80 px-2 py-1 text-white left-1/2 -translate-x-1/2 bottom-full z-100 rounded-md mb-[2px] text-sm whitespace-nowrap htk-hidden group-hover:block">
+                    | Show info
+                </div>
+                <button class="rounded-full hover:bg-zinc-200 px-1 text-zinc-500 hover:text-zinc-700">
+                    <div class="ri-information-line"></div>
+                </button>
+            </div>
+        </li>
+    </ol>
+</div>
 
-    if idx > 0
-      .g-item-count-container(title='total items')
-        i.icon-doc-text-inv
-        .g-item-count
-
-  if idx > 0
-    .g-level-up-button-container
-      a.g-hierarchy-level-up(title="Go up one level")
-        i.icon-level-up
+<!-- Current Directory Information -->
+<ul class="flex items-center">
+    <li class="flex items-baseline text-sm px-3 py-1">
+        <i class="ri-folder-6-line text-base mr-1"></i>
+        <span>
+            <span class="g-subfolder-count"></span> <span class="text-xs text-zinc-400">folder(s)</span>
+        </span>
+    </li>
+    if current.resourceName === 'folder'
+      <li class="flex items-baseline text-sm px-3 py-1">
+          <i class="ri-file-3-line text-base mr-1"></i>
+          <span>
+              <span class="g-item-count"></span> <span class="text-xs text-zinc-400">item(s)</span>
+          </span>
+      </li>
+</ul>

--- a/girder/web_client/src/templates/widgets/hierarchyWidget.pug
+++ b/girder/web_client/src/templates/widgets/hierarchyWidget.pug
@@ -1,88 +1,102 @@
-.g-hierarchy-widget
-  .g-hierarchy-breadcrumb-bar
-    ol.breadcrumb
-  if showActions
-    .g-hierarchy-actions-header
-      if checkboxes
-        input.g-select-all(type="checkbox", title="Select / Unselect all")
+<div class="g-hierarchy-widget">
+  <div class="mb-3">
+    <div class="g-hierarchy-breadcrumb-bar flex bg-zinc-100 border border-b-0 border-zinc-300 rounded-t-lg min-h-10"></div>
+    if showActions
+      .g-hierarchy-actions-header
+        <div class="flex border border-zinc-300 bg-zinc-200 rounded-b-lg min-h-10">
+          <!-- Inputs -->
+          <div class="flex flex-grow items-center p-1 space-x-1">
+            if checkboxes
+              input.g-select-all(type="checkbox", style="margin: 0 !important", title="Select / Unselect all")
+              <div class="g-checked-actions group relative inline-block text-left">
+                  <div class="absolute bg-zinc-800 bg-opacity-80 px-2 py-1 text-white left-1/2 -translate-x-1/2 bottom-full rounded-md mb-[2px] text-sm whitespace-nowrap htk-hidden group-hover:block">
+                      | Checked actions
+                  </div>
+                  <div class="group relative inline-block text-left">
+                    <button class="g-checked-actions-button dropdown-toggle hover:bg-zinc-300 px-2 py-1 rounded-md tracking-tighter text-lg flex items-center focus:outline-none" data-toggle="dropdown" disabled aria-haspopup="true" aria-expanded="true">
+                      <i class="ri-arrow-down-s-line text-base text-zinc-400 group-hover:text-zinc-600"></i>
+                    </button>
+                    <div class="g-checked-actions-menu dropdown-menu pull-left htk-hidden p-1 bg-white absolute mt-2 min-w-80 right-0 rounded-lg shadow-lg ring-1 ring-black ring-opacity-5 z-10"></div>
+                  </div>
+              </div>
+          </div>
 
-        .btn-group
-          button.g-checked-actions-button.btn.btn-sm.btn-default.dropdown-toggle(
-            data-toggle="dropdown", disabled="disabled", title="Checked actions")
-            i.icon-check
-            i.icon-down-dir
-          ul.g-checked-actions-menu.dropdown-menu(role="menu")
+          <div class="g-folder-header-buttons flex items-center p-1 space-x-1">
+            if (type === 'folder')
+              if (level >= AccessType.WRITE)
+                <div class="group relative">
+                  <div class="absolute bg-zinc-800 bg-opacity-80 px-2 py-1 text-white left-1/2 -translate-x-1/2 bottom-full rounded-md mb-[2px] text-sm whitespace-nowrap htk-hidden group-hover:block">
+                    | Upload here
+                  </div>
+                  <button class="g-upload-here-button hover:bg-zinc-300 px-2 py-1 rounded-md tracking-wider uppercase text-lg">
+                    <i class="ri-upload-line"></i>
+                  </button>
+                </div>
+              if (level >= AccessType.ADMIN)
+                <div class="group relative">
+                  <div class="absolute bg-zinc-800 bg-opacity-80 px-2 py-1 text-white left-1/2 -translate-x-1/2 bottom-full rounded-md mb-[2px] text-sm whitespace-nowrap htk-hidden group-hover:block">
+                    | Access control
+                  </div>
+                  <button class="g-edit-access hover:bg-zinc-300 px-2 py-1 rounded-md tracking-wider uppercase text-lg">
+                    <i class="ri-lock-line"></i>
+                  </button>
+                </div>
+            else if (type === 'collection')
+              if (level >= AccessType.ADMIN)
+                <div class="group relative">
+                  <div class="absolute bg-zinc-800 bg-opacity-80 px-2 py-1 text-white left-1/2 -translate-x-1/2 bottom-full rounded-md mb-[2px] text-sm whitespace-nowrap htk-hidden group-hover:block">
+                    | Access control
+                  </div>
+                  <button class="g-edit-access hover:bg-zinc-300 px-2 py-1 rounded-md tracking-wider uppercase text-lg">
+                    <i class="ri-lock-line"></i>
+                  </button>
+                </div>
 
-      .g-folder-header-buttons
-        if (type === 'folder')
-          button.g-folder-info-button.btn.btn-sm.btn-info(title="Show folder info")
-            i.icon-info
-          if (level >= AccessType.WRITE)
-            button.g-upload-here-button.btn.btn-sm.btn-success(title="Upload here")
-              i.icon-upload
-          if (level >= AccessType.ADMIN)
-            button.g-folder-access-button.g-edit-access.btn.btn-sm.btn-warning(title="Access control")
-              i.icon-lock
-        else if (type === 'collection')
-          button.g-collection-info-button.btn.btn-sm.btn-info(title="Show collection info")
-            i.icon-info
-          if (level >= AccessType.ADMIN)
-            button.g-edit-access.btn.btn-sm.btn-warning(title="Access control")
-              i.icon-lock
-        .btn-group
-          button.g-folder-actions-button.btn.btn-sm.btn-default.dropdown-toggle(
-              data-toggle="dropdown", title=`${capitalize(type)} actions`)
-            if type === 'collection'
-              i.icon-sitemap
-            else if type === 'user'
-              i.icon-user
-            else if type === 'folder'
-              i.icon-folder-open
-            i.icon-down-dir
-          ul.g-folder-actions-menu.dropdown-menu.pull-right(role="menu")
-            li.dropdown-header(role="presentation")
-              if type === 'collection'
-                i.icon-sitemap
-              else if type === 'user'
-                i.icon-user
-              else if type === 'folder'
-                i.icon-folder-open
-              |  #{model.name()}
-            if type === 'folder' || type === 'collection'
-              li(role="presentation")
-                a.g-download-folder(role="menuitem", href=model.downloadUrl())
-                  i.icon-download
-                  | Download #{type}
-            if level >= AccessType.WRITE
-              li(role="presentation")
-                a.g-create-subfolder(role="menuitem")
-                  i.icon-folder
-                  | Create folder here
-              if type === 'folder' || type === 'collection'
-                if type === 'folder'
-                  li(role="presentation")
-                    a.g-create-item(role="menuitem")
-                      i.icon-doc
-                      | Create item here
-                li(role="presentation")
-                  a.g-edit-folder(role="menuitem")
-                    i.icon-edit
-                    | Edit #{type}
-            if level >= AccessType.ADMIN && (type === 'folder' || type === 'collection')
-              li.divider(role="presentation")
-              li(role="presentation")
-                a.g-delete-folder(role="menuitem")
-                  i.icon-trash
-                  | Delete this #{type}
-      .g-clear-right
-  if onFolderSelect
-    .g-select-folder-container
-      ul.g-folder-list
-        li.g-folder-list-entry(public='true')
-          button.g-select-folder.btn.btn-sm.btn-info
-            i.icon-folder
-            |  Select this #{type}.
-            i.icon-right-dir
+            <div class="group relative inline-block text-left">
+              <button class="g-folder-actions-button dropdown-toggle hover:bg-zinc-300 px-2 py-1 rounded-md tracking-tighter uppercase text-lg flex items-center focus:outline-none" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <i class="ri-menu-line"></i>
+              </button>
+              <div class=".g-folder-actions-menu dropdown-menu pull-right htk-hidden p-1 bg-white absolute mt-2 min-w-48 right-0 rounded-lg shadow-lg ring-1 ring-black ring-opacity-5 z-10">
+                if type === 'folder' || type === 'collection'
+                  <a class="g-download-folder text-gray-700 block px-3 py-2 text-sm hover:bg-zinc-100 rounded-md" href="#{model.downloadUrl()}">
+                    <i class="ri-download-line pr-2"></i>
+                    | Download #{type}
+                  </a>
+                if level >= AccessType.WRITE
+                  <a class="g-create-subfolder text-gray-700 block px-3 py-2 text-sm hover:bg-zinc-100 rounded-md">
+                    <i class="ri-folder-add-line pr-2"></i>
+                    | Create folder here
+                  </a>
+                  if type === 'folder' || type === 'collection'
+                    if type === 'folder'
+                      <a class="g-create-item text-gray-700 block px-3 py-2 text-sm hover:bg-zinc-100 rounded-md">
+                        <i class="ri-file-add-line pr-2"></i>
+                        | Create item here
+                      </a>
+                    <a class="g-edit-folder text-gray-700 block px-3 py-2 text-sm hover:bg-zinc-100 rounded-md">
+                      <i class="ri-pencil-line pr-2"></i>
+                      | Edit #{type}
+                    </a>
+                if level >= AccessType.ADMIN && (type === 'folder' || type === 'collection')
+                  <a class="g-delete-folder text-gray-700 block px-3 py-2 text-sm hover:bg-zinc-100 rounded-md">
+                    <i class="ri-delete-bin-line pr-2"></i>
+                    | Delete this #{type}
+                  </a>
+              </div>
+            </div>
+          </div>
+        </div>
+
+    if onFolderSelect
+      .g-select-folder-container
+        ul.g-folder-list
+          li.g-folder-list-entry(public='true')
+            button.g-select-folder.btn.btn-sm.btn-info
+              i.icon-folder
+              |  Select this #{type}.
+              i.icon-right-dir
+  </div>
+
   .g-folder-list-container
   .g-item-list-container
   .g-empty-parent-message.g-info-message-container.hide
@@ -92,5 +106,7 @@
     else
       |  This folder is empty.
   .g-hierarachy-paginated-bar
+</div>
+
 if showMetadata
   .g-folder-metadata

--- a/girder/web_client/src/views/App.js
+++ b/girder/web_client/src/views/App.js
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import _ from 'underscore';
 import Backbone from 'backbone';
 import 'typeface-open-sans';
+import 'remixicon/fonts/remixicon.css';
 import 'bootstrap/dist/css/bootstrap.css';
 import 'bootstrap/js/alert';
 import '@girder/fontello/dist/css/animation.css';
@@ -188,7 +189,11 @@ var App = View.extend({
         }
         this.$el.html(LayoutTemplate());
 
-        this.globalNavView.setElement(this.$('#g-global-nav-container')).render();
+        // Only show side navigation if logged in as an admin
+        if (getCurrentUser() && getCurrentUser().get('admin')) {
+            this.globalNavView.setElement(this.$('#g-global-nav-container')).render();
+        }
+
         this.headerView.setElement(this.$('#g-app-header-container')).render();
         this.footerView.setElement(this.$('#g-app-footer-container')).render();
         this.progressListView.setElement(this.$('#g-app-progress-container')).render();
@@ -204,6 +209,9 @@ var App = View.extend({
      */
     navigateTo: function (view, settings, opts) {
         this.globalNavView.deactivateAll();
+
+        // Header changes based on navigation
+        this.headerView.render();
 
         settings = settings || {};
         opts = opts || {};
@@ -346,6 +354,9 @@ var App = View.extend({
         var route = splitRoute(Backbone.history.fragment).base;
         Backbone.history.fragment = null;
         eventStream.close();
+
+        // May need to show or hide side nav based on user
+        this.render();
 
         if (getCurrentUser()) {
             eventStream.open();

--- a/girder/web_client/src/views/layout/GlobalNavView.js
+++ b/girder/web_client/src/views/layout/GlobalNavView.js
@@ -52,27 +52,22 @@ var LayoutGlobalNavView = View.extend({
     },
 
     render: function () {
-        var navItems;
+        var navItems = [];
         if (this.navItems) {
             navItems = this.navItems;
-        } else {
-            navItems = this.defaultNavItems;
-            if (getCurrentUser()) {
-                // copy navItems so that this.defaultNavItems is unchanged
-                navItems = navItems.slice();
-                navItems.push({
-                    name: 'Users',
-                    icon: 'icon-user',
-                    target: 'users'
-                });
-                if (getCurrentUser().get('admin')) {
-                    navItems.push({
-                        name: 'Admin console',
-                        icon: 'icon-wrench',
-                        target: 'admin'
-                    });
-                }
-            }
+        } else if (getCurrentUser() && getCurrentUser().get('admin')) {
+            // copy navItems so that this.defaultNavItems is unchanged
+            navItems = this.defaultNavItems.slice();
+            navItems.push({
+                name: 'Users',
+                icon: 'icon-user',
+                target: 'users'
+            });
+            navItems.push({
+                name: 'Admin console',
+                icon: 'icon-wrench',
+                target: 'admin'
+            });
         }
         this.$el.html(LayoutGlobalNavTemplate({
             navItems: navItems

--- a/girder/web_client/src/views/layout/HeaderView.js
+++ b/girder/web_client/src/views/layout/HeaderView.js
@@ -48,7 +48,7 @@ var LayoutHeaderView = View.extend({
         this.$el.html(LayoutHeaderTemplate({
             brandName: this.brandName,
             bannerColor: this.bannerColor,
-            textColor: textColor
+            hash: Backbone.history.location.hash,
         }));
         this.userView.setElement(this.$('.g-current-user-wrapper')).render();
         if (textColor !== '#ffffff') {

--- a/girder/web_client/src/views/widgets/HierarchyWidget.js
+++ b/girder/web_client/src/views/widgets/HierarchyWidget.js
@@ -288,10 +288,10 @@ var HierarchyWidget = View.extend({
                     this.$('.g-hierarachy-paginated-bar').addClass('g-hierarchy-sticky');
                     this.$('.g-hierarchy-breadcrumb-bar').css({ top: 0 });
                     this.$('.g-hierarachy-paginated-bar').css({ bottom: 0 });
-                    this.$('.g-hierarachy-paginated-bar').removeClass('hidden');
+                    this.$('.g-hierarachy-paginated-bar').removeClass('htk-hidden');
                 } else {
                     // We remove the bar if the current folder doesn't have more than one page, keep the sticky breadcrumb though
-                    this.$('.g-hierarachy-paginated-bar').addClass('hidden');
+                    this.$('.g-hierarachy-paginated-bar').addClass('htk-hidden');
                 }
             });
             // Only emitted when there is more than one page of data
@@ -351,12 +351,12 @@ var HierarchyWidget = View.extend({
             itemFilter: this._itemFilter
         }));
 
-        if (this.$('.g-folder-actions-menu>li>a').length === 0) {
-            // Disable the actions button if actions list is empty
-            this.$('.g-folder-actions-button').girderEnable(false);
-        }
+        // if (this.$('.g-folder-actions-menu>a').length === 0) {
+        //     // Disable the actions button if actions list is empty
+        //     this.$('.g-folder-actions-button').girderEnable(false);
+        // }
 
-        this.breadcrumbView.setElement(this.$('.g-hierarchy-breadcrumb-bar>ol')).render();
+        this.breadcrumbView.setElement(this.$('.g-hierarchy-breadcrumb-bar')).render();
         this.checkedMenuWidget.dropdownToggle = this.$('.g-checked-actions-button');
         this.checkedMenuWidget.setElement(this.$('.g-checked-actions-menu')).render();
         this.folderListView.setElement(this.$('.g-folder-list-container')).render();


### PR DESCRIPTION
Adds tailwind and does some restyling of the core app.

Also enables a `extras` directory which can host custom files and includes `extras.css` (initially empty) which can be replaced with custom CSS at deployment time.

Known issues:
* Quick search is currently not there but I would like to have that integrated back
* Not tested against arbitrary plugins, is intended to work mainly with `large_image` and `histomicsui` plugins at the current time

This branch will be substantially upgraded for Girder 5 and is only being proposed to be merged to an experimental integration branch in Girder 3.

