### PR TITLE
Add a show-download setting that defaults to all

### DIFF
--- a/girder/settings.py
+++ b/girder/settings.py
@@ -235,7 +235,10 @@ class SettingValidator:
 
     @staticmethod
     @setting_utilities.validator(SettingKey.SHOW_DOWNLOAD)
-    def _validateDownloadShown(doc):
+    def _validateshowDownload(doc):
+        if not isinstance(doc['value'], str):
+            raise ValidationException(
+                'Show download must be "all", "user", "admin", or "none".', 'value')
         doc['value'] = doc['value'].lower()
         if doc['value'] not in ('all', 'user', 'admin', 'none'):
             raise ValidationException(

--- a/girder/settings.py
+++ b/girder/settings.py
@@ -26,7 +26,7 @@ class SettingKey:
     CORS_ALLOW_METHODS = 'core.cors.allow_methods'
     CORS_ALLOW_ORIGIN = 'core.cors.allow_origin'
     CORS_EXPOSE_HEADERS = 'core.cors.expose_headers'
-    DOWNLOAD_SHOWN = 'core.download_shown'
+    SHOW_DOWNLOAD = 'core.show_download'
     EMAIL_FROM_ADDRESS = 'core.email_from_address'
     EMAIL_HOST = 'core.email_host'
     EMAIL_VERIFICATION = 'core.email_verification'
@@ -75,7 +75,7 @@ class SettingDefault:
         SettingKey.CORS_ALLOW_METHODS: 'GET, POST, PUT, HEAD, DELETE',
         SettingKey.CORS_ALLOW_ORIGIN: '',
         SettingKey.CORS_EXPOSE_HEADERS: 'Girder-Total-Count, Content-Disposition',
-        SettingKey.DOWNLOAD_SHOWN: 'all',
+        SettingKey.SHOW_DOWNLOAD: 'all',
         # An apache server using reverse proxy would also need
         #  X-Requested-With, X-Forwarded-Server, X-Forwarded-For,
         #  X-Forwarded-Host, Remote-Addr
@@ -234,12 +234,12 @@ class SettingValidator:
             raise ValidationException('CORS exposed headers must be a string', 'value')
 
     @staticmethod
-    @setting_utilities.validator(SettingKey.DOWNLOAD_SHOWN)
+    @setting_utilities.validator(SettingKey.SHOW_DOWNLOAD)
     def _validateDownloadShown(doc):
         doc['value'] = doc['value'].lower()
         if doc['value'] not in ('all', 'user', 'admin', 'none'):
             raise ValidationException(
-                'Download shown be "all", "user", "admin", or "nonde".', 'value')
+                'Show download must be "all", "user", "admin", or "none".', 'value')
 
     @staticmethod
     @setting_utilities.validator(SettingKey.EMAIL_FROM_ADDRESS)

--- a/girder/settings.py
+++ b/girder/settings.py
@@ -26,6 +26,7 @@ class SettingKey:
     CORS_ALLOW_METHODS = 'core.cors.allow_methods'
     CORS_ALLOW_ORIGIN = 'core.cors.allow_origin'
     CORS_EXPOSE_HEADERS = 'core.cors.expose_headers'
+    DOWNLOAD_SHOWN = 'core.download_shown'
     EMAIL_FROM_ADDRESS = 'core.email_from_address'
     EMAIL_HOST = 'core.email_host'
     EMAIL_VERIFICATION = 'core.email_verification'
@@ -74,6 +75,7 @@ class SettingDefault:
         SettingKey.CORS_ALLOW_METHODS: 'GET, POST, PUT, HEAD, DELETE',
         SettingKey.CORS_ALLOW_ORIGIN: '',
         SettingKey.CORS_EXPOSE_HEADERS: 'Girder-Total-Count, Content-Disposition',
+        SettingKey.DOWNLOAD_SHOWN: 'all',
         # An apache server using reverse proxy would also need
         #  X-Requested-With, X-Forwarded-Server, X-Forwarded-For,
         #  X-Forwarded-Host, Remote-Addr
@@ -230,6 +232,14 @@ class SettingValidator:
     def _validateCorsExposeHeaders(doc):
         if not isinstance(doc['value'], str):
             raise ValidationException('CORS exposed headers must be a string', 'value')
+
+    @staticmethod
+    @setting_utilities.validator(SettingKey.DOWNLOAD_SHOWN)
+    def _validateDownloadShown(doc):
+        doc['value'] = doc['value'].lower()
+        if doc['value'] not in ('all', 'user', 'admin', 'none'):
+            raise ValidationException(
+                'Download shown be "all", "user", "admin", or "nonde".', 'value')
 
     @staticmethod
     @setting_utilities.validator(SettingKey.EMAIL_FROM_ADDRESS)

