### PR TITLE
Propagate policy errors in OAuth2 flow

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -378,6 +378,29 @@ if this is the first time logging in with these OAuth credentials).
   callback does not create a new Girder Token, nor sets a new authentication
   cookie.
 
+Using OAuth2 with external UI
+*****************************
+If your custom UI needs to support OAuth2 login, you can use the redirect query
+parameter on the ``/oauth/provider`` endpoint to specify where to send users
+after a successful authentication.
+
+Successful Login
+^^^^^^^^^^^^^^^^
+Upon successful login, a ``girderToken`` query parameter containing the
+authentication token will be appended to your redirect URL. Your application can
+then extract and store this token.
+
+Login Restrictions
+^^^^^^^^^^^^^^^^^^
+If the authentication succeeds but the user cannot log in due to system
+policies, an ``error`` query parameter will be appended to the redirect URL
+instead. The potential error values are:
+
+* ``disabled``: The user's account has been disabled in Girder.
+* ``emailVerification``: The user has not yet verified their email address.
+* ``accountApproval``: The account is awaiting administrator approval under the
+  current authentication policy.
+
 
 README
 ------

--- a/plugins/oauth/girder_oauth/rest.py
+++ b/plugins/oauth/girder_oauth/rest.py
@@ -8,7 +8,7 @@ from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
 from girder.api.rest import Resource
 from girder.constants import AccessType
-from girder.exceptions import RestException
+from girder.exceptions import AccessException, RestException
 from girder.models.setting import Setting
 from girder.models.token import Token
 from girder.models.user import User
@@ -54,6 +54,21 @@ class OAuth(Resource):
             raise RestException('No redirect location (state="%s").' % state)
 
         return redirect
+
+    @staticmethod
+    def _add_qparam_to_url(url, key, value):
+        parsed = urlparse(url)
+        query_params = parse_qs(parsed.query)
+        query_params[key] = value
+        encoded_query_params = urlencode(query_params)
+        return urlunparse((
+            parsed.scheme,
+            parsed.netloc,
+            parsed.path,
+            parsed.params,
+            encoded_query_params,
+            parsed.fragment,
+        ))
 
     @access.public
     @autoDescribeRoute(
@@ -126,7 +141,11 @@ class OAuth(Resource):
             raise cherrypy.HTTPRedirect(redirect)
 
         user = providerObj.getUser(token)
-        User().verifyLogin(user)
+        try:
+            User().verifyLogin(user)
+        except AccessException as e:
+            updated_redirect = self._add_qparam_to_url(redirect, 'error', e.extra)
+            raise cherrypy.HTTPRedirect(updated_redirect)
 
         event = events.trigger('oauth.auth_callback.after', {
             'provider': provider,
@@ -140,18 +159,7 @@ class OAuth(Resource):
         token_id = str(token['_id'])
 
         # Set `girderToken` in the query params of the redirect URL
-        parsed = urlparse(redirect)
-        query_params = parse_qs(parsed.query)
-        query_params['girderToken'] = token_id
-        encoded_query_params = urlencode(query_params)
-        updated_redirect = urlunparse((
-            parsed.scheme,
-            parsed.netloc,
-            parsed.path,
-            parsed.params,
-            encoded_query_params,
-            parsed.fragment,
-        ))
+        updated_redirect = self._add_qparam_to_url(redirect, 'girderToken', token_id)
 
         # The cookie is still used for e.g. file downloads. Send it from the server
         # to support HttpOnly usage.

--- a/plugins/oauth/girder_oauth/web_client/main.js
+++ b/plugins/oauth/girder_oauth/web_client/main.js
@@ -4,6 +4,8 @@ import './routes';
 import './views/LoginView';
 import './views/RegisterView';
 
+const events = girder.events;
+
 // If the current URL contains a `girderToken` query parameter, set the current token to its value
 const girderToken = new URLSearchParams(window.location.search).get('girderToken');
 
@@ -17,3 +19,28 @@ if (girderToken) {
     queryParams.delete('girderToken');
     window.location.search = queryParams.toString();
 }
+
+const error = new URLSearchParams(window.location.search).get('error');
+if (error) {
+    window.localStorage.setItem('oauthError', error);
+    const queryParams = new URLSearchParams(window.location.search);
+    queryParams.delete('error');
+    window.location.search = queryParams.toString();
+}
+
+events.on('g:appload.after', function() {
+    const error = window.localStorage.getItem('oauthError');
+    if (error) {
+        var alertText = `OAuth login failed: ${error}`;
+        if (error === 'accountApproval') {
+            alertText = 'Your account is pending approval by an administrator.';
+        }
+        setTimeout(() => {
+            events.trigger('g:alert', {
+                text: alertText,
+                type: 'danger',
+            });
+        }, 100);
+        window.localStorage.removeItem('oauthError');
+    };
+});

--- a/plugins/oauth/plugin_tests/oauth_test.py
+++ b/plugins/oauth/plugin_tests/oauth_test.py
@@ -331,6 +331,18 @@ class OauthTest(base.TestCase):
         with self.assertRaises(ValidationException):
             Setting().set(PluginSettings.IGNORE_REGISTRATION_POLICY, 'foo')
 
+        # check graceful handling of login when registration policy is set to 'approve'
+        # and ignore registration policy is not set
+        Setting().set(SettingKey.REGISTRATION_POLICY, 'approve')
+        self.accountType = 'new'
+        params = getCallbackParams(getProviderResp())
+        resp = self.request('/oauth/%s/callback' % providerInfo['id'], params=params, isJson=False)
+        self.assertStatus(resp, 303)
+        expr = re.compile(r'^http://localhost/\?error=accountApproval#foo/bar$')
+        self.assertRegex(resp.headers['Location'], expr)
+        self.assertFalse('girderToken' in resp.cookie)
+        Setting().set(SettingKey.REGISTRATION_POLICY, 'closed')
+
         # Try callback for the 'new' account, with registration policy ignored
         Setting().set(PluginSettings.IGNORE_REGISTRATION_POLICY, True)
         new = doOauthLogin('new')


### PR DESCRIPTION
If girder user account is disabled or require an additional action before allowing user to login, inject meaningful 'error' in OAuth callback redirect.

I added a hacky way for showing an alert in Girder UI. I'm happy to improve (or remove)  it if you have any suggestions.