### PR TITLE
Add a show-download setting that defaults to all

### DIFF
--- a/girder/settings.py
+++ b/girder/settings.py
@@ -26,6 +26,7 @@ class SettingKey:
     CORS_ALLOW_METHODS = 'core.cors.allow_methods'
     CORS_ALLOW_ORIGIN = 'core.cors.allow_origin'
     CORS_EXPOSE_HEADERS = 'core.cors.expose_headers'
+    DOWNLOAD_SHOWN = 'core.download_shown'
     EMAIL_FROM_ADDRESS = 'core.email_from_address'
     EMAIL_HOST = 'core.email_host'
     EMAIL_VERIFICATION = 'core.email_verification'
@@ -73,6 +74,7 @@ class SettingDefault:
         SettingKey.CORS_ALLOW_METHODS: 'GET, POST, PUT, HEAD, DELETE',
         SettingKey.CORS_ALLOW_ORIGIN: '',
         SettingKey.CORS_EXPOSE_HEADERS: 'Girder-Total-Count, Content-Disposition',
+        SettingKey.DOWNLOAD_SHOWN: 'all',
         # An apache server using reverse proxy would also need
         #  X-Requested-With, X-Forwarded-Server, X-Forwarded-For,
         #  X-Forwarded-Host, Remote-Addr
@@ -228,6 +230,14 @@ class SettingValidator:
     def _validateCorsExposeHeaders(doc):
         if not isinstance(doc['value'], str):
             raise ValidationException('CORS exposed headers must be a string', 'value')
+
+    @staticmethod
+    @setting_utilities.validator(SettingKey.DOWNLOAD_SHOWN)
+    def _validateDownloadShown(doc):
+        doc['value'] = doc['value'].lower()
+        if doc['value'] not in ('all', 'user', 'admin', 'none'):
+            raise ValidationException(
+                'Download shown be "all", "user", "admin", or "nonde".', 'value')
 
     @staticmethod
     @setting_utilities.validator(SettingKey.EMAIL_FROM_ADDRESS)

--- a/girder/utility/webroot.mako
+++ b/girder/utility/webroot.mako
@@ -249,7 +249,8 @@
                 brandName: '${brandName | js}',
                 bannerColor: '${bannerColor | js}',
                 registrationPolicy: '${registrationPolicy | js}',
-                enablePasswordLogin: ${enablePasswordLogin | n,json,js}
+                enablePasswordLogin: ${enablePasswordLogin | n,json,js},
+                downloadShown: '${downloadShown | js}'
             }).render();
             girder.events.trigger('g:appload.after', girder.app);
         });

--- a/girder/utility/webroot.py
+++ b/girder/utility/webroot.py
@@ -122,5 +122,6 @@ class Webroot(WebrootBase):
         self.vars['bannerColor'] = Setting().get(SettingKey.BANNER_COLOR)
         self.vars['registrationPolicy'] = Setting().get(SettingKey.REGISTRATION_POLICY)
         self.vars['enablePasswordLogin'] = Setting().get(SettingKey.ENABLE_PASSWORD_LOGIN)
+        self.vars['downloadShown'] = Setting().get(SettingKey.DOWNLOAD_SHOWN)
 
         return super()._renderHTML()

--- a/girder/web_client/src/templates/body/collectionPage.pug
+++ b/girder/web_client/src/templates/body/collectionPage.pug
@@ -7,10 +7,11 @@
 //-       |  Actions
 //-       i.icon-down-dir
 //-     ul.g-collection-actions-menu.dropdown-menu.pull-right(role="menu")
-//-       li(role="presentation")
-//-         a.g-download-collection(role="menuitem", href=collection.downloadUrl())
-//-           i.icon-download
-//-           | Download collection
+//-       if (showDownload)
+//-         li(role="presentation")
+//-           a.g-download-collection(role="menuitem", href=collection.downloadUrl())
+//-             i.icon-download
+//-             | Download collection
 //-       if (collection.getAccessLevel() >= AccessType.WRITE)
 //-         li.divider(role="presentation")
 //-         li(role="presentation")
@@ -27,7 +28,6 @@
 //-           a.g-delete-collection(role="menuitem")
 //-             i.icon-trash
 //-             | Delete collection
