### PR TITLE
Adjust redis socket_timeout

### DIFF
--- a/girder/notification.py
+++ b/girder/notification.py
@@ -36,13 +36,13 @@ class ProgressState:
 @functools.lru_cache
 def _redis_client_async() -> aioredis.Redis:
     url = os.environ.get('GIRDER_NOTIFICATION_REDIS_URL', 'redis://localhost:6379')
-    return aioredis.Redis.from_url(url)
+    return aioredis.Redis.from_url(url, socket_timeout=None)
 
 
 @functools.lru_cache
 def _redis_client_sync() -> redis.Redis:
     url = os.environ.get('GIRDER_NOTIFICATION_REDIS_URL', 'redis://localhost:6379')
-    return redis.Redis.from_url(url)
+    return redis.Redis.from_url(url, socket_timeout=None)
 
 
 class UserNotificationsSocket(WebSocketEndpoint):

--- a/pytest_girder/pytest_girder/fixtures.py
+++ b/pytest_girder/pytest_girder/fixtures.py
@@ -161,7 +161,7 @@ def asgiBoundServer(db, request):
     """
     import uvicorn
 
-    from girder.asgi import _WSGIBridge
+    from girder.asgi import app
 
     registry = PluginRegistry()
     with registry():
@@ -170,7 +170,7 @@ def asgiBoundServer(db, request):
             port = _findFreePort()
             server_fixture.boundPort = port
             config = uvicorn.Config(
-                _WSGIBridge(server_fixture.serverRoot),
+                app,
                 host='127.0.0.1',
                 port=port,
                 log_level='warning',

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,17 +32,18 @@ coverage
 httmock
 mongomock
 moto[server]<4.2.12
-pytest>=3.6
+pytest-asyncio
 pytest-cov>=2.6
 pytest-forked
 pytest-mock
+pytest>=3.6
 python-dateutil
 tox
-xdoctest
 virtualenv
+xdoctest
 
 # from extras
-paramiko
 cachetools
 diskcache
 mfusepy>=3.0
+paramiko

--- a/test/test_notification.py
+++ b/test/test_notification.py
@@ -1,0 +1,29 @@
+import asyncio
+
+import pytest
+import websockets
+
+from girder.models.token import Token
+from girder.notification import Notification
+
+
+@pytest.mark.asyncio
+async def test_notification_websocket_timeout(db, asgiBoundServer, admin):
+    """
+    Test that WebSocket notifications don't disconnect after 5 seconds when
+    socket_timeout is set to None.
+    """
+    token = Token().createToken(admin, days=1)
+    ws_url = f'ws://localhost:{asgiBoundServer.boundPort}/notifications/me?token={token["_id"]}'
+    async with websockets.connect(ws_url) as ws:
+        # Send a notification and verify it's received
+        Notification(type='test', data={'a': 'b'}, user=admin).flush()
+        await asyncio.sleep(1)  # Allow time for notification to be processed
+        received = await asyncio.wait_for(ws.recv(), timeout=2)
+        # assert received is not None, 'Failed to receive initial notification'
+        # redis 8 defaults to a 5 second timeout
+        await asyncio.sleep(7)
+        Notification(type='test', data={'a': 'c'}, user=admin).flush()
+        await asyncio.sleep(1)  # Allow time for notification to be processed
+        received = await asyncio.wait_for(ws.recv(), timeout=2)
+        assert received is not None, 'Failed to receive notification'


### PR DESCRIPTION
Before redis 8.0.0, the redis socket_timeout was default None.  With 8.0.0 it is default 5 seconds, which can break some workflows.

Resolves #3828