### PR TITLE
Support eager tasks in girder_worker task instrumentation

### DIFF
--- a/worker/girder_worker/app.py
+++ b/worker/girder_worker/app.py
@@ -150,13 +150,10 @@ def gw_task_success(sender=None, **rest):
         return
 
     try:
-
-        if not is_revoked(sender):
-            _update_status(sender, JobStatus.SUCCESS)
-
-        # For tasks revoked directly
-        else:
+        if is_revoked(sender):
             _update_status(sender, JobStatus.CANCELED)
+        else:
+            _update_status(sender, JobStatus.SUCCESS)
     except AttributeError:
         pass
     except StateTransitionException:

--- a/worker/girder_worker/utils/__init__.py
+++ b/worker/girder_worker/utils/__init__.py
@@ -147,12 +147,16 @@ def is_revoked(task):
     """
     Utility function to check if a task has been revoked.
 
+    Eager tasks are never considered revoked.
+
     :param task: The task.
     :type task: celery.app.task.Task
     :return: True, if this task is in the revoked list for this worker, False
             otherwise.
     :rtype: bool
     """
+    if task.request.is_eager:
+        return False
     return task.request.id in _revoked_tasks(task)
 
 


### PR DESCRIPTION
This is mostly to facilitate the use of `task_always_eager = True` in testing.