### PR TITLE
Fix Docker compose Localworker container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
     depends_on:
       - mongodb
     entrypoint: celery -A girder_worker.app worker -Q local
+    working_dir: /girder
     environment:
       - GIRDER_WORKER_BROKER=amqp://rabbitmq:5672
       - GIRDER_WORKER_BACKEND=rpc://rabbitmq:5672


### PR DESCRIPTION
Celery can't import auditLogger from girder because it's not started from the girder folder.

Fixes #3736 