### PR TITLE
Update dependencies.

### DIFF
--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -52,7 +52,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3'
     ],
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     packages=find_packages(exclude=('tests.*', 'tests')),
     install_requires=install_reqs,
     zip_safe=False,

--- a/plugins/audit_logs/setup.py
+++ b/plugins/audit_logs/setup.py
@@ -41,7 +41,7 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
     ],
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     packages=find_packages(),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/authorized_upload/setup.py
+++ b/plugins/authorized_upload/setup.py
@@ -46,7 +46,7 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     include_package_data=True,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/autojoin/setup.py
+++ b/plugins/autojoin/setup.py
@@ -45,7 +45,7 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     include_package_data=True,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/download_statistics/setup.py
+++ b/plugins/download_statistics/setup.py
@@ -44,7 +44,7 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     include_package_data=True,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/google_analytics/setup.py
+++ b/plugins/google_analytics/setup.py
@@ -45,7 +45,7 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     include_package_data=True,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/gravatar/setup.py
+++ b/plugins/gravatar/setup.py
@@ -45,7 +45,7 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     include_package_data=True,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/hashsum_download/setup.py
+++ b/plugins/hashsum_download/setup.py
@@ -45,7 +45,7 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     include_package_data=True,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/homepage/setup.py
+++ b/plugins/homepage/setup.py
@@ -45,7 +45,7 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     include_package_data=True,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/import_tracker/setup.py
+++ b/plugins/import_tracker/setup.py
@@ -46,11 +46,11 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=[
         'girder-jobs>=3.0.3',

--- a/plugins/item_licenses/setup.py
+++ b/plugins/item_licenses/setup.py
@@ -44,7 +44,7 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     include_package_data=True,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/jobs/setup.py
+++ b/plugins/jobs/setup.py
@@ -45,7 +45,7 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     include_package_data=True,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/ldap/setup.py
+++ b/plugins/ldap/setup.py
@@ -44,7 +44,7 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     include_package_data=True,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3', 'pyldap'],

--- a/plugins/oauth/setup.py
+++ b/plugins/oauth/setup.py
@@ -45,7 +45,7 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     include_package_data=True,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=[

--- a/plugins/readme/setup.py
+++ b/plugins/readme/setup.py
@@ -44,7 +44,7 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     include_package_data=True,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/sentry/setup.py
+++ b/plugins/sentry/setup.py
@@ -44,7 +44,7 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     include_package_data=True,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=[

--- a/plugins/slicer_cli_web/setup.py
+++ b/plugins/slicer_cli_web/setup.py
@@ -49,11 +49,11 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     include_package_data=True,
     packages=find_packages(exclude=['tests', 'test.*']),
@@ -93,5 +93,5 @@ setup(
             'upload-slicer-cli-task = slicer_cli_web.upload_slicer_cli_task:upload_slicer_cli_task'  # noqa: E501
         ]
     },
-    python_requires='>=3.8',
+    python_requires='>=3.9',
 )

--- a/plugins/terms/setup.py
+++ b/plugins/terms/setup.py
@@ -46,7 +46,7 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     include_package_data=True,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/thumbnails/setup.py
+++ b/plugins/thumbnails/setup.py
@@ -44,7 +44,7 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     include_package_data=True,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=[

--- a/plugins/user_quota/setup.py
+++ b/plugins/user_quota/setup.py
@@ -45,7 +45,7 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     include_package_data=True,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/virtual_folders/setup.py
+++ b/plugins/virtual_folders/setup.py
@@ -44,7 +44,7 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     include_package_data=True,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
     install_requires=['girder>=3'],

--- a/plugins/worker/setup.py
+++ b/plugins/worker/setup.py
@@ -44,10 +44,13 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     include_package_data=True,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
-    install_requires=['girder>=3'],
+    install_requires=[
+        'girder>=5.0.0a5',
+        'girder-jobs>=5.0.0a5',
+    ],
     entry_points={
         'girder.plugin': [
             'worker = girder_plugin_worker:WorkerPlugin'

--- a/pytest_girder/setup.py
+++ b/pytest_girder/setup.py
@@ -36,7 +36,7 @@ setup(
     classifiers=[
         'Framework :: Pytest'
     ],
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     packages=find_packages(),
     install_requires=[
         'girder>=3',

--- a/worker/requirements.in
+++ b/worker/requirements.in
@@ -2,7 +2,7 @@ pyyaml>=4.2b1
 Jinja2>=2.10.1
 urllib3>=1.26.8
 celery
-girder-client>=3
+girder-client>=5.0.0a5
 pymongo>=3
 requests[security]>=2.20.0
 setuptools_scm

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -60,11 +60,11 @@ setuptools.setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     packages=setuptools.find_packages(
         exclude=('tests.*', 'tests')
@@ -74,7 +74,7 @@ setuptools.setup(
         'install': CustomInstall
     },
     install_requires=install_reqs,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     zip_safe=False,
     entry_points={
         'girder_worker_plugins': [


### PR DESCRIPTION
Officially require python 3.9

The worker requires the jobs plugin and girder-client; ensure version 5 of those are called for.

Resolved #3711