### PR TITLE
Fix serving from something other than the absolute root

### DIFF
--- a/girder/plugin.py
+++ b/girder/plugin.py
@@ -57,7 +57,7 @@ def registerPluginStaticContent(plugin: str, css: List[str], js: List[str], stat
 
             if '?' in filename:
                 # For now, we assume this means the plugin is managing its own cache busting
-                return f'/plugin_static/{plugin}/{filename}'
+                return f'plugin_static/{plugin}/{filename}'
 
             hash_md5 = hashlib.md5()
 
@@ -65,7 +65,7 @@ def registerPluginStaticContent(plugin: str, css: List[str], js: List[str], stat
                 for chunk in iter(lambda: f.read(4096), b''):
                     hash_md5.update(chunk)
 
-            return f'/plugin_static/{plugin}/{filename}?h={hash_md5.hexdigest()[:10]}'
+            return f'plugin_static/{plugin}/{filename}?h={hash_md5.hexdigest()[:10]}'
 
         _pluginStaticContent[plugin] = PluginStaticContent(
             css=[cache_bust_url(f) for f in css],

--- a/girder/web/src/main.ts
+++ b/girder/web/src/main.ts
@@ -23,7 +23,7 @@ const apiRoot = import.meta.env.VITE_API_ROOT ?? '/api/v1';
     const link = document.createElement('link');
     link.rel = 'stylesheet';
     link.type = 'text/css';
-    link.href = new URL(href, origin).href;
+    link.href = new URL(href, window.location.href).href;
     document.head.appendChild(link);
   });
 
@@ -34,7 +34,7 @@ const apiRoot = import.meta.env.VITE_API_ROOT ?? '/api/v1';
     await new Promise<void>((resolve) => {
       const script = document.createElement('script');
       script.type = 'text/javascript';
-      script.src = new URL(href, origin).href;
+      script.src = new URL(href, window.location.href).href;
       document.head.appendChild(script);
       script.addEventListener('load', function() {
         resolve();


### PR DESCRIPTION
If you rebuild the girder client via a command like `VITE_API_ROOT=/girder/api/v1 npx vite build --base=/girder/` and serve girder through a reverse proxy at <server>/girder, this didn't work because the plugin_static_files endpoint returned absolute paths and the typescript loaded absolute paths.

This change returns relative paths and, in the typescript, adds them relative to window.location.href instead of window.origin.

There probably is a cleaner way to do this.