### PR TITLE
Reenable collection creation policy control

### DIFF
--- a/girder/web/src/templates/body/systemConfiguration.pug
+++ b/girder/web/src/templates/body/systemConfiguration.pug
@@ -83,8 +83,7 @@ form.g-settings-form(role="form")
       p.
         Allow additional users and groups to create collections.
       input.g-setting-switch(type="checkbox",
-          checked="checked", data-size="mini", data-on-color="primary",
-          disabled=true)
+          checked="checked", data-size="mini", data-on-color="primary")
       .access-widget-container
       textarea#g-core-collection-create-policy.hide
         = JSON.stringify(settings['core.collection_create_policy'])

--- a/girder/web/src/views/body/SystemConfigurationView.js
+++ b/girder/web/src/views/body/SystemConfigurationView.js
@@ -160,7 +160,7 @@ var SystemConfigurationView = View.extend({
     _covertCollectionCreationPolicy: function () {
         // get collection creation policy from AccessWidget and format the result properly
         var settingValue = null;
-        if (this.$('.g-setting-switch').bootstrapSwitch('state')) {
+        if (this.$('.g-setting-switch').bootstrapSwitch('state') && this.accessWidget) {
             settingValue = { open: this.$('.g-setting-switch').bootstrapSwitch('state') };
             var accessList = this.accessWidget.getAccessList();
             _.each(_.keys(accessList), (key) => {


### PR DESCRIPTION
It uses values in the database that don't make sense as environment variables (e.g., user and group ids).