### PR TITLE
Pin a circleCI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ executors:
     working_directory: /home/circleci/project
   machine:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2204:2025.09.1
     working_directory: /home/circleci/project
 
 commands:


### PR DESCRIPTION
The switch from python 3.13 to 3.14 breaks some tests.  Until we sort that out, at least allow CI to run.