### PR TITLE
Remove a spurious warning

### DIFF
--- a/girder/web/vite.config.ts
+++ b/girder/web/vite.config.ts
@@ -13,7 +13,7 @@ function pugPlugin() {
     transform(src: string, id: string) {
       if (id.endsWith('.pug')) {
         return {
-          code: `${compileClient(src, {filename: id})}\nexport default template`,
+          code: `${compileClient(src, { filename: id, compileDebug: false })}\nexport default template`,
           map: null,
         };
       }

--- a/plugins/authorized_upload/girder_authorized_upload/web_client/vite.config.ts
+++ b/plugins/authorized_upload/girder_authorized_upload/web_client/vite.config.ts
@@ -10,7 +10,7 @@ function pugPlugin() {
     transform(src: string, id: string) {
       if (id.endsWith('.pug')) {
         return {
-          code: `${compileClient(src, {filename: id})}\nexport default template`,
+          code: `${compileClient(src, { filename: id, compileDebug: false })}\nexport default template`,
           map: null,
         };
       }

--- a/plugins/autojoin/girder_autojoin/web_client/vite.config.ts
+++ b/plugins/autojoin/girder_autojoin/web_client/vite.config.ts
@@ -10,7 +10,7 @@ function pugPlugin() {
     transform(src: string, id: string) {
       if (id.endsWith('.pug')) {
         return {
-          code: `${compileClient(src, {filename: id})}\nexport default template`,
+          code: `${compileClient(src, { filename: id, compileDebug: false })}\nexport default template`,
           map: null,
         };
       }

--- a/plugins/google_analytics/girder_google_analytics/web_client/vite.config.ts
+++ b/plugins/google_analytics/girder_google_analytics/web_client/vite.config.ts
@@ -10,7 +10,7 @@ function pugPlugin() {
     transform(src: string, id: string) {
       if (id.endsWith('.pug')) {
         return {
-          code: `${compileClient(src, {filename: id})}\nexport default template`,
+          code: `${compileClient(src, { filename: id, compileDebug: false })}\nexport default template`,
           map: null,
         };
       }

--- a/plugins/gravatar/girder_gravatar/web_client/vite.config.ts
+++ b/plugins/gravatar/girder_gravatar/web_client/vite.config.ts
@@ -10,7 +10,7 @@ function pugPlugin() {
     transform(src: string, id: string) {
       if (id.endsWith('.pug')) {
         return {
-          code: `${compileClient(src, {filename: id})}\nexport default template`,
+          code: `${compileClient(src, { filename: id, compileDebug: false })}\nexport default template`,
           map: null,
         };
       }

--- a/plugins/hashsum_download/girder_hashsum_download/web_client/vite.config.ts
+++ b/plugins/hashsum_download/girder_hashsum_download/web_client/vite.config.ts
@@ -10,7 +10,7 @@ function pugPlugin() {
     transform(src: string, id: string) {
       if (id.endsWith('.pug')) {
         return {
-          code: `${compileClient(src, {filename: id})}\nexport default template`,
+          code: `${compileClient(src, { filename: id, compileDebug: false })}\nexport default template`,
           map: null,
         };
       }

--- a/plugins/homepage/girder_homepage/web_client/vite.config.ts
+++ b/plugins/homepage/girder_homepage/web_client/vite.config.ts
@@ -10,7 +10,7 @@ function pugPlugin() {
     transform(src: string, id: string) {
       if (id.endsWith('.pug')) {
         return {
-          code: `${compileClient(src, {filename: id})}\nexport default template`,
+          code: `${compileClient(src, { filename: id, compileDebug: false })}\nexport default template`,
           map: null,
         };
       }

--- a/plugins/import_tracker/girder_import_tracker/web_client/vite.config.ts
+++ b/plugins/import_tracker/girder_import_tracker/web_client/vite.config.ts
@@ -9,7 +9,7 @@ function pugPlugin() {
         transform(src: string, id: string) {
             if (id.endsWith('.pug')) {
                 return {
-                    code: `${compileClient(src, {filename: id})}\nexport default template`,
+                    code: `${compileClient(src, { filename: id, compileDebug: false })}\nexport default template`,
                     map: null,
                 };
             }

--- a/plugins/item_licenses/girder_item_licenses/web_client/vite.config.ts
+++ b/plugins/item_licenses/girder_item_licenses/web_client/vite.config.ts
@@ -10,7 +10,7 @@ function pugPlugin() {
     transform(src: string, id: string) {
       if (id.endsWith('.pug')) {
         return {
-          code: `${compileClient(src, {filename: id})}\nexport default template`,
+          code: `${compileClient(src, { filename: id, compileDebug: false })}\nexport default template`,
           map: null,
         };
       }

--- a/plugins/jobs/girder_jobs/web_client/vite.config.ts
+++ b/plugins/jobs/girder_jobs/web_client/vite.config.ts
@@ -10,7 +10,7 @@ function pugPlugin() {
     transform(src: string, id: string) {
       if (id.endsWith('.pug')) {
         return {
-          code: `${compileClient(src, {filename: id})}\nexport default template`,
+          code: `${compileClient(src, { filename: id, compileDebug: false })}\nexport default template`,
           map: null,
         };
       }

--- a/plugins/ldap/girder_ldap/web_client/vite.config.ts
+++ b/plugins/ldap/girder_ldap/web_client/vite.config.ts
@@ -10,7 +10,7 @@ function pugPlugin() {
     transform(src: string, id: string) {
       if (id.endsWith('.pug')) {
         return {
-          code: `${compileClient(src, {filename: id})}\nexport default template`,
+          code: `${compileClient(src, { filename: id, compileDebug: false })}\nexport default template`,
           map: null,
         };
       }

--- a/plugins/oauth/girder_oauth/web_client/vite.config.ts
+++ b/plugins/oauth/girder_oauth/web_client/vite.config.ts
@@ -10,7 +10,7 @@ function pugPlugin() {
     transform(src: string, id: string) {
       if (id.endsWith('.pug')) {
         return {
-          code: `${compileClient(src, {filename: id})}\nexport default template`,
+          code: `${compileClient(src, { filename: id, compileDebug: false })}\nexport default template`,
           map: null,
         };
       }

--- a/plugins/readme/girder_readme/web_client/vite.config.ts
+++ b/plugins/readme/girder_readme/web_client/vite.config.ts
@@ -10,7 +10,7 @@ function pugPlugin() {
     transform(src: string, id: string) {
       if (id.endsWith('.pug')) {
         return {
-          code: `${compileClient(src, {filename: id})}\nexport default template`,
+          code: `${compileClient(src, { filename: id, compileDebug: false })}\nexport default template`,
           map: null,
         };
       }

--- a/plugins/sentry/girder_sentry/web_client/vite.config.ts
+++ b/plugins/sentry/girder_sentry/web_client/vite.config.ts
@@ -10,7 +10,7 @@ function pugPlugin() {
     transform(src: string, id: string) {
       if (id.endsWith('.pug')) {
         return {
-          code: `${compileClient(src, {filename: id})}\nexport default template`,
+          code: `${compileClient(src, { filename: id, compileDebug: false })}\nexport default template`,
           map: null,
         };
       }

--- a/plugins/slicer_cli_web/slicer_cli_web/web_client/vite.config.ts
+++ b/plugins/slicer_cli_web/slicer_cli_web/web_client/vite.config.ts
@@ -9,7 +9,7 @@ function pugPlugin() {
     transform(src: string, id: string) {
       if (id.endsWith('.pug')) {
         return {
-          code: `${compileClient(src, {filename: id})}\nexport default template`,
+          code: `${compileClient(src, { filename: id, compileDebug: false })}\nexport default template`,
           map: null,
         };
       }

--- a/plugins/terms/girder_terms/web_client/vite.config.ts
+++ b/plugins/terms/girder_terms/web_client/vite.config.ts
@@ -10,7 +10,7 @@ function pugPlugin() {
     transform(src: string, id: string) {
       if (id.endsWith('.pug')) {
         return {
-          code: `${compileClient(src, {filename: id})}\nexport default template`,
+          code: `${compileClient(src, { filename: id, compileDebug: false })}\nexport default template`,
           map: null,
         };
       }

--- a/plugins/thumbnails/girder_thumbnails/web_client/vite.config.ts
+++ b/plugins/thumbnails/girder_thumbnails/web_client/vite.config.ts
@@ -10,7 +10,7 @@ function pugPlugin() {
     transform(src: string, id: string) {
       if (id.endsWith('.pug')) {
         return {
-          code: `${compileClient(src, {filename: id})}\nexport default template`,
+          code: `${compileClient(src, { filename: id, compileDebug: false })}\nexport default template`,
           map: null,
         };
       }

--- a/plugins/user_quota/girder_user_quota/web_client/vite.config.ts
+++ b/plugins/user_quota/girder_user_quota/web_client/vite.config.ts
@@ -10,7 +10,7 @@ function pugPlugin() {
     transform(src: string, id: string) {
       if (id.endsWith('.pug')) {
         return {
-          code: `${compileClient(src, {filename: id})}\nexport default template`,
+          code: `${compileClient(src, { filename: id, compileDebug: false })}\nexport default template`,
           map: null,
         };
       }

--- a/plugins/worker/girder_plugin_worker/web_client/vite.config.ts
+++ b/plugins/worker/girder_plugin_worker/web_client/vite.config.ts
@@ -9,7 +9,7 @@ function pugPlugin() {
     transform(src: string, id: string) {
       if (id.endsWith('.pug')) {
         return {
-          code: `${compileClient(src, {filename: id})}\nexport default template`,
+          code: `${compileClient(src, { filename: id, compileDebug: false })}\nexport default template`,
           map: null,
         };
       }


### PR DESCRIPTION
When we compile pug templates, we get a warning about the fs package. This is because of an optional compile debug option.  If we turn off this option, we no longer get the spurious warning.