### PR TITLE
Fix a test fixture to work with uvicorn 0.50

### DIFF
--- a/pytest_girder/pytest_girder/fixtures.py
+++ b/pytest_girder/pytest_girder/fixtures.py
@@ -178,7 +178,6 @@ def asgiBoundServer(db, request):
                 date_header=False,
                 lifespan='off',
                 access_log=False,
-                loop='asyncio',
             )
             asgi_server = uvicorn.Server(config)
             thread = threading.Thread(target=asgi_server.run, daemon=True)

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ installReqs = [
     'redis',
     'requests',
     'starlette',
-    'uvicorn',
+    'uvicorn[standard]',
     'websockets',
 ]
 


### PR DESCRIPTION
We were overspecifying startup parameters which caused some internal conflict when uvicorn switched ws from websockets to websockets-sansio. The defaults are sufficient.