### PR TITLE
Move import tracker to girder repo under plugins/

### DIFF
--- a/plugins/.gitignore
+++ b/plugins/.gitignore
@@ -20,3 +20,4 @@
 !thumbnails/
 !user_quota/
 !virtual_folders/
+!import_tracker/

--- a/plugins/import_tracker/README.md
+++ b/plugins/import_tracker/README.md
@@ -1,0 +1,3 @@
+# import-tracker
+
+A Girder plugin for data import tracking in HistomicsUI

--- a/plugins/import_tracker/girder_import_tracker/__init__.py
+++ b/plugins/import_tracker/girder_import_tracker/__init__.py
@@ -1,0 +1,185 @@
+import time
+
+from girder_jobs.constants import JobStatus
+from girder_jobs.models.job import Job
+
+from girder import plugin
+from girder.api.describe import autoDescribeRoute
+from girder.api.rest import boundHandler
+from girder.constants import AccessType
+from girder.models.file import File
+from girder.utility.abstract_assetstore_adapter import AbstractAssetstoreAdapter
+from girder.utility.model_importer import ModelImporter
+from girder.utility.progress import ProgressContext
+
+from .models import AssetstoreImport, ImportTrackerCancelError
+from .rest import getImport, listAllImports, listImports, moveFolder
+
+
+def wrapImportData(assetstoreResource):
+    baseImportData = assetstoreResource.importData
+    baseImportData.description.param(
+        'excludeExisting',
+        'If true, then a file with an import path that is already in the '
+        'system is not imported, even if it is not in the destination '
+        'hierarchy.', dataType='boolean', required=False, default=False)
+
+    @boundHandler(ctx=assetstoreResource)
+    @autoDescribeRoute(baseImportData.description)
+    def importDataWrapper(
+            self, assetstore, importPath, destinationId, destinationType,
+            progress, leafFoldersAsItems, fileIncludeRegex, fileExcludeRegex,
+            excludeExisting, **kwargs):
+        # We don't actually wrap importData, as it would be excessive
+        # monkey-patching to make the import trackable and cancelable.
+        user = self.getCurrentUser()
+        parent = ModelImporter.model(destinationType).load(
+            destinationId, user=user, level=AccessType.ADMIN, exc=True)
+
+        # Capture any additional parameters passed to route
+        extraParams = kwargs.get('params', {})
+
+        params = {
+            'destinationId': destinationId,
+            'destinationType': destinationType,
+            'importPath': importPath,
+            'leafFoldersAsItems': str(leafFoldersAsItems).lower(),
+            'progress': str(progress).lower(),
+            **extraParams
+        }
+
+        if fileIncludeRegex:
+            params['fileIncludeRegex'] = fileIncludeRegex
+        if fileExcludeRegex:
+            params['fileExcludeRegex'] = fileExcludeRegex
+        if excludeExisting:
+            params['excludeExisting'] = str(excludeExisting).lower()
+
+        importRecord = AssetstoreImport().createAssetstoreImport(assetstore, params)
+
+        job = Job().createJob(
+            title='Import from %s : %s' % (assetstore['name'], importPath),
+            type='assetstore_import',
+            public=False,
+            user=user,
+            kwargs=params,
+        )
+        job = Job().updateJob(job, '%s - Starting import from %s : %s\n' % (
+            time.strftime('%Y-%m-%d %H:%M:%S'),
+            assetstore['name'], importPath,
+        ), status=JobStatus.RUNNING)
+
+        try:
+            with ProgressContext(progress, user=user, title='Importing data') as ctx:
+                try:
+                    jobRec = {
+                        'id': str(job['_id']),
+                        'count': 0,
+                        'skip': 0,
+                        'lastlog': time.time(),
+                        'logcount': 0,
+                    }
+                    self._model.importData(
+                        assetstore, parent=parent, parentType=destinationType,
+                        params={
+                            **params,
+                            '_job': jobRec,
+                        },
+                        progress=ctx, user=user,
+                        leafFoldersAsItems=leafFoldersAsItems)
+                    # TODO: if excludeExisting, then find any folders in the
+                    # destination that contain no items or folders and remove
+                    # them.
+                    success = True
+                    Job().updateJob(job, '%s - Finished.  Checked %d, skipped %d\n' % (
+                        time.strftime('%Y-%m-%d %H:%M:%S'),
+                        jobRec['count'], jobRec['skip'],
+                    ), status=JobStatus.SUCCESS)
+                except ImportTrackerCancelError:
+                    Job().updateJob(job, '%s - Canceled' % (
+                        time.strftime('%Y-%m-%d %H:%M:%S'),
+                    ))
+                    success = 'canceled'
+        except Exception as exc:
+            Job().updateJob(job, '%s - Failed with %s\n' % (
+                time.strftime('%Y-%m-%d %H:%M:%S'),
+                exc,
+            ), status=JobStatus.ERROR)
+            success = False
+
+        importRecord = AssetstoreImport().markEnded(importRecord, success)
+        return importRecord
+
+    for key in {'accessLevel', 'description', 'requiredScopes'}:
+        setattr(importDataWrapper, key, getattr(baseImportData, key))
+
+    assetstoreResource.importData = importDataWrapper
+    assetstoreResource.removeRoute('POST', (':id', 'import'))
+    assetstoreResource.route('POST', (':id', 'import'), assetstoreResource.importData)
+
+
+def wrapShouldImportFile():
+    baseShouldImportFile = AbstractAssetstoreAdapter.shouldImportFile
+
+    def shouldImportFileWrapper(self, path, params):
+        jobRec = params.get('_job')
+        job = None
+        if jobRec:
+            job = Job().load(jobRec['id'], force=True, includeLog=False)
+        if job:
+            if job['status'] == JobStatus.CANCELED:
+                raise ImportTrackerCancelError()
+            if time.time() - jobRec['lastlog'] > 10:
+                Job().updateJob(
+                    job,
+                    log='%s - Checked %d, skipped %d; checking %s\n' % (
+                        time.strftime('%Y-%m-%d %H:%M:%S'),
+                        jobRec['count'], jobRec['skip'], path),
+                    overwrite=(jobRec['logcount'] > 1000))
+                if jobRec['logcount'] > 1000:
+                    jobRec['logcount'] = 0
+                jobRec['logcount'] += 1
+                jobRec['lastlog'] = time.time()
+        result = True
+        if params.get('excludeExisting'):
+            idx1 = ([('assetstoreId', 1), ('path', 1)], {})
+            idx2 = ([('assetstoreId', 1), ('s3Key', 1)], {})
+            if idx1 not in File()._indices:
+                File().ensureIndex(idx1)
+            if idx2 not in File()._indices:
+                File().ensureIndex(idx2)
+            if File().findOne({
+                'assetstoreId': self.assetstore['_id'],
+                '$or': [{'path': path}, {'s3Key': path}],
+                'imported': True
+            }):
+                result = False
+        if result:
+            result = baseShouldImportFile(self, path, params)
+        if jobRec:
+            if not result:
+                jobRec['skip'] += 1
+            else:
+                jobRec['count'] += 1
+        return result
+
+    AbstractAssetstoreAdapter.shouldImportFile = shouldImportFileWrapper
+
+
+class GirderPlugin(plugin.GirderPlugin):
+    DISPLAY_NAME = 'import_tracker'
+    CLIENT_SOURCE_PATH = 'web_client'
+
+    def load(self, info):
+        plugin.getPlugin('jobs').load(info)
+        ModelImporter.registerModel(
+            'assetstoreImport', AssetstoreImport, 'import_tracker'
+        )
+
+        info['apiRoot'].assetstore.route('GET', (':id', 'imports'), listImports)
+        info['apiRoot'].assetstore.route('GET', ('all_imports',), listAllImports)
+        info['apiRoot'].assetstore.route('GET', ('import', ':id'), getImport)
+        wrapShouldImportFile()
+        wrapImportData(info['apiRoot'].assetstore)
+
+        info['apiRoot'].folder.route('PUT', (':id', 'move'), moveFolder)

