### PR TITLE
Allow to set cherrypy thread_pool and db.replica_set via env vars

### DIFF
--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -202,6 +202,15 @@ via the config file alone. Now, the caching modules are configured via environme
 Config keys prefixed by ``cache.global.`` are used to configure the global dogpile cache, and
 keys prefixed by ``cache.request.`` are used to configure the request cache.
 
+CherryPy specific settings are now passed via environment variables as well. List of settings that
+can be configured:
+
+* ``GIRDER_HOST`` corresponds to ``server.socket_host``
+* ``GIRDER_PORT`` corresponds to ``server.socket_port``
+* ``GIRDER_THREAD_POOL`` corresponds to ``server.thread_pool``
+* ``GIRDER_MONGO_URI`` corresponds to ``database.uri``
+* ``GIRDER_MONGO_REPLICA_SET`` corresponds to ``database.replica_set``
+
 WSGI app for production deployments
 +++++++++++++++++++++++++++++++++++
 

--- a/girder/utility/config.py
+++ b/girder/utility/config.py
@@ -10,6 +10,7 @@ def loadConfig():
     # values from the environment. It is called at import time of the girder package.
     cherrypy.config['server.socket_host'] = os.getenv('GIRDER_HOST', '127.0.0.1')
     cherrypy.config['server.socket_port'] = int(os.getenv('GIRDER_PORT', 8080))
+    cherrypy.config['server.thread_pool'] = int(os.getenv('GIRDER_THREAD_POOL', 100))
     cherrypy.config['tools.proxy.on'] = True
 
     if 'database' not in cherrypy.config:
@@ -20,6 +21,7 @@ def loadConfig():
     else:
         cherrypy.config['database']['uri'] = os.getenv(
             'GIRDER_MONGO_URI', 'mongodb://localhost:27017/girder')
+        cherrypy.config['database']['replica_set'] = os.getenv('GIRDER_MONGO_REPLICA_SET')
 
 
 def getConfig():


### PR DESCRIPTION
After the config removal cherrypy settings default to 10 threads and there's no way to change that. This PR introduces support for setting cherrypy thread pool size vie env var `GIRDER_THREAD_POOL`. Additionally I added support for `database.replica_set` (via `GIRDER_MONGO_REPLICA_SET`) for full backward compatibility.