### PR TITLE
Add a "Search here" option to top search

### DIFF
--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -4,7 +4,7 @@ from girder.constants import AccessType, TokenScope
 from girder.exceptions import RestException
 from girder.api import access
 from girder.utility import parseTimestamp
-from girder.utility.search import getSearchModeHandler
+from girder.utility.search import getSearchModeHandler, handlerSupportsHierarchy
 from girder.utility import ziputil
 from girder.utility import path as path_util
 from girder.utility.model_importer import ModelImporter
@@ -53,6 +53,7 @@ class Resource(BaseResource):
         .pagingParams(defaultSort=None, defaultLimit=10)
         .errorResponse('Invalid type list format.')
         .errorResponse('parentType and parentId must be passed together.')
+        .errorResponse('The search mode cannot be restricted to a location in the hierarchy.')
     )
     def search(self, q, mode, types, level, limit, offset, parentType, parentId):
         """
@@ -67,6 +68,10 @@ class Resource(BaseResource):
             raise RestException('parentType and parentId must be passed together.')
         kwargs = {}
         if parentType:
+            if not handlerSupportsHierarchy(handler):
+                raise RestException(
+                    'The %r search mode cannot be restricted to a location in the '
+                    'hierarchy.' % mode)
             kwargs['parentType'] = parentType
             kwargs['parentId'] = parentId
         results = handler(

--- a/girder/api/v1/resource.py
+++ b/girder/api/v1/resource.py
@@ -44,10 +44,17 @@ class Resource(BaseResource):
                    '["user", "folder", "item"].', requireArray=True)
         .param('level', 'Minimum required access level.', required=False,
                dataType='integer', default=AccessType.READ)
+        .param('parentType', 'The type of the resource to search within. Must be passed together '
+               'with parentId. Types that are not part of the hierarchy (user, group, collection, '
+               'file) return no results when this is set.', required=False,
+               enum=['collection', 'folder', 'user'])
+        .param('parentId', 'The id of the resource to search within. Must be passed together '
+               'with parentType.', required=False)
         .pagingParams(defaultSort=None, defaultLimit=10)
         .errorResponse('Invalid type list format.')
+        .errorResponse('parentType and parentId must be passed together.')
     )
-    def search(self, q, mode, types, level, limit, offset):
+    def search(self, q, mode, types, level, limit, offset, parentType, parentId):
         """
         Perform a search using one of the registered search modes.
         """
@@ -56,13 +63,20 @@ class Resource(BaseResource):
         handler = getSearchModeHandler(mode)
         if handler is None:
             raise RestException('Search mode handler %r not found.' % mode)
+        if bool(parentType) != bool(parentId):
+            raise RestException('parentType and parentId must be passed together.')
+        kwargs = {}
+        if parentType:
+            kwargs['parentType'] = parentType
+            kwargs['parentId'] = parentId
         results = handler(
             query=q,
             types=types,
             user=user,
             limit=limit,
             offset=offset,
-            level=level
+            level=level,
+            **kwargs
         )
         return results
 

--- a/girder/models/folder.py
+++ b/girder/models/folder.py
@@ -660,6 +660,38 @@ class Folder(AccessControlledModel):
 
         return folders.count()
 
+    def subtreeFolderIds(self, folder, includeRoot=True):
+        """
+        Return the set of ids of every folder in the subtree rooted at the given folder.
+
+        Folders record only their immediate parent, so this walks the tree one depth level at a
+        time, grouping each level into a single query.
+
+        :param folder: The root of the subtree.
+        :type folder: dict
+        :param includeRoot: Whether to include the root folder's own id.
+        :type includeRoot: bool
+        :returns: The set of folder ids.
+        :rtype: set
+        """
+        seen = {folder['_id']}
+        parentIds = [folder['_id']]
+
+        while parentIds:
+            children = [
+                child['_id']
+                for child in self.find(
+                    {'parentId': {'$in': parentIds}, 'parentCollection': 'folder'},
+                    fields=['_id'])
+                if child['_id'] not in seen
+            ]
+            seen.update(children)
+            parentIds = children
+
+        if not includeRoot:
+            seen.discard(folder['_id'])
+        return seen
+
     def subtreeCount(self, folder, includeItems=True, user=None, level=None):
         """
         Return the size of the subtree rooted at the given folder. Includes

