### PR TITLE
Pin a deep subdependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ COPY . /girder/
 
 # Build girder wheel file, and install it
 RUN python3 setup.py bdist_wheel \
- && cd dist && python3 -m pip install --no-cache-dir girder && cd .. \
+ && cd dist && python3 -m pip install --no-cache-dir `ls *.whl` && cd .. \
  && rm -rf build dist
 
 RUN girder build && \

--- a/girder/web_client/package.json.template
+++ b/girder/web_client/package.json.template
@@ -16,6 +16,7 @@
         "css-loader": "^0.26.1",
         "extract-text-webpack-plugin": "^3.0.2",
         "file-loader": "^0.11.2",
+        "get-intrinsic": "1.3.0",
         "grunt": "^1.5.0",
         "grunt-contrib-copy": "^1.0.0",
         "grunt-contrib-pug": "^1.0.0",
@@ -26,6 +27,7 @@
         "lodash.mergewith": "^4.6.2",
         "mkdirp": "^0.5.1",
         "nib": "^1.1.2",
+        "npm-force-resolutions": "^0.0.10",
         "pug": "^2.0.0-rc.3",
         "pug-loader": "^2.3.0",
         "style-loader": "^0.13.2",
@@ -43,9 +45,13 @@
         "babel-polyfill": "^6.26.0",
         "event-source": "^0.1.1"
     },
+    "resolutions": {
+        "get-intrinsic": "1.3.0"
+    },
     "scripts": {
         "build": "grunt",
-        "watch": "grunt --watch"
+        "watch": "grunt --watch",
+        "preinstall": "if [ ! -f package-lock.json ]; then npm install --package-lock-only --ignore-scripts; fi && npx npm-force-resolutions"
     },
     "girder": {
         "plugins": []


### PR DESCRIPTION
Pin get-intrinsic, which is required transitively by other packages, such as webpack.  Version 1.3.1 breaks our build.

This also fixes an issue that the CI docker build was building the current branch but installing the latest published version.

Note that this seems pretty hacky -- npm 6 doesn't have a good mechanism for pinning a deep dependency.  Instead, we use another package to override the versions in the package-lock and node_modules directory, but this can only run if the package lock exists.  On first run, we run a preinstall script which creates the package lock if it doesn't exist AND then patches the package-lock to ensure the pinned library.