### PR TITLE
Girder worker log mixing

### DIFF
--- a/worker/girder_worker/app.py
+++ b/worker/girder_worker/app.py
@@ -18,6 +18,8 @@ from girder_worker.utils import (JobSpecNotFound, JobStatus, StateTransitionExce
 from girder_worker.utils.transform import ResultTransform
 from kombu.serialization import register
 
+CeleryAppInfo = {'threads_pool': False}
+
 
 @before_task_publish.connect  # noqa: C901
 def girder_before_task_publish(sender=None, body=None, exchange=None,
@@ -76,6 +78,25 @@ def girder_before_task_publish(sender=None, body=None, exchange=None,
     except Exception:
         logger.exception('An error occurred in girder_before_task_publish.')
         raise
+
+
+@worker_ready.connect
+def _capture_celery_pool(sender, **kwargs):
+    """
+    Determine if the celery task pool is thread based; we use this to govern
+    some logging choices.
+
+    :param sender:  a celery.worker.worker.Worker instance
+    """
+    pool = getattr(sender, 'pool', None)
+    try:
+        if pool and 'thread' in type(pool).__module__.lower():
+            CeleryAppInfo['threads_pool'] = True
+            logger.info('Using a threads pool')
+        else:
+            logger.info('Not using a threads pool')
+    except Exception:
+        logger.exception('Failed to determine pool type')
 
 
 @worker_ready.connect

--- a/worker/girder_worker/docker/tasks/__init__.py
+++ b/worker/girder_worker/docker/tasks/__init__.py
@@ -40,6 +40,10 @@ def _pull_image(image):
         raise
 
 
+def _is_no_such_container(exc):
+    return 'No such container' in str(exc) or type(exc).__name__ == 'NotFound'
+
+
 def _get_docker_network():
     try:
         ip = socket.gethostbyname(socket.gethostname())
@@ -48,10 +52,23 @@ def _get_docker_network():
             client = docker.from_env(version='auto', timeout=timeout)
         else:
             client = docker.from_env(version='auto')
-        for container in client.containers.list(all=True, filters={'status': 'running'}):
-            for nw in container.attrs['NetworkSettings']['Networks'].values():
+        # we use client.api.containers rather than client.containers.list
+        # because containers.lists casts to a list which can throw an
+        # exception rather than allowing graceful handling.
+        for container in client.api.containers(all=True, filters={'status': ['running']}):
+            cid = container.get('Id') or container.get('ID')
+            if not cid:
+                continue
+            try:
+                data = client.api.inspect_container(cid)
+            except Exception as exc:
+                if _is_no_such_container(exc):
+                    continue
+                raise
+            networks = (data.get('NetworkSettings', {}) or {}).get('Networks', {}) or {}
+            for nw in networks.values():
                 if nw['IPAddress'] == ip:
-                    return 'container:%s' % container.id
+                    return 'container:%s' % cid
     except Exception:
         logger.exception('Failed to get docker network')
 
@@ -59,12 +76,23 @@ def _get_docker_network():
 def _remove_stopped_container(client, name):
     if name is None:
         return
-    for container in client.containers.list(all=True, filters={'name': name}):
-        try:
-            logger.info('Removing container %s ' % (name))
-            container.remove()
-        except Exception:
-            pass
+    # we use client.api.containers rather than client.containers.list
+    # because containers.lists casts to a list which can throw an
+    # exception rather than allowing graceful handling.
+    try:
+        for container in client.api.containers(all=True, filters={'name': [name]}):
+            cid = container.get('Id') or container.get('ID')
+            if not cid:
+                continue
+            try:
+                logger.info('Removing container %s ' % (name))
+                client.api.remove_container(cid)
+            except Exception:
+                pass
+    except Exception as exc:
+        if _is_no_such_container(exc):
+            return
+        raise
 
 
 def _run_container(image, container_args, **kwargs):

--- a/worker/girder_worker/task.py
+++ b/worker/girder_worker/task.py
@@ -172,3 +172,19 @@ class Task(celery.Task):
             if hasattr(self.request, 'girder_result_hooks'):
                 for hook in self.request.girder_result_hooks:
                     self._maybe_cleanup(hook)
+
+    @property
+    def job_manager(self):
+        return getattr(self.request, 'girder_job_manager', None)
+
+    @job_manager.setter
+    def job_manager(self, value):
+        self.request.girder_job_manager = value
+
+    @property
+    def girder_client(self):
+        return getattr(self.request, 'girder_client_instance', None)
+
+    @girder_client.setter
+    def girder_client(self, value):
+        self.request.girder_client_instance = value

--- a/worker/girder_worker/utils/__init__.py
+++ b/worker/girder_worker/utils/__init__.py
@@ -358,6 +358,13 @@ class JobManager:
         :type interval: int or float
         :param reference: optional reference to store with the job.
         """
+        from ..app import CeleryAppInfo
+
+        # When we are using a threads pool, tee-ing stdout and stderr to
+        # logPrint can lead to the logs being written to multiple threads and
+        # therefore multiple workers.
+        if CeleryAppInfo['threads_pool']:
+            logPrint = None
         self.logPrint = logPrint
         self.method = method or 'PUT'
         self.url = url


### PR DESCRIPTION
Change how we find the worker's network.  This upstreams https://github.com/girder/girder_worker/pull/413

Make job_manager and girder_client per request. This upstreams https://github.com/girder/girder_worker/pull/414

When using a celery threads-pool for the workers, do not tee logPrint.  This upstreams https://github.com/girder/girder_worker/pull/416