### PR TITLE
Ensure we are not using stale or duplicate headers

### DIFF
--- a/girder/asgi.py
+++ b/girder/asgi.py
@@ -64,19 +64,18 @@ class _WSGIBridge:
         rsock, wsock = socket.socketpair()
         rsock.setblocking(True)
         wsock.setblocking(False)
-        response_started = asyncio.Event()
         response_status = {}
         response_headers = []
         response_chunks = []
         error = []
 
         def start_response(status, headers, exc_info=None):
+            response_headers.clear()
             response_status['code'] = int(status.split()[0])
             response_headers.extend(
                 (k.encode('latin-1'), v.encode('latin-1'))
                 for k, v in headers
             )
-            response_started.set()
 
             def write(data):
                 if data:

--- a/pytest_girder/pytest_girder/fixtures.py
+++ b/pytest_girder/pytest_girder/fixtures.py
@@ -1,13 +1,15 @@
 import hashlib
 import os
 import shutil
+import threading
+import time
 import unittest.mock
 
 import mongomock
 import pytest
 
 from .plugin_registry import PluginRegistry
-from .utils import serverContext
+from .utils import _findFreePort, serverContext
 
 
 def _uid(node):
@@ -146,6 +148,52 @@ def boundServer(db, request):
 
 
 @pytest.fixture
+def asgiBoundServer(db, request):
+    """
+    Require an ASGI server that listens on a port.
+
+    Provides a started uvicorn server with a bound port. The returned value has
+    a `boundPort` property identifying where the server can be reached.
+    """
+    import uvicorn
+
+    from girder.asgi import _WSGIBridge
+
+    registry = PluginRegistry()
+    with registry():
+        plugins = _getPluginsFromMarker(request, registry)
+        with serverContext(plugins, bindPort=False) as server_fixture:
+            port = _findFreePort()
+            server_fixture.boundPort = port
+            config = uvicorn.Config(
+                _WSGIBridge(server_fixture.serverRoot),
+                host='127.0.0.1',
+                port=port,
+                log_level='warning',
+                server_header=False,
+                date_header=False,
+                lifespan='off',
+                access_log=False,
+                loop='asyncio',
+            )
+            asgi_server = uvicorn.Server(config)
+            thread = threading.Thread(target=asgi_server.run, daemon=True)
+            thread.start()
+            deadline = time.monotonic() + 10
+            while not asgi_server.started and thread.is_alive() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            if not asgi_server.started:
+                asgi_server.should_exit = True
+                thread.join(timeout=5)
+                raise RuntimeError('ASGI server failed to start')
+            try:
+                yield server_fixture
+            finally:
+                asgi_server.should_exit = True
+                thread.join(timeout=5)
+
+
+@pytest.fixture
 def email_stdout(db):
     old_env_val = os.environ.get('GIRDER_EMAIL_TO_CONSOLE')
     os.environ['GIRDER_EMAIL_TO_CONSOLE'] = 'true'
@@ -209,11 +257,12 @@ def fsAssetstore(db, request):
 
 __all__ = (
     'admin',
+    'asgiBoundServer',
+    'boundServer',
     'db',
+    'eagerWorkerTasks',
+    'email_stdout',
     'fsAssetstore',
     'server',
-    'boundServer',
     'user',
-    'email_stdout',
-    'eagerWorkerTasks',
 )

--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -1527,6 +1527,7 @@ pytest_girder
             assertStatusOk
         fixtures
             admin
+            asgiBoundServer
             boundServer
             db
             eagerWorkerTasks

--- a/test/test_asgi_headers.py
+++ b/test/test_asgi_headers.py
@@ -1,0 +1,26 @@
+import os
+import stat
+
+import requests
+
+from girder.models.file import File
+from girder.models.folder import Folder
+from pytest_girder.utils import uploadFile
+
+
+def test_download_unreadable_file(asgiBoundServer, admin, fsAssetstore):
+    dest = Folder().childFolders(admin, parentType='user')[0]
+    test_file = uploadFile('test.txt', b'content', admin, dest)
+    file = File().load(test_file['_id'], force=True)
+    adapter = File().getAssetstoreAdapter(file)
+    path = adapter.getLocalFilePath(file)
+    original_mode = os.stat(path).st_mode
+    try:
+        os.chmod(path, original_mode & ~stat.S_IROTH & ~stat.S_IRGRP & ~stat.S_IRUSR)
+        resp = requests.get(
+            f'http://127.0.0.1:{asgiBoundServer.boundPort}/api/v1/file/{file["_id"]}/download',
+        )
+    finally:
+        os.chmod(path, original_mode)
+    assert resp.status_code == 500
+    assert int(resp.headers['Content-Length']) > 10


### PR DESCRIPTION
This address a problem reported in the field.  It also adds a asgiBoundServer fixture to make testing this possible.

A user reports:

Girder 5 ASGI Bridge — Duplicate Content-Length Headers

Symptom: ChunkedEncodingError: IncompleteRead(0 bytes read, 30 more expected) when the worker tried to download files from Girder.

Cause: Girder 5 introduced an ASGI/WSGI bridge (asgi.py) wrapping the old CherryPy WSGI app in uvicorn. The WSGI spec allows start_response to be called more than once (e.g. on error recovery), but the bridge used extend instead of clear + extend when accumulating response headers.

This caused duplicate Content-Length headers on some responses, which the h11 HTTP parser used by uvicorn rejects by silently dropping the connection — producing the truncated read on the worker side.

Fix: Patched asgi.py to call response_headers.clear() at the start of start_response, and added a deduplication pass on Content-Length headers before sending the response.