### PR TITLE
Correct registration policy values in docs

### DIFF
--- a/docs/list_env_settings.yaml
+++ b/docs/list_env_settings.yaml
@@ -25,7 +25,7 @@ GIRDER_SETTING_CORE_CORS_EXPOSE_HEADERS: >-
   CORS header listing headers that should be exposed to the client.
 
 GIRDER_SETTING_CORE_REGISTRATION_POLICY: >-
-  Controls user registration policy. Values: "open", "admin", or "closed".
+  Controls user registration policy. Values: "open", "approve", or "closed".
 
 GIRDER_SETTING_CORE_EMAIL_VERIFICATION: >-
   Whether email verification is required for new accounts. Set to "true" or "false".


### PR DESCRIPTION
Code is using `'approve'`:
 * https://github.com/girder/girder/blob/0553d4b46f690ddcbf1c929cf0298ba9fc9c6113/girder/models/user.py#L407
 * https://github.com/girder/girder/blob/0553d4b46f690ddcbf1c929cf0298ba9fc9c6113/girder/models/user.py#L478