--- a/plugins/import_tracker/girder_import_tracker/models.py
+++ b/plugins/import_tracker/girder_import_tracker/models.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+
+from bson.objectid import ObjectId
+
+from girder.exceptions import ValidationException
+from girder.models.model_base import Model
+
+
+class AssetstoreImport(Model):
+    """A model that tracks assetstore import events."""
+
+    def initialize(self):
+        self.name = 'assetstoreImport'
+
+    def validate(self, doc):
+        fields = {'name', 'started', 'assetstoreId', 'params'}
+        missing_keys = fields - doc.keys()
+        if missing_keys:
+            raise ValidationException('Fields missing.', ','.join(missing_keys))
+
+        return doc
+
+    def createAssetstoreImport(self, assetstore, params):
+        now = datetime.utcnow()
+        record = self.save(
+            {
+                'name': now.isoformat(),
+                'started': now,
+                'assetstoreId': ObjectId(assetstore['_id']),
+                'params': {k: v for k, v in sorted(params.items())},
+            }
+        )
+        return record
+
+    def markEnded(self, record, success=None):
+        now = datetime.utcnow()
+        record['ended'] = now
+        if success is not None:
+            record['success'] = success
+        record = self.save(record)
+        return record
+
+
+class ImportTrackerCancelError(Exception):
+    pass

