### PR TITLE
Increase the pageLimit for assetstores

### DIFF
--- a/girder/web_client/src/collections/AssetstoreCollection.js
+++ b/girder/web_client/src/collections/AssetstoreCollection.js
@@ -3,7 +3,8 @@ import Collection from '@girder/core/collections/Collection';
 
 var AssetstoreCollection = Collection.extend({
     resourceName: 'assetstore',
-    model: AssetstoreModel
+    model: AssetstoreModel,
+    pageLimit: 1000
 });
 
 export default AssetstoreCollection;


### PR DESCRIPTION
We currently don't have any UI for paging the list of assetstores.  As such, once there are more than 25 assetstores, they later ones became inaccessible.  We should revisit this with proper paging, but for now this just increases the page size for the assetstore collection to 1000.