### PR TITLE
Fix scrolling on login

### DIFF
--- a/girder/web_client/src/views/App.js
+++ b/girder/web_client/src/views/App.js
@@ -351,9 +351,6 @@ var App = View.extend({
         Backbone.history.fragment = null;
         eventStream.close();
 
-        // May need to show or hide side nav based on user
-        this.render();
-
         if (getCurrentUser()) {
             eventStream.open();
             router.navigate(route, { trigger: true });


### PR DESCRIPTION
There was code to rerender the app on login which clobbered the modal state, leaving behind CSS that made the background unscrollable. Now that we are not changing sidebar logic on this branch, that re-render is no longer needed.