### PR TITLE
Remove local girder folder mapping in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+# This docker compose setup is exclusively intended to be used as a development environment
 
 services:
   mongodb:
@@ -20,7 +20,8 @@ services:
       - GIRDER_WORKER_BACKEND=rpc://rabbitmq:5672
       - GIRDER_NOTIFICATION_REDIS_URL=redis://redis:6379
     volumes:
-      - ".:/girder"
+      - .:/girder # Map local Girder files to the container
+      - /girder/girder/web/dist # but exclude the built web client files.
       - assetstore:/assetstore
 
   rabbitmq:


### PR DESCRIPTION
This volume maps the content of the local girder folder in the container, shadowing what was previously there.
This prevents the front-end files that were built in the image to be used by the server, preventing people from accessing Girder's front-end.

While this volume is convenient for development purposes, I don't think it should be in the default docker-compose.yml file since it prevents users from easily setting up the project and have a working app.