### PR TITLE
Ensure `build-lib` is built during npm package publication

### DIFF
--- a/.circleci/publish_npm.sh
+++ b/.circleci/publish_npm.sh
@@ -18,6 +18,7 @@ for directory in "${PUBLISHED_NPM_PACKAGES[@]}"; do
   pushd "$directory"
   # Trying to set the auth token via 'npm_config_' environment variables does not work
   echo '//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}' > ./.npmrc
+  npm ci
   npm version --allow-same-version --no-git-tag-version "$GIT_VERSION"
   npm publish --access public
   rm --interactive=never ./.npmrc

--- a/girder/web/package.json
+++ b/girder/web/package.json
@@ -31,7 +31,8 @@
     "build-only": "vite build",
     "build-lib": "BUILD_LIB=true vite build",
     "type-check": "vue-tsc --noEmit -p tsconfig.json --composite false",
-    "install-browsers": "playwright install --with-deps"
+    "install-browsers": "playwright install --with-deps",
+    "prepublishOnly": "npm run build-lib"
   },
   "dependencies": {
     "@girder/fontello": "^5.0.0-a7",


### PR DESCRIPTION
`npm publish --dry-run` is useful for testing this locally.