### PR TITLE
Fix checked-resource count and picked-resource merge bugs

### DIFF
--- a/girder/web/src/views/widgets/FolderListWidget.js
+++ b/girder/web/src/views/widgets/FolderListWidget.js
@@ -25,12 +25,14 @@ var FolderListWidget = View.extend({
         'change .g-list-checkbox': function (event) {
             const target = $(event.currentTarget);
             const cid = target.attr('g-folder-cid');
-            if (target.prop('checked')) {
-                this.checked.push(cid);
-            } else {
-                const idx = this.checked.indexOf(cid);
-                if (idx !== -1) {
-                    this.checked.splice(idx, 1);
+            if (!this.checked.includes(cid)) {
+                if (target.prop('checked')) {
+                    this.checked.push(cid);
+                } else {
+                    const idx = this.checked.indexOf(cid);
+                    if (idx !== -1) {
+                        this.checked.splice(idx, 1);
+                    }
                 }
             }
             this.trigger('g:checkboxesChanged');

--- a/girder/web/src/views/widgets/HierarchyWidget.js
+++ b/girder/web/src/views/widgets/HierarchyWidget.js
@@ -918,14 +918,24 @@ var HierarchyWidget = View.extend({
         }
         var resources = this._getCheckedResourceParam(true);
         var pickDesc = this._describeResources(resources);
-        /* Merge these resources with any that are already picked */
+        /* Merge these resources with any that are already picked. For each resource type, any ids
+         * that are visible in the current view but are not currently checked are dropped from the
+         * picked set (so unchecking a previously picked resource removes it). Ids that belong to
+         * resources not visible here (e.g. from another folder or page) are left alone so
+         * resources can still be collected across pages. */
+        var visible = {
+            folder: this.folderListView.collection.map(function (model) {
+                return model.id;
+            }),
+            item: this.itemListView ? this.itemListView.collection.map(function (model) {
+                return model.id;
+            }) : []
+        };
         var existing = pickedResources.resources;
         _.each(existing, function (list, resource) {
-            if (!resources[resource]) {
-                resources[resource] = list;
-            } else {
-                resources[resource] = _.union(list, resources[resource]);
-            }
+            var checked = resources[resource] || [];
+            var stillPicked = _.difference(list, _.difference(visible[resource] || [], checked));
+            resources[resource] = _.union(stillPicked, checked);
         });
         pickedResources.resources = resources;
         this.updateChecked();

--- a/girder/web/src/views/widgets/ItemListWidget.js
+++ b/girder/web/src/views/widgets/ItemListWidget.js
@@ -25,12 +25,14 @@ var ItemListWidget = View.extend({
         'change .g-list-checkbox': function (event) {
             const target = $(event.currentTarget);
             const cid = target.attr('g-item-cid');
-            if (target.prop('checked')) {
-                this.checked.push(cid);
-            } else {
-                const idx = this.checked.indexOf(cid);
-                if (idx !== -1) {
-                    this.checked.splice(idx, 1);
+            if (!this.checked.includes(cid)) {
+                if (target.prop('checked')) {
+                    this.checked.push(cid);
+                } else {
+                    const idx = this.checked.indexOf(cid);
+                    if (idx !== -1) {
+                        this.checked.splice(idx, 1);
+                    }
                 }
             }
             this.trigger('g:checkboxesChanged');


### PR DESCRIPTION
Fixes #3855 and a related bug:
- `ItemListWidget`: guard against re-adding a `cid` already in `checked`on repeated change events (e.g. `shift-click` range selection), which previously caused the checked count to inflate.
- `HierarchyWidget.pickChecked`: only keep previously picked ids that are either still checked or not visible in the current folder/item list, so unchecking a picked resource actually removes it from the picked set instead of being silently re-added by the union merge.

- PREVIOUSLY
    - Select an item
    - Select `Pick checked resources for Move or Copy`
    - See that "selection" count is `1` and "picked" count is `1`
    - <img width="360" height="176" alt="Screenshot from 2026-07-08 11-53-54" src="https://github.com/user-attachments/assets/43e0cf93-2a52-4fba-b486-7e592d3f9b30" />
    - Shift+click to select a second item
    - Select `Pick checked resources for Move or Copy`
    - See that "selection" count is `3` [incorrect] and "picked" count is `2`
    -  <img width="360" height="176" alt="Screenshot from 2026-07-08 11-54-19" src="https://github.com/user-attachments/assets/586b1566-b18b-4f23-9680-475b6e9600f6" />
    - Shift+click to de-select the second item
    - Select `Pick checked resources for Move or Copy`
    - See that "selection" count is `1` and "picked" count is `2` [incorrect]
    -  <img width="360" height="176" alt="Screenshot from 2026-07-08 11-56-08" src="https://github.com/user-attachments/assets/73e787ec-cbda-485b-8ef9-0226d328681c" />
- CURRENTLY
    - Select an item
    - Select `Pick checked resources for Move or Copy`
    - See that "selection" count is `1` and "picked" count is `1`
    - <img width="365" height="253" alt="Screenshot from 2026-07-08 11-59-04" src="https://github.com/user-attachments/assets/a7428580-dac6-4f80-862f-c73d199293da" />
    - Shift+click to select a second item
    - Select `Pick checked resources for Move or Copy`
    - See that "selection" count is `2` and "picked" count is `2`
    -  <img width="365" height="253" alt="Screenshot from 2026-07-08 11-59-15" src="https://github.com/user-attachments/assets/16912d86-1310-469a-b4b2-77836a2cf6f3" />
    - Shift+click to de-select the second item
    - Select `Pick checked resources for Move or Copy`
    - See that "selection" count is `1` and "picked" count is `1`
    -  <img width="365" height="253" alt="Screenshot from 2026-07-08 11-59-26" src="https://github.com/user-attachments/assets/9e78680a-e344-49e0-a637-89b38e619845" />