### PR TITLE
Add a flag to rabbitmq in CI to handle 4.3 changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,17 +40,17 @@ commands:
       - run:
           name: start mongo
           command: |
-            docker run --rm -d -p 127.0.0.1:27017:27017 mongo:latest bash -c "mongod --noauth --bind_ip_all"
+            docker run --rm -d -p 127.0.0.1:27017:27017 --name mongo mongo:latest bash -c "mongod --noauth --bind_ip_all"
           no_output_timeout: 1h
       - run:
           name: start rabbitmq
           command: |
-            docker run -d -p 5672:5672 rabbitmq
+            docker run -d -p 5672:5672 -v $(pwd)/girder/.circleci/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf --name rabbitmq rabbitmq
           no_output_timeout: 1h
       - run:
           name: start redis
           command: |
-            docker run -d -p 6379:6379 redis
+            docker run -d -p 6379:6379 --name redis redis
           no_output_timeout: 1h
   install-girder:
     description: "Install Girder in a virtualenv and configure CTest"
@@ -111,9 +111,10 @@ jobs:
     # with bind-mounted paths that don't work with docker-in-docker on CircleCI
     executor: machine
     steps:
-      - prerequisites
       - checkout:
           path: girder
+      # After checkout, since we need files in the .circleci folder
+      - prerequisites
       - install-girder
       - build-plugins
       - run:
@@ -246,11 +247,11 @@ jobs:
       - run:
           name: Start mongod
           command: |
-            docker run --rm -d -p 127.0.0.1:27017:27017 mongo:latest bash -c "mongod --noauth --bind_ip_all"
+            docker run --rm -d -p 127.0.0.1:27017:27017 --name mongo mongo:latest bash -c "mongod --noauth --bind_ip_all"
       - run:
           name: Start redis
           command: |
-            docker run -d -p 6379:6379 redis
+            docker run -d -p 6379:6379 --name redis redis
       - run:
           name: Install and build @girder/core
           command: |

--- a/.circleci/rabbitmq.conf
+++ b/.circleci/rabbitmq.conf
@@ -1,0 +1,1 @@
+deprecated_features.permit.transient_nonexcl_queues = true


### PR DESCRIPTION
We should be able to remove this once celery 5.7 is released