### PR TITLE
Dynamically adjust column widths based on screensize

### DIFF
--- a/girder/web/src/misc.js
+++ b/girder/web/src/misc.js
@@ -10,6 +10,7 @@ import { linkify } from 'remarkable/linkify';
 /**
  * This file contains utility functions for general use in the application
  */
+var DATE_YYMMDD = -1;
 var DATE_MONTH = 0;
 var DATE_DAY = 1;
 var DATE_MINUTE = 2;
@@ -26,6 +27,13 @@ function formatDate(datestr, resolution) {
     var output = MONTHS[date.getMonth()];
 
     resolution = resolution || DATE_MONTH;
+
+    if (resolution === DATE_YYMMDD) {
+        var yyyy = date.getFullYear();
+        var mm = ('0' + (date.getMonth() + 1)).slice(-2);
+        var dd = ('0' + date.getDate()).slice(-2);
+        return yyyy + '-' + mm + '-' + dd;
+    }
 
     if (resolution >= DATE_DAY) {
         output += ' ' + date.getDate() + ',';
@@ -241,6 +249,7 @@ function _whenAll(promises) {
 }
 
 export {
+    DATE_YYMMDD,
     DATE_MONTH,
     DATE_DAY,
     DATE_MINUTE,

--- a/girder/web/src/stylesheets/body/collectionList.styl
+++ b/girder/web/src/stylesheets/body/collectionList.styl
@@ -37,3 +37,8 @@
 
     .form-group
       display inline-block
+
+@media (max-width 600px)
+  .g-collection-list-entry
+    .g-collection-right-column
+      width 115px

--- a/girder/web/src/stylesheets/body/groupList.styl
+++ b/girder/web/src/stylesheets/body/groupList.styl
@@ -41,3 +41,8 @@
   .g-group-search-form
     display inline-block
     margin-right 15px
+
+@media (max-width 600px)
+  .g-group-list-entry
+    .g-group-right-column
+      width 115px

--- a/girder/web/src/stylesheets/layout/global.styl
+++ b/girder/web/src/stylesheets/layout/global.styl
@@ -152,3 +152,13 @@ textarea
   &[public="false"]
     box-shadow inset 0 0 2px 2px #fff0e0
     background-color #fff9ea
+
+@media (max-width 600px)
+  .g-top-level-list-title-container
+    width calc(100% - 175px)
+  .g-large-screen
+    display none
+
+@media (min-width 601px)
+  .g-small-screen
+    display none

--- a/girder/web/src/templates/body/collectionList.pug
+++ b/girder/web/src/templates/body/collectionList.pug
@@ -13,14 +13,22 @@ each collection in collections
   .g-collection-list-entry.g-top-level-list-entry(public=(collection.get('public') ? "true" : "false"))
     .g-collection-right-column
       .g-collection-created
-        i.icon-clock
-        | Created on
-        span.g-collection-created-date  #{formatDate(collection.get('created'), DATE_MINUTE)}
+        .g-large-screen
+          i.icon-clock
+          | Created on
+          span.g-collection-created-date  #{formatDate(collection.get('created'), DATE_MINUTE)}
+        .g-small-screen
+          i.icon-clock
+          span.g-collection-created-date  #{formatDate(collection.get('created'), DATE_YYMMDD)}
       if collection.has('size')
         .g-space-used
-          i.icon-floppy
-          | Currently using
-          span.g-user-space-used  #{formatSize(collection.get('size'))}
+          .g-large-screen
+            i.icon-floppy
+            | Currently using
+            span.g-user-space-used  #{formatSize(collection.get('size'))}
+          .g-small-screen
+            i.icon-floppy
+            span.g-user-space-used  #{formatSize(collection.get('size'))}
     .g-list-public-status-icon
       if collection.get('public')
         i.icon-globe(title="Public collection")

--- a/girder/web/src/templates/body/groupList.pug
+++ b/girder/web/src/templates/body/groupList.pug
@@ -13,9 +13,13 @@ each group in groups
   .g-group-list-entry.g-top-level-list-entry(public=(group.get('public') ? "true" : "false"))
     .g-group-right-column
       .g-group-created
-        i.icon-clock
-        | Created on
-        span.g-group-created-date  #{formatDate(group.get('created'), DATE_DAY)}
+        .g-large-screen
+          i.icon-clock
+          | Created on
+          span.g-group-created-date  #{formatDate(group.get('created'), DATE_DAY)}
+        .g-small-screen
+          i.icon-clock
+          span.g-group-created-date  #{formatDate(group.get('created'), DATE_YYMMDD)}
     .g-list-public-status-icon
       if group.get('public')
         i.icon-globe(title="Public group")
@@ -25,6 +29,8 @@ each group in groups
       .g-group-title
         a.g-group-link(g-group-cid=group.cid)
           b= group.name()
+        span.g-text-fade(public=(group.get('public') ? 'true' : 'false'))
       .g-group-subtitle
         span.g-group-description= group.get('description')
+        span.g-text-fade(public=(group.get('public') ? 'true' : 'false'))
     .g-clear-right

--- a/girder/web/src/views/body/CollectionsView.js
+++ b/girder/web/src/views/body/CollectionsView.js
@@ -8,7 +8,7 @@ import router from '@girder/core/router';
 import SearchFieldWidget from '@girder/core/views/widgets/SearchFieldWidget';
 import View from '@girder/core/views/View';
 import { cancelRestRequests } from '@girder/core/rest';
-import { formatDate, formatSize, renderMarkdown, DATE_MINUTE } from '@girder/core/misc';
+import { formatDate, formatSize, renderMarkdown, DATE_YYMMDD, DATE_MINUTE } from '@girder/core/misc';
 import { getCurrentUser } from '@girder/core/auth';
 
 import CollectionListTemplate from '@girder/core/templates/body/collectionList.pug';
@@ -73,6 +73,7 @@ var CollectionsView = View.extend({
             getCurrentUser: getCurrentUser,
             formatDate: formatDate,
             DATE_MINUTE: DATE_MINUTE,
+            DATE_YYMMDD: DATE_YYMMDD,
             formatSize: formatSize
         }));
 

--- a/girder/web/src/views/body/GroupsView.js
+++ b/girder/web/src/views/body/GroupsView.js
@@ -8,7 +8,7 @@ import router from '@girder/core/router';
 import SearchFieldWidget from '@girder/core/views/widgets/SearchFieldWidget';
 import View from '@girder/core/views/View';
 import { cancelRestRequests } from '@girder/core/rest';
-import { formatDate, DATE_DAY } from '@girder/core/misc';
+import { formatDate, DATE_DAY, DATE_YYMMDD } from '@girder/core/misc';
 import { getCurrentUser } from '@girder/core/auth';
 
 import GroupListTemplate from '@girder/core/templates/body/groupList.pug';
@@ -58,7 +58,8 @@ var GroupsView = View.extend({
             groups: this.collection.toArray(),
             getCurrentUser: getCurrentUser,
             formatDate: formatDate,
-            DATE_DAY: DATE_DAY
+            DATE_DAY: DATE_DAY,
+            DATE_YYMMDD: DATE_YYMMDD
         }));
 
         this.paginateWidget.setElement(this.$('.g-group-pagination')).render();


### PR DESCRIPTION
Automatically contracts the right-most column in Collections and Groups views, by reducing their content and css width. Extra space is used to make titles/descriptions wider.

I assume previous iteration (#3734) was closed due to v4-integration merge. If not yell at me.