### PR TITLE
Subpath api route

### DIFF
--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -244,6 +244,17 @@ Then, build the core front-end application with the desired base path:
 With that variable set in your environment, the Girder core web client will now be served under
 ``/new_root/`` rather than ``/``.
 
+.. note::
+
+   Remapping ``apps['']`` only moves the static SPA. The REST API (including Swagger at
+   ``/api/v1``) stays on its original ``/api`` mount unless you duplicate it. After the remount
+   above, and before `del info['serverRoot'].apps['']`, add:
+
+   .. code-block:: python
+
+       api_cp_app = info['serverRoot'].apps['/api']
+       info['serverRoot'].mount(api_cp_app.root, '/new_root/api', api_cp_app.config)
+
 Logging changes
 +++++++++++++++
 

--- a/girder/utility/server.py
+++ b/girder/utility/server.py
@@ -98,8 +98,15 @@ def create_app(mode: str) -> dict:
         '/': static_opts
     })
 
-    # Mount the web API
+    # Mount the web API at /api (always).
     tree.mount(apiRoot, '/api', appconf)
+
+    # When GIRDER_URL_ROOT names a public path prefix (e.g. "girder" for
+    # https://host/girder/...), mount the same API object at /<prefix>/api so
+    # /api/v1 and /<prefix>/api/v1 hit identical handlers
+    if custom_root:
+        prefix = '/' + custom_root.strip('/')
+        tree.mount(apiRoot, f'{prefix}/api', appconf)
 
     return info
 

--- a/test/test_custom_root.py
+++ b/test/test_custom_root.py
@@ -81,6 +81,8 @@ class CustomRoot(GirderPlugin):
     def load(self, info):
         path = os.path.join(os.path.dirname(__file__), 'data', 'static.txt')
         info['serverRoot'].mount(staticFile(path), '/static_route', info['config'])
+        api_cp_app = info['serverRoot'].apps['/api']
+        info['serverRoot'].mount(api_cp_app.root, '/new_root/api', api_cp_app.config)
 
         info['apiRoot'].collection.route('GET', ('unbound', 'default', 'noargs'),
                                          unboundHandlerDefaultNoArgs)
@@ -116,6 +118,15 @@ def testApiRedirect(server):
     resp = server.request('/api', prefix='', isJson=False)
     assertStatus(resp, 303)
     assert urllib.parse.urlparse(resp.headers['Location']).path == '/api/v1'
+
+
+def testApiDocsContent(server):
+    resp = server.request('/api/v1', method='GET', isJson=False, prefix='')
+    assertStatusOk(resp)
+    body = getResponseBody(resp)
+
+    assert 'Girder - REST API Documentation' in body
+    assert 'id="swagger-ui-container"' in body
 
 
 @pytest.mark.plugin('test_plugin', CustomRoot)


### PR DESCRIPTION
resolves #3809 

From what I can see in the code, there are two ways to move the root girder app:  one is utilizing the GIRDER_URL_ROOT environment variable and the other is mentioned in the [migration-guide](https://github.com/girder/girder/blob/master/docs/migration-guide.rst?plain=1#L207) about the deprecated `girder.plugin.registerPluginWebroot`.

I don't think the GIRDER_URL_ROOT duplicate is strictly required (as long as the nginx reverse proxy is configured properly), but is an extra guard if the proxy strips the prefix or other varying configs.

- If `GIRDER_URL_ROOT` is set (and not `/`) it will duplicate the /api/route to the `{GIRDER_URL_ROOT}/api/` so it can be used there
- Adds instructions to migration when the SPA is moved to also duplicate and allow for the REST and Swagger API to move to the new subroute as well.  This duplicates the behavior experienced in Girder 3
- Adds a minor test to make sure the updated migration guide instructions work properly and the api is accessible through the new subpath.

Tested the migration guide instructions on DIVE Girder 5 Branch and it works properly.