### PR TITLE
Remove rollup/plugin-inject

### DIFF
--- a/girder/web/package-lock.json
+++ b/girder/web/package-lock.json
@@ -28,7 +28,6 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
-        "@rollup/plugin-inject": "^5.0.3",
         "@tsconfig/node20": "^20.0.0",
         "@types/istanbul-lib-report": "^3.0.0",
         "@types/istanbul-reports": "^3.0.1",
@@ -142,9 +141,9 @@
       }
     },
     "node_modules/@girder/fontello": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/@girder/fontello/-/fontello-5.0.11.tgz",
-      "integrity": "sha512-+YnlMBGfiHcyHZKtcUWfbEuNt8Mr5JG+2XJ4V+ImlonqL0sYK4ecED7BsKxcmuaKPTWc2FShSCo4UuXOGJ6Rlw==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@girder/fontello/-/fontello-5.0.12.tgz",
+      "integrity": "sha512-Qm6eE5VaAbT6kqSbGYC1tdgU+24gbxgF1FCbmvZr6vLSpaxhQJKmVQu7waqCzPE6lJbfhG6yqEcbfsx0Z8Y8QQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@isaacs/cliui": {
@@ -675,29 +674,6 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@rollup/plugin-inject": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz",
-      "integrity": "sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.0.1",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.3"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.4.0",

--- a/girder/web/package.json
+++ b/girder/web/package.json
@@ -54,7 +54,6 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.61.0",
-    "@rollup/plugin-inject": "^5.0.3",
     "@tsconfig/node20": "^20.0.0",
     "@types/istanbul-lib-report": "^3.0.0",
     "@types/istanbul-reports": "^3.0.1",

--- a/girder/web/vite.config.ts
+++ b/girder/web/vite.config.ts
@@ -5,7 +5,6 @@ import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import { compileClient } from 'pug';
 import dts from 'vite-plugin-dts';
-import inject from "@rollup/plugin-inject";
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 
 function pugPlugin() {
@@ -72,11 +71,6 @@ if (process.env.BUILD_LIB) {
 export default defineConfig({
   base: './',
   plugins: [
-    inject({
-      $: 'jquery',
-      jQuery: 'jquery',
-      exclude: 'src/**/*.pug',
-    }),
     vue(),
     pugPlugin(),
     inlineFaviconPlugin('public/Girder_Favicon.png', 'image/png'),
@@ -99,5 +93,13 @@ export default defineConfig({
     sourcemap: !process.env.SKIP_SOURCE_MAPS,
     outDir,
     ...buildOpts,
+    rollupOptions: {transform: {
+    inject: {
+      $: 'jquery',
+      jQuery: 'jquery',
+      exclude: 'src/**/*.pug',
+    },
+    },
+    },
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -755,9 +755,9 @@
       }
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
-      "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
       "dev": true,
       "license": "ISC"
     },
@@ -5586,9 +5586,9 @@
       }
     },
     "node_modules/stylelint/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/plugins/authorized_upload/girder_authorized_upload/web_client/package-lock.json
+++ b/plugins/authorized_upload/girder_authorized_upload/web_client/package-lock.json
@@ -42,7 +42,6 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
-        "@rollup/plugin-inject": "^5.0.3",
         "@tsconfig/node20": "^20.0.0",
         "@types/istanbul-lib-report": "^3.0.0",
         "@types/istanbul-reports": "^3.0.1",

--- a/plugins/autojoin/girder_autojoin/web_client/package-lock.json
+++ b/plugins/autojoin/girder_autojoin/web_client/package-lock.json
@@ -42,7 +42,6 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
-        "@rollup/plugin-inject": "^5.0.3",
         "@tsconfig/node20": "^20.0.0",
         "@types/istanbul-lib-report": "^3.0.0",
         "@types/istanbul-reports": "^3.0.1",

--- a/plugins/google_analytics/girder_google_analytics/web_client/package-lock.json
+++ b/plugins/google_analytics/girder_google_analytics/web_client/package-lock.json
@@ -42,7 +42,6 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
-        "@rollup/plugin-inject": "^5.0.3",
         "@tsconfig/node20": "^20.0.0",
         "@types/istanbul-lib-report": "^3.0.0",
         "@types/istanbul-reports": "^3.0.1",

--- a/plugins/gravatar/girder_gravatar/web_client/package-lock.json
+++ b/plugins/gravatar/girder_gravatar/web_client/package-lock.json
@@ -42,7 +42,6 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
-        "@rollup/plugin-inject": "^5.0.3",
         "@tsconfig/node20": "^20.0.0",
         "@types/istanbul-lib-report": "^3.0.0",
         "@types/istanbul-reports": "^3.0.1",

--- a/plugins/hashsum_download/girder_hashsum_download/web_client/package-lock.json
+++ b/plugins/hashsum_download/girder_hashsum_download/web_client/package-lock.json
@@ -42,7 +42,6 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
-        "@rollup/plugin-inject": "^5.0.3",
         "@tsconfig/node20": "^20.0.0",
         "@types/istanbul-lib-report": "^3.0.0",
         "@types/istanbul-reports": "^3.0.1",

--- a/plugins/homepage/girder_homepage/web_client/package-lock.json
+++ b/plugins/homepage/girder_homepage/web_client/package-lock.json
@@ -42,7 +42,6 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
-        "@rollup/plugin-inject": "^5.0.3",
         "@tsconfig/node20": "^20.0.0",
         "@types/istanbul-lib-report": "^3.0.0",
         "@types/istanbul-reports": "^3.0.1",

--- a/plugins/import_tracker/girder_import_tracker/web_client/package-lock.json
+++ b/plugins/import_tracker/girder_import_tracker/web_client/package-lock.json
@@ -42,7 +42,6 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
-        "@rollup/plugin-inject": "^5.0.3",
         "@tsconfig/node20": "^20.0.0",
         "@types/istanbul-lib-report": "^3.0.0",
         "@types/istanbul-reports": "^3.0.1",

--- a/plugins/item_licenses/girder_item_licenses/web_client/package-lock.json
+++ b/plugins/item_licenses/girder_item_licenses/web_client/package-lock.json
@@ -42,7 +42,6 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
-        "@rollup/plugin-inject": "^5.0.3",
         "@tsconfig/node20": "^20.0.0",
         "@types/istanbul-lib-report": "^3.0.0",
         "@types/istanbul-reports": "^3.0.1",

--- a/plugins/jobs/girder_jobs/web_client/package-lock.json
+++ b/plugins/jobs/girder_jobs/web_client/package-lock.json
@@ -44,7 +44,6 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
-        "@rollup/plugin-inject": "^5.0.3",
         "@tsconfig/node20": "^20.0.0",
         "@types/istanbul-lib-report": "^3.0.0",
         "@types/istanbul-reports": "^3.0.1",

--- a/plugins/ldap/girder_ldap/web_client/package-lock.json
+++ b/plugins/ldap/girder_ldap/web_client/package-lock.json
@@ -43,7 +43,6 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
-        "@rollup/plugin-inject": "^5.0.3",
         "@tsconfig/node20": "^20.0.0",
         "@types/istanbul-lib-report": "^3.0.0",
         "@types/istanbul-reports": "^3.0.1",

--- a/plugins/oauth/girder_oauth/web_client/package-lock.json
+++ b/plugins/oauth/girder_oauth/web_client/package-lock.json
@@ -42,7 +42,6 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
-        "@rollup/plugin-inject": "^5.0.3",
         "@tsconfig/node20": "^20.0.0",
         "@types/istanbul-lib-report": "^3.0.0",
         "@types/istanbul-reports": "^3.0.1",

--- a/plugins/readme/girder_readme/web_client/package-lock.json
+++ b/plugins/readme/girder_readme/web_client/package-lock.json
@@ -42,7 +42,6 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
-        "@rollup/plugin-inject": "^5.0.3",
         "@tsconfig/node20": "^20.0.0",
         "@types/istanbul-lib-report": "^3.0.0",
         "@types/istanbul-reports": "^3.0.1",

--- a/plugins/sentry/girder_sentry/web_client/package-lock.json
+++ b/plugins/sentry/girder_sentry/web_client/package-lock.json
@@ -43,7 +43,6 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
-        "@rollup/plugin-inject": "^5.0.3",
         "@tsconfig/node20": "^20.0.0",
         "@types/istanbul-lib-report": "^3.0.0",
         "@types/istanbul-reports": "^3.0.1",
@@ -784,30 +783,32 @@
       "license": "MIT"
     },
     "node_modules/@sentry/browser": {
-      "version": "10.64.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.64.0.tgz",
-      "integrity": "sha512-CHZ7+79evh8knBtVHjW/XqV3mRaWs2TdjX7i55zpFe9vcNngQHV++0ss8ird/xfMY1mfCDtbyAN+Z6XY2o5aJA==",
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.65.0.tgz",
+      "integrity": "sha512-XUDDsx0qxzeIlcOu1fDEqTcDl0eiOqghsgV+ReuuNP4jYjZ9kUQxE3rXWM5mlT1pBi4VaQ4FHqvQZZrRXy+oDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser-utils": "10.64.0",
-        "@sentry/core": "10.64.0",
-        "@sentry/feedback": "10.64.0",
-        "@sentry/replay": "10.64.0",
-        "@sentry/replay-canvas": "10.64.0"
+        "@sentry/browser-utils": "10.65.0",
+        "@sentry/conventions": "^0.15.1",
+        "@sentry/core": "10.65.0",
+        "@sentry/feedback": "10.65.0",
+        "@sentry/replay": "10.65.0",
+        "@sentry/replay-canvas": "10.65.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/browser-utils": {
-      "version": "10.64.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.64.0.tgz",
-      "integrity": "sha512-qXvUpsZdE0+6SovhDZvjN4JkqQEpzeYsrOF5g63wMsqJWWv2vW/pQZIlJs0F6C0t4q5AHZL4fl5rNkvpVqFdKA==",
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.65.0.tgz",
+      "integrity": "sha512-4J0mkfNJAGUOkpg1ZggizyftFTn9N20b+Jl87UnWsDUkNG0Ic1l/FIzMPTVxXrAnhBGu0ULO0TFWMoQ5s3QtZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.64.0"
+        "@sentry/conventions": "^0.15.1",
+        "@sentry/core": "10.65.0"
       },
       "engines": {
         "node": ">=18"
@@ -824,9 +825,9 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.64.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.64.0.tgz",
-      "integrity": "sha512-HjojJcXD1l2qZ1AXje2s0XY/nYsaUt00wsM1HMBImA8vAClyPisFE/CC0/UD6pEvsGFhVgi8Dcxo7EN41uyeFw==",
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.65.0.tgz",
+      "integrity": "sha512-3aqtmM5NgNGo45BNaaBzi0LPQZAw//NEL4HKS5fXm12pJMa4KEkze8DEKnkTEIrGnWaOJKamecHKlnNg/Mqf/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -837,41 +838,41 @@
       }
     },
     "node_modules/@sentry/feedback": {
-      "version": "10.64.0",
-      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.64.0.tgz",
-      "integrity": "sha512-YrmKwRoAto+nwo26DoAhnpNmhkrVkuQFIAXqlTD8ipERjhcSNUYJAkAB+nH4w1KIgm9QQZE1sTq3iNQdPl1XMQ==",
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.65.0.tgz",
+      "integrity": "sha512-ck8h7wgd3F3bYNk0v1OgohmyLBeXcKxqlfBJRtQq4k6KZUq+pXimOG7ckNguVMYjCo3PEfuG+ckKc21yqotKug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.64.0"
+        "@sentry/core": "10.65.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "10.64.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.64.0.tgz",
-      "integrity": "sha512-q8nke2GDSwEiu1zYoctDDvnSNTjHWoVAKo2JXTleD0nwOO6IlAgUYmsm3qEQiSW7BVla9W1TRbW6ChFAUXYZbw==",
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.65.0.tgz",
+      "integrity": "sha512-aW988CcQBNArbOMzOFOziipHz6uQyXSa4i5CPWsu+nhVPTJHafosi5Lv9n6NM/icDX5e23VdnX6mZd8SyJuo8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser-utils": "10.64.0",
-        "@sentry/core": "10.64.0"
+        "@sentry/browser-utils": "10.65.0",
+        "@sentry/core": "10.65.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/replay-canvas": {
-      "version": "10.64.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.64.0.tgz",
-      "integrity": "sha512-EioBwcnnhtPiXzTZJTbZKaMEg3qNM5YZlX1VanoXomPATqfJD62cb/M27zhgiWXXJ7e8/NGVHvwNDYGrqsN39g==",
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.65.0.tgz",
+      "integrity": "sha512-A7X3RVk1Gk+knK8Ip/2EjejckNCLgCfRZo6eGlsy6qyz904KBpYmys1a0o7QkzFRjhIndjHAfcVxwt6jSLJlrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.64.0",
-        "@sentry/replay": "10.64.0"
+        "@sentry/core": "10.65.0",
+        "@sentry/replay": "10.65.0"
       },
       "engines": {
         "node": ">=18"

--- a/plugins/terms/girder_terms/web_client/package-lock.json
+++ b/plugins/terms/girder_terms/web_client/package-lock.json
@@ -42,7 +42,6 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
-        "@rollup/plugin-inject": "^5.0.3",
         "@tsconfig/node20": "^20.0.0",
         "@types/istanbul-lib-report": "^3.0.0",
         "@types/istanbul-reports": "^3.0.1",

--- a/plugins/thumbnails/girder_thumbnails/web_client/package-lock.json
+++ b/plugins/thumbnails/girder_thumbnails/web_client/package-lock.json
@@ -42,7 +42,6 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
-        "@rollup/plugin-inject": "^5.0.3",
         "@tsconfig/node20": "^20.0.0",
         "@types/istanbul-lib-report": "^3.0.0",
         "@types/istanbul-reports": "^3.0.1",

--- a/plugins/user_quota/girder_user_quota/web_client/package-lock.json
+++ b/plugins/user_quota/girder_user_quota/web_client/package-lock.json
@@ -43,7 +43,6 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
-        "@rollup/plugin-inject": "^5.0.3",
         "@tsconfig/node20": "^20.0.0",
         "@types/istanbul-lib-report": "^3.0.0",
         "@types/istanbul-reports": "^3.0.1",

--- a/plugins/worker/girder_plugin_worker/web_client/package-lock.json
+++ b/plugins/worker/girder_plugin_worker/web_client/package-lock.json
@@ -42,7 +42,6 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
-        "@rollup/plugin-inject": "^5.0.3",
         "@tsconfig/node20": "^20.0.0",
         "@types/istanbul-lib-report": "^3.0.0",
         "@types/istanbul-reports": "^3.0.1",


### PR DESCRIPTION
It is built in elsewhere, so unneeded, and we were being given warnings to this effect.