### PR TITLE
Add an explicit timeout for SMTP connection

### DIFF
--- a/girder/utility/mail_utils.py
+++ b/girder/utility/mail_utils.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import smtplib
+import urllib.parse
 from email.mime.text import MIMEText
 
 from mako.lookup import TemplateLookup
@@ -11,6 +12,12 @@ from girder.constants import PACKAGE_DIR
 from girder.settings import SettingKey
 
 logger = logging.getLogger(__name__)
+
+# Socket timeout (seconds) for SMTP connections. Without an explicit value smtplib
+# inherits the global socket default, which is normally ``None``, potentially blocking
+# server thread forever if connection is silently dropped in transit.
+# Explicit timeout results in error that we can handle instead
+SMTP_TIMEOUT = 30
 
 
 def validateEmailAddress(address):
@@ -120,20 +127,40 @@ def _createMessage(subject, text, to, bcc):
     return msg, recipients
 
 
+def _localHostname():
+    """
+    Return the name to announce in the SMTP EHLO, or None to let smtplib choose.
+
+    Derived from the ``core.email_host`` setting, which already names this instance as
+    the outside world sees it. Without one, smtplib falls back to ``socket.getfqdn()``,
+    which inside a container typically cannot resolve a real name and yields a bracketed
+    address literal leaking the container's private address in every message.
+    """
+    from girder.models.setting import Setting
+
+    host = Setting().get(SettingKey.EMAIL_HOST)
+    if not host:
+        return None
+    return urllib.parse.urlparse(host).hostname or None
+
+
 class _SMTPConnection:
-    def __init__(self, host, port=None, encryption=None,
-                 username=None, password=None):
+    def __init__(self, host, port=None, encryption=None, username=None, password=None,
+                 timeout=SMTP_TIMEOUT, localHostname=None):
         self.host = host
         self.port = port
         self.encryption = encryption
         self.username = username
         self.password = password
+        self.timeout = timeout
+        self.localHostname = localHostname
 
     def __enter__(self):
+        kwargs = {'local_hostname': self.localHostname, 'timeout': self.timeout}
         if self.encryption == 'ssl':
-            self.connection = smtplib.SMTP_SSL(self.host, self.port)
+            self.connection = smtplib.SMTP_SSL(self.host, self.port, **kwargs)
         else:
-            self.connection = smtplib.SMTP(self.host, self.port)
+            self.connection = smtplib.SMTP(self.host, self.port, **kwargs)
             if self.encryption == 'starttls':
                 self.connection.starttls()
         if self.username and self.password:
@@ -161,7 +188,8 @@ def _submitEmail(msg, recipients):
         port=setting.get(SettingKey.SMTP_PORT),
         encryption=setting.get(SettingKey.SMTP_ENCRYPTION),
         username=setting.get(SettingKey.SMTP_USERNAME),
-        password=setting.get(SettingKey.SMTP_PASSWORD)
+        password=setting.get(SettingKey.SMTP_PASSWORD),
+        localHostname=_localHostname()
     )
 
     logger.info('Sending email to %s through %s', ', '.join(recipients), smtp.host)

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -82,3 +82,80 @@ def testBcc(email_stdout, capsys):
     message = _get_mail_from_stdout(capsys.readouterr().out)
     assert message['To'] == 'first@a.com'
     assert message['Bcc'] == ', '.join(bcc)
+
+
+class _FakeSMTP:
+    """Records the arguments smtplib would have been constructed with."""
+
+    instances = []
+
+    def __init__(self, host, port, local_hostname=None, timeout=None):
+        self.host = host
+        self.port = port
+        self.local_hostname = local_hostname
+        self.timeout = timeout
+        self.startedTls = False
+        self.loggedIn = None
+        _FakeSMTP.instances.append(self)
+
+    def starttls(self):
+        self.startedTls = True
+
+    def login(self, username, password):
+        self.loggedIn = (username, password)
+
+    def sendmail(self, fromAddress, toAddresses, message):
+        pass
+
+    def quit(self):
+        pass
+
+
+@pytest.fixture
+def fakeSmtp(monkeypatch):
+    _FakeSMTP.instances = []
+    monkeypatch.setattr(mail_utils.smtplib, 'SMTP', _FakeSMTP)
+    monkeypatch.setattr(mail_utils.smtplib, 'SMTP_SSL', _FakeSMTP)
+    yield _FakeSMTP
+
+
+@pytest.mark.parametrize('encryption,expectTls', [
+    ('none', False),
+    ('starttls', True),
+    ('ssl', False),
+])
+def testSmtpConnectionPassesTimeoutAndHostname(fakeSmtp, encryption, expectTls):
+    # A connection must never be created without a timeout: smtplib would otherwise
+    # inherit the global socket default (normally None) and block forever on a
+    # submission that is dropped rather than refused.
+    with mail_utils._SMTPConnection(
+            host='smtp.test', port=587, encryption=encryption,
+            localHostname='girder.test'):
+        pass
+
+    conn, = fakeSmtp.instances
+    assert conn.timeout == mail_utils.SMTP_TIMEOUT
+    assert conn.local_hostname == 'girder.test'
+    assert conn.startedTls is expectTls
+    assert conn.loggedIn is None
+
+
+def testSmtpConnectionLoginRequiresBoth(fakeSmtp):
+    with mail_utils._SMTPConnection(host='smtp.test', port=587, username='u'):
+        pass
+    assert fakeSmtp.instances[-1].loggedIn is None
+
+    with mail_utils._SMTPConnection(host='smtp.test', port=587, username='u', password='p'):
+        pass
+    assert fakeSmtp.instances[-1].loggedIn == ('u', 'p')
+
+
+@pytest.mark.parametrize('emailHost,expected', [
+    ('https://girder.test', 'girder.test'),
+    ('http://girder.test:8080', 'girder.test'),
+    ('', None),
+    ('not a url', None),
+])
+def testLocalHostname(db, emailHost, expected):
+    Setting().set(SettingKey.EMAIL_HOST, emailHost)
+    assert mail_utils._localHostname() == expected


### PR DESCRIPTION
When you run Girder on extremely unreliable infrastructure, you encounter weird bugs. This is one of them. Lack of timeout in SMTP connection + lousy network can result in all girder threads hanging.