--- a/plugins/import_tracker/girder_import_tracker/rest.py
+++ b/plugins/import_tracker/girder_import_tracker/rest.py
@@ -1,0 +1,129 @@
+from bson.objectid import ObjectId
+
+from girder.api import access
+from girder.api.describe import Description, autoDescribeRoute
+from girder.api.rest import boundHandler
+from girder.constants import AccessType, SortDir
+from girder.models.assetstore import Assetstore
+from girder.models.folder import Folder
+from girder.utility import model_importer, path
+
+from . import utils
+from .models import AssetstoreImport
+
+
+def processCursor(cursor, user):
+    lookedupAssetstores = {}
+    results = list(cursor)
+
+    for row in results:
+        if row['assetstoreId'] not in lookedupAssetstores:
+            assetstore = list(Assetstore().find({'_id': row['assetstoreId']}))
+            lookedupAssetstores[row['assetstoreId']] = assetstore[0][
+                'name'] if assetstore else None
+
+        row['_assetstoreName'] = (
+            lookedupAssetstores[row['assetstoreId']] or row['assetstoreId'])
+        model = model_importer.ModelImporter.model(row['params']['destinationType'])
+        doc = model.load(row['params']['destinationId'], user=user)
+        if doc:
+            row['_destinationPath'] = path.getResourcePath(
+                row['params']['destinationType'],
+                doc,
+                user=user
+            )
+        else:
+            row['_destinationPath'] = 'does not exist'
+    return results
+
+
+def getImports(query=None, user=None, unique=False, limit=None, offset=None, sort=None):
+    if not unique:
+        cursor = AssetstoreImport().find(
+            query or {},
+            limit=limit,
+            offset=offset,
+            sort=sort,
+        )
+    else:
+        cursor = AssetstoreImport().collection.aggregate([
+            {'$match': query or {}},
+            {'$sort': {k: v for k, v in sort}},
+            {'$group': {
+                '_id': {
+                    'assetstoreId': '$assetstoreId',
+                    'params': '$params'
+                },
+                '_count': {'$sum': 1},
+                'started': {'$first': '$started'},
+                'ended': {'$first': '$ended'},
+                'first_id': {'$first': '$_id'},
+            }},
+            {'$project': {
+                'assetstoreId': '$_id.assetstoreId',
+                'params': '$_id.params',
+                '_count': '$_count',
+                'started': '$started',
+                'ended': '$ended',
+                '_id': '$first_id',
+            }},
+            {'$sort': {k: v for k, v in sort}},
+            {'$skip': offset or 0},
+            {'$limit': limit or 0}
+        ])
+    return processCursor(cursor, user)
+
+
+@access.admin
+@boundHandler
+@autoDescribeRoute(
+    Description('List all imports for a given assetstore.')
+    .param('id', 'An assetstore ID', paramType='path')
+    .param('unique', 'If true, only show unique imports', required=False,
+           dataType='boolean', default=False)
+    .pagingParams(defaultSort='started', defaultSortDir=SortDir.DESCENDING)
+)
+def listImports(self, id, unique, limit, offset, sort):
+    return getImports(
+        {'assetstoreId': ObjectId(id)},
+        self.getCurrentUser(), unique, limit, offset, sort)
+
+
+@access.admin
+@boundHandler
+@autoDescribeRoute(
+    Description('List all past imports for all assetstores.')
+    .param('unique', 'If true, only show unique imports', required=False,
+           dataType='boolean', default=False)
+    .pagingParams(defaultSort='started', defaultSortDir=SortDir.DESCENDING)
+)
+def listAllImports(self, unique, limit, offset, sort):
+    return getImports(
+        None,
+        self.getCurrentUser(), unique, limit, offset, sort)
+
+
+@access.admin
+@boundHandler
+@autoDescribeRoute(
+    Description('Get import for record from ID.')
+    .modelParam('id', 'ID of an import', model=AssetstoreImport)
+)
+def getImport(self, assetstoreImport):
+    return assetstoreImport
+
+
+@access.admin
+@boundHandler
+@autoDescribeRoute(
+    Description('Move folder contents to an assetstore.')
+    .modelParam('id', 'Source folder ID', model=Folder, level=AccessType.WRITE)
+    .modelParam('assetstoreId', 'Destination assetstore ID', model=Assetstore, paramType='formData')
+    .param('ignoreImported', 'Ignore files that have been directly imported', dataType='boolean',
+           default=True, required=True)
+    .param('progress', 'Whether to record progress on the move.', dataType='boolean', default=False,
+           required=False)
+)
+def moveFolder(self, folder, assetstore, ignoreImported, progress):
+    user = self.getCurrentUser()
+    return utils.moveFolder(user, folder, assetstore, ignoreImported, progress)

--- a/plugins/import_tracker/girder_import_tracker/utils.py
+++ b/plugins/import_tracker/girder_import_tracker/utils.py
@@ -1,0 +1,125 @@
+import time
+
+from bson.objectid import ObjectId
+from girder_jobs.constants import JobStatus
+from girder_jobs.models.job import Job
+
+from girder.models.file import File
+from girder.models.folder import Folder
+from girder.models.upload import Upload
+from girder.utility.progress import ProgressContext, setResponseTimeLimit
+
+from .models import ImportTrackerCancelError
+
+
+def moveFile(file, folder, user, assetstore, progress, job):
+    # check if the move has been canceled
+    job = Job().load(job['_id'], force=True)
+    if job['status'] == JobStatus.CANCELED:
+        raise ImportTrackerCancelError()
+
+    message = f'Moving {folder["name"]}/{file["name"]}\n'
+    job = Job().updateJob(job, log=f'{time.strftime("%Y-%m-%d %H:%M:%S")} - {message}')
+    progress.update(message=message)
+
+    setResponseTimeLimit(86400)
+    return Upload().moveFileToAssetstore(file, user, assetstore, progress=progress)
+
+
+def moveFolder(user, folder, assetstore, ignoreImported, progress):
+    """
+    Move a folder to a different assetstore.
+
+    :param user: the user requesting the move.
+    :param folder: the folder to move.
+    :param assetstore: the target assetstore.
+    :param ignoreImported: if True, do not move imported files.
+    :param progress: a boolean specifying if prgress should be reported.
+    """
+    job = Job().createJob(
+        title='Move folder "%s" to assetstore "%s"' % (
+            folder['name'], assetstore['name']),
+        type='folder_move', public=False, user=user,
+    )
+    job = Job().updateJob(job, '%s - Starting folder move "%s" to assetstore "%s" (%s)\n' % (
+        time.strftime(
+            '%Y-%m-%d %H:%M:%S'), folder['name'], assetstore['name'], assetstore['_id']
+    ), status=JobStatus.RUNNING)
+
+    result = None
+    try:
+        with ProgressContext(progress, user=user,
+                             title='Moving folder "%s" (%s) to assetstore "%s" (%s)' % (
+                                 folder['name'],
+                                 folder['_id'],
+                                 assetstore['name'],
+                                 assetstore['_id'])) as ctx:
+            try:
+                result = _moveLeafFiles(
+                    folder, user, assetstore, ignoreImported, ctx, job)
+
+                Job().updateJob(job, '%s - Finished folder move.\n' % (
+                    time.strftime('%Y-%m-%d %H:%M:%S'),
+                ), status=JobStatus.SUCCESS)
+
+            except ImportTrackerCancelError:
+                return 'Job canceled'
+
+    except Exception as exc:
+        Job().updateJob(job, '%s - Failed with %s\n' % (
+            time.strftime('%Y-%m-%d %H:%M:%S'),
+            exc,
+        ), status=JobStatus.ERROR)
+
+    return result
+
+
+def _moveLeafFiles(folder, user, assetstore, ignoreImported, progress, job):
+    # check if the move has been canceled
+    job = Job().load(job['_id'], force=True)
+    if job['status'] == JobStatus.CANCELED:
+        raise ImportTrackerCancelError()
+
+    Folder().updateFolder(folder)
+
+    # only move files that are not already in the assetstore
+    query = {'assetstoreId': {'$ne': ObjectId(assetstore['_id'])}}
+
+    # ignore imported files if desired
+    if ignoreImported:
+        query['imported'] = {'$ne': True}
+
+    child_folders = Folder().childFolders(folder, 'folder', user=user)
+    child_items = Folder().childItems(folder, filters=query)
+
+    uploads = []
+
+    def tryToMoveFile(file):
+        try:
+            upload = moveFile(file, folder, user, assetstore, progress, job)
+            uploads.append(upload)
+        except Exception as e:
+            # Ignore failed move of files
+            Job().updateJob(
+                job,
+                log=f'{time.strftime("%Y-%m-%d %H:%M:%S")} - Failed to move {file["name"]}: {e}\n'
+            )
+
+    # get all files attached to an object
+    def moveAttachedFiles(attachedToId):
+        for attached_file in File().find({'attachedToId': attachedToId, **query}):
+            tryToMoveFile(attached_file)
+
+    moveAttachedFiles(folder['_id'])
+    for item in child_items:
+        # upload all attached files for each item
+        moveAttachedFiles(item['_id'])
+
+        for file in File().find({'itemId': ObjectId(item['_id']), **query}):
+            tryToMoveFile(file)
+
+    for child_folder in child_folders:
+        uploads += _moveLeafFiles(child_folder, user, assetstore,
+                                  ignoreImported, progress, job)
+
+    return uploads

