### PR TITLE
Switch from fusepy to mfusepy

### DIFF
--- a/girder/cli/mount.py
+++ b/girder/cli/mount.py
@@ -13,7 +13,7 @@ import time
 import cachetools
 import cherrypy
 import click
-import fuse
+import mfusepy as fuse
 
 from girder import events, plugin
 from girder.constants import ServerMode

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -45,4 +45,4 @@ virtualenv
 paramiko
 cachetools
 diskcache
-fusepy>=3.0
+mfusepy>=3.0

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ extrasReqs = {
     'mount': [
         'cachetools',
         'diskcache',
-        'fusepy>=3.0'
+        'mfusepy>=3.0'
     ]
 }
 

--- a/tests/cases/mount_test.py
+++ b/tests/cases/mount_test.py
@@ -6,7 +6,7 @@ import tempfile
 import threading
 import time
 
-import fuse
+import mfusepy as fuse
 
 from girder.cli import mount
 from girder.exceptions import ValidationException

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,web-lint,docs,public-names,web-test,pytest,legacy-test,integration-test
+envlist = lint,web-lint,docs,public-names,web-test,pytest,legacy-test,integration-test,coverage
 
 [testenv:pytest]
 passenv =


### PR DESCRIPTION
mfusepy is maintained and works with libfuse2 or libfuse3.  fusepy hasn't been maintained in a long time (though has been rock-solid).