### PR TITLE
Harden S3 imports.

### DIFF
--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -468,6 +468,14 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
                     progress.update(message=obj['Prefix'])
 
                 name = obj['Prefix'].rstrip('/').rsplit('/', 1)[-1]
+                # If there is already an item with the folder's name, append
+                # '/'.  This is what S3 does internally, allowing a folder and
+                # file to have the same name once stripped of the right /.
+                if parentType == 'folder' and Item().findOne({
+                    'folderId': parent['_id'],
+                    'name': self.safeName(name),
+                }):
+                    name = name + '/'
                 folder = Folder().createFolder(
                     parent=parent, name=self.safeName(name),
                     parentType=parentType, creator=user, reuseExisting=True)

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -469,8 +469,8 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
 
                 name = obj['Prefix'].rstrip('/').rsplit('/', 1)[-1]
                 # If there is already an item with the folder's name, append
-                # '/'.  This is what S3 does internally, allowing a folder and
-                # file to have the same name once stripped of the right /.
+                # '/'.  This is how S3 presents the names, allowing a folder
+                # and file to have the same name once stripped of the right /.
                 if parentType == 'folder' and Item().findOne({
                     'folderId': parent['_id'],
                     'name': self.safeName(name),

--- a/tox.ini
+++ b/tox.ini
@@ -169,6 +169,8 @@ ignore =
     N818,
     # W503 - Line break occurred before a binary operator
     W503,
+    # B041 - Duplicate key-values in a dictionary
+    B041,
 
 [pytest]
 addopts = --verbose --strict --showlocals


### PR DESCRIPTION
S3 buckets can have folders and items with the same name.  We want to reuse existing folders so when we import a second time we don't duplicate data.  In an item already exists with the name of the folder, append a / (this is what S3 does internally) and use that as a name.