--- a/plugins/import_tracker/girder_import_tracker/web_client/JobStatus.js
+++ b/plugins/import_tracker/girder_import_tracker/web_client/JobStatus.js
@@ -1,0 +1,9 @@
+import JobStatus from '@girder/jobs/JobStatus';
+
+const jobPluginIsCancelable = JobStatus.isCancelable;
+JobStatus.isCancelable = function (job) {
+    if (['assetstore_import', 'folder_move'].includes(job.get('type'))) {
+        return ![JobStatus.CANCELED, JobStatus.SUCCESS, JobStatus.ERROR].includes(job.get('status'));
+    }
+    return jobPluginIsCancelable(job);
+};

--- a/plugins/import_tracker/girder_import_tracker/web_client/main.js
+++ b/plugins/import_tracker/girder_import_tracker/web_client/main.js
@@ -1,0 +1,161 @@
+import $ from 'jquery';
+
+import AssetstoreView from '@girder/core/views/body/AssetstoresView';
+import FilesystemImportView from '@girder/core/views/body/FilesystemImportView';
+import S3ImportView from '@girder/core/views/body/S3ImportView';
+
+import CollectionModel from '@girder/core/models/CollectionModel';
+import FolderModel from '@girder/core/models/FolderModel';
+import UserModel from '@girder/core/models/UserModel';
+
+import { wrap } from '@girder/core/utilities/PluginUtils';
+import events from '@girder/core/events';
+import router from '@girder/core/router';
+
+import importDataButton from './templates/assetstoreButtonsExtension.pug';
+import importListView from './views/importList';
+import reImportView from './views/reImport';
+import excludeExistingInput from './templates/excludeExistingInput.pug';
+
+// import modules for side effects
+import './JobStatus';
+
+// Inject button to navigate to imports page in each assetstore in view
+wrap(AssetstoreView, 'render', function (render) {
+    // Call the underlying render function that we are wrapping
+    render.call(this);
+    // defer adding buttons so optional plugins can render first.
+    window.setTimeout(() => {
+        this.$el.find('.g-current-assetstores-container .g-body-title').after(
+            '<a class="g-view-imports btn btn-sm btn-primary" href="#assetstore/all_unique_imports"><i class="icon-link-ext"></i>View all past Imports</a>'
+        );
+
+        // Inject new button into each assetstore
+        const assetstores = this.collection;
+        this.$('.g-assetstore-import-button-container').after(
+            function () {
+                // we can't just use the index of the after call, since not
+                // all assetstores will have import buttons.
+                const assetstore = assetstores.get($(this).closest('.g-assetstore-buttons').find('[cid]').attr('cid'));
+                return importDataButton({ importsPageLink: `#assetstore/${assetstore.id}/unique_imports` });
+            }
+        );
+    }, 0);
+});
+
+// Add duplicate_files option to Import Asset form
+wrap(FilesystemImportView, 'render', function (render) {
+    render.call(this);
+
+    this.$('.form-group').last().after(excludeExistingInput({ type: 'filesystem' }));
+});
+wrap(S3ImportView, 'render', function (render) {
+    render.call(this);
+
+    this.$('.form-group').last().after(excludeExistingInput({ type: 's3' }));
+});
+
+const setBrowserRoot = (view, type) => {
+    const browserWidget = view._browserWidgetView;
+    const destinationType = view.$(`#g-${type}-import-dest-type`).val();
+    const destinationId = view.$(`#g-${type}-import-dest-id`).val();
+    const resourceId = destinationId.trim().split(/\s/)[0];
+
+    const models = {
+        collection: CollectionModel,
+        folder: FolderModel,
+        user: UserModel
+    };
+
+    if (resourceId && destinationType in models) {
+        const model = new models[destinationType]({ _id: resourceId });
+
+        model.once('g:fetched', () => {
+            if (!browserWidget.root || browserWidget.root.id !== model.id) {
+                browserWidget.root = model;
+                browserWidget._renderRootSelection();
+            }
+        }).on('g:error', (err) => {
+            if (err.status === 400) {
+                events.trigger('g:alert', {
+                    icon: 'cancel',
+                    text: `No ${destinationType.toUpperCase()} with ID ${resourceId} found.`,
+                    type: 'danger',
+                    timeout: 4000
+                });
+            }
+        }).fetch({ ignoreError: true });
+    }
+};
+
+// If a root folder has already been set in the browser, make it the root
+wrap(FilesystemImportView, '_openBrowser', function (_openBrowser) {
+    setBrowserRoot(this, 'filesystem');
+    _openBrowser.call(this);
+});
+wrap(S3ImportView, '_openBrowser', function (_openBrowser) {
+    setBrowserRoot(this, 's3');
+    _openBrowser.call(this);
+});
+
+// We can't just wrap the submit events, as we need to modify what is passed to
+// the assetstore import method
+const importSubmit = (view, type) => {
+    const destinationId = view.$(`#g-${type}-import-dest-id`).val().trim().split(/\s/)[0];
+    const destinationType = view.$(`#g-${type}-import-dest-type`).val();
+    const excludeExisting = view.$(`#g-${type}-import-exclude-existing`).val();
+
+    const importParams = { destinationId, destinationType, excludeExisting, progress: true };
+
+    if (type === 'filesystem') {
+        importParams.leafFoldersAsItems = view.$(`#g-${type}-import-leaf-items`).val();
+    }
+    if (type === 'dwas') {
+        importParams.filters = view.$(`#g-${type}-import-filters`).val().trim();
+        importParams.limit = view.$(`#g-${type}-import-limit`).val().trim();
+    } else {
+        importParams.importPath = view.$(`#g-${type}-import-path`).val().trim();
+    }
+
+    view.$('.g-validation-failed-message').empty();
+    view.$(`.g-submit-${type}-import`).addClass('disabled');
+
+    let model = view.assetstore;
+    model = model.off().on('g:imported', function () {
+        router.navigate(destinationType + '/' + destinationId, { trigger: true });
+    }, view).on('g:error', function (err) {
+        view.$(`.g-submit-${type}-import`).removeClass('disabled');
+        view.$('.g-validation-failed-message').html(err.responseJSON.message);
+    }, view);
+
+    model.import(importParams);
+};
+
+FilesystemImportView.prototype.events['submit .g-filesystem-import-form'] = function (e) {
+    e.preventDefault();
+    importSubmit(this, 'filesystem');
+};
+S3ImportView.prototype.events['submit .g-s3-import-form'] = function (e) {
+    e.preventDefault();
+    importSubmit(this, 's3');
+};
+
+// Setup router to assetstore imports view
+router.route('assetstore/:id/imports', 'importsPage', function (id) {
+    events.trigger('g:navigateTo', importListView, { id });
+});
+router.route('assetstore/:id/unique_imports', 'importsPage', function (id) {
+    events.trigger('g:navigateTo', importListView, { id, unique: true });
+});
+router.route('assetstore/all_imports', 'importsPage', function () {
+    events.trigger('g:navigateTo', importListView);
+});
+router.route('assetstore/all_unique_imports', 'importsPage', function () {
+    events.trigger('g:navigateTo', importListView, { unique: true });
+});
+
+// Setup router for re-import view
+router.route('assetstore/:id/re-import/:prev', 'assetstoreImport', function (assetstoreId, importId) {
+    events.trigger('g:navigateTo', reImportView, { assetstoreId, importId });
+    AssetstoreView.import(assetstoreId);
+});

