### PR TITLE
Publish wheels and source to pypi.

### DIFF
--- a/.circleci/publish_pypi.sh
+++ b/.circleci/publish_pypi.sh
@@ -20,6 +20,7 @@ for directory in "${PUBLISHED_PYTHON_PACKAGES[@]}"; do
     pushd "$directory"
     rm -fr dist
     python -m build
+    pip wheel . --no-deps -w dist
     twine upload --verbose --skip-existing dist/*
     popd
 done


### PR DESCRIPTION
Before we were just publishing source.  We get faster installations if we publish wheels, too.