-
 //-   .g-collection-name.g-body-title= collection.name()
 //-   if collection.get('description')
 //-     .g-collection-description!= renderMarkdown(collection.get('description'))

--- a/girder/web_client/src/templates/body/itemPage.pug
+++ b/girder/web_client/src/templates/body/itemPage.pug
@@ -5,28 +5,30 @@
     if (accessLevel >= AccessType.WRITE)
       button.g-upload-into-item.btn.btn-sm.btn-success(title="Upload files into item")
         i.icon-upload
-    .btn-group
-      button.g-item-actions-button.btn.btn-sm.btn-default.dropdown-toggle(
-          data-toggle="dropdown", title="Item actions")
-        i.icon-doc-text-inv
-        |  Actions
-        i.icon-down-dir
-      ul.g-item-actions-menu.dropdown-menu.pull-right(role="menu")
-        li(role="presentation")
-          a.g-download-item(role="menuitem", href=item.downloadUrl())
-            i.icon-download
-            | Download item
-        if (accessLevel >= AccessType.WRITE)
-          li.divider(role="presentation")
-          li(role="presentation")
-            a.g-edit-item(role="menuitem")
-              i.icon-edit
-              | Edit item
-          li.divider(role="presentation")
-          li(role="presentation")
-            a.g-delete-item(role="menuitem")
-              i.icon-trash
-              | Delete item
+    if showDownload || accessLevel >= AccessType.WRITE
+      .btn-group
+        button.g-item-actions-button.btn.btn-sm.btn-default.dropdown-toggle(
+            data-toggle="dropdown", title="Item actions")
+          i.icon-doc-text-inv
+          |  Actions
+          i.icon-down-dir
+        ul.g-item-actions-menu.dropdown-menu.pull-right(role="menu")
+          if (showDownload)
+            li(role="presentation")
+              a.g-download-item(role="menuitem", href=item.downloadUrl())
+                i.icon-download
+                | Download item
+          if (accessLevel >= AccessType.WRITE)
+            li.divider(role="presentation")
+            li(role="presentation")
+              a.g-edit-item(role="menuitem")
+                i.icon-edit
+                | Edit item
+            li.divider(role="presentation")
+            li(role="presentation")
+              a.g-delete-item(role="menuitem")
+                i.icon-trash
+                | Delete item
 
   .g-item-name.g-body-title= item.name()
 

--- a/girder/web_client/src/templates/widgets/checkedActionsMenu.pug
+++ b/girder/web_client/src/templates/widgets/checkedActionsMenu.pug
@@ -11,10 +11,11 @@
 </a>
 
 if folderCount || itemCount
-  <a class="g-download-checked text-gray-700 block px-3 py-2 text-sm hover:bg-zinc-100 rounded-md">
-    <i class="ri-download-line pr-2"></i>
-    | Download checked resources
-  </a>
+  if showDownload
+    <a class="g-download-checked text-gray-700 block px-3 py-2 text-sm hover:bg-zinc-100 rounded-md">
+      <i class="ri-download-line pr-2"></i>
+      | Download checked resources
+    </a>
   <a class="g-pick-checked text-gray-700 block px-3 py-2 text-sm hover:bg-zinc-100 rounded-md">
     <i class="ri-add-circle-line pr-2"></i>
     | Pick checked resources for Move or Copy

--- a/girder/web_client/src/templates/widgets/fileList.pug
+++ b/girder/web_client/src/templates/widgets/fileList.pug
@@ -1,19 +1,30 @@
 ul.g-file-list
   each file in files
     li.g-file-list-entry
