### PR TITLE
Reduce spurious warning about index creation

### DIFF
--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -206,27 +206,31 @@ class Model(metaclass=_ModelSingleton):
         return self.filterDocument(doc, allow=keys)
 
     def _createIndex(self, index):
-        if isinstance(index, (list, tuple)):
-            keys, opts = index[0], index[1]
-            if isinstance(keys, str):
-                keys = [(keys, pymongo.ASCENDING)]
-            if 'background' not in opts:
-                opts = opts.copy()
-                opts['background'] = True
-            try:
-                self.collection.create_index(keys, **opts)
-            except pymongo.errors.OperationFailure as e:
-                code_name = e.details.get('codeName') if hasattr(e, 'details') else None
-                if code_name in ('IndexOptionsConflict', 'IndexKeySpecsConflict'):
-                    for idx in self.collection.list_indexes():
-                        if list(idx['key'].items()) == keys:
-                            self.collection.drop_index(idx['name'])
-                            break
+        try:
+            if isinstance(index, (list, tuple)):
+                keys, opts = index[0], index[1]
+                if isinstance(keys, str):
+                    keys = [(keys, pymongo.ASCENDING)]
+                if 'background' not in opts:
+                    opts = opts.copy()
+                    opts['background'] = True
+                try:
                     self.collection.create_index(keys, **opts)
-                else:
-                    raise
-        else:
-            self.collection.create_index(index, background=True)
+                except pymongo.errors.OperationFailure as e:
+                    code_name = e.details.get('codeName') if hasattr(e, 'details') else None
+                    if code_name in ('IndexOptionsConflict', 'IndexKeySpecsConflict'):
+                        for idx in self.collection.list_indexes():
+                            if list(idx['key'].items()) == keys:
+                                self.collection.drop_index(idx['name'])
+                                break
+                        self.collection.create_index(keys, **opts)
+                    else:
+                        raise
+            else:
+                self.collection.create_index(index, background=True)
+        except Exception as exc:
+            # index creation is best-effort
+            logger.info('Index creation raised an exception (%r)', exc)
 
     def ensureTextIndex(self, index, language='english'):
         """

--- a/pytest_girder/pytest_girder/fixtures.py
+++ b/pytest_girder/pytest_girder/fixtures.py
@@ -62,7 +62,11 @@ def db(request):
     # Since models store a local reference to the current database, we need to force them all to
     # reconnect
     for model in model_base._modelSingletons:
-        model.reconnect()
+        try:
+            model.reconnect()
+        except OSError:
+            # Ignore lazy index creation errors
+            pass
 
     # Use faster password hashing to avoid unnecessary testing bottlenecks. Any test case
     # that creates a user goes through the password hashing process, so we avoid actual bcrypt.
@@ -247,12 +251,22 @@ def fsAssetstore(db, request):
     path = os.path.join(ROOT_DIR, 'tests', 'assetstore', name)
 
     if os.path.isdir(path):
-        shutil.rmtree(path)
+        for _ in range(5):
+            try:
+                shutil.rmtree(path)
+                break
+            except Exception:
+                time.sleep(1)
 
     yield Assetstore().createFilesystemAssetstore(name=name, root=path)
 
     if os.path.isdir(path):
-        shutil.rmtree(path)
+        for _ in range(5):
+            try:
+                shutil.rmtree(path)
+                break
+            except Exception:
+                time.sleep(1)
 
 
 __all__ = (


### PR DESCRIPTION
We allow indices to be created in the background.  If girder is started and stopped quickly, there will be many messages about index creation being interrupted; this is not an actual error condition -- they will be finished on the next run.  In testing, this is just noise, since the index is not usefully in existence by the time the test end.  Further, the index creation can sometimes block cleaning up temporary directories.