### PR TITLE
Girder Worker Override API URL using Enviroment Variable

### DIFF
--- a/docs/list_env_settings.yaml
+++ b/docs/list_env_settings.yaml
@@ -93,6 +93,13 @@ GIRDER_WORKER_BROKER: >-
 GIRDER_WORKER_BACKEND: >-
   URL for the Celery result backend (e.g., redis://localhost:6379/0).
 
+GIRDER_WORKER_API_URL: >-
+  Optional per-worker override for the Girder API base URL used when calling
+  back to the server (job status, logs, data transfer). When set, this takes
+  precedence over the girder_api_url header attached when the job was scheduled.
+  Useful when workers run in a different network context than the web server
+  (for example Docker hostname vs localhost).
+
 GIRDER_WORKER_JOB_GC_SCOPE: >-
   A comma-separated list of extra default scopes for worker jobs.  For instance to allow jobs to schedule and check on other jobs, set this to "jobs.rest.create_job,jobs.rest.list_job"
 

--- a/docs/list_env_settings.yaml
+++ b/docs/list_env_settings.yaml
@@ -72,6 +72,9 @@ GIRDER_SETTING_CORE_FILEHANDLE_MAX_SIZE: >-
 GIRDER_SETTING_CORE_UPLOAD_MINIMUM_CHUNK_SIZE: >-
   Minimum chunk size for file uploads in bytes. Default is 5MB (1024 * 1024 * 5).
 
+GIRDER_SETTING_WORKER_API_URL: >-
+  The base URL for the Girder API when creating worker jobs.  This is used to call back to the server (job status, logs, data transfer) from workers.  This setting makes all jobs that are launched by a the server utilize the URL set here.  If GIRDER_WORKER_API_URL is set on a worker container, that will override this setting on that specific worker.
+
 GIRDER_HOST: >-
   Hostname or IP address to bind the server to. Use '0.0.0.0' to bind to all interfaces.
 
@@ -94,11 +97,7 @@ GIRDER_WORKER_BACKEND: >-
   URL for the Celery result backend (e.g., redis://localhost:6379/0).
 
 GIRDER_WORKER_API_URL: >-
-  Optional per-worker override for the Girder API base URL used when calling
-  back to the server (job status, logs, data transfer). When set, this takes
-  precedence over the girder_api_url header attached when the job was scheduled.
-  Useful when workers run in a different network context than the web server
-  (for example Docker hostname vs localhost).
+  Optional per-worker override for the Girder API base URL (or GIRDER_SETTING_WORKER_API_URL) used when calling back to the server (job status, logs, data transfer). When set, this takes precedence over the girder_api_url header attached when the job was scheduled. Useful when workers run in a different network context than the web server (for example Docker hostname vs localhost).
 
 GIRDER_WORKER_JOB_GC_SCOPE: >-
   A comma-separated list of extra default scopes for worker jobs.  For instance to allow jobs to schedule and check on other jobs, set this to "jobs.rest.create_job,jobs.rest.list_job"

--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -393,6 +393,11 @@ following environment variables:
 
 * ``GIRDER_WORKER_BROKER``: The URL of the message broker to use for celery
 * ``GIRDER_WORKER_BACKEND``: The URL of the result backend to use for celery
+* ``GIRDER_WORKER_API_URL``: Optional per-worker override for the Girder API
+  base URL used when the worker calls back to the server. When set, this takes
+  precedence over the ``girder_api_url`` header attached at schedule time, so
+  each worker can use an API URL appropriate for its own network location
+  (for example ``http://girder:8080/api/v1`` inside Docker).
 
 Switch to HttpOnly cookies in core web client
 +++++++++++++++++++++++++++++++++++++++++++++

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -465,3 +465,11 @@ and builds in some useful Girder integrations on top of celery. Namely,
   UI in real time. If the script prints any logging information, it is automatically
   collected in the job log on the server, and if the script raises an exception,
   the job status is automatically set to an error state.
+
+When a job is scheduled, Girder attaches a ``girder_api_url`` header so the worker
+can call back to the API. That URL is derived from the ``worker.api_url`` setting
+(or ``GIRDER_SETTING_WORKER_API_URL``), falling back to the server root. If a
+worker runs in a different network context than the web server (for example inside
+Docker), set ``GIRDER_WORKER_API_URL`` on that worker process to override the
+callback URL independently of the scheduling server. See the worker package
+``README.rst`` for details.

--- a/test/worker/task_signal_test.py
+++ b/test/worker/task_signal_test.py
@@ -38,3 +38,27 @@ def test_gw_task_failure_with_builtin_tasks_should_noop(name):
         task.name = name
         gw_task_failure(sender=task)
         us.assert_not_called()
+
+
+def test_gw_task_prerun_applies_girder_api_url_env_override(monkeypatch):
+    monkeypatch.setenv('GIRDER_WORKER_API_URL', 'http://worker-host/api/v1')
+
+    task = mock.MagicMock()
+    task.name = 'example.task'
+    task.request.girder_api_url = 'http://server-host/api/v1'
+    task.request.girder_client_token = 'token'
+    task.request.jobInfoSpec = {
+        'url': 'http://server-host/api/v1/job/jobid',
+        'method': 'PUT',
+        'logPrint': False,
+    }
+    task.request.headers = None
+
+    with mock.patch('girder_worker.app.GirderClient') as GirderClient, \
+            mock.patch('girder_worker.app._update_status'):
+        gw_task_prerun(task=task, sender=task)
+
+    assert task.request.girder_api_url == 'http://worker-host/api/v1'
+    assert task.request.jobInfoSpec['url'] == 'http://worker-host/api/v1/job/jobid'
+    GirderClient.assert_called_once_with(apiUrl='http://worker-host/api/v1')
+    assert task.girder_client.token == 'token'

--- a/test/worker/test_utils.py
+++ b/test/worker/test_utils.py
@@ -1,6 +1,9 @@
 import sys
+from unittest import mock
 
-from girder_worker.utils import TeeStdOutCustomWrite
+import pytest
+from girder_worker.utils import (TeeStdOutCustomWrite, _job_manager, apply_girder_api_url_override,
+                                 resolve_girder_api_url, rewrite_url_api_base)
 
 
 def test_TeeStdOutCustomWrite(capfd):
@@ -17,3 +20,106 @@ def test_TeeStdOutCustomWrite(capfd):
 
     out, err = capfd.readouterr()
     assert out == 'Test String'
+
+
+def test_resolve_girder_api_url_returns_passed_url_when_env_unset(monkeypatch):
+    monkeypatch.delenv('GIRDER_WORKER_API_URL', raising=False)
+    assert resolve_girder_api_url('http://server/api/v1') == 'http://server/api/v1'
+    assert resolve_girder_api_url(None) is None
+    assert resolve_girder_api_url() is None
+
+
+def test_resolve_girder_api_url_prefers_env_override(monkeypatch):
+    monkeypatch.setenv('GIRDER_WORKER_API_URL', 'http://worker-view/api/v1')
+    assert resolve_girder_api_url('http://server/api/v1') == 'http://worker-view/api/v1'
+    assert resolve_girder_api_url() == 'http://worker-view/api/v1'
+
+
+@pytest.mark.parametrize('url,original,new,expected', [
+    (
+        'http://server/api/v1/job/abc',
+        'http://server/api/v1',
+        'http://worker/api/v1',
+        'http://worker/api/v1/job/abc',
+    ),
+    (
+        'http://server/api/v1/job/abc/',
+        'http://server/api/v1/',
+        'http://worker/api/v1/',
+        'http://worker/api/v1/job/abc/',
+    ),
+    (
+        'http://other/api/v1/job/abc',
+        'http://server/api/v1',
+        'http://worker/api/v1',
+        'http://other/api/v1/job/abc',
+    ),
+    (
+        None,
+        'http://server/api/v1',
+        'http://worker/api/v1',
+        None,
+    ),
+])
+def test_rewrite_url_api_base(url, original, new, expected):
+    assert rewrite_url_api_base(url, original, new) == expected
+
+
+def test_rewrite_url_api_base_warns_when_original_missing(caplog):
+    url = 'http://server/api/v1/job/abc'
+    with caplog.at_level('WARNING', logger='girder_worker'):
+        assert rewrite_url_api_base(url, None, 'http://worker/api/v1') == url
+
+    assert any(
+        'Cannot rewrite API URL' in record.getMessage()
+        and 'original API base URL is missing' in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_apply_girder_api_url_override_updates_request_and_job_info_spec(monkeypatch):
+    monkeypatch.setenv('GIRDER_WORKER_API_URL', 'http://worker/api/v1')
+    request = mock.MagicMock()
+    request.girder_api_url = 'http://server/api/v1'
+    request.apiUrl = 'http://server/api/v1'
+    request.jobInfoSpec = {
+        'url': 'http://server/api/v1/job/abc123',
+        'method': 'PUT',
+        'logPrint': True,
+    }
+
+    resolved = apply_girder_api_url_override(request)
+
+    assert resolved == 'http://worker/api/v1'
+    assert request.girder_api_url == 'http://worker/api/v1'
+    assert request.apiUrl == 'http://worker/api/v1'
+    assert request.jobInfoSpec['url'] == 'http://worker/api/v1/job/abc123'
+
+
+def test_apply_girder_api_url_override_noop_when_env_unset(monkeypatch):
+    monkeypatch.delenv('GIRDER_WORKER_API_URL', raising=False)
+    request = mock.MagicMock()
+    request.girder_api_url = 'http://server/api/v1'
+    request.jobInfoSpec = {'url': 'http://server/api/v1/job/abc123'}
+
+    resolved = apply_girder_api_url_override(request)
+
+    assert resolved == 'http://server/api/v1'
+    assert request.girder_api_url == 'http://server/api/v1'
+    assert request.jobInfoSpec['url'] == 'http://server/api/v1/job/abc123'
+
+
+def test_job_manager_uses_api_url_override_from_headers(monkeypatch):
+    monkeypatch.setenv('GIRDER_WORKER_API_URL', 'http://worker/api/v1')
+    headers = {
+        'girder_api_url': 'http://server/api/v1',
+        'jobInfoSpec': {
+            'url': 'http://server/api/v1/job/abc123',
+            'method': 'PUT',
+            'logPrint': False,
+        },
+    }
+
+    manager = _job_manager(headers=headers)
+
+    assert manager.url == 'http://worker/api/v1/job/abc123'

--- a/worker/girder_worker/app.py
+++ b/worker/girder_worker/app.py
@@ -13,7 +13,8 @@ from girder_worker.context import get_context
 from girder_worker.entrypoint import discover_tasks
 from girder_worker.task import Task
 from girder_worker.utils import (JobSpecNotFound, JobStatus, StateTransitionException, _job_manager,
-                                 _update_status, is_builtin_celery_task, is_revoked)
+                                 _update_status, apply_girder_api_url_override,
+                                 is_builtin_celery_task, is_revoked)
 from girder_worker.utils.transform import ResultTransform
 from kombu.serialization import register
 
@@ -90,13 +91,17 @@ def gw_task_prerun(task=None, sender=None, task_id=None,
                    args=None, kwargs=None, **rest):
     """Deserialize the jobInfoSpec passed in through the headers.
 
-    This provides the a JobManager class as an attribute of the
+    This provides the JobManager class as an attribute of the
     task before task execution.  decorated functions may bind to
     their task and have access to the job_manager for logging and
     updating their status in girder.
     """
     if is_builtin_celery_task(sender.name):
         return
+
+    # Allow each worker to override the API URL attached at schedule time so
+    # callbacks use a URL reachable from this worker's network context.
+    apply_girder_api_url_override(task.request)
 
     try:
         task.job_manager = _job_manager(task.request, task.request.headers)

--- a/worker/girder_worker/context/nongirder_context.py
+++ b/worker/girder_worker/context/nongirder_context.py
@@ -4,7 +4,7 @@ import requests
 from celery import current_app
 from girder_client import GirderClient
 from girder_worker import logger
-from girder_worker.utils import _maybe_model_repr, _walk_obj
+from girder_worker.utils import _maybe_model_repr, _walk_obj, resolve_girder_api_url
 
 
 class MissingJobArguments(RuntimeError):
@@ -33,7 +33,8 @@ def create_task_job(job_defaults, sender=None, body=None,
         if 'id' not in headers:
             raise MissingJobArguments('id is not in headers')
 
-        gc = GirderClient(apiUrl=parent_task.request.girder_api_url)
+        api_url = resolve_girder_api_url(parent_task.request.girder_api_url)
+        gc = GirderClient(apiUrl=api_url)
         gc.token = parent_task.request.girder_client_token
 
         task_args = tuple(_walk_obj(body[0], _maybe_model_repr))
@@ -80,7 +81,8 @@ def attach_girder_api_url(sender=None, body=None, exchange=None,
         if not hasattr(parent_task.request, 'girder_api_url'):
             raise MissingJobArguments(
                 "Parent task's request does not contain girder_api_url")
-        headers['girder_api_url'] = parent_task.request.girder_api_url
+        headers['girder_api_url'] = resolve_girder_api_url(
+            parent_task.request.girder_api_url)
     except MissingJobArguments as e:
         logger.warning(f'Could not get girder_api_url from parent task: {str(e)}')
 

--- a/worker/girder_worker/utils/__init__.py
+++ b/worker/girder_worker/utils/__init__.py
@@ -1,10 +1,12 @@
 import importlib.metadata
+import os
 import time
 
 import requests
 # Disable urllib3 warnings about certificate validation. As they are printed in the console, the
 # messages are sent to Girder, creating an infinite loop.
 import urllib3
+from girder_worker import logger
 from requests import HTTPError
 
 from .tee import Tee, tee_stderr, tee_stdout
@@ -16,6 +18,96 @@ try:
 except importlib.metadata.PackageNotFoundError:
     # package is not installed
     pass
+
+# Per-worker override for the Girder API URL used when calling back to the server.
+# When set, this takes precedence over the girder_api_url header attached at schedule time.
+GIRDER_WORKER_API_URL_ENV = 'GIRDER_WORKER_API_URL'
+
+
+def resolve_girder_api_url(api_url=None):
+    """Resolve the Girder API URL, preferring a per-worker environment override.
+
+    When a job is scheduled, the Girder server attaches a ``girder_api_url`` header
+    based on its own view of the API root. Workers that run in a different network
+    context (for example inside Docker, or on a remote host) can set
+    ``GIRDER_WORKER_API_URL`` so callbacks use a URL reachable from that worker
+    instead of the URL provided by the scheduling server.
+
+    Called with no argument (or ``None``), this returns the override value alone,
+    or ``None`` if the environment variable is unset.
+
+    :param api_url: The API URL from the task headers / scheduling server.
+    :type api_url: str or None
+    :returns: The override URL if ``GIRDER_WORKER_API_URL`` is set, otherwise
+        ``api_url``.
+    :rtype: str or None
+    """
+    return os.environ.get(GIRDER_WORKER_API_URL_ENV) or api_url
+
+
+def rewrite_url_api_base(url, original_api_url, new_api_url):
+    """Rewrite a URL that starts with ``original_api_url`` to use ``new_api_url``.
+
+    Used to update embedded job callback URLs (for example in ``jobInfoSpec``)
+    when a worker overrides the Girder API base URL.
+
+    :param url: A full URL that may begin with ``original_api_url``.
+    :type url: str or None
+    :param original_api_url: The API base URL originally embedded in ``url``.
+    :type original_api_url: str or None
+    :param new_api_url: The API base URL that should replace ``original_api_url``.
+    :type new_api_url: str or None
+    :returns: The rewritten URL, or ``url`` unchanged if a rewrite is not possible.
+        When ``url`` and ``new_api_url`` are set but ``original_api_url`` is
+        missing, a warning is logged and ``url`` is returned unchanged.
+    :rtype: str or None
+    """
+    if not url or not new_api_url:
+        return url
+    if not original_api_url:
+        logger.warning(
+            'Cannot rewrite API URL %r to %r because the original API base URL '
+            'is missing; leaving the URL unchanged.',
+            url, new_api_url)
+        return url
+    original = original_api_url.rstrip('/')
+    replacement = new_api_url.rstrip('/')
+    if url.startswith(original):
+        return replacement + url[len(original):]
+    return url
+
+
+def apply_girder_api_url_override(request):
+    """Apply ``GIRDER_WORKER_API_URL`` to a Celery task request in place.
+
+    Updates ``girder_api_url`` (and legacy ``apiUrl`` when present) on the request,
+    and rewrites the ``jobInfoSpec`` callback URL so job status/log updates use the
+    overridden API base.
+
+    :param request: The Celery task request / context object.
+    :returns: The resolved API URL after applying any override, or ``None``.
+    :rtype: str or None
+    """
+    original_api_url = getattr(request, 'girder_api_url', None)
+    if original_api_url is None:
+        original_api_url = getattr(request, 'apiUrl', None)
+
+    override = resolve_girder_api_url()
+    if not override:
+        return original_api_url
+
+    if hasattr(request, 'jobInfoSpec') and request.jobInfoSpec:
+        jobSpec = dict(request.jobInfoSpec)
+        if 'url' in jobSpec:
+            jobSpec['url'] = rewrite_url_api_base(
+                jobSpec['url'], original_api_url, override)
+            request.jobInfoSpec = jobSpec
+
+    request.girder_api_url = override
+    if hasattr(request, 'apiUrl'):
+        request.apiUrl = override
+
+    return override
 
 
 def _walk_obj(obj, func, leaf_condition=None):
@@ -134,6 +226,20 @@ def _job_manager(request=None, headers=None, kwargs=None):
 
     else:
         raise JobSpecNotFound
+
+    override = resolve_girder_api_url()
+    if override:
+        original = None
+        if request is not None:
+            original = getattr(request, 'girder_api_url', None)
+            if original is None:
+                original = getattr(request, 'apiUrl', None)
+        if original is None and headers is not None:
+            original = headers.get('girder_api_url') or headers.get('apiUrl')
+        jobSpec = dict(jobSpec)
+        if 'url' in jobSpec:
+            jobSpec['url'] = rewrite_url_api_base(
+                jobSpec['url'], original, override)
 
     return deserialize_job_info_spec(
         **jobSpec, girder_client_session_kwargs=girder_client_session_kwargs)


### PR DESCRIPTION

resolves #3857

Currently a Draft PR so I can easily access it in the PR review and test within DIVE.
The main functionality is to provide a way to override the girder_api_url in tasks that are initiated by the server but happen to live in a different network context.
Specifically when the server and localworker have a shared context that is not publicly accessible but workers may need to be remote.

It relates to an issue in DIVE where a deployment is behind a GCP VPC

__init__.py
- new `GIRDER_WORKER_API_URL` environment variable that can be used to override the tasks bound apiURL with a system environment variable.  Allowing for workers to have a different network path to the server compared to locations deploying the task
- `resolve_girder_api_url(api_url=None)` -  returns either the provided url or the override from the environment value if one exists
- `rewrite_url_pai_base(url, original_api_url, new_api_url)` - The `jobInfoSpec` in girder tasks has it's own URL for reporting back to the server the job.  This utility function is used to replace the default URL with a new one from the environment variable override.  Shouldn't happen but if no api_url is found it will create a warning in the logs and return the original.
- `apply_girder_api_url_override(request)`- takes a request inside of a task (`task.request`) and replaces the `girder_api_url` and  the `jobInfoSpec` url with the environment variable's URL
- within the job_manager initialization the override is applied if found to the jobSpec['url'] as well

nongirder_context.py
- Replaces the girder client api url and sets the header `girder_api_url` to the environment variable url so that any jobs launched from the worker have the proper girder api url used for communication

app.py
- during the prerun for a task this will apply the `GIRDER_WORKER_API_URL` settings for an updated URL to the `task.request` to override the server's girder_api_url setting as well as the job_manager through the `jobInfoSpec`

list_env_settings.yaml
- Added the newer `GIRDER_WORKER_API_URL` environment variable and description
- Added `GIRDER_SETTING_WORKER_API_URL` and explained how it sets the worker apiURL on job creation time

Testing:
- Plan to use this branch in DIVE and test with a remote worker (outside of the docker context in another compose stack) as well as having the local worker for girder 5
	- local worker: http://girder:8080/api/v1 - uses the internal docker network to point to the worker
	- external worker: http://host.docker.internal:8010/api/v1 - so it communicates outside of the docker network.  Need to make sure that the worker docker network will access the external system
	- Ensure both have access to the message broker (may need to expose in DIVE)
	- Could also try running it on separate LAN systems with a public api and broker

Results:
- Testing worked properly and was able to have two disconnected instances the Job updates/status and pushing/pulling of data worked properly.