### PR TITLE
The girder server mode could only be specified from the command line

### DIFF
--- a/girder/utility/server.py
+++ b/girder/utility/server.py
@@ -67,7 +67,7 @@ def configureServer(mode=None, plugins=None, curConfig=None):
         curConfig['server']['mode'] = mode
 
     logprint.info('Running in mode: ' + curConfig['server']['mode'])
-    cherrypy.config['engine.autoreload.on'] = mode == ServerMode.DEVELOPMENT
+    cherrypy.config['engine.autoreload.on'] = curConfig['server']['mode'] == ServerMode.DEVELOPMENT
 
     _setupCache()
 


### PR DESCRIPTION
The mode in the environment variables or in girder.cfg was ignored, though it was the value reported in the log if there was no command line value.