### PR TITLE
Pin cheroot

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ with open('README.rst') as f:
 installReqs = [
     'boto3',
     'botocore',
+    # Pinned because of issue https://github.com/cherrypy/cheroot/issues/769
+    'cheroot<11',
     'CherryPy',
     'click',
     'click-plugins',


### PR DESCRIPTION
As of cheroot 11.0.0, the cheroot server creates a non-daemon thread that prevents pytest from shutting down in some instances.  Pin cheroot until the upstream library resolves this (see https://github.com/cherrypy/cheroot/issues/769).