### PR TITLE
Add an index to the file collection to speed up s3 deletions

### DIFF
--- a/girder/utility/assetstore_utilities.py
+++ b/girder/utility/assetstore_utilities.py
@@ -60,11 +60,13 @@ def removeAssetstoreAdapter(storeType):
 
 def fileIndexFields():
     """
-    This will return a set of all required index fields from all of the
-    different assetstore types.
+    This will return a unique list of all required index fields from all of
+    the different assetstore types.
     """
-    return list(set(
-        FilesystemAssetstoreAdapter.fileIndexFields()
-        + GridFsAssetstoreAdapter.fileIndexFields()
-        + S3AssetstoreAdapter.fileIndexFields()
-    ))
+    indices = (FilesystemAssetstoreAdapter.fileIndexFields()
+               + GridFsAssetstoreAdapter.fileIndexFields()
+               + S3AssetstoreAdapter.fileIndexFields())
+    for idx in range(len(indices) - 1, -1):
+        if indices[idx] in indices[: idx - 1]:
+            indices[idx:idx + 1] = []
+    return indices

--- a/girder/utility/s3_assetstore_adapter.py
+++ b/girder/utility/s3_assetstore_adapter.py
@@ -9,6 +9,7 @@ import uuid
 import boto3
 import botocore
 import cherrypy
+import pymongo
 import requests
 
 from girder import events, logger
@@ -106,6 +107,19 @@ class S3AssetstoreAdapter(AbstractAssetstoreAdapter):
                     'Unable to write into bucket "%s".' % doc['bucket'], 'bucket')
 
         return doc
+
+    @staticmethod
+    def fileIndexFields():
+        """
+        S3 documents should have an index on their relpath field for efficient
+        deletion.
+        """
+        return [
+            ([
+                ('assetstoreId', pymongo.ASCENDING),
+                ('relpath', pymongo.ASCENDING),
+            ], {}),
+        ]
 
     def __init__(self, assetstore):
         super().__init__(assetstore)

--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -902,6 +902,7 @@ girder
                 cancelUpload
                 deleteFile
                 downloadFile
+                fileIndexFields
                 fileUpdated
                 finalizeUpload
                 importData


### PR DESCRIPTION
This changes the generalized collector of indices to not explicitly use sets, as we support compound indices