### PR TITLE
Pin dogpile.cache

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ installReqs = [
     'CherryPy',
     'click',
     'click-plugins',
-    'dogpile.cache',
+    'dogpile.cache<1.4',
     'filelock',
     'jsonschema',
     'Mako',


### PR DESCRIPTION
dogpile.cache 1.4 doesn't play well with pkg_reosurces on some python versions, seemingly over how the period in the package name is handled. The real solution should be to switch away from pkg_resources to importlib, but that probably requires using the importlib_metadata package so we don't have to maintain variations based on python versions and refactoring how we test plugins.  Pinning docpile.cache is a short-term solution that should be revisited later.