--- a/girder/utility/webroot.mako
+++ b/girder/utility/webroot.mako
@@ -24,7 +24,8 @@
                 brandName: '${brandName | js}',
                 bannerColor: '${bannerColor | js}',
                 registrationPolicy: '${registrationPolicy | js}',
-                enablePasswordLogin: ${enablePasswordLogin | n,json,js}
+                enablePasswordLogin: ${enablePasswordLogin | n,json,js},
+                downloadShown: '${downloadShown | js}'
             }).render();
             girder.events.trigger('g:appload.after', girder.app);
         });

--- a/girder/utility/webroot.mako
+++ b/girder/utility/webroot.mako
@@ -25,7 +25,7 @@
                 bannerColor: '${bannerColor | js}',
                 registrationPolicy: '${registrationPolicy | js}',
                 enablePasswordLogin: ${enablePasswordLogin | n,json,js},
-                downloadShown: '${downloadShown | js}'
+                showDownload: '${showDownload | js}'
             }).render();
             girder.events.trigger('g:appload.after', girder.app);
         });

--- a/girder/utility/webroot.py
+++ b/girder/utility/webroot.py
@@ -122,5 +122,6 @@ class Webroot(WebrootBase):
         self.vars['bannerColor'] = Setting().get(SettingKey.BANNER_COLOR)
         self.vars['registrationPolicy'] = Setting().get(SettingKey.REGISTRATION_POLICY)
         self.vars['enablePasswordLogin'] = Setting().get(SettingKey.ENABLE_PASSWORD_LOGIN)
+        self.vars['downloadShown'] = Setting().get(SettingKey.DOWNLOAD_SHOWN)
 
         return super()._renderHTML()

--- a/girder/utility/webroot.py
+++ b/girder/utility/webroot.py
@@ -122,6 +122,6 @@ class Webroot(WebrootBase):
         self.vars['bannerColor'] = Setting().get(SettingKey.BANNER_COLOR)
         self.vars['registrationPolicy'] = Setting().get(SettingKey.REGISTRATION_POLICY)
         self.vars['enablePasswordLogin'] = Setting().get(SettingKey.ENABLE_PASSWORD_LOGIN)
-        self.vars['downloadShown'] = Setting().get(SettingKey.DOWNLOAD_SHOWN)
+        self.vars['showDownload'] = Setting().get(SettingKey.SHOW_DOWNLOAD)
 
         return super()._renderHTML()

--- a/girder/web_client/src/templates/body/collectionPage.pug
+++ b/girder/web_client/src/templates/body/collectionPage.pug
@@ -7,10 +7,11 @@
       |  Actions
       i.icon-down-dir
     ul.g-collection-actions-menu.dropdown-menu.pull-right(role="menu")
-      li(role="presentation")
-        a.g-download-collection(role="menuitem", href=collection.downloadUrl())
-          i.icon-download
-          | Download collection
+      if (showDownload)
+        li(role="presentation")
+          a.g-download-collection(role="menuitem", href=collection.downloadUrl())
+            i.icon-download
+            | Download collection
       if (collection.getAccessLevel() >= AccessType.WRITE)
         li.divider(role="presentation")
         li(role="presentation")

--- a/girder/web_client/src/templates/body/itemPage.pug
+++ b/girder/web_client/src/templates/body/itemPage.pug
@@ -5,28 +5,30 @@
     if (accessLevel >= AccessType.WRITE)
       button.g-upload-into-item.btn.btn-sm.btn-success(title="Upload files into item")
         i.icon-upload
-    .btn-group
-      button.g-item-actions-button.btn.btn-sm.btn-default.dropdown-toggle(
-          data-toggle="dropdown", title="Item actions")
-        i.icon-doc-text-inv
-        |  Actions
-        i.icon-down-dir
-      ul.g-item-actions-menu.dropdown-menu.pull-right(role="menu")
-        li(role="presentation")
-          a.g-download-item(role="menuitem", href=item.downloadUrl())
-            i.icon-download
-            | Download item
-        if (accessLevel >= AccessType.WRITE)
-          li.divider(role="presentation")
-          li(role="presentation")
-            a.g-edit-item(role="menuitem")
-              i.icon-edit
-              | Edit item
-          li.divider(role="presentation")
-          li(role="presentation")
-            a.g-delete-item(role="menuitem")
-              i.icon-trash
-              | Delete item
+    if showDownload || accessLevel >= AccessType.WRITE
+      .btn-group
+        button.g-item-actions-button.btn.btn-sm.btn-default.dropdown-toggle(
+            data-toggle="dropdown", title="Item actions")
+          i.icon-doc-text-inv
+          |  Actions
+          i.icon-down-dir
+        ul.g-item-actions-menu.dropdown-menu.pull-right(role="menu")
+          if (showDownload)
+            li(role="presentation")
+              a.g-download-item(role="menuitem", href=item.downloadUrl())
+                i.icon-download
+                | Download item
+          if (accessLevel >= AccessType.WRITE)
+            li.divider(role="presentation")
+            li(role="presentation")
+              a.g-edit-item(role="menuitem")
+                i.icon-edit
+                | Edit item
+            li.divider(role="presentation")
+            li(role="presentation")
+              a.g-delete-item(role="menuitem")
+                i.icon-trash
+                | Delete item
 
   .g-item-name.g-body-title= item.name()
 

