### PR TITLE
Adjust where tox builds docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,7 @@ build:
 sphinx:
   configuration: docs/conf.py
   fail_on_warning: true
+  output: build/docs/html
 
 python:
   install:
@@ -16,3 +17,5 @@ python:
       path: .
     - method: pip
       path: ./clients/python
+    - method: pip
+      path: ./worker

--- a/girder/utility/config.py
+++ b/girder/utility/config.py
@@ -9,10 +9,12 @@ logger = logging.getLogger(__name__)
 def loadConfig():
     # Calling this has the side effect of populating the cherrypy.config object with
     # values from the environment. It is called at import time of the girder package.
-    cherrypy.config.update({'server.socket_host': os.getenv('GIRDER_HOST', '127.0.0.1')})
-    cherrypy.config.update({'server.socket_port': int(os.getenv('GIRDER_PORT', 8080))})
-    cherrypy.config.update({'server.thread_pool': int(os.getenv('GIRDER_THREAD_POOL', 100))})
-    cherrypy.config.update({'tools.proxy.on': True})
+    cherrypy.config.update({
+        'server.socket_host': os.getenv('GIRDER_HOST', '127.0.0.1'),
+        'server.socket_port': int(os.getenv('GIRDER_PORT', 8080)),
+        'server.thread_pool': int(os.getenv('GIRDER_THREAD_POOL', 100)),
+        'tools.proxy.on': True,
+    })
 
     if 'database' not in cherrypy.config:
         cherrypy.config.update({'database': {}})
@@ -20,9 +22,10 @@ def loadConfig():
     if 'GIRDER_TEST_DB' in os.environ:
         cherrypy.config['database'].update({'uri': os.environ['GIRDER_TEST_DB'].replace('.', '_')})
     else:
-        cherrypy.config['database'].update({'uri': os.getenv(
-            'GIRDER_MONGO_URI', 'mongodb://localhost:27017/girder')})
-        cherrypy.config['database'].update({'replica_set': os.getenv('GIRDER_MONGO_REPLICA_SET')})
+        cherrypy.config['database'].update({
+            'uri': os.getenv('GIRDER_MONGO_URI', 'mongodb://localhost:27017/girder'),
+            'replica_set': os.getenv('GIRDER_MONGO_REPLICA_SET')
+        })
 
 
 def getConfig():

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ commands =
         -b html \
         -d {envtmpdir}/doctrees \
         docs \
-        build/docs/python
+        build/docs/html
 
 [testenv:coverage]
 skip_install = true


### PR DESCRIPTION
This allows running tox -e docs multiple times without errors