### PR TITLE
Fix API Key creation for other users

### DIFF
--- a/girder/api/v1/api_key.py
+++ b/girder/api/v1/api_key.py
@@ -48,13 +48,15 @@ class ApiKey(Resource):
                'key will last.', required=False)
         .param('active', 'Whether the key is currently active.', required=False,
                dataType='boolean', default=True)
+        .modelParam('targetUserId', 'Id of user to apply the key to', model=User, paramType='query',
+                    level=AccessType.ADMIN, destName='targetUser', required=False)
         .errorResponse()
     )
-    def createKey(self, name, scope, tokenDuration, active):
+    def createKey(self, name, scope, tokenDuration, active, targetUser):
         if Setting().get(SettingKey.API_KEYS):
             return ApiKeyModel().createApiKey(
-                user=self.getCurrentUser(), name=name, scope=scope, days=tokenDuration,
-                active=active)
+                user=targetUser or self.getCurrentUser(),
+                name=name, scope=scope, days=tokenDuration, active=active)
         else:
             raise RestException('API key functionality is disabled on this instance.')
 

--- a/girder/web_client/src/views/widgets/EditApiKeyWidget.js
+++ b/girder/web_client/src/views/widgets/EditApiKeyWidget.js
@@ -22,7 +22,8 @@ var EditApiKeyWidget = View.extend({
             var fields = {
                 name: this.$('#g-api-key-name').val(),
                 tokenDuration: this.$('#g-api-key-token-duration').val(),
-                scope: null
+                scope: null,
+                targetUserId: this.targetUserId
             };
 
             if (this._getSelectedScopeMode() === 'custom') {
@@ -52,6 +53,7 @@ var EditApiKeyWidget = View.extend({
     initialize: function (settings) {
         this.model = settings.model || null;
         this.scopeInfo = null;
+        this.targetUserId = settings.parentView.model.id;
         this._shouldRender = false;
 
         restRequest({


### PR DESCRIPTION
Fixes: https://github.com/girder/girder/issues/2747  
Only admin users can create an API key for someone else.