--- a/girder/web_client/src/templates/widgets/checkedActionsMenu.pug
+++ b/girder/web_client/src/templates/widgets/checkedActionsMenu.pug
@@ -9,10 +9,11 @@ li.g-checked-menu-header.dropdown-header(role="presentation")
     i.icon-plus-circled
     span.g-checked-picked-count #{pickedCount}
 if folderCount || itemCount
-  li
-    a.g-download-checked
-      i.icon-download
-      | Download checked resources
+  if showDownload
+    li
+      a.g-download-checked
+        i.icon-download
+        | Download checked resources
   li
     a.g-pick-checked
       i.icon-plus-circled

--- a/girder/web_client/src/templates/widgets/fileList.pug
+++ b/girder/web_client/src/templates/widgets/fileList.pug
@@ -1,19 +1,30 @@
 ul.g-file-list
   each file in files
     li.g-file-list-entry
-      a.g-file-list-link(cid=file.cid, title="Download file",
-          target=file.get('linkUrl') ? '_blank' : '_self', href=file.downloadUrl(),
-          rel="noopener noreferrer")
-        if file.get('linkUrl')
-          i.icon-link
-          span.g-file-name= file.name()
-          i.icon-link-ext
-        else
-          i.icon-doc-inv
-          = file.name()
-      a.g-view-inline(title="View in browser", target="_blank", rel="noopener noreferrer",
-          href=file.downloadUrl({contentDisposition: 'inline'}))
-        i.icon-eye
+      if (showDownload)
+        a.g-file-list-link(cid=file.cid, title="Download file",
+            target=file.get('linkUrl') ? '_blank' : '_self', href=file.downloadUrl(),
+            rel="noopener noreferrer")
+          if file.get('linkUrl')
+            i.icon-link
+            span.g-file-name= file.name()
+            i.icon-link-ext
+          else
+            i.icon-doc-inv
+            = file.name()
+      else
+        span.g-file-list-link(cid=file.cid)
+          if file.get('linkUrl')
+            i.icon-link
+            span.g-file-name= file.name()
+            i.icon-link-ext
+          else
+            i.icon-doc-inv
+            = file.name()
+      if (showDownload || !file.has('size') || file.get('size') < 100000)
+        a.g-view-inline(title="View in browser", target="_blank", rel="noopener noreferrer",
+            href=file.downloadUrl({contentDisposition: 'inline'}))
+          i.icon-eye
       a.g-show-info(file-cid=file.cid, title="Show info")
         i.icon-info
       if file.has('size')

--- a/girder/web_client/src/templates/widgets/hierarchyWidget.pug
+++ b/girder/web_client/src/templates/widgets/hierarchyWidget.pug
@@ -49,10 +49,11 @@
                 i.icon-folder-open
               |  #{model.name()}
             if type === 'folder' || type === 'collection'
-              li(role="presentation")
-                a.g-download-folder(role="menuitem", href=model.downloadUrl())
-                  i.icon-download
-                  | Download #{type}
+              if (showDownload)
+                li(role="presentation")
+                  a.g-download-folder(role="menuitem", href=model.downloadUrl())
+                    i.icon-download
+                    | Download #{type}
             if level >= AccessType.WRITE
               li(role="presentation")
                 a.g-create-subfolder(role="menuitem")

--- a/girder/web_client/src/utilities/ShowDownload.js
+++ b/girder/web_client/src/utilities/ShowDownload.js
@@ -1,0 +1,15 @@
+/**
+ * Given a view, returns whether or not the download widget(s)
+ * should be displayed to the user.
+ *
+ * @param {Backbone.View} view
+ * @returns the value of the SHOW_DOWNLOAD setting in the current
+ * view hierarchy. Defaults to `true`.
+ */
+export function showDownload(view) {
+    let baseView = view;
+    while (baseView.parentView) {
+        baseView = baseView.parentView;
+    }
+    return baseView && baseView.showDownload ? baseView.showDownload() : true;
+}

