### PR TITLE
Install Tini with `apt` to fix arm64 builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,13 @@ RUN apt-get update && apt-get install -qy \
     libsasl2-dev \
     python3-pip \
     curl \
+    tini \
 && apt-get clean && rm -rf /var/lib/apt/lists/* \
 && python3 -m pip install --upgrade --no-cache-dir \
     pip \
     setuptools \
     setuptools_scm \
     wheel
-
-RUN curl -LJ https://github.com/krallin/tini/releases/download/v0.19.0/tini -o /sbin/tini && \
-    chmod +x /sbin/tini
 
 RUN curl -sL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -qy nodejs
@@ -36,4 +34,4 @@ RUN pip install -e /girder
 
 EXPOSE 8080
 
-ENTRYPOINT ["/sbin/tini", "--", "girder", "serve"]
+ENTRYPOINT ["tini", "--", "girder", "serve"]


### PR DESCRIPTION
For the developer container, Tini was installed by directly copying the x86_64 binary from GitHub, making the container incompatible with arm64 systems. This gets resolved by letting `apt` install Tini instead.

Alternatively, since Docker 1.13, Tini is included in Docker by passing the `--init` flag. I opted out of this solution as it changes how the container is run, potentially introducing hard-to-find bugs for anyone that doesn't know to add the new flag. 