### PR TITLE
Plugins should show short descriptions.

### DIFF
--- a/girder/plugin.py
+++ b/girder/plugin.py
@@ -142,7 +142,7 @@ class GirderPlugin(metaclass=_PluginMeta):
     @property
     def description(self):
         """Return the plugin description defaulting to the classes docstring."""
-        return self._metadata.get('description', self._metadata.get('Summary', ''))
+        return self._metadata.get('Summary', self._metadata.get('description', ''))
 
     @property
     def url(self):


### PR DESCRIPTION
When switching away from pkg_resources, some plugins showed long descriptions instead of short descriptions.