--- a/girder/web_client/src/utilities/index.js
+++ b/girder/web_client/src/utilities/index.js
@@ -1,9 +1,11 @@
 import eventStream from './EventStream';
 import * as PluginUtils from './PluginUtils';
 import * as S3UploadHandler from './S3UploadHandler';
+import { showDownload } from './ShowDownload';
 
 export {
     eventStream,
     PluginUtils,
-    S3UploadHandler
+    S3UploadHandler,
+    showDownload
 };

--- a/girder/web_client/src/views/App.js
+++ b/girder/web_client/src/views/App.js
@@ -47,6 +47,7 @@ var App = View.extend({
         this.bannerColor = settings.bannerColor || null;
         this.registrationPolicy = settings.registrationPolicy || null;
         this.enablePasswordLogin = _.has(settings, 'enablePasswordLogin') ? settings.enablePasswordLogin : true;
+        this.downloadShown = settings.downloadShown || 'all';
 
         if (settings.start === undefined || settings.start) {
             this.start();
@@ -336,6 +337,12 @@ var App = View.extend({
                 });
             }, options.timeout);
         }
+    },
+
+    showDownload: function () {
+        const user = getCurrentUser();
+        const isAdmin = !!(user && user.get('admin'));
+        return this.downloadShown === undefined || this.downloadShown === null || this.downloadShown === 'all' || (this.downloadShown === 'user' && user) || (this.downloadShown === 'admin' && isAdmin);
     },
 
     /**

--- a/girder/web_client/src/views/App.js
+++ b/girder/web_client/src/views/App.js
@@ -47,7 +47,7 @@ var App = View.extend({
         this.bannerColor = settings.bannerColor || null;
         this.registrationPolicy = settings.registrationPolicy || null;
         this.enablePasswordLogin = _.has(settings, 'enablePasswordLogin') ? settings.enablePasswordLogin : true;
-        this.downloadShown = settings.downloadShown || 'all';
+        this.downloadShown = settings.showDownload || 'all';
 
         if (settings.start === undefined || settings.start) {
             this.start();

--- a/girder/web_client/src/views/App.js
+++ b/girder/web_client/src/views/App.js
@@ -342,7 +342,11 @@ var App = View.extend({
     showDownload: function () {
         const user = getCurrentUser();
         const isAdmin = !!(user && user.get('admin'));
-        return this.downloadShown === undefined || this.downloadShown === null || this.downloadShown === 'all' || (this.downloadShown === 'user' && user) || (this.downloadShown === 'admin' && isAdmin);
+        return this.downloadShown === undefined ||
+            this.downloadShown === null ||
+            this.downloadShown === 'all' ||
+            (this.downloadShown === 'user' && user) ||
+            (this.downloadShown === 'admin' && isAdmin);
     },
 
     /**

--- a/girder/web_client/src/views/body/CollectionView.js
+++ b/girder/web_client/src/views/body/CollectionView.js
@@ -21,6 +21,8 @@ import '@girder/core/stylesheets/body/collectionPage.styl';
 
 import 'bootstrap/js/dropdown';
 
+import { showDownload } from '../../utilities';
+
 /**
  * This view shows a single collection's page.
  */
