### PR TITLE
Reduce logs for "docs" test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,13 +47,18 @@ deps =
 setenv =
     GIRDER_SPHINX_BUILD = true
 commands =
-    pip install --editable . --editable clients/python --editable ./worker
+    pip install \
+        --quiet \
+        --disable-pip-version-check \
+        --editable . \
+        --editable clients/python \
+        --editable ./worker
     sphinx-build \
-        -W \
-        -b html \
-        -d {envtmpdir}/doctrees \
-        docs \
-        build/docs/html
+        --quiet \
+        --fail-on-warning \
+        --builder html \
+        --doctree-dir {envtmpdir}/doctrees \
+        docs build/docs/html
 
 [testenv:coverage]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 [tox]
 envlist = lint,web-lint,docs,public-names,web-test,pytest,legacy-test,integration-test,coverage
+setenv =
+  PIP_PROGRESS_BAR = off
+  PIP_DISABLE_PIP_VERSION_CHECK = 1
 
 [testenv:pytest]
 passenv =
@@ -45,11 +48,10 @@ skipsdist = true
 deps =
     -rdocs/requirements-docs.txt
 setenv =
+    {[tox]setenv}
     GIRDER_SPHINX_BUILD = true
 commands =
     pip install \
-        --quiet \
-        --disable-pip-version-check \
         --editable . \
         --editable clients/python \
         --editable ./worker
@@ -195,6 +197,7 @@ deps =
     {[testenv:pytest]deps}
 passenv = *
 setenv =
+    {[tox]setenv}
     CTEST_SOURCE_DIRECTORY = {toxinidir}
     CTEST_BINARY_DIRECTORY = {toxinidir}/build/integration
     PYTHON_VERSION = 3.10


### PR DESCRIPTION
When `tox -e docs` is run, both `pip` and `sphinx` output a lot of unhelpful information: long lists of dependencies being installed. By adding the `--quiet` flag to both commands those information-level logs are suppressed but any errors are still output. 

Additionally, `--disable-pip-version-check` means Pip won't check if there's a new version of Pip available because it's neither the time or place for that. 

I've also done some minor syntactical changes to make the commands more readable without changing their behavior. 