### PR TITLE
Fix a timeout in the match_path endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,7 +338,7 @@ jobs:
           path: girder
       - run:
           name: Install tox
-          command: pip install tox
+          command: pip install --user tox
       - run:
           name: Publish Python packages
           command: tox -e publish


### PR DESCRIPTION
The slicer_cli_web plugin exposes a match_path endpoint.  This specifies a mongo cursor timeout of 10 seconds, but if the returned data needs filtering that cannot easily be done in the database, the cursor is looped through until success or exhaustion.  This doesn't count toward the timeout, since the cursor is actively returning data.  While in the guincorn world, this would be stopped, it is better to stop intentionally when the timeout is exhausted.