--- a/girder/utility/search.py
+++ b/girder/utility/search.py
@@ -1,6 +1,9 @@
 from functools import partial
 
-from girder.exceptions import GirderException
+from bson.objectid import ObjectId
+
+from girder.constants import AccessType
+from girder.exceptions import GirderException, ValidationException
 from girder.utility.model_importer import ModelImporter
 
 _allowedSearchMode = {}
@@ -26,6 +29,11 @@ def addSearchMode(mode, handler):
     must take parameters: `query`, `types`, `user`, `level`, `limit`, `offset`, and return the
     search results.
 
+    Handlers should also accept `**kwargs`, as searches may pass additional optional parameters.
+    Currently a search that is restricted to a location in the data hierarchy also passes
+    `parentType` and `parentId`; a handler that does not accept them will only be called for
+    unrestricted searches.
+
     :param mode: A search mode identifier.
     :type mode: str
     :param handler: A search mode handler function.
@@ -50,7 +58,42 @@ def removeSearchMode(mode):
     return _allowedSearchMode.pop(mode, None) is not None
 
 
-def _commonSearchModeHandler(mode, query, types, user, level, limit, offset):
+def _hierarchySearchFilters(parentType, parentId, user):
+    """
+    Build the query filters that restrict a search to the subtree rooted at a point in the data
+    hierarchy.
+
+    :param parentType: One of 'collection', 'folder', or 'user'.
+    :type parentType: str
+    :param parentId: The id of the resource to search within.
+    :param user: The user performing the search, for access checks.
+    :returns: A mapping of model name to a filters dict.
+    :rtype: dict
+    """
+    # Avoid circular import
+    from girder.models.folder import Folder
+
+    try:
+        parentId = ObjectId(parentId)
+    except Exception:
+        raise ValidationException('Invalid parentId.', field='parentId')
+
+    if parentType == 'folder':
+        folder = Folder().load(parentId, user=user, level=AccessType.READ, exc=True)
+        folderIds = list(Folder().subtreeFolderIds(folder))
+        return {
+            # The folder being searched from is the container, not a result.
+            'folder': {'_id': {'$in': [
+                folderId for folderId in folderIds if folderId != folder['_id']]}},
+            'item': {'folderId': {'$in': folderIds}},
+        }
+
+    filters = {'baseParentType': parentType, 'baseParentId': parentId}
+    return {'folder': dict(filters), 'item': dict(filters)}
+
+
+def _commonSearchModeHandler(mode, query, types, user, level, limit, offset,
+                             parentType=None, parentId=None):
     """
     The common handler for `text` and `prefix` search modes.
     """
@@ -60,9 +103,19 @@ def _commonSearchModeHandler(mode, query, types, user, level, limit, offset):
     method = '%sSearch' % mode
     results = {}
 
+    hierarchyFilters = None
+    if parentType is not None:
+        hierarchyFilters = _hierarchySearchFilters(parentType, parentId, user)
+
     for modelName in types:
         if modelName not in allowedSearchTypes:
             continue
+
+        filters = None
+        if hierarchyFilters is not None:
+            if modelName not in hierarchyFilters:
+                continue
+            filters = hierarchyFilters[modelName]
 
         if '.' in modelName:
             name, plugin = modelName.rsplit('.', 1)
@@ -73,7 +126,8 @@ def _commonSearchModeHandler(mode, query, types, user, level, limit, offset):
         if model is not None:
             results[modelName] = [
                 model.filter(d, user) for d in getattr(model, method)(
-                    query=query, user=user, limit=limit, offset=offset, level=level)
+                    query=query, user=user, limit=limit, offset=offset, level=level,
+                    filters=filters)
             ]
     return results
 

