### PR TITLE
Cache public settings in UI

### DIFF
--- a/girder/web/src/index.ts
+++ b/girder/web/src/index.ts
@@ -29,6 +29,7 @@ const initializeDefaultApp = async (apiRoot: string, el: string | HTMLElement = 
                 url: `system/public_settings`,
                 method: 'GET',
             }).done((resp: any) => {
+                rest.setPublicSettings(resp);
                 const app = new views.App({
                     el,
                     parentView: null,

--- a/girder/web/src/rest.js
+++ b/girder/web/src/rest.js
@@ -6,6 +6,7 @@ import events from '@girder/core/events';
 import { getCurrentToken, setCurrentUser, setCurrentToken } from '@girder/core/auth';
 
 let apiRoot;
+let publicSettings = null;
 var uploadHandlers = {};
 var uploadChunkSize = 1024 * 1024 * 64; // 64MB
 
@@ -29,6 +30,26 @@ function getApiRoot() {
 function setApiRoot(root) {
     // Strip trailing slash
     apiRoot = root.replace(/\/$/, '');
+}
+
+/**
+ * Get the public settings fetched at application startup (from
+ * "system/public_settings"), so callers don't need to re-fetch them.
+ *
+ * @returns {?Object} The cached public settings, or null if not yet fetched.
+ */
+function getPublicSettings() {
+    return publicSettings;
+}
+
+/**
+ * Set the cached public settings. Called once by the application bootstrap
+ * after fetching "system/public_settings".
+ *
+ * @param {Object} settings The public settings response.
+ */
+function setPublicSettings(settings) {
+    publicSettings = settings;
 }
 
 /**
@@ -212,6 +233,8 @@ function setUploadChunkSize(val) {
 export {
     getApiRoot,
     setApiRoot,
+    getPublicSettings,
+    setPublicSettings,
     uploadHandlers,
     restRequest,
     numberOutstandingRestRequests,


### PR DESCRIPTION
This PR stores the response from `GET system/public_settings` that triggers upon up initialization.

### Rationale
This allows plugins to inject custom settings via simple girder events, e.g.:

```python
@access.public
@girderRest.boundHandler
def add_public_settings(self, event):
    settings = event.info["returnVal"]
    public_settings = [PluginSettings.AIMDL_COUNTS]
    settings.update({key: Setting().get(key) for key in public_settings})
```

and later use it in UI extensions without reinventing a lot of internal Girder's machinery.