### PR TITLE
Clamp privilege level in inviteToGroup force path

### DIFF
--- a/girder/api/v1/group.py
+++ b/girder/api/v1/group.py
@@ -222,6 +222,12 @@ class Group(Resource):
                     mustBeAdmin = False
                 if mustBeAdmin:
                     self.requireAdmin(user)
+            if not user['admin']:
+                # A non-site-admin may only grant an access level that they
+                # themselves hold. Without this clamp, a moderator (WRITE)
+                # could promote an arbitrary user to ADMIN via the force path,
+                # bypassing the level check that the non-force branch applies.
+                groupModel.requireAccess(group, user, level)
             groupModel.addUser(group, userToInvite, level=level)
         else:
             # Can only invite into access levels that you yourself have

--- a/tests/cases/group_test.py
+++ b/tests/cases/group_test.py
@@ -511,3 +511,58 @@ class GroupTestCase(base.TestCase):
                     else:
                         self.assertStatus(resp, 403)
         Setting().unset(SettingKey.ADD_TO_GROUP_POLICY)
+
+    def testModeratorForceGrantAdmin(self):
+        """
+        Test that a group moderator cannot escalate privilege to admin via force option.
+
+        When core.add_to_group_policy = 'yesmod' and addAllowed = 'yesmod',
+        a moderator should be able to force-add users to the group, but with
+        level <= WRITE (their own access level). Attempting to grant ADMIN (level 2)
+        via force=true should be rejected.
+        """
+        # Setup policy to allow mods to add members
+        Setting().set(SettingKey.ADD_TO_GROUP_POLICY, 'yesmod')
+
+        # Create a group and add users as admin, moderator
+        group = Group().createGroup('priv_esc_group', self.users[0], public=True)
+        resp = self.request(
+            path='/group/%s/invitation' % group['_id'],
+            params={
+                'force': 'true',
+                'userId': self.users[1]['_id'],
+                'level': AccessType.ADMIN
+            }, method='POST', user=self.users[0])
+        self.assertStatusOk(resp)
+
+        resp = self.request(
+            path='/group/%s/invitation' % group['_id'],
+            params={
+                'force': 'true',
+                'userId': self.users[2]['_id'],
+                'level': AccessType.WRITE
+            }, method='POST', user=self.users[0])
+        self.assertStatusOk(resp)
+
+        # Configure addAllowed for this group to yesmod
+        resp = self.request(
+            path='/group/%s' % group['_id'],
+            user=self.users[0], method='PUT',
+            params={'addAllowed': 'yesmod'})
+        self.assertStatusOk(resp)
+        group = Group().load(group['_id'], force=True)
+
+        # Now, try to use the moderator (user 2) to force-add user 3 as admin
+        resp = self.request(
+            path='/group/%s/invitation' % group['_id'],
+            params={
+                'force': 'true',
+                'userId': self.users[3]['_id'],
+                'level': AccessType.ADMIN
+            }, method='POST', user=self.users[2])
+
+        # This should fail with 403 because moderator can't grant admin rights
+        self.assertStatus(resp, 403)
+
+        # Clean up
+        Setting().unset(SettingKey.ADD_TO_GROUP_POLICY)


### PR DESCRIPTION
A group moderator could leverage the 'force' code path in the inviteToGroup endpoint to add users with an access level higher than their own (CWE-862: Missing Authorization / CWE-269: Improper Privilege Management). The non-force branch correctly enforced a level clamp via requireAccess, but the force path (used under specific add_allowed / add_to_group_policy settings) bypassed this check, allowing privilege escalation to group admin.

This patch adds the same requireAccess level clamp to the force path for non-site-admins, ensuring users may only grant permissions they already hold. Added unit test testModeratorForceGrantAdmin to verify the constraint prevents unauthorized escalation while preserving legitimate moderator functionality.