--- a/plugins/import_tracker/girder_import_tracker/web_client/package.json
+++ b/plugins/import_tracker/girder_import_tracker/web_client/package.json
@@ -1,0 +1,50 @@
+{
+    "name": "@girder/import_tracker",
+    "version": "0.1.0",
+    "private": true,
+    "description": "A Girder plu",
+    "homepage": "https://github.com/girder/import_tracker",
+    "license": "Apache-2.0",
+    "peerDependencies": {
+        "@girder/core": "*",
+        "@girder/jobs": "*"
+    },
+    "girderPlugin": {
+        "name": "import_tracker",
+        "main": "./main.js",
+        "dependencies": [
+            "jobs"
+        ]
+    },
+    "scripts": {
+        "lint": "eslint . && pug-lint . && stylus-supremacy format --compare ./**/*.styl --options package.json",
+        "format": "eslint --cache --fix . && stylus-supremacy format ./**/*.styl --replace --options package.json"
+    },
+    "devDependencies": {
+        "@girder/eslint-config": "*",
+        "@girder/pug-lint-config": "*",
+        "eslint": "^8.20.0",
+        "eslint-config-semistandard": "^17.0.0",
+        "eslint-config-standard": "^17.0.0",
+        "eslint-plugin-backbone": "^2.1.1",
+        "eslint-plugin-import": "^2.25.3",
+        "eslint-plugin-n": "^15.2.4",
+        "eslint-plugin-promise": "^6.0.0",
+        "pug-lint": "^2.6.0",
+        "stylus-supremacy": "^2.17.5"
+    },
+    "eslintConfig": {
+        "extends": "@girder",
+        "root": true
+    },
+    "pugLintConfig": {
+        "extends": "@girder/pug-lint-config"
+    },
+    "stylusSupremacy.insertColons": false,
+    "stylusSupremacy.insertSemicolons": false,
+    "stylusSupremacy.insertBraces": false,
+    "stylusSupremacy.tabStopChar": "  ",
+    "stylusSupremacy.quoteChar": "\"",
+    "stylusSupremacy.alwaysUseZeroWithoutUnit": true,
+    "stylusSupremacy.reduceMarginAndPaddingValues": true
+}

