### PR TITLE
Add `girder_job_disable` arg to task invocations

### DIFF
--- a/girder/api/v1/assetstore.py
+++ b/girder/api/v1/assetstore.py
@@ -142,7 +142,7 @@ class Assetstore(Resource):
                 'importPath': importPath,
                 **extraParams
             }, progress=progress, user=user, leafFoldersAsItems=leafFoldersAsItems,
-            girder_job_title=f'Import data from assetstore {assetstore["name"]}')
+            girder_job_disable=True)
 
     @access.admin
     @autoDescribeRoute(

--- a/test/worker/test_app.py
+++ b/test/worker/test_app.py
@@ -25,7 +25,8 @@ RESERVED_OPTIONS = [
     ('girder_job_type', 'GIRDER_JOB_TYPE'),
     ('girder_job_public', 'GIRDER_JOB_PUBLIC'),
     ('girder_job_handler', 'GIRDER_JOB_HANDLER'),
-    ('girder_job_other_fields', 'GIRDER_JOB_OTHER_FIELDS')
+    ('girder_job_other_fields', 'GIRDER_JOB_OTHER_FIELDS'),
+    ('girder_job_disable', 'GIRDER_JOB_DISABLE'),
 ]
 
 

--- a/worker/girder_worker/app.py
+++ b/worker/girder_worker/app.py
@@ -49,7 +49,7 @@ def girder_before_task_publish(sender=None, body=None, exchange=None,
 
     try:
         context = get_context()
-        if 'jobInfoSpec' not in headers:
+        if 'jobInfoSpec' not in headers and not headers.get('girder_job_disable'):
             job = context.create_task_job(
                 Task.girder_job_defaults(), sender=sender, body=body, exchange=exchange,
                 routing_key=routing_key, headers=headers, properties=properties, declare=declare,

--- a/worker/girder_worker/task.py
+++ b/worker/girder_worker/task.py
@@ -48,7 +48,8 @@ class Task(celery.Task):
         'girder_client_token',
         'girder_api_url',
         'girder_result_hooks',
-        'girder_client_session_kwargs']
+        'girder_client_session_kwargs',
+    ]
 
     # These keys will be available in the 'properties' dictionary inside
     # girder_before_task_publish() but will not be passed along in the message
@@ -58,7 +59,9 @@ class Task(celery.Task):
         'girder_job_type',
         'girder_job_public',
         'girder_job_handler',
-        'girder_job_other_fields']
+        'girder_job_other_fields',
+        'girder_job_disable',
+    ]
 
     def AsyncResult(self, task_id, **kwargs):
         return GirderAsyncResult(task_id, backend=self.backend,


### PR DESCRIPTION
This can be set to prevent the behavior of internal Job record creation when invoking a celery task.

Refs #3657 