### PR TITLE
Return partial paths for public resources

### DIFF
--- a/girder/api/v1/folder.py
+++ b/girder/api/v1/folder.py
@@ -431,4 +431,4 @@ class Folder(Resource):
         .errorResponse('Read access was denied for the folder.', 403)
     )
     def rootpath(self, folder, params):
-        return self._model.parentsToRoot(folder, user=self.getCurrentUser())
+        return self._model.parentsToRoot(folder, user=self.getCurrentUser(), hideInaccessible=True)

--- a/girder/api/v1/item.py
+++ b/girder/api/v1/item.py
@@ -314,7 +314,7 @@ class Item(Resource):
         .errorResponse('Read access was denied for the item.', 403)
     )
     def rootpath(self, item):
-        return self._model.parentsToRoot(item, self.getCurrentUser())
+        return self._model.parentsToRoot(item, self.getCurrentUser(), hideInaccessible=True)
 
     @access.user(scope=TokenScope.DATA_WRITE)
     @filtermodel(model=ItemModel)

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -564,7 +564,15 @@ class Folder(AccessControlledModel):
 
         return filteredDoc
 
-    def parentsToRoot(self, folder, curPath=None, user=None, force=False, level=AccessType.READ):
+    def parentsToRoot(
+        self,
+        folder,
+        curPath=None,
+        user=None,
+        force=False,
+        level=AccessType.READ,
+        hideInaccessible=False,
+    ):
         """
         Get the path to traverse to a root of the hierarchy.
 
@@ -572,6 +580,7 @@ class Folder(AccessControlledModel):
         :type folder: dict
         :returns: an ordered list of dictionaries from root to the current folder
         """
+        force = force or hideInaccessible
         curPath = curPath or []
         curParentId = folder['parentId']
         curParentType = folder['parentCollection']
@@ -585,10 +594,30 @@ class Folder(AccessControlledModel):
             else:
                 parentFiltered = ModelImporter.model(curParentType).filter(curParentObject, user)
 
-            return [{
+            curPaths = [{
                 'type': curParentType,
                 'object': parentFiltered
             }] + curPath
+            if hideInaccessible:
+                consolidatedPaths = []
+                # Walk the hierarchy from root to leaf, and return only the objects
+                # that the user has access to, providing they don't leak any parent
+                # information to the client.
+                for path in curPaths:
+                    pathModel = ModelImporter.model(path['type'])
+                    if not pathModel.hasAccess(path['object'], user, level):
+                        # If the user does not have access to a folder/collection/user,
+                        # discard all the accumulated hierarchy so as to not leak any
+                        # relational information.
+                        consolidatedPaths = []
+                        continue
+                    consolidatedPaths.append({
+                        'type': path['type'],
+                        'object': pathModel.filter(path['object'], user)
+                    })
+
+                return consolidatedPaths
+            return curPaths
         else:
             curParentObject = self.load(curParentId, user=user, level=level, force=force)
             curPath = [{
@@ -596,7 +625,13 @@ class Folder(AccessControlledModel):
                 'object': curParentObject if force else self.filter(curParentObject, user)
             }] + curPath
 
-            return self.parentsToRoot(curParentObject, curPath, user=user, force=force)
+            return self.parentsToRoot(
+                curParentObject,
+                curPath,
+                user=user,
+                force=force,
+                hideInaccessible=hideInaccessible
+            )
 
     def countItems(self, folder):
         """

--- a/girder/models/item.py
+++ b/girder/models/item.py
@@ -380,7 +380,7 @@ class Item(acl_mixin.AccessControlMixin, Model):
 
         return self.save(item)
 
-    def parentsToRoot(self, item, user=None, force=False):
+    def parentsToRoot(self, item, user=None, force=False, hideInaccessible=False):
         """
         Get the path to traverse to a root of the hierarchy.
 
@@ -399,7 +399,12 @@ class Item(acl_mixin.AccessControlMixin, Model):
         curFolder = folderModel.load(
             item['folderId'], user=user, level=AccessType.READ, force=force)
         folderIdsToRoot = folderModel.parentsToRoot(
-            curFolder, user=user, level=AccessType.READ, force=force)
+            curFolder,
+            user=user,
+            level=AccessType.READ,
+            force=force,
+            hideInaccessible=hideInaccessible,
+        )
 
         if force:
             folderIdsToRoot.append({'type': 'folder', 'object': curFolder})

--- a/girder/web/src/views/body/CollectionView.js
+++ b/girder/web/src/views/body/CollectionView.js
@@ -13,6 +13,7 @@ import { cancelRestRequests } from '@girder/core/rest';
 import { confirm } from '@girder/core/dialog';
 import { renderMarkdown, formatSize } from '@girder/core/misc';
 import events from '@girder/core/events';
+import CollectionsView from '@girder/core/views/body/CollectionsView';
 
 import CollectionPageTemplate from '@girder/core/templates/body/collectionPage.pug';
 
@@ -181,6 +182,13 @@ var CollectionView = View.extend({
             events.trigger('g:navigateTo', CollectionView, _.extend({
                 collection: collection
             }, params || {}));
+        }, this).on('g:error', function () {
+            if (params.folderId) {
+                const folderRoute = `folder/${params.folderId}`;
+                router.navigate(folderRoute, { trigger: true });
+            } else {
+                events.trigger('g:navigateTo', CollectionsView);
+            }
         }, this).fetch();
     }
 });