-      a.g-file-list-link(cid=file.cid, title="Download file",
-          target=file.get('linkUrl') ? '_blank' : '_self', href=file.downloadUrl(),
-          rel="noopener noreferrer")
-        if file.get('linkUrl')
-          i.icon-link
-          span.g-file-name= file.name()
-          i.icon-link-ext
-        else
-          i.icon-doc-inv
-          = file.name()
-      a.g-view-inline(title="View in browser", target="_blank", rel="noopener noreferrer",
-          href=file.downloadUrl({contentDisposition: 'inline'}))
-        i.icon-eye
+      if (showDownload)
+        a.g-file-list-link(cid=file.cid, title="Download file",
+            target=file.get('linkUrl') ? '_blank' : '_self', href=file.downloadUrl(),
+            rel="noopener noreferrer")
+          if file.get('linkUrl')
+            i.icon-link
+            span.g-file-name= file.name()
+            i.icon-link-ext
+          else
+            i.icon-doc-inv
+            = file.name()
+      else
+        span.g-file-list-link(cid=file.cid)
+          if file.get('linkUrl')
+            i.icon-link
+            span.g-file-name= file.name()
+            i.icon-link-ext
+          else
+            i.icon-doc-inv
+            = file.name()
+      if (showDownload || !file.has('size') || file.get('size') < 100000)
+        a.g-view-inline(title="View in browser", target="_blank", rel="noopener noreferrer",
+            href=file.downloadUrl({contentDisposition: 'inline'}))
+          i.icon-eye
       a.g-show-info(file-cid=file.cid, title="Show info")
         i.icon-info
       if file.has('size')

--- a/girder/web_client/src/templates/widgets/hierarchyWidget.pug
+++ b/girder/web_client/src/templates/widgets/hierarchyWidget.pug
@@ -58,10 +58,11 @@
               </button>
               <div class="g-folder-actions-menu dropdown-menu pull-right htk-hidden p-1 bg-white absolute mt-2 min-w-48 right-0 rounded-lg shadow-lg ring-1 ring-black ring-opacity-5 z-10">
                 if type === 'folder' || type === 'collection'
-                  <a class="g-download-folder text-gray-700 block px-3 py-2 text-sm hover:bg-zinc-100 rounded-md" href="#{model.downloadUrl()}">
-                    <i class="ri-download-line pr-2"></i>
-                    | Download #{type}
-                  </a>
+                  if (showDownload)
+                    <a class="g-download-folder text-gray-700 block px-3 py-2 text-sm hover:bg-zinc-100 rounded-md" href="#{model.downloadUrl()}">
+                      <i class="ri-download-line pr-2"></i>
+                      | Download #{type}
+                    </a>
                 if level >= AccessType.WRITE
                   <a class="g-create-subfolder text-gray-700 block px-3 py-2 text-sm hover:bg-zinc-100 rounded-md">
                     <i class="ri-folder-add-line pr-2"></i>

--- a/girder/web_client/src/views/App.js
+++ b/girder/web_client/src/views/App.js
@@ -48,6 +48,7 @@ var App = View.extend({
         this.bannerColor = settings.bannerColor || null;
         this.registrationPolicy = settings.registrationPolicy || null;
         this.enablePasswordLogin = _.has(settings, 'enablePasswordLogin') ? settings.enablePasswordLogin : true;
+        this.downloadShown = settings.downloadShown || 'all';
 
         if (settings.start === undefined || settings.start) {
             this.start();
@@ -340,6 +341,12 @@ var App = View.extend({
                 });
             }, options.timeout);
         }
