### PR TITLE
add `-e` flag to `pip install` for web tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -157,7 +157,7 @@ allowlist_externals =
     npx
 passenv = *
 commands =
-    pip install {toxinidir}
+    pip install -e {toxinidir}
     python {toxinidir}/.circleci/build_plugins.py {toxinidir}/plugins --extra {toxinidir} --extra {toxinidir}/girder/web --extra {toxinidir}/girder/web/fontello
     npm ci
     npm run build


### PR DESCRIPTION
When running `tox -e web-test`, the `pip install {toxindir}` will install Girder in a sub-directory different from where `npm run build` installs, causing tests to fail. Adding the `-e` flag to `pip install` resolves this.