### PR TITLE
Codecov generates spurious complaints.  Tone it down

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,23 +2,13 @@
 comment: false
 coverage:
   status:
-    # Patch status gives meaningless results whenever a test is modified without changing the
-    # correspondingly tested code, and may be difficult to interpret without context. Disable
-    # posting it to GitHub.
-    patch: false
+    # We have some variation in tests due to variations in the test runs.  We
+    # want to ignore these changes, but not let code coverage slip too much.
     project:
-      default: false
-      server:
-        target: 80%
-        paths:
-          - girder
-          - plugins/*/server
-      python_client:
-        target: 80%
-        paths:
-          - clients/python/girder_client
-      web_client:
-        target: 75%
-        paths:
-          - girder/web_client/src
-          - plugins/*/web_client
+      default:
+        threshold: 1
+    # This applies to the changed code.
+    patch:
+      default:
+        threshold: 25
+        only_pulls: true


### PR DESCRIPTION
In other projects we use these settings.  We can revisit this later.

I see different results from codecov than from local coverage tools.  There are some parts of code that are a bit random in coverage (e.g., when we generate a uuid4 for S3, we exclude uuids that contain the subdirectory name "ad" because it erroneously triggers ad blockers, but since uuid4 is random, this doesn't always happen, so the exclusion code doesn't always run and therefore doesn't always get covered).  codecov complains that coverage went down, but it is not on or related to the patch.