### PR TITLE
Add CILogon oauth provider

### DIFF
--- a/plugins/oauth/girder_oauth/providers/__init__.py
+++ b/plugins/oauth/girder_oauth/providers/__init__.py
@@ -7,6 +7,7 @@ from .linkedin import LinkedIn
 from .bitbucket import Bitbucket
 from .microsoft import Microsoft
 from .box import Box
+from .cilogon import CILogon
 
 
 def addProvider(provider):
@@ -23,3 +24,4 @@ addProvider(LinkedIn)
 addProvider(Bitbucket)
 addProvider(Microsoft)
 addProvider(Box)
+addProvider(CILogon)

--- a/plugins/oauth/girder_oauth/providers/cilogon.py
+++ b/plugins/oauth/girder_oauth/providers/cilogon.py
@@ -1,0 +1,93 @@
+import warnings
+
+from girder.api.rest import getApiUrl
+from girder.exceptions import RestException
+from girder.models.setting import Setting
+
+from ..settings import PluginSettings
+from .base import ProviderBase
+import requests
+
+
+class CILogon(ProviderBase):
+    _AUTH_SCOPES = ['openid', 'email', 'profile']
+    _API_USER_URL = 'https://cilogon.org/oauth2/userinfo'
+
+    @classmethod
+    def _authority(cls):
+        return 'https://cilogon.org'
+
+    def getClientIdSetting(self):
+        return Setting().get(PluginSettings.CILOGON_CLIENT_ID)
+
+    def getClientSecretSetting(self):
+        return Setting().get(PluginSettings.CILOGON_CLIENT_SECRET)
+
+    @classmethod
+    def getUrl(cls, state):
+        clientId = Setting().get(PluginSettings.CILOGON_CLIENT_ID)
+        if not clientId:
+            raise Exception('No CILogon client ID setting is present.')
+
+        redirectUri = '/'.join((getApiUrl(), 'oauth', 'cilogon', 'callback'))
+
+        url = (
+            f'{cls._authority()}/authorize'
+            f'?client_id={clientId}'
+            f'&response_type=code'
+            f'&scope={" ".join(cls._AUTH_SCOPES)}'
+            f'&redirect_uri={redirectUri}'
+            f'&state={state}'
+        )
+        return url
+
+    def getToken(self, code):
+        clientId = self.getClientIdSetting()
+        clientSecret = self.getClientSecretSetting()
+        redirectUri = '/'.join((getApiUrl(), 'oauth', 'cilogon', 'callback'))
+
+        if not clientId or not clientSecret or not redirectUri:
+            raise Exception('CILogon settings are incomplete.')
+
+        token_url = f'{self._authority()}/oauth2/token'
+        data = {
+            'grant_type': 'authorization_code',
+            'code': code,
+            'redirect_uri': redirectUri,
+            'client_id': clientId,
+            'client_secret': clientSecret,
+        }
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            response = requests.post(token_url, data=data)
+
+        if response.status_code != 200:
+            raise Exception('Error acquiring token: %s' % response.json().get('error_description', 'Unknown error'))
+
+        return response.json()
+
+    def getUser(self, token):
+        headers = {
+            'Authorization': f'Bearer {token["access_token"]}',
+            'Accept': 'application/json'
+        }
+
+        # Get user's info
+        resp = requests.get(self._API_USER_URL, headers=headers)
+        if resp.status_code != 200:
+            raise RestException('Failed to fetch user info from CILogon.', code=502)
+
+        user_data = resp.json()
+        oauthId = user_data.get('sub')
+        if not oauthId:
+            raise RestException('CILogon did not return user ID.', code=502)
+
+        email = user_data.get('email')
+        if not email:
+            raise RestException('CILogon user has no registered email address.', code=502)
+
+        firstName = user_data.get('firstname', '')
+        lastName = user_data.get('lastname', '')
+
+        user = self._createOrReuseUser(oauthId, email, firstName, lastName)
+        return user

--- a/plugins/oauth/girder_oauth/settings.py
+++ b/plugins/oauth/girder_oauth/settings.py
@@ -28,6 +28,9 @@ class PluginSettings:
     BOX_CLIENT_ID = 'oauth.box_client_id'
     BOX_CLIENT_SECRET = 'oauth.box_client_secret'
 
+    CILOGON_CLIENT_ID = 'oauth.cilogon_client_id'
+    CILOGON_CLIENT_SECRET = 'oauth.cilogon_client_secret'
+
 
 @setting_utilities.default(PluginSettings.PROVIDERS_ENABLED)
 def _defaultProvidersEnabled():