@@ -89,7 +91,7 @@ var CollectionView = View.extend({
             collection: this.model,
             AccessType: AccessType,
             renderMarkdown: renderMarkdown,
-            showDownload: this.parentView.showDownload()
+            showDownload: showDownload(this)
         }));
 
         if (!this.hierarchyWidget) {

--- a/girder/web_client/src/views/body/CollectionView.js
+++ b/girder/web_client/src/views/body/CollectionView.js
@@ -88,7 +88,8 @@ var CollectionView = View.extend({
         this.$el.html(CollectionPageTemplate({
             collection: this.model,
             AccessType: AccessType,
-            renderMarkdown: renderMarkdown
+            renderMarkdown: renderMarkdown,
+            showDownload: this.parentView.showDownload()
         }));
 
         if (!this.hierarchyWidget) {

--- a/girder/web_client/src/views/body/ItemView.js
+++ b/girder/web_client/src/views/body/ItemView.js
@@ -110,6 +110,10 @@ var ItemView = View.extend({
         // Fetch the access level asynchronously and render once we have
         // it. TODO: load the page and adjust only the action menu once
         // the access level is fetched.
+        let baseParent = this.parentView;
+        while (baseParent && !baseParent.showDownload) {
+            baseParent = baseParent.parentView;
+        }
         this.model.getAccessLevel((accessLevel) => {
             this.accessLevel = accessLevel;
             this.$el.html(ItemPageTemplate({
@@ -119,6 +123,7 @@ var ItemView = View.extend({
                 formatSize: formatSize,
                 formatDate: formatDate,
                 renderMarkdown: renderMarkdown,
+                showDownload: baseParent && baseParent.showDownload ? baseParent.showDownload() : false,
                 DATE_SECOND: DATE_SECOND
             }));
 

--- a/girder/web_client/src/views/body/ItemView.js
+++ b/girder/web_client/src/views/body/ItemView.js
@@ -21,6 +21,8 @@ import '@girder/core/stylesheets/body/itemPage.styl';
 
 import 'bootstrap/js/dropdown';
 
+import { showDownload } from '../../utilities';
+
 /**
  * This view shows a single item's page.
  */
@@ -110,10 +112,6 @@ var ItemView = View.extend({
         // Fetch the access level asynchronously and render once we have
         // it. TODO: load the page and adjust only the action menu once
         // the access level is fetched.
-        let baseParent = this.parentView;
-        while (baseParent && !baseParent.showDownload) {
-            baseParent = baseParent.parentView;
-        }
         this.model.getAccessLevel((accessLevel) => {
             this.accessLevel = accessLevel;
             this.$el.html(ItemPageTemplate({
@@ -123,7 +121,7 @@ var ItemView = View.extend({
                 formatSize: formatSize,
                 formatDate: formatDate,
                 renderMarkdown: renderMarkdown,
-                showDownload: baseParent && baseParent.showDownload ? baseParent.showDownload() : false,
+                showDownload: showDownload(this),
                 DATE_SECOND: DATE_SECOND
             }));
 

--- a/girder/web_client/src/views/widgets/CheckedMenuWidget.js
+++ b/girder/web_client/src/views/widgets/CheckedMenuWidget.js
@@ -24,6 +24,10 @@ var CheckedMenuWidget = View.extend({
             return;
         }
 
+        let baseParent = this.parentView;
+        while (baseParent && !baseParent.showDownload) {
+            baseParent = baseParent.parentView;
+        }
         this.dropdownToggle.girderEnable(true);
         this.$el.html(CheckedActionsMenuTemplate({
             minFolderLevel: this.minFolderLevel,
@@ -35,6 +39,7 @@ var CheckedMenuWidget = View.extend({
             pickedCopyAllowed: this.pickedCopyAllowed,
             pickedMoveAllowed: this.pickedMoveAllowed,
             pickedDesc: this.pickedDesc,
+            showDownload: baseParent && baseParent.showDownload ? baseParent.showDownload() : false,
             HierarchyWidget: HierarchyWidget
         }));
 

--- a/girder/web_client/src/views/widgets/CheckedMenuWidget.js
+++ b/girder/web_client/src/views/widgets/CheckedMenuWidget.js
@@ -6,6 +6,8 @@ import CheckedActionsMenuTemplate from '@girder/core/templates/widgets/checkedAc
 
 import '@girder/core/utilities/jquery/girderEnable';
 
+import { showDownload } from '../../utilities';
+
 /**
  * This widget presents a list of available batch actions
  * on a set of selected resources.
@@ -24,10 +26,6 @@ var CheckedMenuWidget = View.extend({
             return;
         }
 
-        let baseParent = this.parentView;
-        while (baseParent && !baseParent.showDownload) {
-            baseParent = baseParent.parentView;
-        }
         this.dropdownToggle.girderEnable(true);
         this.$el.html(CheckedActionsMenuTemplate({
             minFolderLevel: this.minFolderLevel,
@@ -39,7 +37,7 @@ var CheckedMenuWidget = View.extend({
             pickedCopyAllowed: this.pickedCopyAllowed,
             pickedMoveAllowed: this.pickedMoveAllowed,
             pickedDesc: this.pickedDesc,
-            showDownload: baseParent && baseParent.showDownload ? baseParent.showDownload() : false,
+            showDownload: showDownload(this),
             HierarchyWidget: HierarchyWidget
         }));
 

--- a/girder/web_client/src/views/widgets/FileListWidget.js
+++ b/girder/web_client/src/views/widgets/FileListWidget.js
@@ -119,11 +119,16 @@ var FileListWidget = View.extend({
 
     render: function () {
         this.checked = [];
+        let baseParent = this.parentView;
+        while (baseParent && !baseParent.showDownload) {
+            baseParent = baseParent.parentView;
+        }
         this.$el.html(FileListTemplate({
             files: this.collection.toArray(),
             hasMore: this.collection.hasNextPage(),
             AccessType: AccessType,
             formatSize: formatSize,
+            showDownload: baseParent && baseParent.showDownload ? baseParent.showDownload() : false,
             parentItem: this.parentItem
         }));
 

--- a/girder/web_client/src/views/widgets/FileListWidget.js
+++ b/girder/web_client/src/views/widgets/FileListWidget.js
@@ -12,6 +12,8 @@ import events from '@girder/core/events';
 
 import FileListTemplate from '@girder/core/templates/widgets/fileList.pug';
 
+import { showDownload } from '../../utilities';
+
 /**
  * This widget shows a list of files in a given item.
  */
@@ -119,16 +121,12 @@ var FileListWidget = View.extend({
 
     render: function () {
         this.checked = [];
-        let baseParent = this.parentView;
-        while (baseParent && !baseParent.showDownload) {
-            baseParent = baseParent.parentView;
-        }
         this.$el.html(FileListTemplate({
             files: this.collection.toArray(),
             hasMore: this.collection.hasNextPage(),
             AccessType: AccessType,
             formatSize: formatSize,
-            showDownload: baseParent && baseParent.showDownload ? baseParent.showDownload() : false,
+            showDownload: showDownload(this),
             parentItem: this.parentItem
         }));
 

--- a/girder/web_client/src/views/widgets/HierarchyWidget.js
+++ b/girder/web_client/src/views/widgets/HierarchyWidget.js
@@ -30,6 +30,8 @@ import '@girder/core/stylesheets/widgets/hierarchyWidget.styl';
 
 import 'bootstrap/js/dropdown';
 
+import { showDownload } from '../../utilities';
+
 var pickedResources = null;
 
 /**
@@ -345,10 +347,6 @@ var HierarchyWidget = View.extend({
         this.folderCount = null;
         this.itemCount = null;
 
-        let baseParent = this.parentView;
-        while (baseParent && !baseParent.showDownload) {
-            baseParent = baseParent.parentView;
-        }
         this.$el.html(HierarchyWidgetTemplate({
             type: this.parentModel.resourceName,
             model: this.parentModel,
@@ -359,7 +357,7 @@ var HierarchyWidget = View.extend({
             showMetadata: this._showMetadata,
             checkboxes: this._checkboxes,
             capitalize: capitalize,
-            showDownload: baseParent && baseParent.showDownload ? baseParent.showDownload() : false,
+            showDownload: showDownload(this),
             itemFilter: this._itemFilter
         }));
 

--- a/girder/web_client/src/views/widgets/HierarchyWidget.js
+++ b/girder/web_client/src/views/widgets/HierarchyWidget.js
@@ -345,6 +345,10 @@ var HierarchyWidget = View.extend({
         this.folderCount = null;
         this.itemCount = null;
 
+        let baseParent = this.parentView;
+        while (baseParent && !baseParent.showDownload) {
+            baseParent = baseParent.parentView;
+        }
         this.$el.html(HierarchyWidgetTemplate({
             type: this.parentModel.resourceName,
             model: this.parentModel,
@@ -355,6 +359,7 @@ var HierarchyWidget = View.extend({
             showMetadata: this._showMetadata,
             checkboxes: this._checkboxes,
             capitalize: capitalize,
+            showDownload: baseParent && baseParent.showDownload ? baseParent.showDownload() : false,
             itemFilter: this._itemFilter
         }));
 

--- a/girder/web_client/src/views/widgets/ItemListWidget.js
+++ b/girder/web_client/src/views/widgets/ItemListWidget.js
@@ -9,6 +9,8 @@ import { restRequest } from '@girder/core/rest';
 
 import ItemListTemplate from '@girder/core/templates/widgets/itemList.pug';
 
+import { showDownload } from '../../utilities';
+
 /**
  * This widget shows a list of items under a given folder.
  */
@@ -44,11 +46,7 @@ var ItemListWidget = View.extend({
         this._checkboxes = settings.checkboxes;
         this._downloadLinks = (
             _.has(settings, 'downloadLinks') ? settings.downloadLinks : true);
-        let baseParent = this.parentView;
-        while (baseParent && !baseParent.showDownload) {
-            baseParent = baseParent.parentView;
-        }
-        if (!baseParent || !baseParent.showDownload || !baseParent.showDownload()) {
+        if (!showDownload(this)) {
             this._downloadLinks = false;
         }
         this._viewLinks = (

--- a/girder/web_client/src/views/widgets/ItemListWidget.js
+++ b/girder/web_client/src/views/widgets/ItemListWidget.js
@@ -44,6 +44,13 @@ var ItemListWidget = View.extend({
         this._checkboxes = settings.checkboxes;
         this._downloadLinks = (
             _.has(settings, 'downloadLinks') ? settings.downloadLinks : true);
+        let baseParent = this.parentView;
+        while (baseParent && !baseParent.showDownload) {
+            baseParent = baseParent.parentView;
+        }
+        if (!baseParent || !baseParent.showDownload || !baseParent.showDownload()) {
+            this._downloadLinks = false;
+        }
         this._viewLinks = (
             _.has(settings, 'viewLinks') ? settings.viewLinks : true);
         this._showSizes = (

--- a/girder/web_client/test/spec/dataSpec.js
+++ b/girder/web_client/test/spec/dataSpec.js
@@ -191,6 +191,52 @@ describe('Create a data hierarchy', function () {
         });
     });
 
+    it('can\'t download file if showDownload is false', function () {
+        var originalShowDownload;
+
+        runs(function () {
+            originalShowDownload = girder.app.showDownload;
+            girder.app.showDownload = function () { return false; };
+        });
+
+        runs(function () {
+            $('.g-hierarchy-level-up').trigger('click');
+        });
+
+        waitsFor(function () {
+            return $('.g-item-list-link').length === 1;
+        }, 'navigate back to the folder');
+
+        runs(function () {
+            $('.g-item-list-link').trigger('click');
+        });
+
+        waitsFor(function () {
+            return $('.g-file-list-link').length === 1;
+        }, 'the item page to display the file list');
+
+        runs(function () {
+            expect($('a.g-file-list-link').length).toBe(0);
+            expect($('span.g-file-list-link').length).toBe(1);
+        });
+
+        runs(function () {
+            $('.g-item-actions-button').trigger('click');
+        });
+
+        waitsFor(function () {
+            return $('.g-item-actions-menu.dropdown-menu').length === 1;
+        }, 'the actions menu to appear');
+
+        runs(function () {
+            expect($('a.g-download-item').length).toBe(0);
+        });
+
+        runs(function () {
+            girder.app.showDownload = originalShowDownload;
+        });
+    });
+
     it('search using quick search box', function () {
         runs(function () {
             $('.g-quick-search-container input.g-search-field')
@@ -327,8 +373,42 @@ describe('Create a data hierarchy', function () {
         });
     });
 
+    it('can\'t download a folder if showDownload is false', function () {
+        var originalShowDownload;
+        var widget;
+
+        runs(function () {
+            widget = girder.events._events['g:navigateTo'][0].ctx.bodyView.hierarchyWidget;
+            originalShowDownload = girder.app.showDownload;
+            girder.app.showDownload = function () { return false; };
+            widget.render();
+        });
+
+        waitsFor(function () {
+            return $('.g-folder-actions-button:visible').length === 1;
+        }, 'the folder actions button to appear');
+
+        runs(function () {
+            $('.g-folder-actions-button').trigger('click');
+        });
+
+        runs(function () {
+            expect($('.g-download-folder:visible').length).toBe(0);
+        });
+
+        runs(function () {
+            girder.app.showDownload = originalShowDownload;
+            widget.render();
+        });
+
+        waitsFor(function () {
+            return $('.g-folder-actions-button:visible').length === 1;
+        }, 'the folder actions button to appear again');
+    });
+
     it('download checked items', function () {
         var redirect = { method: null, url: null, data: { resources: null } }, widget;
+
         /* select a folder and the first item */
         runs(function () {
             $('.g-list-checkbox').slice(0, 2).trigger('click');
@@ -354,6 +434,29 @@ describe('Create a data hierarchy', function () {
                 .test(redirect.url)).toBe(true);
             expect(/{"folder":.*,"item":.*}/.test(redirect.data.resources))
                 .toBe(true);
+        });
+    });
+
+    it('can\'t download checked items if showDownload is false', function () {
+        var originalShowDownload;
+        runs(function () {
+            originalShowDownload = girder.app.showDownload;
+            girder.app.showDownload = function () { return false; };
+        });
+
+        runs(function () {
+            $('.g-list-checkbox').slice(0, 2).trigger('click');
+        });
+        waitsFor(function () {
+            return $('.g-checked-actions-menu').length > 0 &&
+                   $('a.g-pick-checked').length > 0;
+        }, 'checked actions menu');
+        runs(function () {
+            expect($('a.g-download-checked').length).toBe(0);
+        });
+
+        runs(function () {
+            girder.app.showDownload = originalShowDownload;
         });
     });
 

--- a/girder/web_client/test/spec/utilitiesSpec.js
+++ b/girder/web_client/test/spec/utilitiesSpec.js
@@ -74,3 +74,18 @@ describe('Test EventStream', function () {
         }, 'EventStream to trigger stop and close events');
     });
 });
+
+describe('test showDialog traversal', function () {
+    it('checks the root view', function () {
+        var rootView = { showDownload: function () { return false; } };
+        var parentView = { showDownload: function () { return true; }, parentView: rootView };
+        var childView = { parentView: parentView };
+        expect(girder.utilities.showDownload(childView)).toBe(false);
+        expect(girder.utilities.showDownload(parentView)).toBe(false);
+    });
+
+    it('defaults to true', function () {
+        var view = {};
+        expect(girder.utilities.showDownload(view)).toBe(true);
+    });
+});

--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -744,6 +744,7 @@ girder
             CORS_ALLOW_ORIGIN
             CORS_EXPOSE_HEADERS
             DISABLE_ANONYMOUS_ACCESS
+            DOWNLOAD_SHOWN
             EMAIL_FROM_ADDRESS
             EMAIL_HOST
             EMAIL_VERIFICATION

--- a/scripts/publicNames.txt
+++ b/scripts/publicNames.txt
@@ -744,7 +744,6 @@ girder
             CORS_ALLOW_ORIGIN
             CORS_EXPOSE_HEADERS
             DISABLE_ANONYMOUS_ACCESS
-            DOWNLOAD_SHOWN
             EMAIL_FROM_ADDRESS
             EMAIL_HOST
             EMAIL_VERIFICATION
@@ -757,6 +756,7 @@ girder
             REGISTRATION_POLICY
             ROUTE_TABLE
             SERVER_ROOT
+            SHOW_DOWNLOAD
             SMTP_ENCRYPTION
             SMTP_HOST
             SMTP_PASSWORD

--- a/test/test_show_download.py
+++ b/test/test_show_download.py
@@ -1,0 +1,35 @@
+"""
+Tests for the core.show_download setting.
+
+Since this setting purely drives UI, these tests only ensure validation is correct.
+"""
+import pytest
+
+from girder.exceptions import ValidationException
+
+from girder.models.setting import Setting
+from girder.settings import SettingKey
+
+
+class TestShowDownloadSetting:
+    """Tests for the core.show_download setting validation."""
+
+    def testSettingDefaultIsAll(self, db):
+        assert Setting().getDefault(SettingKey.SHOW_DOWNLOAD) == 'all'
+
+    def testSettingValidationValid(self, db):
+        test_pairs = [
+            ('all', 'all'),
+            ('user', 'user'),
+            ('admin', 'admin'),
+            ('none', 'none'),
+            ('ALL', 'all'),
+        ]
+        for pair in test_pairs:
+            Setting().set(SettingKey.SHOW_DOWNLOAD, pair[0])
+            assert Setting().get(SettingKey.SHOW_DOWNLOAD) == pair[1]
+
+    def testSettingValidationInvalid(self, db):
+        for invalid in [1, True, 'true', None, [], {}]:
+            with pytest.raises(ValidationException):
+                Setting().set(SettingKey.SHOW_DOWNLOAD, invalid)

--- a/test/test_webroot.py
+++ b/test/test_webroot.py
@@ -35,23 +35,30 @@ def testAccessWebRoot(server):
     assert 'girder_app.min.js' in body
     assert 'girder_lib.min.js' in body
 
+    defaultShowDownload = Setting().getDefault(SettingKey.SHOW_DOWNLOAD)
+    assert "showDownload: '%s'" % defaultShowDownload in body
+
     # Change webroot settings
     Setting().set(SettingKey.CONTACT_EMAIL_ADDRESS, 'foo@bar.com')
     Setting().set(SettingKey.BRAND_NAME, 'FooBar')
+    Setting().set(SettingKey.SHOW_DOWNLOAD, 'user')
     resp = server.request(path='/', method='GET', isJson=False, prefix='')
     assertStatusOk(resp)
     body = getResponseBody(resp)
     assert WebrootBase._escapeJavascript('foo@bar.com') in body
     assert '<title>FooBar</title>' in body
+    assert "showDownload: '%s'" % 'user' in body
 
     # Remove webroot settings
     Setting().unset(SettingKey.CONTACT_EMAIL_ADDRESS)
     Setting().unset(SettingKey.BRAND_NAME)
+    Setting().unset(SettingKey.SHOW_DOWNLOAD)
     resp = server.request(path='/', method='GET', isJson=False, prefix='')
     assertStatusOk(resp)
     body = getResponseBody(resp)
     assert WebrootBase._escapeJavascript(defaultEmailAddress) in body
     assert '<title>%s</title>' % defaultBrandName in body
+    assert "showDownload: '%s'" % defaultShowDownload in body
 
 
 def testWebRootProperlyHandlesCustomStaticPublicPath(server):


### PR DESCRIPTION
@manthey I found a branch from ~2 years ago where it looked like you had started the work for this.

I made a couple of changes, including renaming `DOWNLOAD_SHOWN` -> `SHOW_DOWNLOAD` to fit the existing pattern, which was dominated by VERB_ACTION. I also deduplicated the hierarchy traversal to get the setting value from the top level `App` view into a utility.

Tests have been added for validation of the setting, unit test of the utility function, and some integration tests to verify the setting affects the UI.