### PR TITLE
In tox, build the girder web client

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ passenv =
 deps =
     -rrequirements-dev.txt
 commands =
-    python {toxinidir}/.circleci/build_plugins.py {toxinidir}/plugins
+    python {toxinidir}/.circleci/build_plugins.py {toxinidir}/plugins --extra {toxinidir} --extra {toxinidir}/girder/web --extra {toxinidir}/girder/web/fontello
     pytest --forked {posargs}
 
 [testenv:lint]
@@ -158,7 +158,7 @@ allowlist_externals =
 passenv = *
 commands =
     pip install {toxinidir}
-    python {toxinidir}/.circleci/build_plugins.py {toxinidir}/plugins
+    python {toxinidir}/.circleci/build_plugins.py {toxinidir}/plugins --extra {toxinidir} --extra {toxinidir}/girder/web --extra {toxinidir}/girder/web/fontello
     npm ci
     npm run build
     npx playwright install
@@ -178,7 +178,7 @@ setenv =
 allowlist_externals =
     ctest
 commands =
-    python {toxinidir}/.circleci/build_plugins.py {toxinidir}/plugins
+    python {toxinidir}/.circleci/build_plugins.py {toxinidir}/plugins --extra {toxinidir} --extra {toxinidir}/girder/web --extra {toxinidir}/girder/web/fontello
     ctest \
       --extra-verbose \
       --script "{toxinidir}/.circleci/ci_test.cmake" \
@@ -201,7 +201,7 @@ allowlist_externals =
     npm
 commands =
     pip install {toxinidir}
-    python {toxinidir}/.circleci/build_plugins.py {toxinidir}/plugins
+    python {toxinidir}/.circleci/build_plugins.py {toxinidir}/plugins --extra {toxinidir} --extra {toxinidir}/girder/web --extra {toxinidir}/girder/web/fontello
     npm --prefix {toxinidir}/girder/web ci
     npm --prefix {toxinidir}/girder/web run build
     cmake -B {toxinidir}/build/integration .


### PR DESCRIPTION
We had only been automatically building the plugins' web clients.