--- a/girder/web/src/views/body/UserView.js
+++ b/girder/web/src/views/body/UserView.js
@@ -157,7 +157,11 @@ var UserView = View.extend({
                 user: user
             }, params || {}));
         }, this).on('g:error', function () {
-            events.trigger('g:navigateTo', UsersView);
+            if (params.folderId) {
+                router.navigate(`folder/${params.folderId}`, { trigger: true });
+            } else {
+                events.trigger('g:navigateTo', UsersView);
+            }
         }, this).fetch();
     }
 });

--- a/girder/web/src/views/widgets/HierarchyWidget.js
+++ b/girder/web/src/views/widgets/HierarchyWidget.js
@@ -316,12 +316,19 @@ var HierarchyWidget = View.extend({
 
     _setRoute: function () {
         if (this._routing) {
-            var route = this.breadcrumbs[0].resourceName + '/' +
-                this.breadcrumbs[0].get('_id');
-            if (this.parentModel.resourceName === 'folder') {
-                route += '/folder/' + this.parentModel.get('_id');
+            var route;
+            if (this.breadcrumbs[0].resourceName === 'folder') {
+                // Case where the user doesn't have access to the root collection/user
+                route = 'folder/' + this.parentModel.get('_id');
+                router.navigate(route);
+            } else {
+                route = this.breadcrumbs[0].resourceName + '/' +
+                    this.breadcrumbs[0].get('_id');
+                if (this.parentModel.resourceName === 'folder') {
+                    route += '/folder/' + this.parentModel.get('_id');
+                }
+                router.navigate(route);
             }
-            router.navigate(route);
             events.trigger('g:hierarchy.route', { route: route });
         }
     },

--- a/test/test_folder.py
+++ b/test/test_folder.py
@@ -21,11 +21,15 @@ def parentChain(admin):
     F4 = Folder().createFolder(
         parent=privateFolder, parentType='folder', creator=admin,
         name='F4', public=True)
+    F5 = Folder().createFolder(
+        parent=F4, parentType='folder', creator=admin,
+        name='F5', public=True)
     yield {
         'folder1': F1,
         'folder2': F2,
         'privateFolder': privateFolder,
-        'folder4': F4
+        'folder4': F4,
+        'folder5': F5
     }
 
 
@@ -53,6 +57,17 @@ def testParentsToRootNoUsers(parentChain):
         assert parents[1]['object']['name'] == 'F1'
         assert parents[2]['object']['name'] == 'F2'
         assert parents[3] is None
+
+
+def testParentsToRootNoUserPublicFolderNoPublicParent(parentChain):
+    parents = Folder().parentsToRoot(parentChain['folder4'], user=None, hideInaccessible=True)
+    assert parents == []
+
+
+def testParentsToRootNoUserPublicFolderPublicParent(parentChain):
+    parents = Folder().parentsToRoot(parentChain['folder5'], user=None, hideInaccessible=True)
+    assert len(parents) == 1
+    assert parents[0]['object']['name'] == 'F4'
 
 
 def testGetResourceByPathForAdmin(server, parentChain, admin):

--- a/tests/cases/folder_test.py
+++ b/tests/cases/folder_test.py
@@ -567,6 +567,11 @@ class FolderTestCase(base.TestCase):
         for parent in parents:
             self.assertIn('_accessLevel', parent['object'])
 
+        # Make sure hideInaccessble returns filtered documents
+        parents = Folder().parentsToRoot(subFolder, user=self.admin, hideInaccessible=True)
+        for parent in parents:
+            self.assertIn('_accessLevel', parent['object'])
+
     def testFolderAccessAndDetails(self):
         # create a folder to work with
         folder = Folder().createFolder(


### PR DESCRIPTION
Forward port #3907.

Previously these endpoints would 403 if any resource in the hierarchy was private/inaccessible to the requester. Now, a partial hierarchy is returned if the requester can access the given resource.