### PR TITLE
Fix relative import path in girder worker

### DIFF
--- a/worker/girder_worker/utils/__init__.py
+++ b/worker/girder_worker/utils/__init__.py
@@ -83,9 +83,9 @@ def _worker_inspector(task):
     if _inspector is None:
         try:
             # Celery >= 5
-            from .app import app
+            from ..app import app
             inspect = app.control.inspect
-        except Exception:
+        except AttributeError:
             # Celecy < 5
             from celery.app.control import Inspect as inspect  # noqa: N813
         _inspector = inspect([task.request.hostname])


### PR DESCRIPTION
While testing `v4-integration` branch I noticed that successful celery tasks do not set a corresponding job status to `SUCCESS`. It turns out this bare exception, which is probably meant to catch things like missing attribute, swallows:

```
[2024-11-18 19:26:57,087: ERROR/ForkPoolWorker-1] Signal handler <function gw_task_success at 0x7f92f37adc60> raised: ModuleNotFoundError("No module named 'girder_worker.utils.app'")
Traceback (most recent call last):
  File "/home/ubuntu/venv/lib/python3.12/site-packages/celery/utils/dispatch/signal.py", line 276, in send
    response = receiver(signal=self, sender=sender, **named)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/venv/lib/python3.12/site-packages/girder_worker/app.py", line 158, in gw_task_success
    if not is_revoked(sender):
           ^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/venv/lib/python3.12/site-packages/girder_worker/utils/__init__.py", line 159, in is_revoked
    return task.request.id in _revoked_tasks(task)
                              ^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/venv/lib/python3.12/site-packages/girder_worker/utils/__init__.py", line 100, in _revoked_tasks
    _revoked = _worker_inspector(task).revoked()
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/venv/lib/python3.12/site-packages/girder_worker/utils/__init__.py", line 87, in _worker_inspector
    from .app import app
ModuleNotFoundError: No module named 'girder_worker.utils.app'
```