### PR TITLE
Don't run uvicorn with reload in production mode

### DIFF
--- a/girder/cli/serve.py
+++ b/girder/cli/serve.py
@@ -39,7 +39,7 @@ def main(mode: str, database: str, host: str, port: int, with_temp_assetstore: b
             'girder.asgi:app',
             host=host,
             port=port,
-            reload=True,
+            reload=mode != ServerMode.PRODUCTION,
             server_header=False,
             date_header=False,
             log_level='warning',


### PR DESCRIPTION
I ran `girder serve --mode production` from container's `/`, with a lot external volumes present. Turns out storage engineers don't appreciate continuous `os.walk` doing `fstat` on their network filesystems. Who could have known?!