### PR TITLE
Skip building source maps

### DIFF
--- a/.circleci/build_plugins.py
+++ b/.circleci/build_plugins.py
@@ -14,7 +14,7 @@ for plugin_dir in plugins_dir.iterdir():
         for web_client_dir in search_dirs:
             if web_client_dir.exists() and (web_client_dir / 'package-lock.json').exists():
                 subprocess.run(
-                    'npm ci && npm run build',
+                    'npm ci && SKIP_SOURCE_MAPS=true npm run build',
                     check=True,
                     shell=True,
                     stdout=sys.stdout,

--- a/.circleci/publish_pypi.sh
+++ b/.circleci/publish_pypi.sh
@@ -3,7 +3,7 @@ set -e
 
 pushd girder/web
 npm ci
-npm run build
+SKIP_SOURCE_MAPS=true npm run build
 popd
 
 python .circleci/build_plugins.py plugins/

--- a/girder/web/vite.config.ts
+++ b/girder/web/vite.config.ts
@@ -68,7 +68,7 @@ export default defineConfig({
     }
   },
   build: {
-    sourcemap: true,
+    sourcemap: !process.env.SKIP_SOURCE_MAPS,
     outDir,
     ...buildOpts,
   },

--- a/plugins/authorized_upload/girder_authorized_upload/web_client/vite.config.ts
+++ b/plugins/authorized_upload/girder_authorized_upload/web_client/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     }),
   ],
   build: {
-    sourcemap: true,
+    sourcemap: !process.env.SKIP_SOURCE_MAPS,
     lib: {
       entry: resolve(__dirname, 'main.js'),
       name: 'GirderPluginAuthorizedUpload',

--- a/plugins/autojoin/girder_autojoin/web_client/vite.config.ts
+++ b/plugins/autojoin/girder_autojoin/web_client/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     }),
   ],
   build: {
-    sourcemap: true,
+    sourcemap: !process.env.SKIP_SOURCE_MAPS,
     lib: {
       entry: resolve(__dirname, 'main.js'),
       name: 'GirderPluginAutojoin',

--- a/plugins/google_analytics/girder_google_analytics/web_client/vite.config.ts
+++ b/plugins/google_analytics/girder_google_analytics/web_client/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     }),
   ],
   build: {
-    sourcemap: true,
+    sourcemap: !process.env.SKIP_SOURCE_MAPS,
     lib: {
       entry: resolve(__dirname, 'main.js'),
       name: 'GirderPluginGoogleAnalytics',

--- a/plugins/gravatar/girder_gravatar/web_client/vite.config.ts
+++ b/plugins/gravatar/girder_gravatar/web_client/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     }),
   ],
   build: {
-    sourcemap: true,
+    sourcemap: !process.env.SKIP_SOURCE_MAPS,
     lib: {
       entry: resolve(__dirname, 'main.js'),
       name: 'GirderPluginGravatar',

--- a/plugins/hashsum_download/girder_hashsum_download/web_client/vite.config.ts
+++ b/plugins/hashsum_download/girder_hashsum_download/web_client/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     }),
   ],
   build: {
-    sourcemap: true,
+    sourcemap: !process.env.SKIP_SOURCE_MAPS,
     lib: {
       entry: resolve(__dirname, 'main.js'),
       name: 'GirderPluginHashsumDownload',

--- a/plugins/homepage/girder_homepage/web_client/vite.config.ts
+++ b/plugins/homepage/girder_homepage/web_client/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     }),
   ],
   build: {
-    sourcemap: true,
+    sourcemap: !process.env.SKIP_SOURCE_MAPS,
     lib: {
       entry: resolve(__dirname, 'main.js'),
       name: 'GirderPluginHomepage',

--- a/plugins/import_tracker/girder_import_tracker/web_client/vite.config.ts
+++ b/plugins/import_tracker/girder_import_tracker/web_client/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
         pugPlugin(),
     ],
     build: {
-        sourcemap: true,
+        sourcemap: !process.env.SKIP_SOURCE_MAPS,
         lib: {
             entry: resolve(__dirname, 'main.js'),
             name: 'GirderPluginImportTracker',

--- a/plugins/item_licenses/girder_item_licenses/web_client/vite.config.ts
+++ b/plugins/item_licenses/girder_item_licenses/web_client/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     }),
   ],
   build: {
-    sourcemap: true,
+    sourcemap: !process.env.SKIP_SOURCE_MAPS,
     lib: {
       entry: resolve(__dirname, 'main.js'),
       name: 'GirderPluginItemLicenses',

--- a/plugins/jobs/girder_jobs/web_client/vite.config.ts
+++ b/plugins/jobs/girder_jobs/web_client/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     }),
   ],
   build: {
-    sourcemap: true,
+    sourcemap: !process.env.SKIP_SOURCE_MAPS,
     lib: {
       entry: resolve(__dirname, 'main.js'),
       name: 'GirderPluginJobs',

--- a/plugins/ldap/girder_ldap/web_client/vite.config.ts
+++ b/plugins/ldap/girder_ldap/web_client/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     }),
   ],
   build: {
-    sourcemap: true,
+    sourcemap: !process.env.SKIP_SOURCE_MAPS,
     lib: {
       entry: resolve(__dirname, 'main.js'),
       name: 'GirderPluginLdap',

--- a/plugins/oauth/girder_oauth/web_client/vite.config.ts
+++ b/plugins/oauth/girder_oauth/web_client/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     }),
   ],
   build: {
-    sourcemap: true,
+    sourcemap: !process.env.SKIP_SOURCE_MAPS,
     lib: {
       entry: resolve(__dirname, 'main.js'),
       name: 'GirderPluginOauth',

--- a/plugins/readme/girder_readme/web_client/vite.config.ts
+++ b/plugins/readme/girder_readme/web_client/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     }),
   ],
   build: {
-    sourcemap: true,
+    sourcemap: !process.env.SKIP_SOURCE_MAPS,
     lib: {
       entry: resolve(__dirname, 'main.js'),
       name: 'GirderPluginReadme',

--- a/plugins/sentry/girder_sentry/web_client/vite.config.ts
+++ b/plugins/sentry/girder_sentry/web_client/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     }),
   ],
   build: {
-    sourcemap: true,
+    sourcemap: !process.env.SKIP_SOURCE_MAPS,
     lib: {
       entry: resolve(__dirname, 'main.js'),
       name: 'GirderPluginSentry',

--- a/plugins/slicer_cli_web/girder_slicer_cli_web/web_client/vite.config.ts
+++ b/plugins/slicer_cli_web/girder_slicer_cli_web/web_client/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     pugPlugin(),
   ],
   build: {
-    sourcemap: true,
+    sourcemap: !process.env.SKIP_SOURCE_MAPS,
     lib: {
       entry: resolve(__dirname, 'main.js'),
       name: 'GirderPluginSlicerCLIWeb',

--- a/plugins/terms/girder_terms/web_client/vite.config.ts
+++ b/plugins/terms/girder_terms/web_client/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     }),
   ],
   build: {
-    sourcemap: true,
+    sourcemap: !process.env.SKIP_SOURCE_MAPS,
     lib: {
       entry: resolve(__dirname, 'main.js'),
       name: 'GirderPluginTerms',

--- a/plugins/thumbnails/girder_thumbnails/web_client/vite.config.ts
+++ b/plugins/thumbnails/girder_thumbnails/web_client/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     }),
   ],
   build: {
-    sourcemap: true,
+    sourcemap: !process.env.SKIP_SOURCE_MAPS,
     lib: {
       entry: resolve(__dirname, 'main.js'),
       name: 'GirderPluginThumbnails',

--- a/plugins/user_quota/girder_user_quota/web_client/vite.config.ts
+++ b/plugins/user_quota/girder_user_quota/web_client/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     }),
   ],
   build: {
-    sourcemap: true,
+    sourcemap: !process.env.SKIP_SOURCE_MAPS,
     lib: {
       entry: resolve(__dirname, 'main.js'),
       name: 'GirderPluginUserQuota',

--- a/plugins/worker/girder_plugin_worker/web_client/vite.config.ts
+++ b/plugins/worker/girder_plugin_worker/web_client/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     pugPlugin(),
   ],
   build: {
-    sourcemap: true,
+    sourcemap: !process.env.SKIP_SOURCE_MAPS,
     lib: {
       entry: resolve(__dirname, 'main.js'),
       name: 'GirderPluginWorker',


### PR DESCRIPTION
@manthey PTAL, you can now set `SKIP_SOURCE_MAPS=true` when running `npm run build` to disable creation of source maps. I've enabled this in CI/CD such that our distributed packages for girder core and the plugins in this repo do not contain source maps.