### PR TITLE
Add a scope to allow tokens to list jobs

### DIFF
--- a/plugins/jobs/girder_jobs/constants.py
+++ b/plugins/jobs/girder_jobs/constants.py
@@ -6,6 +6,7 @@ JOB_HANDLER_LOCAL = 'jobs._local'
 
 # Scope used allow RESTful creation of girder job models
 REST_CREATE_JOB_TOKEN_SCOPE = 'jobs.rest.create_job'
+REST_LIST_JOB_TOKEN_SCOPE = 'jobs.rest.list_job'
 
 
 # integer enum describing job states. Note, no order is implied.

--- a/plugins/jobs/girder_jobs/job_rest.py
+++ b/plugins/jobs/girder_jobs/job_rest.py
@@ -24,7 +24,7 @@ class Job(Resource):
         self.route('GET', ('typeandstatus', 'all',), self.allJobsTypesAndStatuses)
         self.route('GET', ('typeandstatus',), self.jobsTypesAndStatuses)
 
-    @access.public
+    @access.public(scope=constants.REST_LIST_JOB_TOKEN_SCOPE)
     @filtermodel(model=JobModel)
     @autoDescribeRoute(
         Description('List jobs for a given user.')
@@ -87,7 +87,7 @@ class Job(Resource):
         }
         return self._model.createJob(**params)
 
-    @access.admin
+    @access.user(scope=constants.REST_LIST_JOB_TOKEN_SCOPE)
     @filtermodel(model=JobModel)
     @autoDescribeRoute(
         Description('List all jobs.')
@@ -175,7 +175,7 @@ class Job(Resource):
     def deleteJob(self, job):
         self._model.remove(job)
 
-    @access.admin
+    @access.user(scope=constants.REST_LIST_JOB_TOKEN_SCOPE)
     @autoDescribeRoute(
         Description('Get types and statuses of all jobs')
         .errorResponse('Admin access was denied for the job.', 403)
@@ -183,7 +183,7 @@ class Job(Resource):
     def allJobsTypesAndStatuses(self):
         return self._model.getAllTypesAndStatuses(user='all')
 
-    @access.user
+    @access.user(scope=constants.REST_LIST_JOB_TOKEN_SCOPE)
     @autoDescribeRoute(
         Description('Get types and statuses of jobs of current user')
     )

--- a/plugins/jobs/plugin_tests/jobs_test.py
+++ b/plugins/jobs/plugin_tests/jobs_test.py
@@ -202,9 +202,9 @@ class JobsTestCase(base.TestCase):
         self.assertStatusOk(resp)
         self.assertEqual(len(resp.json), 0)
 
-        # User 1, as non site admin, should encounter http 403 (Forbidden)
+        # User 1, as non site admin, should still get an answer
         resp = self.request('/job/all', user=self.users[1])
-        self.assertStatus(resp, 403)
+        self.assertStatusOk(resp)
 
         # Not authenticated user should encounter http 401 (unauthorized)
         resp = self.request('/job/all')
@@ -446,9 +446,9 @@ class JobsTestCase(base.TestCase):
         self.jobModel.createJob(title='anonymous job', type='t5')
         self.jobModel.createJob(title='anonymous public job', type='t6', public=True)
 
-        # User 1, as non site admin, should encounter http 403 (Forbidden)
+        # User 1, as non site admin, should get an answer
         resp = self.request('/job/typeandstatus/all', user=self.users[1])
-        self.assertStatus(resp, 403)
+        self.assertStatusOk(resp)
 
         # Admin user gets all types and statuses
         resp = self.request('/job/typeandstatus/all', user=self.users[0])

--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -1104,6 +1104,7 @@ plugins
                     validTransitions
                     valid_transitions
                 REST_CREATE_JOB_TOKEN_SCOPE
+                REST_LIST_JOB_TOKEN_SCOPE
             job_rest
                 Job
                     allJobsTypesAndStatuses


### PR DESCRIPTION
Permit non-admin users to list jobs that they could have already accessed by id.  For some reason, the "all" endpoints were marked admin access, even though there are jobs that a non-admin is allowed to access that are not their own (jobs marked public, for instance).