### PR TITLE
Fix the cilogon icon on the oauth config page.

### DIFF
--- a/plugins/oauth/girder_oauth/web_client/views/ConfigView.js
+++ b/plugins/oauth/girder_oauth/web_client/views/ConfigView.js
@@ -123,7 +123,7 @@ var ConfigView = View.extend({
         }, {
             id: 'cilogon',
             name: 'CILogon',
-            icon: 'box-brand',
+            icon: 'cilogon',
             hasAuthorizedOrigins: false,
             takesTenantId: false,
             instructions: 'Client IDs and secret keys are managed through the CILogon ' +


### PR DESCRIPTION
I missed a spot where the cilogon logo should be used.