--- a/plugins/import_tracker/girder_import_tracker/web_client/stylesheets/importList.styl
+++ b/plugins/import_tracker/girder_import_tracker/web_client/stylesheets/importList.styl
@@ -1,0 +1,102 @@
+@import "~nib/index.styl"
+
+.check-menu-dropdown
+  position relative
+  width 20px
+  left -2px
+
+  .g-job-check-menu-button
+    padding 2px 1px 0 2px
+
+    i
+      position relative
+      top -3px
+
+.g-imports-list-table
+  width 100%
+  hyphenate-character ""
+
+  th
+    border-bottom 1px solid #a5a5a5
+    padding 0 10px
+
+  tbody>tr
+    transition background 0.1s linear
+    border-bottom 1px solid #d7d7d7
+
+    td
+      padding 3px 5px
+
+    &:hover
+      background-color rgb(221, 221, 221)
+
+    &.g-highlight
+      background-color #f1db74
+
+    button+button
+      margin-left 5px
+
+    .g-imports-buttons
+      display flex
+      padding-right 1em
+
+.g-job-list-header
+  padding-bottom 10px
+
+#g-job-checkbox-menu
+  display inline
+
+a.g-job-checkbox-menu-link
+  display inline-block
+  overflow hidden
+  text-overflow ellipsis
+  white-space nowrap
+  color #333
+
+.g-job-filter-container
+  margin-top 7px
+
+  > div
+    float left
+    margin-right 10px
+
+  > .checkbox
+    margin 0 0 0 10px
+
+  .dropdown
+    .dropdown-menu
+      ul
+        list-style-type none
+        padding 0
+        margin 0
+
+    .checkbox
+      margin 8px
+
+    .checkbox.g-job-checkall
+      padding-bottom 8px
+      border-bottom 1px solid #ddd
+
+.g-page-size-container
+  float right
+  margin-top 7px
+
+  > span
+    margin-right 10px
+
+ul.g-jobs
+  margin 10px 0
+
+.g-jobs-graph
+  height calc(100vh - 230px)
+  overflow-y hidden
+  overflow-x auto
+
+.g-no-job-record
+  text-align center
+
+.g-job-worker-task-info
+  margin-top 10px
+
+.it-controls
+  margin-bottom 10px

--- a/plugins/import_tracker/girder_import_tracker/web_client/templates/assetstoreButtonsExtension.pug
+++ b/plugins/import_tracker/girder_import_tracker/web_client/templates/assetstoreButtonsExtension.pug
@@ -1,0 +1,4 @@
+.g-assetstore-button-container
+  a.g-view-imports.btn.btn-sm.btn-primary(href=importsPageLink)
+    i.icon-link-ext
+    |  View past imports

--- a/plugins/import_tracker/girder_import_tracker/web_client/templates/excludeExistingInput.pug
+++ b/plugins/import_tracker/girder_import_tracker/web_client/templates/excludeExistingInput.pug
@@ -1,0 +1,5 @@
+.form-group
+  label(for="g-" + type + "-import-exclude-existing") Exclude Existing Files
+  select.form-control(id="g-" + type + "-import-exclude-existing")
+    option(value="false") False
+    option(value="true") True

