### PR TITLE
Minor UI fixes

### DIFF
--- a/girder/web_client/src/templates/widgets/hierarchyBreadcrumb.pug
+++ b/girder/web_client/src/templates/widgets/hierarchyBreadcrumb.pug
@@ -2,13 +2,12 @@
 <div class="flex flex-grow">
   <div class="flex items-center p-1">
     <div class="group relative">
-      if links.length > 0
-        <div class="absolute bg-zinc-800 bg-opacity-80 px-2 py-1 text-white left-1/2 -translate-x-1/2 bottom-full z-100 rounded-md mb-[2px] text-sm whitespace-nowrap htk-hidden group-hover:block">
-          | Go up one level
-        </div>
-        <button class="g-hierarchy-level-up htk-btn htk-btn-ghost htk-btn-secondary htk-btn-sm htk-btn-icon">
-          <i class="ri-corner-left-up-line text-base"></i>
-        </button>
+      <div class="absolute bg-zinc-800 bg-opacity-80 px-2 py-1 text-white left-1/2 -translate-x-1/2 bottom-full z-100 rounded-md mb-[2px] text-sm whitespace-nowrap htk-hidden group-hover:block">
+        | Go up one level
+      </div>
+      <button class="g-hierarchy-level-up htk-btn htk-btn-ghost htk-btn-secondary htk-btn-sm htk-btn-icon">
+        <i class="ri-corner-left-up-line text-base"></i>
+      </button>
     </div>
   </div>
 

--- a/girder/web_client/src/templates/widgets/searchField.pug
+++ b/girder/web_client/src/templates/widgets/searchField.pug
@@ -6,5 +6,5 @@
   .g-search-results.dropdown
     ul.dropdown-menu(role="menu")
   if modes.length > 1
-    a.g-search-mode-choose.btn.btn-sm(title="Search mode")
+    a.g-search-mode-choose.btn.btn-sm(title="Search mode" data-trigger="focus" tabindex="0")
       i.icon-down-dir

--- a/girder/web_client/src/views/widgets/HierarchyWidget.js
+++ b/girder/web_client/src/views/widgets/HierarchyWidget.js
@@ -416,6 +416,14 @@ var HierarchyWidget = View.extend({
      */
     upOneLevel: function () {
         this.breadcrumbs.pop();
+        if (this.breadcrumbs.length === 0) {
+            if (this.parentModel.resourceName === 'collection') {
+                router.navigate('collections', { trigger: true });
+            } else if (this.parentModel.resourceName === 'user') {
+                router.navigate('users', { trigger: true });
+            }
+            return;
+        }
         this.setCurrentModel(this.breadcrumbs[this.breadcrumbs.length - 1]);
     },
 

--- a/girder/web_client/src/views/widgets/SearchFieldWidget.js
+++ b/girder/web_client/src/views/widgets/SearchFieldWidget.js
@@ -181,7 +181,7 @@ var SearchFieldWidget = View.extend({
         });
 
         this.$('.g-search-mode-choose').popover({
-            trigger: 'manual',
+            trigger: 'focus',
             viewport: {
                 selector: 'body',
                 padding: 10


### PR DESCRIPTION
Handles two pieces of feedback

> User is able to select two Search (Quick Search and Search Collections) at same time. But however, user performs search which is displayed in front. (item 3)

> Whenever User selects any collections from the available list or whenever a search is performed, User is not able to go back to the main collections list by using any breadcrumbs link. Instead, User needs to click on either “Collections” or “Image Explorer” to see the list again. (item 5)