### PR TITLE
Retry s3 requests when fetching from the assetstore

### DIFF
--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -1,5 +1,7 @@
 import datetime
+import errno
 import json
+import os
 import re
 import urllib.parse
 import uuid
@@ -404,7 +406,7 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
                 file['additionalFinalizeKeys'] = ('s3FinalizeRequest',)
         return file
 
-    def downloadFile(self, file, offset=0, headers=True, endByte=None,
+    def downloadFile(self, file, offset=0, headers=True, endByte=None,  # noqa
                      contentDisposition=None, extraParameters=None, **kwargs):
         """
         When downloading a single file with HTTP, we redirect to S3. Otherwise,
@@ -441,12 +443,46 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
                 if endByte is None or endByte > file['size']:
                     endByte = file['size']
                 headers = {'Range': 'bytes=%d-%d' % (offset, endByte - 1)}
+            else:
+                offset = 0
+                if endByte is None or endByte > file['size']:
+                    endByte = file['size']
+            # Our request can get interrupted for several reasons.  If it does
+            # we will typically get some form of IOError.  In this case, we
+            # want to retry it up to a point.
+            envval = os.environ.get('GIRDER_S3_DOWNLOAD_RETRIES')
+            maxRetriesWithoutData = int(envval) if str(envval).isdigit() else 3
 
             def stream():
-                pipe = requests.get(url, stream=True, headers=headers)
-                for chunk in pipe.iter_content(chunk_size=BUF_LEN):
-                    if chunk:
-                        yield chunk
+                streamOffset = offset
+                retries = 0
+                halt = False
+                while streamOffset < endByte and not halt:
+                    try:
+                        pipe = requests.get(url, stream=True, headers=headers)
+                        for chunk in pipe.iter_content(chunk_size=BUF_LEN):
+                            if chunk:
+                                streamOffset += len(chunk)
+                                try:
+                                    yield chunk
+                                    # If we actually got any data, reset our
+                                    # retry count
+                                    retries = 0
+                                except Exception:
+                                    # if the exception occurred because of the
+                                    # consumer, just stop
+                                    halt = True
+                                    raise
+                        halt = True
+                    except IOError as exc:
+                        retries += 1
+                        if halt or retries >= maxRetriesWithoutData:
+                            if not hasattr(exc, 'errno'):
+                                exc.errno = errno.EIO
+                            raise
+                        headers['Range'] = 'bytes=%d-%d' % (streamOffset, endByte - 1)
+                    except Exception:
+                        raise
             return stream
 
     def importData(self, parent, parentType, params, progress,


### PR DESCRIPTION
We find that occasionally the s3 request gets interrupted with a ChunkedEncodingError.  This is marked as an IOError, but doesn't have an errno set on it.  Both retry, in case the problem is recoverable, and set an errno so downstream handlers (such as the fuse.py library) break less.