@@ -47,6 +50,7 @@ def _defaultIgnoreRegistrationPolicy():
     PluginSettings.BITBUCKET_CLIENT_ID,
     PluginSettings.MICROSOFT_CLIENT_ID,
     PluginSettings.BOX_CLIENT_ID,
+    PluginSettings.CILOGON_CLIENT_ID,
     PluginSettings.GOOGLE_CLIENT_SECRET,
     PluginSettings.GLOBUS_CLIENT_SECRET,
     PluginSettings.GITHUB_CLIENT_SECRET,
@@ -54,6 +58,7 @@ def _defaultIgnoreRegistrationPolicy():
     PluginSettings.BITBUCKET_CLIENT_SECRET,
     PluginSettings.MICROSOFT_CLIENT_SECRET,
     PluginSettings.BOX_CLIENT_SECRET,
+    PluginSettings.CILOGON_CLIENT_SECRET,
     PluginSettings.MICROSOFT_TENANT_ID,
 })
 def _defaultOtherSettings():
@@ -80,6 +85,7 @@ def _validateIgnoreRegistrationPolicy(doc):
     PluginSettings.BITBUCKET_CLIENT_ID,
     PluginSettings.MICROSOFT_CLIENT_ID,
     PluginSettings.BOX_CLIENT_ID,
+    PluginSettings.CILOGON_CLIENT_ID,
     PluginSettings.GOOGLE_CLIENT_SECRET,
     PluginSettings.GLOBUS_CLIENT_SECRET,
     PluginSettings.GITHUB_CLIENT_SECRET,
@@ -87,6 +93,7 @@ def _validateIgnoreRegistrationPolicy(doc):
     PluginSettings.BITBUCKET_CLIENT_SECRET,
     PluginSettings.MICROSOFT_CLIENT_SECRET,
     PluginSettings.BOX_CLIENT_SECRET,
+    PluginSettings.CILOGON_CLIENT_SECRET,
     PluginSettings.MICROSOFT_TENANT_ID,
 })
 def _validateOtherSettings(doc):

--- a/plugins/oauth/girder_oauth/web_client/stylesheets/oauthLoginView.styl
+++ b/plugins/oauth/girder_oauth/web_client/stylesheets/oauthLoginView.styl
@@ -127,3 +127,16 @@
 
   .g-oauth-button-icon
     border-right-color darken($brandColor, 30%)
+
+.g-oauth-button-cilogon
+  $brandColor = #669966
+
+  background-color $brandColor
+  border 1px solid darken($brandColor, 30%)
+  color white
+
+  &:hover
+    background-color darken($brandColor, 15%)
+
+  .g-oauth-button-icon
+    border-right-color darken($brandColor, 30%)

--- a/plugins/oauth/girder_oauth/web_client/views/ConfigView.js
+++ b/plugins/oauth/girder_oauth/web_client/views/ConfigView.js
@@ -120,6 +120,15 @@ var ConfigView = View.extend({
             instructions: 'Client IDs and secret keys are managed in the Box ' +
                           'Developer Services page. When creating your client ID ' +
                           'there, use the following as the authorization callback URL:'
+        }, {
+            id: 'cilogon',
+            name: 'CILogon',
+            icon: 'box-brand',
+            hasAuthorizedOrigins: false,
+            takesTenantId: false,
+            instructions: 'Client IDs and secret keys are managed through the CILogon ' +
+                          'Client Registration page. When creating your client ID ' +
+                          'there, use the following as the authorization callback URL:'
         }];
         this.providerIds = _.pluck(this.providers, 'id');
 

--- a/plugins/oauth/girder_oauth/web_client/views/OAuthLoginView.js
+++ b/plugins/oauth/girder_oauth/web_client/views/OAuthLoginView.js
@@ -92,6 +92,10 @@ var OAuthLoginView = View.extend({
         box: {
             icon: 'box',
             class: 'g-oauth-button-box'
+        },
+        cilogon: {
+            icon: 'box',
+            class: 'g-oauth-button-box'
         }
     }
 });


### PR DESCRIPTION
Resolves #3594 

Issues with this PR that I'd like comments on:
1. I have not written a test for this
2. I am using the Box icon for CILogon currently. Not sure how to add the CILogon logo.
3. I don't know if this is a bug or not, when running Girder through the DSA docker container, the `getApiUrl()` function from `girder/api/rest.py` is returning `localhost:8080` when it should return the site URL as far as I can tell. This is causing some issues for my site, but I am not sure how to fix it. I copied how the other plugins were written, so I think this is just an issue with the function. I have also seen behavior before where the most recently added callback URL for the OAuth service is the only one it redirects to. I'm not sure how that affects this function though, so they may be unrelated issues.