+    },
+
+    showDownload: function () {
+        const user = getCurrentUser();
+        const isAdmin = !!(user && user.get('admin'));
+        return this.downloadShown === undefined || this.downloadShown === null || this.downloadShown === 'all' || (this.downloadShown === 'user' && user) || (this.downloadShown === 'admin' && isAdmin);
     },
 
     /**

--- a/girder/web_client/src/views/body/CollectionView.js
+++ b/girder/web_client/src/views/body/CollectionView.js
@@ -87,7 +87,8 @@ var CollectionView = View.extend({
         this.$el.html(CollectionPageTemplate({
             collection: this.model,
             AccessType: AccessType,
-            renderMarkdown: renderMarkdown
+            renderMarkdown: renderMarkdown,
+            showDownload: this.parentView.showDownload()
         }));
 
         if (!this.hierarchyWidget) {

--- a/girder/web_client/src/views/body/ItemView.js
+++ b/girder/web_client/src/views/body/ItemView.js
@@ -110,6 +110,10 @@ var ItemView = View.extend({
         // Fetch the access level asynchronously and render once we have
         // it. TODO: load the page and adjust only the action menu once
         // the access level is fetched.
+        let baseParent = this.parentView;
+        while (baseParent && !baseParent.showDownload) {
+            baseParent = baseParent.parentView;
+        }
         this.model.getAccessLevel((accessLevel) => {
             this.accessLevel = accessLevel;
             this.$el.html(ItemPageTemplate({
@@ -119,6 +123,7 @@ var ItemView = View.extend({
                 formatSize: formatSize,
                 formatDate: formatDate,
                 renderMarkdown: renderMarkdown,
+                showDownload: baseParent && baseParent.showDownload ? baseParent.showDownload() : false,
                 DATE_SECOND: DATE_SECOND
             }));
 

--- a/girder/web_client/src/views/widgets/CheckedMenuWidget.js
+++ b/girder/web_client/src/views/widgets/CheckedMenuWidget.js
@@ -24,6 +24,10 @@ var CheckedMenuWidget = View.extend({
             return;
         }
 
+        let baseParent = this.parentView;
+        while (baseParent && !baseParent.showDownload) {
+            baseParent = baseParent.parentView;
+        }
         this.dropdownToggle.girderEnable(true);
         this.$el.html(CheckedActionsMenuTemplate({
             minFolderLevel: this.minFolderLevel,
@@ -35,6 +39,7 @@ var CheckedMenuWidget = View.extend({
             pickedCopyAllowed: this.pickedCopyAllowed,
             pickedMoveAllowed: this.pickedMoveAllowed,
             pickedDesc: this.pickedDesc,
+            showDownload: baseParent && baseParent.showDownload ? baseParent.showDownload() : false,
             HierarchyWidget: HierarchyWidget
         }));
 

--- a/girder/web_client/src/views/widgets/FileListWidget.js
+++ b/girder/web_client/src/views/widgets/FileListWidget.js
@@ -119,11 +119,16 @@ var FileListWidget = View.extend({
 
     render: function () {
         this.checked = [];
+        let baseParent = this.parentView;
+        while (baseParent && !baseParent.showDownload) {
+            baseParent = baseParent.parentView;
+        }
         this.$el.html(FileListTemplate({
             files: this.collection.toArray(),
             hasMore: this.collection.hasNextPage(),
             AccessType: AccessType,
             formatSize: formatSize,
+            showDownload: baseParent && baseParent.showDownload ? baseParent.showDownload() : false,
             parentItem: this.parentItem
         }));
 

--- a/girder/web_client/src/views/widgets/HierarchyWidget.js
+++ b/girder/web_client/src/views/widgets/HierarchyWidget.js
@@ -338,6 +338,10 @@ var HierarchyWidget = View.extend({
         this.folderCount = null;
         this.itemCount = null;
 
+        let baseParent = this.parentView;
+        while (baseParent && !baseParent.showDownload) {
+            baseParent = baseParent.parentView;
+        }
         this.$el.html(HierarchyWidgetTemplate({
             type: this.parentModel.resourceName,
             model: this.parentModel,
@@ -348,6 +352,7 @@ var HierarchyWidget = View.extend({
             showMetadata: this._showMetadata,
             checkboxes: this._checkboxes,
             capitalize: capitalize,
+            showDownload: baseParent && baseParent.showDownload ? baseParent.showDownload() : false,
             itemFilter: this._itemFilter
         }));
 

--- a/girder/web_client/src/views/widgets/ItemListWidget.js
+++ b/girder/web_client/src/views/widgets/ItemListWidget.js
@@ -42,6 +42,13 @@ var ItemListWidget = View.extend({
         this._checkboxes = settings.checkboxes;
         this._downloadLinks = (
             _.has(settings, 'downloadLinks') ? settings.downloadLinks : true);
+        let baseParent = this.parentView;
+        while (baseParent && !baseParent.showDownload) {
+            baseParent = baseParent.parentView;
+        }
+        if (!baseParent || !baseParent.showDownload || !baseParent.showDownload()) {
+            this._downloadLinks = false;
+        }
         this._viewLinks = (
             _.has(settings, 'viewLinks') ? settings.viewLinks : true);
         this._showSizes = (

--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -741,6 +741,7 @@ girder
             CORS_ALLOW_METHODS
             CORS_ALLOW_ORIGIN
             CORS_EXPOSE_HEADERS
+            DOWNLOAD_SHOWN
             EMAIL_FROM_ADDRESS
             EMAIL_HOST
             EMAIL_VERIFICATION


### PR DESCRIPTION
This setting is core.download_shown and can be "all" (default), "user", "admin", or "none".  If not all, download controls are only shown for a subset of users -- any logged in user, only those who are admins, or no one.

This doesn't effect endpoints, just what is shown in the UI.