--- a/girder/utility/search.py
+++ b/girder/utility/search.py
@@ -1,3 +1,4 @@
+import inspect
 from functools import partial
 
 from bson.objectid import ObjectId
@@ -32,7 +33,8 @@ def addSearchMode(mode, handler):
     Handlers should also accept `**kwargs`, as searches may pass additional optional parameters.
     Currently a search that is restricted to a location in the data hierarchy also passes
     `parentType` and `parentId`; a handler that does not accept them will only be called for
-    unrestricted searches.
+    unrestricted searches, and a restricted search for that mode fails with an exception rather
+    than silently searching everywhere.
 
     :param mode: A search mode identifier.
     :type mode: str
@@ -42,6 +44,28 @@ def addSearchMode(mode, handler):
     if _allowedSearchMode.get(mode) is not None:
         raise GirderException('A search mode %r already exists.' % mode)
     _allowedSearchMode[mode] = handler
+
+
+def handlerSupportsHierarchy(handler):
+    """
+    Determine whether a search mode handler can be passed the optional `parentType` and `parentId`
+    parameters, either by naming them or by accepting `**kwargs`.
+
+    :param handler: A search mode handler function.
+    :type handler: function
+    :returns: Whether the handler accepts both parameters.
+    :rtype: bool
+    """
+    try:
+        params = inspect.signature(handler).parameters
+    except (TypeError, ValueError):
+        return False
+    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in params.values()):
+        return True
+    return all(
+        name in params and params[name].kind in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+        for name in ('parentType', 'parentId'))
 
 
 def removeSearchMode(mode):

--- a/girder/web_client/src/routes.js
+++ b/girder/web_client/src/routes.js
@@ -226,6 +226,8 @@ import SearchResultsView from '@girder/core/views/body/SearchResultsView';
 router.route('search/results', 'SearchResults', function (params) {
     events.trigger('g:navigateTo', SearchResultsView, {
         query: params.query,
-        mode: params.mode
+        mode: params.mode,
+        parentType: params.parentType,
+        parentId: params.parentId
     });
 });

--- a/girder/web_client/src/stylesheets/widgets/searchFieldWidget.styl
+++ b/girder/web_client/src/stylesheets/widgets/searchFieldWidget.styl
@@ -11,6 +11,7 @@ $borderRadius = 3px
     display none
 
   .popover .radio
+  .popover .checkbox
     display block
     min-height 20px
     margin-top 10px
@@ -18,8 +19,13 @@ $borderRadius = 3px
     vertical-align middle
 
     input[type="radio"]
+    input[type="checkbox"]
       margin-right 3px
       margin-top 3px
+
+  .popover .g-search-local
+    border-top 1px solid #ddd
+    padding-top 8px
 
   .g-search-options-button
     color #333

--- a/girder/web_client/src/templates/widgets/searchField.pug
+++ b/girder/web_client/src/templates/widgets/searchField.pug
@@ -1,10 +1,11 @@
+- var showOptions = modes.length > 1 || localSearchSupported
 .g-search-wrapper
   a.g-search-options-button.btn.btn-sm(title="Show search help")
     i.g-search-state.icon-search
   input.g-search-field.form-control.input-sm(
-    type="text", placeholder=placeholder, mode-select=(modes.length > 1 ? "on" : "off"))
+    type="text", placeholder=placeholder, mode-select=(showOptions ? "on" : "off"))
   .g-search-results.dropdown
     ul.dropdown-menu(role="menu")
-  if modes.length > 1
-    a.g-search-mode-choose.btn.btn-sm(title="Search mode")
+  if showOptions
+    a.g-search-mode-choose.btn.btn-sm(title="Search options")
       i.icon-down-dir

--- a/girder/web_client/src/templates/widgets/searchModeSelect.pug
+++ b/girder/web_client/src/templates/widgets/searchModeSelect.pug
@@ -1,9 +1,19 @@
-p Choose search mode:
+if modes.length > 1
+  p Choose search mode:
 
