### PR TITLE
Import export assetstore import view map

### DIFF
--- a/girder/web/src/views/body/index.js
+++ b/girder/web/src/views/body/index.js
@@ -1,5 +1,5 @@
 import AdminView from './AdminView';
-import AssetstoresView from './AssetstoresView';
+import * as AssetstoresView from './AssetstoresView';
 import CollectionView from './CollectionView';
 import CollectionsView from './CollectionsView';
 import FilesystemImportView from './FilesystemImportView';

--- a/girder/web/src/views/body/index.js
+++ b/girder/web/src/views/body/index.js
@@ -1,5 +1,5 @@
 import AdminView from './AdminView';
-import * as AssetstoresView from './AssetstoresView';
+import AssetstoresView, { assetstoreImportViewMap } from './AssetstoresView';
 import CollectionView from './CollectionView';
 import CollectionsView from './CollectionsView';
 import FilesystemImportView from './FilesystemImportView';
@@ -19,6 +19,7 @@ import UsersView from './UsersView';
 export {
     AdminView,
     AssetstoresView,
+    assetstoreImportViewMap,
     CollectionView,
     CollectionsView,
     FilesystemImportView,


### PR DESCRIPTION
I ran into an issue converting the DICOMweb assetstore plugin to girder 5. I was unable to access the `assetstoreImportViewMap` object. 

I expect this is due to how `views/body/index.js` imports/exports everything.