### PR TITLE
Pin setuptools-scm version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     name='girder',
     use_scm_version={'local_scheme': prerelease_local_scheme},
     setup_requires=[
-        'setuptools-scm',
+        'setuptools-scm<8.1.0',
     ],
     description='Web-based data management platform',
     long_description=readme,


### PR DESCRIPTION
The latest release breaks if a pyproject.toml file isn't present.

At some point we should support the new behavior instead of the current way, but that's out of scope of v4-integration.