### PR TITLE
Upgrade to node 22 for testing

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update \
     setuptools \
     tox
 
-ENV NODE_VERSION=20
+ENV NODE_VERSION=22
 
 RUN mkdir /.nvm && \
     curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | NVM_DIR=/.nvm bash && \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
       - run:
           name: install nodejs
           command: |
-            curl -sL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+            curl -sL https://deb.nodesource.com/setup_22.x | sudo -E bash -
             sudo apt-get install -y nodejs
       - run:
           name: install apt libraries for Girder
@@ -203,14 +203,14 @@ jobs:
       - checkout:
           path: girder
       - run:
-          name: Install NodeJS 20
+          name: Install NodeJS 22
           # CircleCI resets the Bash environment between every step, so any steps using node or npm
           # must first:
           #   source $NVM_DIR/nvm.sh
           command: |
             source $NVM_DIR/nvm.sh
-            nvm install v20
-            nvm alias default v20
+            nvm install v22
+            nvm alias default v22
             NODE_DIR=$(dirname $(which node))
             echo "export PATH=$NODE_DIR:\$PATH" >> $BASH_ENV
       - run:
@@ -326,7 +326,7 @@ jobs:
           name: Build the Girder test docker
           command: |
             cd .circleci
-            docker build --force-rm -t girder/girder_test:py310-node20 .
+            docker build --force-rm -t girder/girder_test:py310-node22 .
 
   publish-dockers:
     machine:
@@ -341,7 +341,7 @@ jobs:
           name: Build the Girder test docker
           command: |
             cd .circleci
-            docker build --force-rm -t girder/girder_test:py310-node20 .
+            docker build --force-rm -t girder/girder_test:py310-node22 .
       - run:
           name: Publish the images to Docker Hub
           command: |
@@ -355,7 +355,7 @@ jobs:
               docker tag girder/girder:latest "girder/girder:${CIRCLE_TAG}-py3"
               docker push "girder/girder:${CIRCLE_TAG}-py3"
               fi
-              docker push girder/girder_test:py310-node20
+              docker push girder/girder_test:py310-node22
 
   publish:
     docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -qy \
 RUN curl -LJ https://github.com/krallin/tini/releases/download/v0.19.0/tini -o /sbin/tini && \
     chmod +x /sbin/tini
 
-RUN curl -sL https://deb.nodesource.com/setup_20.x | bash - && \
+RUN curl -sL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -qy nodejs
 
 RUN mkdir /girder


### PR DESCRIPTION
This is done in two PRs since we need to publish our test dockers before we use them.

Node 20 is EOL, so use 22 as the base for testing