### PR TITLE
Plugin Client path adjustments

### DIFF
--- a/girder/web/src/main.ts
+++ b/girder/web/src/main.ts
@@ -30,7 +30,7 @@ let apiRoot = import.meta.env.VITE_API_ROOT;
   // The plugin root defaults to root location of the api
   // That is correct for most deployments but if girder is being served from a different base path compared to the api
   // then the plugin root must be modified to match the api location
-  const pluginRoot = apiRoot.indexOf(':') >= 0 ? apiRoot.replace(/\/api\/v1\/?$/, '') : window.location.origin + apiRoot.replace(/\/api\/v1\/?$/, '');
+  const pluginRoot = apiRoot.indexOf(':') >= 0 ? apiRoot.replace(/\/api\/v1\/?$/, '/') : window.location.origin + apiRoot.replace(/\/api\/v1\/?$/, '/');
 
   staticFiles.css.forEach((href) => {
     const link = document.createElement('link');


### PR DESCRIPTION
If you move the base girder web UI to a different subpath I.E. '/girder' but leave the api at the root path '/'.
The client calls `/api/v1/system/plugin_static_files` to get the location of the plugin static files which will be referenced to a root path of `/`
But the problem occurs when the `/girder` location of the root app means all requests will be to `/girder/plugin_static/` instead of the root location of `plugin_static/`

The simplest solution is to assign the plugin static file location to be the same URL as the `api/v1` because the files should be hosted there.

This has the assumption that the API URL is properly configured if there is a more complex setup.  I.E if there is no http: or https: it will use the current `window.location.origin` as the root of the apiURL (This is what the girder rest client side code does, so I duplicated that).
