### PR TITLE
Pytest 9.1.0 changed how parameterized list ides are auto-generated

### DIFF
--- a/test/test_rest_utils.py
+++ b/test/test_rest_utils.py
@@ -40,7 +40,7 @@ class TestResource:
     (' ', False),
     (False, False),
     (True, True)
-])
+], ids=lambda x: f'{type(x).__name__}_{x}')
 def testBoolParam(input, expected):
     assert rest.Resource().boolParam('some_key', {'some_key': input}) == expected
 


### PR DESCRIPTION
This causes `('False', False),` and `(False, False),` to have the same id, which then throws an error.