-for mode in modes
-  .radio
-    label
-      input.g-search-mode-radio(
-          type="radio", name="search-mode", value=mode,
-          checked=(mode === currentMode ? 'checked' : undefined))
-      = getModeDescription(mode)
+  for mode in modes
+    .radio
+      label
+        input.g-search-mode-radio(
+            type="radio", name="search-mode", value=mode,
+            checked=(mode === currentMode ? 'checked' : undefined))
+        = getModeDescription(mode)
+
+if localSearchSupported
+  .checkbox.g-search-local
+    label(
+        title="Only return folders and items inside the folder or collection you are viewing.")
+      input.g-search-local-checkbox(
+          type="checkbox",
+          checked=(localSearch ? 'checked' : undefined))
+      | Search here

--- a/girder/web_client/src/views/body/SearchResultsView.js
+++ b/girder/web_client/src/views/body/SearchResultsView.js
@@ -17,18 +17,27 @@ var SearchResultsView = View.extend({
     initialize: function (settings) {
         this._query = settings.query || '';
         this._mode = settings.mode || 'text';
+        // When set, the search was restricted to a subtree of the hierarchy.
+        this._parentType = settings.parentType || null;
+        this._parentId = settings.parentId || null;
 
         this._sizeOneElement = 28;
         this.pageLimit = 10;
 
+        const data = {
+            q: this._query,
+            mode: this._mode,
+            types: JSON.stringify(SearchFieldWidget.getModeTypes(this._mode)),
+            limit: this.pageLimit
+        };
+        if (this._parentType && this._parentId) {
+            data.parentType = this._parentType;
+            data.parentId = this._parentId;
+        }
+
         this._request = restRequest({
             url: 'resource/search',
-            data: {
-                q: this._query,
-                mode: this._mode,
-                types: JSON.stringify(SearchFieldWidget.getModeTypes(this._mode)),
-                limit: this.pageLimit
-            }
+            data: data
         });
         this.render();
     },
@@ -65,6 +74,8 @@ var SearchResultsView = View.extend({
                             parentView: this,
                             query: this._query,
                             mode: this._mode,
+                            parentType: this._parentType,
+                            parentId: this._parentId,
                             type: type,
                             limit: this.pageLimit,
                             initResults: results[type],
@@ -106,6 +117,8 @@ var SearchResultsTypeView = View.extend({
             type: this._type,
             query: this._query,
             mode: this._mode,
+            parentType: settings.parentType,
+            parentId: settings.parentId,
             limit: this._pageLimit
         })
             .on('g:changed', () => {

--- a/girder/web_client/src/views/widgets/SearchFieldWidget.js
+++ b/girder/web_client/src/views/widgets/SearchFieldWidget.js
@@ -1,11 +1,13 @@
 import $ from 'jquery';
 import _ from 'underscore';
+import Backbone from 'backbone';
 // Bootstrap tooltip is required by popover
 import 'bootstrap/js/tooltip';
 import 'bootstrap/js/popover';
 
 import View from '@girder/core/views/View';
 import { restRequest } from '@girder/core/rest';
+import events from '@girder/core/events';
 import router from '@girder/core/router';
 
 import SearchFieldTemplate from '@girder/core/templates/widgets/searchField.pug';
@@ -13,6 +15,56 @@ import SearchHelpTemplate from '@girder/core/templates/widgets/searchHelp.pug';
 import SearchModeSelectTemplate from '@girder/core/templates/widgets/searchModeSelect.pug';
 import SearchResultsTemplate from '@girder/core/templates/widgets/searchResults.pug';
 import '@girder/core/stylesheets/widgets/searchFieldWidget.styl';
+
+/**
+ * The most recent location in the data hierarchy the user has visited, shared by every search
+ * field on the page.
+ *
+ * A local search needs somewhere to search in, but plenty of routes are not hierarchy locations
+ * (e.g., the search results page). Rather than dropping the restriction on those pages, we keep
+ * searching the last place the user actually was. It stays null until the user visits a hierarchy
+ * location, and a local search with no location searches everywhere.
+ */
+let lastHierarchyParent = null;
+
+/**
+ * Parse the location in the data hierarchy out of a route fragment. Routes that are not a
+ * hierarchy location yield null.
+ *
+ * @returns An object with "type" and "id", or null.
+ */
+function parseHierarchyParent(fragment) {
+    const parts = (fragment || '').split('?')[0].split('/');
+    let parent = null;
+
+    for (let i = 0; i + 1 < parts.length; i += 2) {
+        if (!_.contains(['collection', 'folder', 'user'], parts[i]) ||
+                !/^[0-9a-fA-F]{24}$/.test(parts[i + 1])) {
+            return null;
+        }
+        parent = { type: parts[i], id: parts[i + 1] };
+    }
+    return parent;
+}
+
+/**
+ * Read the current route, remembering it if it is a hierarchy location, and return the location a
+ * local search should use.
+ */
+function activeHierarchyParent() {
+    const current = parseHierarchyParent(Backbone.history.fragment);
+    if (current) {
+        lastHierarchyParent = current;
+    }
+    return lastHierarchyParent;
+}
+
+// Moving around within the hierarchy updates the route without triggering it, so the router alone
+// won't tell us the location changed. Get the route on this event too, so that browsing into a
+// folder and then searching from a non-hierarchy page uses the folder actually last visited.
+events.on('g:hierarchy.route', () => {
+    activeHierarchyParent();
+});
 
 /**
  * This widget provides a text field that will search any set of data types
@@ -25,6 +77,15 @@ var SearchFieldWidget = View.extend({
 
         'click .g-search-mode-radio': function (e) {
             this.currentMode = $(e.target).val();
+            this.hideResults().search();
+
+            window.setTimeout(() => {
+                this.$('.g-search-mode-choose').popover('hide');
+            }, 250);
+        },
+
+        'change .g-search-local-checkbox': function (e) {
+            this.localSearch = $(e.target).prop('checked');
             this.hideResults().search();
 
             window.setTimeout(() => {
@@ -93,6 +154,8 @@ var SearchFieldWidget = View.extend({
      *        via a dropdown.
      * @param [settings.noResultsPage=false] If truthy, don't jump to a results
      *        page if enter is typed with a list of search results.
+     * @param [settings.localSearch=false] If truthy, start with the "search only in the current
+     *        location" option checked.
      */
     initialize: function (settings) {
         this.ajaxLock = false;
@@ -116,30 +179,53 @@ var SearchFieldWidget = View.extend({
 
         this.currentMode = this.modes[0];
 
+        // Restricting a search to a subtree can only ever filter types that
+        // live in the data hierarchy, so don't offer the option on widgets
+        // that search only users or groups.
+        this.localSearchSupported = !_.isEmpty(
+            _.intersection(this.types, SearchFieldWidget.hierarchyTypes));
+        this.localSearch = this.localSearchSupported && !!settings.localSearch;
+
         // Do not change the icon for fast searches, to prevent jitter
         this._animatePending = _.debounce(this._animatePending, 100);
     },
 
-    search: function () {
-        var q = this.$('.g-search-field').val();
+    /**
+     * The hierarchy location to restrict the current search to, or null if the search should not
+     * be restricted.
+     */
+    _localSearchParent: function () {
+        const parent = activeHierarchyParent();
+        return this.localSearch ? parent : null;
+    },
 
-        if (!q) {
+    search: function () {
+        var query = this.$('.g-search-field').val();
+
+        if (!query) {
             this.hideResults();
             return this;
         }
 
         if (this.ajaxLock) {
-            this.pending = q;
+            this.pending = query;
         } else {
-            this._doSearch(q);
+            this._doSearch(query);
         }
 
         return this;
     },
 
     _goToResultPage: function (query, mode) {
+        // Resolve the location before navigating, since the results page is not itself a hierarchy
+        // location.
+        const parent = this._localSearchParent();
         this.resetState();
-        router.navigate(`#search/results?query=${query}&mode=${mode}`, { trigger: true });
+        let route = `#search/results?query=${query}&mode=${mode}`;
+        if (parent) {
+            route += `&parentType=${parent.type}&parentId=${parent.id}`;
+        }
+        router.navigate(route, { trigger: true });
     },
 
     _resultClicked: function (link) {
@@ -159,7 +245,8 @@ var SearchFieldWidget = View.extend({
         this.$el.html(SearchFieldTemplate({
             placeholder: this.placeholder,
             modes: this.modes,
-            currentMode: this.currentMode
+            currentMode: this.currentMode,
+            localSearchSupported: this.localSearchSupported
         }));
 
         this.$('.g-search-options-button').popover({
@@ -190,7 +277,9 @@ var SearchFieldWidget = View.extend({
                 return SearchModeSelectTemplate({
                     modes: this.modes,
                     currentMode: this.currentMode,
-                    getModeDescription: SearchFieldWidget.getModeDescription
+                    getModeDescription: SearchFieldWidget.getModeDescription,
+                    localSearchSupported: this.localSearchSupported,
+                    localSearch: this.localSearch
                 });
             },
             html: true,
@@ -233,21 +322,28 @@ var SearchFieldWidget = View.extend({
             .toggleClass('icon-spin4 animate-spin', isPending);
     },
 
-    _doSearch: function (q) {
+    _doSearch: function (query) {
         this.ajaxLock = true;
         this.pending = null;
         this._animatePending();
 
+        const data = {
+            q: query,
+            mode: this.currentMode,
+            types: JSON.stringify(_.intersection(
+                this.types,
+                SearchFieldWidget.getModeTypes(this.currentMode))
+            )
+        };
+        const parent = this._localSearchParent();
+        if (parent) {
+            data.parentType = parent.type;
+            data.parentId = parent.id;
+        }
+
         restRequest({
             url: 'resource/search',
-            data: {
-                q: q,
-                mode: this.currentMode,
-                types: JSON.stringify(_.intersection(
-                    this.types,
-                    SearchFieldWidget.getModeTypes(this.currentMode))
-                )
-            }
+            data: data
         }).done((results) => {
             this.ajaxLock = false;
             this._animatePending();
@@ -313,6 +409,12 @@ var SearchFieldWidget = View.extend({
 }, {
     _allowedSearchMode: {},
 
+    /**
+     * The resource types that live in the data hierarchy and can be restricted to a subtree by a
+     * local search.
+     */
+    hierarchyTypes: ['folder', 'item'],
+
     addMode: function (mode, types, description, help) {
         if (_.has(SearchFieldWidget._allowedSearchMode, mode)) {
             throw new Error(`The mode "${mode}" exist already. You can't change it`);
@@ -361,5 +463,4 @@ SearchFieldWidget.addMode(
     `You are searching by prefix.
      Start typing the first letters of whatever you are searching for.`
 );
-
 export default SearchFieldWidget;

--- a/girder/web_client/src/views/widgets/SearchPaginateWidget.js
+++ b/girder/web_client/src/views/widgets/SearchPaginateWidget.js
@@ -25,6 +25,9 @@ var SearchPaginateWidget = View.extend({
         this._type = settings.type;
         this._query = settings.query;
         this._mode = settings.mode;
+        // When set, the search is restricted to a subtree of the hierarchy.
+        this._parentType = settings.parentType || null;
+        this._parentId = settings.parentId || null;
         this._limit = settings.limit;
 
         this._offset = 0;
@@ -130,18 +133,24 @@ var SearchPaginateWidget = View.extend({
     },
 
     _fetch: function (offset) {
+        const data = {
+            q: this._query,
+            mode: this._mode,
+            types: JSON.stringify(_.intersection(
+                [this._type],
+                SearchFieldWidget.getModeTypes(this._mode))
+            ),
+            limit: this._limit,
+            offset: offset
+        };
+        if (this._parentType && this._parentId) {
+            data.parentType = this._parentType;
+            data.parentId = this._parentId;
+        }
+
         return restRequest({
             url: 'resource/search',
-            data: {
-                q: this._query,
-                mode: this._mode,
-                types: JSON.stringify(_.intersection(
-                    [this._type],
-                    SearchFieldWidget.getModeTypes(this._mode))
-                ),
-                limit: this._limit,
-                offset: offset
-            }
+            data: data
         });
     }
 });

--- a/girder/web_client/test/spec/customWidgetsSpec.js
+++ b/girder/web_client/test/spec/customWidgetsSpec.js
@@ -681,7 +681,10 @@ describe('Test search widget with non-standard options', function () {
             }).render();
 
             expect($('input.g-search-field[placeholder="test ph"]').length).toBe(1);
-            expect($('.g-search-mode-choose').length).toBe(0);
+            // A single fixed mode offers no mode choice, but the options button is still shown to
+            // expose the "Search here" checkbox, since "folder" is a type a local search can
+            // restrict.
+            expect($('.g-search-mode-choose').length).toBe(1);
 
             $('.g-search-field').val('to').trigger('input');
         });

--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -918,6 +918,7 @@ girder
         search
             addSearchMode
             getSearchModeHandler
+            handlerSupportsHierarchy
             removeSearchMode
         server
             configureServer

--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -549,6 +549,7 @@ girder
                 setAccessList
                 setMetadata
                 subtreeCount
+                subtreeFolderIds
                 updateFolder
                 updateSize
                 validate

--- a/tests/cases/search_test.py
+++ b/tests/cases/search_test.py
@@ -239,7 +239,47 @@ class SearchTestCase(base.TestCase):
             'types': ['collection']
         })
 
+        # A handler that does not accept parentType and parentId is only called for unrestricted
+        # searches; restricting the search is rejected rather than searching the whole hierarchy or
+        # failing with an internal error.
+        coll = Collection().findOne({'name': 'Test Collection'})
+        resp = self.request(path='/resource/search', params={
+            'q': 'Test',
+            'mode': 'testSearch',
+            'types': json.dumps(['collection']),
+            'parentType': 'collection',
+            'parentId': coll['_id']
+        })
+        self.assertStatus(resp, 400)
+        self.assertEqual(
+            "The 'testSearch' search mode cannot be restricted to a location in the hierarchy.",
+            resp.json['message'])
+
         search.removeSearchMode('testSearch')
+
+        # A handler that accepts **kwargs is passed the parameters.
+        def kwargsSearchHandler(query, types, user, level, limit, offset, **kwargs):
+            return {
+                'parentType': kwargs.get('parentType'),
+                'parentId': str(kwargs.get('parentId'))
+            }
+
+        search.addSearchMode('kwargsSearch', kwargsSearchHandler)
+
+        resp = self.request(path='/resource/search', params={
+            'q': 'Test',
+            'mode': 'kwargsSearch',
+            'types': json.dumps(['collection']),
+            'parentType': 'collection',
+            'parentId': coll['_id']
+        })
+        self.assertStatusOk(resp)
+        self.assertDictEqual(resp.json, {
+            'parentType': 'collection',
+            'parentId': str(coll['_id'])
+        })
+
+        search.removeSearchMode('kwargsSearch')
 
         # Use the deleted search mode.
         resp = self.request(path='/resource/search', params={


### PR DESCRIPTION
Adds a "Search here" checkbox to the search field that restricts results to wherever the user currently is in the data hierarchy. It defaults to off, so search behavior is unchanged unless the option is checked.

Some routes, like the search results page, aren't hierarchy locations. Rather than disabling the option there, the last hierarchy location the user visited is remembered and reused.

[Screencast from 08-27-2026 04:39:20 PM.webm](https://github.com/user-attachments/assets/bbda1067-d84c-4cfc-93e3-c009895c4189)

Fixes #3895 