--- a/plugins/import_tracker/girder_import_tracker/web_client/templates/importList.pug
+++ b/plugins/import_tracker/girder_import_tracker/web_client/templates/importList.pug
@@ -1,0 +1,101 @@
+.it-controls
+  if !unique
+    if !assetstoreId
+      a.g-view-imports.btn.btn-sm.btn-primary(href='#assetstore/all_unique_imports')
+        i.icon-link-ext
+        | View unique past Imports
+    else
+      a.g-view-imports.btn.btn-sm.btn-primary(href=`#assetstore/${assetstoreId}/unique_imports`)
+        i.icon-link-ext
+        | View unique past Imports
+  else
+    if !assetstoreId
+      a.g-view-imports.btn.btn-sm.btn-primary(href='#assetstore/all_imports')
+        i.icon-link-ext
+        | View all past Imports
+    else
+      a.g-view-imports.btn.btn-sm.btn-primary(href=`#assetstore/${assetstoreId}/imports`)
+        i.icon-link-ext
+        | View all past Imports
+table.g-imports-list-table
+  -
+    var anyRegex = false;
+    var anyLeafed = false;
+    var anyImportPath = false;
+    var anyNoProgress = false;
+    var otherParams = [];
+    var showCount = false;
+  for _import in imports
+    if _import.get('params').fileIncludeRegex || _import.get('params').fileExcludeRegex
+      - anyRegex = True
+    if _import.get('params').leafFoldersAsItems && _import.get('params').leafFoldersAsItems !== 'false'
+      - anyLeafed = true
+    if !_import.get('params').progress
+      - anyNoProgress = true
+    - Object.keys(_import.get('params')).forEach((key) => { if (['importPath', 'destinationId', 'leafFoldersAsItems', 'progress', 'fileIncludeRegex', 'fileExcludeRegex'].indexOf(key) < 0 && otherParams.indexOf(key) < 0) { otherParams.push(key); } });
+    if _import.get('_count')
+      - showCount = true
+    if _import.get('params').importPath
+      - anyImportPath = true
+  thead
+    tr
+      th Actions
+      if showCount
+        th Repeats
+      th Started
+      th Ended
+      th Assetstore Name
+      if anyImportPath
+        th Import Path
+      //- th Destination Type
+      th Destination Path
+      if anyLeafed
+        th Leafed Folders
+      if anyNoProgress
+        th Progress
+      if anyRegex
+        th File Include Regex
+        th File Exclude Regex
+      for key in otherParams
+        th= key.replace(/([A-Z])/g, ' $1').replace(/^./, (str) => str.toUpperCase())
+  tbody
+    each _import, i in imports
+      tr
+        td
+          if assetstores.includes(_import.get('assetstoreId'))
+            .g-imports-buttons
+              button.re-import-btn.btn.btn-sm.btn-success(index=i, disabled=(_import.get('_destinationPath') == 'does not exist'))
+                i.icon-cw
+                |  Re-Import
+              button.re-import-edit-btn.btn.btn-sm.btn-primary(index=i, data-toggle='tooltip', title='Edit Import Parameters')
+                i.icon-pencil
+        if showCount
+          td(data-id=_import.get('_count'), data-toggle='tooltip', title=_import.get('_count') !== 1 ? `Imported ${_import.get('_count')} times` : 'Imported once')
+            span= _import.get('_count')
+        td(data-id=_import.get('started'), data-toggle='tooltip', title=_import.get('started'))
+          span= moment(_import.get('started')).format('YYYY-MM-DD HH:mm:ss.SSS')
+        td(data-id=_import.get('ended'), data-toggle='tooltip', title=_import.get('ended') || '')
+          span= _import.get('ended') ? moment(_import.get('ended')).format('YYYY-MM-DD HH:mm:ss.SSS') : ''
+        td(data-id=_import.get('_assetstoreName'), data-toggle='tooltip', title=_import.get('_assetstoreName'))
+          span= _import.get('_assetstoreName')
+        if anyImportPath
+          td(data-id=_import.get('params').importPath, data-toggle='tooltip', title=_import.get('params').importPath)
+            span= (_import.get('params').importPath || '').replaceAll(/(?!^)\//g, '/\u00AD')
+        td(data-id=_import.get('params').destinationId, data-toggle='tooltip', title=_import.get('_destinationPath') + '\n' + _import.get('params').destinationId)
+          span= (_import.get('_destinationPath') || '').replaceAll(/(?!^)\//g, '/\u00AD')
+        if anyLeafed
+          td
+            span= _import.get('params').leafFoldersAsItems
+        if anyNoProgress
+          td
+            span= _import.get('params').progress
+        if anyRegex
+          td
+            span= _import.get('params').fileIncludeRegex
+          td
+            span= _import.get('params').fileExcludeRegex
+        for key in otherParams
+          td
+            span= _import.get('params')[key]
+
+.g-imports-pagination

--- a/plugins/import_tracker/girder_import_tracker/web_client/views/importList.js
+++ b/plugins/import_tracker/girder_import_tracker/web_client/views/importList.js
@@ -1,0 +1,111 @@
+import $ from 'jquery';
+import moment from 'moment';
+
+import PaginateWidget from '@girder/core/views/widgets/PaginateWidget';
+import Collection from '@girder/core/collections/Collection';
+
+import AssetstoreModel from '@girder/core/models/AssetstoreModel';
+import { SORT_DESC } from '@girder/core/constants';
+import View from '@girder/core/views/View';
+import router from '@girder/core/router';
+import { restRequest } from '@girder/core/rest';
+
+import importListTemplate from '../templates/importList.pug';
+import '../stylesheets/importList.styl';
+
+var importList = View.extend({
+    events: {
+        'click .re-import-btn': function (e) {
+            const index = Number($(e.currentTarget).attr('index'));
+            const importEvent = this.imports[index];
+            if (importEvent === undefined) {
+                return;
+            }
+
+            // Re-perform import
+            const assetstore = new AssetstoreModel({ _id: importEvent.get('assetstoreId') });
+            const destType = importEvent.get('params').destinationType;
+            const destId = importEvent.get('params').destinationId;
+
+            assetstore.off('g:imported').on('g:imported', function () {
+                router.navigate(destType + '/' + destId, { trigger: true });
+            }, this).on('g:error', function (resp) {
+                this.$('.g-validation-failed-message').text(resp.responseJSON.message);
+            }, this);
+
+            assetstore.once('g:fetched', () => {
+                assetstore.import(importEvent.get('params'));
+            }).fetch();
+        },
+        'click .re-import-edit-btn': function (e) {
+            const index = Number($(e.currentTarget).attr('index'));
+            const importEvent = this.imports[index];
+            if (importEvent === undefined) {
+                return;
+            }
+
+            // Navigate to re-import page
+            const navigate = (assetstoreId, importId) => {
+                const assetstore = new AssetstoreModel({ _id: assetstoreId });
+                assetstore.once('g:fetched', () => {
+                    router.navigate(`assetstore/${assetstoreId}/re-import/${importId}`, { trigger: true });
+                }).fetch();
+            };
+
+            const assetstoreId = importEvent.get('assetstoreId');
+            const importId = importEvent.get('_id');
+            navigate(assetstoreId, importId);
+        }
+    },
+
+    initialize({ id, unique }) {
+        this._unique = unique;
+        this._assetstoreId = id;
+        this.imports = [];
+
+        const route = id ? `${id}/imports` : 'all_imports';
+        this.collection = new Collection();
+        this.collection.altUrl = `assetstore/${route}`;
+        this.collection.sortField = 'started';
+        this.collection.sortDir = SORT_DESC;
+        this.collection.params = { unique: unique || false };
+
+        this.listenTo(this.collection, 'update reset', this._updateData);
+
+        this.paginateWidget = new PaginateWidget({
+            collection: this.collection,
+            parentView: this
+        });
+
+        restRequest({
+            url: 'assetstore',
+            data: { limit: 0 }
+        }).done((result) => {
+            this.assetstores = result.map((a) => a._id);
+
+            this.collection.fetch({}, true);
+        });
+    },
+
+    _updateData() {
+        this.imports = this.collection.toArray();
+        this.render();
+    },
+
+    render() {
+        this.$el.html(importListTemplate({
+            imports: this.imports,
+            assetstores: this.assetstores,
+            moment: moment,
+            unique: this._unique,
+            assetstoreId: this._assetstoreId
+        }));
+        this.$el.tooltip();
+
+        this.paginateWidget.setElement(this.$('.g-imports-pagination')).render();
+
+        return this;
+    }
+});
+
+export default importList;

--- a/plugins/import_tracker/girder_import_tracker/web_client/views/reImport.js
+++ b/plugins/import_tracker/girder_import_tracker/web_client/views/reImport.js
@@ -1,0 +1,92 @@
+import AssetstoreModel from '@girder/core/models/AssetstoreModel';
+import View from '@girder/core/views/View';
+import { AssetstoreType } from '@girder/core/constants';
+
+import router from '@girder/core/router';
+import events from '@girder/core/events';
+import { restRequest } from '@girder/core/rest';
+
+const goBack = (assetstoreId, message) => {
+    events.trigger('g:alert', {
+        icon: 'cancel',
+        text: `Could not re-import: ${message}`,
+        type: 'danger'
+    });
+    router.navigate(
+        `assetstore/${assetstoreId}/import`,
+        { trigger: true, replace: true }
+    );
+};
+
+var reImportView = View.extend({
+    initialize({ assetstoreId, importId }) {
+        this.importId = importId;
+        this.assetstoreId = assetstoreId;
+        this.type = '';
+
+        restRequest({
+            url: `assetstore/import/${importId}`,
+            error: null
+        }).done((assetstoreImport) => {
+            if (!assetstoreImport) {
+                goBack(this.assetstoreId, `Unable to find import ${importId}`);
+                return;
+            }
+
+            this.import = assetstoreImport;
+
+            // collect assetstore type info and render
+            const assetstore = new AssetstoreModel({ _id: assetstoreId });
+            assetstore.once('g:fetched', () => {
+                const assetstoreType = assetstore.get('type');
+                if (assetstoreType === AssetstoreType.FILESYSTEM) {
+                    this.type = 'filesystem';
+                } else if (assetstoreType === AssetstoreType.S3) {
+                    this.type = 's3';
+                } else if (assetstoreType === AssetstoreType.DICOMWEB) {
+                    this.type = 'dwas';
+                } else if (assetstoreType === AssetstoreType.GIRDER) {
+                    this.type = 'gas';
+                } else {
+                    goBack(this.assetstoreId, `Unsupported assetstore type '${assetstoreType}'`);
+                }
+                this.render();
+            }).fetch();
+        }).fail(() => {
+            goBack(this.assetstoreId, 'Unable to fetch base import information');
+        });
+    },
+
+    render() {
+        const params = this.import.params;
+        const destId = params.destinationId;
+        const destType = params.destinationType;
+        const excludeExisting = params.excludeExisting ? 'true' : 'false';
+
+        this.$(`#g-${this.type}-import-path`).val(params.importPath);
+        this.$(`#g-${this.type}-import-dest-type`).val(destType);
+        this.$(`#g-${this.type}-import-dest-id`).val(destId);
+        this.$(`#g-${this.type}-import-leaf-items`).val(params.leafFoldersAsItems);
+        this.$(`#g-${this.type}-import-exclude-existing`).val(excludeExisting);
+
+        if (this.type === 'dwas') {
+            this.$(`#g-${this.type}-import-filters`).val(params.filters);
+            this.$(`#g-${this.type}-import-limit`).val(params.limit);
+        }
+
+        restRequest({
+            url: `resource/${destId}/path`,
+            method: 'GET',
+            data: { type: destType },
+            error: null
+        }).done((path) => {
+            this.$(`#g-${this.type}-import-dest-id`).val(`${destId} (${path})`);
+        }).fail(() => {
+            this.$(`#g-${this.type}-import-dest-id`).val('');
+        });
+
+        return this;
+    }
+});
+
+export default reImportView;

--- a/plugins/import_tracker/plugin.cmake
+++ b/plugins/import_tracker/plugin.cmake
@@ -1,0 +1,1 @@
+add_standard_plugin_tests(PACKAGE "girder_import_tracker")

--- a/plugins/import_tracker/plugin_tests/test_load.py
+++ b/plugins/import_tracker/plugin_tests/test_load.py
@@ -1,0 +1,8 @@
+import pytest
+
+from girder.plugin import loadedPlugins
+
+
+@pytest.mark.plugin('import_tracker')
+def test_import(server):
+    assert 'import_tracker' in loadedPlugins()

--- a/plugins/import_tracker/setup.py
+++ b/plugins/import_tracker/setup.py
@@ -1,0 +1,62 @@
+import os
+
+from setuptools import find_packages, setup
+
+
+def prerelease_local_scheme(version):
+    """Return local scheme version unless building on master in CircleCI.
+
+    This function returns the local scheme version number
+    (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
+    pre-release in which case it ignores the hash and produces a
+    PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
+    """
+    from setuptools_scm.version import get_local_node_and_date
+
+    if 'CIRCLE_BRANCH' in os.environ and \
+       os.environ['CIRCLE_BRANCH'] in {'master', 'main'}:
+        return ''
+    else:
+        return get_local_node_and_date(version)
+
+
+with open('README.md') as readme_file:
+    readme = readme_file.read()
+
+
+setup(
+    name='import_tracker',
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    setup_requires=['setuptools_scm'],
+    description='A Girder plugin for data import tracking in HistomicsUI',
+    long_description=readme,
+    long_description_content_type='text/markdown',
+    author='Kitware, Inc.',
+    author_email='kitware@kitware.com',
+    url='https://github.com/girder/girder/tree/master/plugins/import_tracker',
+    license='Apache 2.0',
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'License :: OSI Approved :: Apache Software License',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+    ],
+    install_requires=[
+        'girder-jobs>=3.0.3',
+        'girder>=3.1.23',
+    ],
+    include_package_data=True,
+    keywords='girder-plugin, import_tracker',
+    packages=find_packages(exclude=['plugin_tests']),
+    zip_safe=False,
+    entry_points={
+        'girder.plugin': [
+            'import_tracker = girder_import_tracker:GirderPlugin'
+        ]
+    }
+)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,6 +22,7 @@
 -e plugins/thumbnails
 -e plugins/user_quota
 -e plugins/virtual_folders
+-e plugins/import_tracker
 
 # External dependencies
 configparser


### PR DESCRIPTION
Moves the import tracker defined in the Digital Slide Archive ([here](https://github.com/DigitalSlideArchive/import-tracker)) into `girder/plugins`.

The functionality cannot be added to core girder because of the dependency on the jobs plugin.