### PR TITLE
Introduce "local" celery task queue for long-running async tasks that need database and/or local filesystem access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,28 @@ services:
       - ".:/girder"
       - assetstore:/assetstore
 
+  rabbitmq:
+    image: rabbitmq:3-management
+    environment:
+      - RABBITMQ_FEATURE_FLAGS=
+    ports:
+      - ${DOCKER_RABBITMQ_PORT-5672}:5672
+      - ${DOCKER_RABBITMQ_CONSOLE_PORT-15672}:15672
+    volumes:
+      - rabbitmq:/var/lib/rabbitmq/mnesia
+
+  localworker:
+    build: .
+    depends_on:
+      - mongodb
+    entrypoint: celery -A girder_worker.app worker -Q local
+    environment:
+      - GIRDER_WORKER_BROKER=amqp://rabbitmq:5672
+      - GIRDER_WORKER_BACKEND=rpc://rabbitmq:5672
+      - GIRDER_MONGO_URI=mongodb://mongodb:27017/girder
+      - C_FORCE_ROOT=1
+
 volumes:
   mongodb_data:
   assetstore:
+  rabbitmq:

--- a/girder/api/v1/assetstore.py
+++ b/girder/api/v1/assetstore.py
@@ -6,8 +6,8 @@ from girder.exceptions import RestException
 from girder.api import access
 from girder.models.assetstore import Assetstore as AssetstoreModel
 from girder.models.file import File
+from girder.tasks import importDataTask
 from girder.utility.model_importer import ModelImporter
-from girder.utility.progress import ProgressContext
 from girder.utility.s3_assetstore_adapter import DEFAULT_REGION
 
 
@@ -133,14 +133,14 @@ class Assetstore(Resource):
         # Capture any additional parameters passed to route
         extraParams = kwargs.get('params', {})
 
-        with ProgressContext(progress, user=user, title='Importing data') as ctx:
-            return self._model.importData(
-                assetstore, parent=parent, parentType=destinationType, params={
-                    'fileIncludeRegex': fileIncludeRegex,
-                    'fileExcludeRegex': fileExcludeRegex,
-                    'importPath': importPath,
-                    **extraParams
-                }, progress=ctx, user=user, leafFoldersAsItems=leafFoldersAsItems)
+        # Run the import data task on the local celery queue since it can take a long time
+        importDataTask.delay(
+            assetstore, parent=parent, parentType=destinationType, params={
+                'fileIncludeRegex': fileIncludeRegex,
+                'fileExcludeRegex': fileExcludeRegex,
+                'importPath': importPath,
+                **extraParams
+            }, progress=progress, user=user, leafFoldersAsItems=leafFoldersAsItems)
 
     @access.admin
     @autoDescribeRoute(

--- a/girder/tasks.py
+++ b/girder/tasks.py
@@ -1,0 +1,20 @@
+from girder.models.assetstore import Assetstore
+from girder.utility.progress import ProgressContext
+from girder_worker.app import app
+
+
+@app.task(queue='local')
+def importDataTask(
+    assetstore: dict,
+    parent: dict,
+    parentType: str,
+    params: dict,
+    progress: bool,
+    user: dict,
+    leafFoldersAsItems: bool
+):
+    with ProgressContext(progress, user=user, title='Importing data') as ctx:
+        return Assetstore().importData(
+            assetstore, parent=parent, parentType=parentType, params=params,
+            progress=ctx, user=user, leafFoldersAsItems=leafFoldersAsItems,
+        )

--- a/girder/worker_plugin.py
+++ b/girder/worker_plugin.py
@@ -1,0 +1,9 @@
+from girder_worker import GirderWorkerPluginABC
+
+
+class CoreWorkerPlugin(GirderWorkerPluginABC):
+    def __init__(self, app, *args, **kwargs):
+        self.app = app
+
+    def task_imports(self):
+        return ['girder.tasks']

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ installReqs = [
     'click-plugins',
     'dogpile.cache',
     'filelock',
+    'girder-worker>=5.0.0a5',
     'jsonschema',
     'Mako',
     'passlib [bcrypt,totp]',
@@ -95,6 +96,9 @@ setup(
             'mount = girder.cli.mount:main',
             'shell = girder.cli.shell:main',
             'sftpd = girder.cli.sftpd:main',
-        ]
+        ],
+        'girder_worker_plugins': [
+            'girder_local = girder.worker_plugin:CoreWorkerPlugin',
+        ],
     }
 )

--- a/worker/girder_worker/celeryconfig.py
+++ b/worker/girder_worker/celeryconfig.py
@@ -6,4 +6,4 @@ broker_url = os.environ.get(
     'GIRDER_WORKER_BROKER', 'amqp://guest:guest@localhost/')
 
 result_backend = os.environ.get(
-    'GIRDER_WORKER_BACKEND', 'rpc://guest:guest@localhost/') or broker_url
+    'GIRDER_WORKER_BACKEND', 'rpc://guest:guest@localhost/')


### PR DESCRIPTION
This is the Girder 5 replacement for the now-removed events daemon. All tasks that might take longer than 1-2 seconds should eventually be converted to use this mechanism.

This introduces the need to run an additional process on a machine that can connect to the mongo database, namely `celery -A girder_worker.app worker -Q local`.

I still need to document these changes.