### PR TITLE
Satisfy bugbear B041 linting rule

### DIFF
--- a/plugins/user_quota/plugin_tests/user_quota_test.py
+++ b/plugins/user_quota/plugin_tests/user_quota_test.py
@@ -445,8 +445,10 @@ class QuotaTestCase(base.TestCase):
         self._setPolicy({'fileSizeQuota': None},
                         'user', self.user, self.admin)
         # useDefaultQuota can be True, False, None, yes, no, 0, 1.
-        valdict = {None: True, True: True, 'true': True, 1: True, 'True': True,
-                   False: False, 'false': False, 0: False, 'False': False}
+        # 0 and 1 are included because True and False as keys map to 0 and 1
+        # directly
+        valdict = {None: True, True: True, 'true': True, 'True': True,
+                   False: False, 'false': False, 'False': False}
         for val in valdict:
             self._setPolicy({'useQuotaDefault': val},
                             'user', self.user, self.admin,

--- a/tox.ini
+++ b/tox.ini
@@ -169,8 +169,6 @@ ignore =
     N818,
     # W503 - Line break occurred before a binary operator
     W503,
-    # B041 - Duplicate key-values in a dictionary
-    B041,
 
 [pytest]
 addopts = --verbose --strict --showlocals


### PR DESCRIPTION
In python a dictionary can't have both a True and 1 key or a False and 0 key.  The constructed dictionary for mapping truthy and falsy values had {True: True, 1: True, False: False, 0: False, ...}, but this is the same as just specifying the first of these {True: True, False: False, ...}.