### PR TITLE
Avoid passing arguments to the web-lint tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -142,7 +142,7 @@ allowlist_externals =
     npm
 commands =
     npm ci
-    npm run lint -- "{posargs}"
+    npm run lint
 
 [testenv:web-format]
 description = Run Javascript linting fixes


### PR DESCRIPTION
It doesn't work due to the fact it is multiple commands