### PR TITLE
Expose assetstoreImportViewMap as a property of AssetsoresView

### DIFF
--- a/girder/web/src/views/body/AssetstoresView.js
+++ b/girder/web/src/views/body/AssetstoresView.js
@@ -214,7 +214,9 @@ var AssetstoresView = View.extend({
             this.render();
         }, this);
         editAssetstoreWidget.render();
-    }
+    },
+
+    assetstoreImportViewMap,
 }, {
     import: function (assetstoreId) {
         var assetstore = new AssetstoreModel({ _id: assetstoreId });
@@ -231,5 +233,4 @@ var AssetstoresView = View.extend({
     }
 });
 
-export { assetstoreImportViewMap };
 export default AssetstoresView;

--- a/girder/web/src/views/body/index.js
+++ b/girder/web/src/views/body/index.js
@@ -1,5 +1,5 @@
 import AdminView from './AdminView';
-import AssetstoresView, { assetstoreImportViewMap } from './AssetstoresView';
+import AssetstoresView from './AssetstoresView';
 import CollectionView from './CollectionView';
 import CollectionsView from './CollectionsView';
 import FilesystemImportView from './FilesystemImportView';
@@ -19,7 +19,6 @@ import UsersView from './UsersView';
 export {
     AdminView,
     AssetstoresView,
-    assetstoreImportViewMap,
     CollectionView,
     CollectionsView,
     FilesystemImportView,


### PR DESCRIPTION
This is needed for girder_assetstore because of the `import @girder/core` -> `window.girder` changes:
girder_assetstore can no longer import `assetstoreImportViewMap` from AssetsoresView.js.