### PR TITLE
Fix measuring coverage on client code

### DIFF
--- a/girder/web/tests/coverage.ts
+++ b/girder/web/tests/coverage.ts
@@ -32,13 +32,13 @@ export const outputCoverageReport = async (page: Page) => {
     for (const entry of coverage) {
       let converter;
       if (/plugin_static/.test(entry.url)) {
-        const [plugin, filename] = entry.url.split('/').slice(-2);
-
+        const urlParts = entry.url.split('/');
+        const plugin = urlParts[urlParts.length - 2];
+        const [filename] = urlParts[urlParts.length - 1].split('?');
         const pathsToCheck = [
           `../../plugins/${plugin}/girder_${plugin}/web_client/dist/${filename}`,
           `../../plugins/${plugin}/girder_plugin_${plugin}/web_client/dist/${filename}`
         ];
-
         let path;
         for (const p of pathsToCheck) {
           try {

--- a/girder/web/tests/coverage.ts
+++ b/girder/web/tests/coverage.ts
@@ -27,17 +27,23 @@ export const startCoverage = async (page: Page) => {
 };
 
 export const outputCoverageReport = async (page: Page) => {
+  let coverage;
   try {
-    const coverage = await page.coverage.stopJSCoverage();
+    coverage = await page.coverage.stopJSCoverage();
+  } catch (e) {
+    return;
+  }
+  try {
     for (const entry of coverage) {
       let converter;
       if (/plugin_static/.test(entry.url)) {
         const urlParts = entry.url.split('/');
-        const plugin = urlParts[urlParts.length - 2];
+        const plugin = urlParts[urlParts.length - 2].replace(/-/g, '_');
         const [filename] = urlParts[urlParts.length - 1].split('?');
         const pathsToCheck = [
           `../../plugins/${plugin}/girder_${plugin}/web_client/dist/${filename}`,
-          `../../plugins/${plugin}/girder_plugin_${plugin}/web_client/dist/${filename}`
+          `../../plugins/${plugin}/girder_plugin_${plugin}/web_client/dist/${filename}`,
++          `../../plugins/${plugin}/${plugin}/web_client/dist/${filename}`
         ];
         let path;
         for (const p of pathsToCheck) {


### PR DESCRIPTION
Reduce warnings when running web tests.  playwright can only measure coverage on chromium, not on firefox.

There is still more work to do in this area -- I'm not sure we are collecting coverage for slicer_cli_web and when I look at the report the coverage seems to be for the built plugins rather than the source files.