### PR TITLE
Guess mimeType during import if none was provided

### DIFF
--- a/girder/utility/filesystem_assetstore_adapter.py
+++ b/girder/utility/filesystem_assetstore_adapter.py
@@ -1,6 +1,7 @@
 import filelock
 from hashlib import sha512
 import io
+import mimetypes
 import os
 import psutil
 import shutil
@@ -334,6 +335,7 @@ class FilesystemAssetstoreAdapter(AbstractAssetstoreAdapter):
                      path, item['_id'], self.assetstore['_id'])
         stat = os.stat(path)
         name = name or os.path.basename(path)
+        mimeType = mimeType or mimetypes.guess_type(name)[0]
 
         file = File().createFile(
             name=name, creator=user, item=item, reuseExisting=True, assetstore=self.assetstore,

--- a/test/test_fs_assetstore_import.py
+++ b/test/test_fs_assetstore_import.py
@@ -1,0 +1,67 @@
+import os
+import tempfile
+
+import pytest
+from girder.models.folder import Folder
+from girder.utility import path as path_util
+from pytest_girder.assertions import assertStatusOk
+
+
+@pytest.fixture
+def temp_files():
+    """Creates temporary .csv, .png, and .jpg files and deletes them after use."""
+    temp_dir = tempfile.mkdtemp()
+    file_paths = {
+        'csv': os.path.join(temp_dir, 'test.csv'),
+        'png': os.path.join(temp_dir, 'test.png'),
+        'jpg': os.path.join(temp_dir, 'test.jpg'),
+    }
+
+    # Create empty files
+    for path in file_paths.values():
+        with open(path, 'wb') as f:
+            f.write(b'')
+
+    yield file_paths
+
+    # Cleanup
+    for path in file_paths.values():
+        os.remove(path)
+    os.rmdir(temp_dir)
+
+
+def test_mimetype_guessing(server, admin, fsAssetstore, temp_files):
+    """Test that the assetstore correctly guesses the mimetype of files."""
+    # Upload files
+
+    folder = next(
+        Folder().childFolders(
+            admin, parentType='user', force=True, filters={'name': 'Public'}
+        )
+    )
+
+    for key, value in temp_files.items():
+        params = {
+            'importPath': value,
+            'destinationType': 'folder',
+            'destinationId': str(folder['_id']),
+        }
+        resp = server.request(
+            path=f'/assetstore/{fsAssetstore["_id"]}/import',
+            method='POST',
+            user=admin,
+            params=params,
+        )
+        assertStatusOk(resp)
+        file = path_util.lookUpPath(
+            f'/user/{admin["login"]}/Public/test.{key}/test.{key}', admin
+        )['document']
+
+        assert (
+            file['mimeType']
+            == {
+                'csv': 'text/csv',
+                'png': 'image/png',
+                'jpg': 'image/jpeg',
+            }[key]
+        )


### PR DESCRIPTION
Fixes #1645

I run into a weird issue where a) `item_previews` were not rendering images and b) clicking on "eye" icon in Item/File view resulted in images being downloaded instead of opened in a browser. Turns out it's all due to mimeType and those file had mimeType undefined / octet-stream because they were imported. 