### PR TITLE
Remove references to "Resonant"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,9 +3,8 @@
 
 **Data Management Platform**
 
-Girder is a free and open source web-based data management platform developed by
-`Kitware <https://kitware.com>`_ as part of the `Resonant <http://resonant.kitware.com>`_
-data and analytics ecosystem.
+Girder is a free and open source web-based data management platform, developed by
+`Kitware <https://kitware.com>`_.
 
 |kitware-logo|
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,9 +27,8 @@ Girder: a data management platform
 What is Girder?
 ---------------
 
-Girder is a free and open source web-based **data management platform** developed by
-`Kitware <http://www.kitware.com/>`_ as part of the
-`Resonant data and analytics ecosystem <http://resonant.kitware.com/>`_. What does
+Girder is a free and open source web-based **data management platform**, developed by
+`Kitware <http://www.kitware.com/>`_. What does
 that mean? Girder is both a standalone application and a platform for building new web
 services. It's meant to enable quick and easy construction of web applications
 that have some or all of the following requirements:

--- a/girder/web_client/src/templates/body/frontPage.pug
+++ b/girder/web_client/src/templates/body/frontPage.pug
@@ -52,18 +52,17 @@
           | Girder is
         else
           | #{brandName} is powered by Girder,
-        |  a part of
-        a(target="_blank", href="http://resonant.kitware.com")  Resonant
-        | , Kitware's open-source platform for data management, analytics, and
-        | visualization. To learn more, you can read our series of
-        a(target="_blank", href="https://blog.kitware.com/tag/resonant/")  blog posts
-        |  about Resonant, or
+        | Kitware's open-source platform for data management, analytics, and
+        | visualization. To learn more about how Kitware and Girder can help to solve your
+        | data challenges, read our series of
+        a(target="_blank", href="https://blog.kitware.com/tag/girder/")  blog posts
+        | or
         a(target="_blank", href="http://www.kitware.com/contact-us")  contact us
-        |  to learn how we can help you solve your data problems.
+        | directly.
 
         ul
           li
-            | To learn more about Girder, including how you can host your own
+            | To learn more about Girder's software, including how you can host your own
             | instance either locally or in the cloud, see the
             a(target="_blank", href="http://girder.readthedocs.io/en/latest/user-guide.html")  User Guide
             | , the


### PR DESCRIPTION
Resonant has become a distinct product. Any benefits of cross-marketing are outweighed by the likelihood of ongoing confusion for consumers, especially given the historical usage of "Resonant" to refer to direct parts of the Girder stack.